### PR TITLE
eval / exec improvements

### DIFF
--- a/.changeset/neat-islands-guess.md
+++ b/.changeset/neat-islands-guess.md
@@ -1,0 +1,6 @@
+---
+"@env-spec/parser": patch
+"varlock": patch
+---
+
+rename eval to exec

--- a/.cursor/rules/varlock.mdc
+++ b/.cursor/rules/varlock.mdc
@@ -74,7 +74,7 @@ actions:
          - varlock() - For encrypted values
          - fallback() - For fallback values
          - concat() - For concatenated values
-         - eval() - For command output
+         - exec() - For command output
          - ref() - For referencing other variables
 
 examples:

--- a/example-repo/.env.schema
+++ b/example-repo/.env.schema
@@ -7,7 +7,7 @@
 
 CONCAT_EXAMPLE=concat(foo, bar)
 FALLBACK_EXAMPLE=fallback("", undefined, default)
-EVAL_EXAMPLE=eval(concat("who", "ami"))
+EXEC_EXAMPLE=exec(concat("who", "ami"))
 # BAD_FN_EXAMPLE=foo()
 # BAD_FN_NESTED_EXAMPLE=concat(foo(), bar())
 
@@ -15,12 +15,12 @@ FOO=FOOVAL!
 REF_EXAMPLE=concat("pre-", ref(FOO), "-post")
 REF_EXAMPLE2="pre-${FOO}-post"
 
-EVAL_OP_EXAMPLE=eval('op read "op://dev test/example/credential"')
+EXEC_OP_EXAMPLE=exec('op read "op://dev test/example/credential"')
 
 OP_VAULT='example'
-OP_EXAMPLE1=eval(`op read "op://dev test/${OP_VAULT}/credential"`)
-OP_EXAMPLE2=$(op read "op://dev test/${OP_VAULT}/credential")
-OP_EXAMPLE3=eval(concat(`op read "op://dev test/`, ref(OP_VAULT), `/credential"`))
+EXEC_EXAMPLE1=exec(`op read "op://dev test/${OP_VAULT}/credential"`)
+EXEC_EXAMPLE2=$(op read "op://dev test/${OP_VAULT}/credential")
+EXEC_EXAMPLE3=exec(concat(`op read "op://dev test/`, ref(OP_VAULT), `/credential"`))
 
 # Env flag
 # @type=enum(development, staging, production, test)

--- a/packages/env-graph/src/lib/resolver.ts
+++ b/packages/env-graph/src/lib/resolver.ts
@@ -6,6 +6,7 @@ import { Constructor } from '@env-spec/utils/type-utils';
 
 import { ResolutionError, SchemaError } from './errors';
 import { ConfigItem } from './config-item';
+import { SimpleQueue } from './simple-queue';
 
 const execAsync = promisify(exec);
 
@@ -195,6 +196,8 @@ export class ExecResolver extends ResolverInstance {
     }
   }
 
+  static execQueue = new SimpleQueue();
+
   protected async _resolve() {
     if (!Array.isArray(this.fnArgs) || this.fnArgs.length !== 1) {
       throw new Error('exec() expects a single child arg');
@@ -206,7 +209,10 @@ export class ExecResolver extends ResolverInstance {
     }
 
     try {
-      const { stdout, stderr } = await execAsync(commandStr);
+      // ? NOTE - putting these calls through a simple queue for now
+      // this avoids multiple 1password auth popups, but it also makes multiple 1p calls very slow
+      // we likely want to remove this once we have the specific 1Password plugin re-implemented
+      const { stdout, stderr } = await ExecResolver.execQueue.enqueue(() => execAsync(commandStr));
       // trim trailing newline by default
       // we could allow options here?
       return stdout.replace(/\n$/, '');

--- a/packages/env-graph/src/lib/resolver.ts
+++ b/packages/env-graph/src/lib/resolver.ts
@@ -182,27 +182,27 @@ export class FallbackResolver extends ResolverInstance {
   }
 }
 
-export class EvalResolver extends ResolverInstance {
-  label = 'eval';
+export class ExecResolver extends ResolverInstance {
+  label = 'exec';
   icon = 'iconoir:terminal';
 
   async _process() {
     if (!Array.isArray(this.fnArgs)) {
-      throw new SchemaError('eval() expects a single child arg, not a key-value object');
+      throw new SchemaError('exec() expects a single child arg, not a key-value object');
     }
     if (this.fnArgs.length !== 1) {
-      throw new SchemaError('eval() expects a single child arg');
+      throw new SchemaError('exec() expects a single child arg');
     }
   }
 
   protected async _resolve() {
     if (!Array.isArray(this.fnArgs) || this.fnArgs.length !== 1) {
-      throw new Error('eval() expects a single child arg');
+      throw new Error('exec() expects a single child arg');
     }
 
     const commandStr = await this.fnArgs[0].resolve();
     if (typeof commandStr !== 'string') {
-      throw new ResolutionError('eval() expects a string child arg');
+      throw new ResolutionError('exec() expects a string child arg');
     }
 
     try {
@@ -211,8 +211,8 @@ export class EvalResolver extends ResolverInstance {
       // we could allow options here?
       return stdout.replace(/\n$/, '');
     } catch (err) {
-      console.log('eval() failed', err);
-      throw new ResolutionError(`eval() command failed: ${commandStr}`);
+      console.log('exec() failed', err);
+      throw new ResolutionError(`exec() command failed: ${commandStr}`);
     }
   }
 }
@@ -253,5 +253,5 @@ export const BaseResolvers: Record<string, Constructor<ResolverInstance>> = {
   concat: ConcatResolver,
   fallback: FallbackResolver,
   ref: RefResolver,
-  eval: EvalResolver,
+  exec: ExecResolver,
 };

--- a/packages/env-graph/src/lib/simple-queue.ts
+++ b/packages/env-graph/src/lib/simple-queue.ts
@@ -1,0 +1,39 @@
+/** A simple queue implementation for sequential execution of async operations */
+export class SimpleQueue {
+  private queue: Array<() => Promise<any>> = [];
+  private processing = false;
+
+  /** Add a task to the queue and return a promise that resolves when the task is complete */
+  async enqueue<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      this.queue.push(async () => {
+        try {
+          const result = await task();
+          resolve(result);
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+      this.processQueue();
+    });
+  }
+
+  private async processQueue() {
+    if (this.processing || this.queue.length === 0) {
+      return;
+    }
+
+    this.processing = true;
+    const task = this.queue.shift();
+
+    if (task) {
+      try {
+        await task();
+      } finally {
+        this.processing = false;
+        this.processQueue();
+      }
+    }
+  }
+}

--- a/packages/env-graph/test/resolvers.test.ts
+++ b/packages/env-graph/test/resolvers.test.ts
@@ -114,17 +114,17 @@ describe('fallback()', functionValueTests({
   },
 }));
 
-describe('eval()', functionValueTests({
+describe('exec()', functionValueTests({
   'working example': {
-    input: 'ITEM=eval("echo moo")',
+    input: 'ITEM=exec("echo moo")',
     expected: { ITEM: 'moo' },
   },
   'error - no command': {
-    input: 'ITEM=eval()',
+    input: 'ITEM=exec()',
     expected: { ITEM: SchemaError },
   },
   'error - key/val args': {
-    input: 'ITEM=eval(cmd="echo moo")',
+    input: 'ITEM=exec(cmd="echo moo")',
     expected: { ITEM: SchemaError },
   },
 }));

--- a/packages/env-spec-parser/README.md
+++ b/packages/env-spec-parser/README.md
@@ -175,8 +175,8 @@ Examples:
 ## Notable differences with dotenv/dotenv-expand/dotenvx
 - we do not support _nested_ default expansion (ex: `VAR=${FOO:-${BAR}}`
   - instead you can use the `fallback` function directly `VAR=fallback(ref(FOO), ref(BAR))`
-- we do not support _unescaped_ quotes within eval expansion (ex: `VAR="$(echo "foo")"`)
-  - we support backtick quotes, escaped quotes, or you can use `eval` function directly `VAR=eval(echo "foo")`
+- we do not support _unescaped_ quotes within exec expansion (ex: `VAR="$(echo "foo")"`)
+  - we support backtick quotes, escaped quotes, or you can use `exec` function directly `VAR=exec(echo "foo")`
 ------------------
 
 ## Local dev and testing workflow

--- a/packages/env-spec-parser/src/simple-resolver.ts
+++ b/packages/env-spec-parser/src/simple-resolver.ts
@@ -40,7 +40,7 @@ export function simpleResolver(
           }
         });
         return resolvedArgs.join('');
-      } else if (valOrFn.name === 'eval') {
+      } else if (valOrFn.name === 'exec') {
         const args = valOrFn.simplifiedArgs;
         if (Array.isArray(args)) {
           const cmdStr = args[0];
@@ -51,7 +51,7 @@ export function simpleResolver(
             },
           ).toString().trim();
         } else {
-          throw new Error('Invalid `eval` args');
+          throw new Error('Invalid `exec` args');
         }
       } else if (valOrFn.name === 'fallback') {
         const args = valOrFn.data.args.values;

--- a/packages/env-spec-parser/test/functions.test.ts
+++ b/packages/env-spec-parser/test/functions.test.ts
@@ -39,8 +39,8 @@ describe('function calls', functionValueTests({
     input: 'ITEM=fallback("", undefined, "default-val")',
     expected: { ITEM: 'default-val' },
   },
-  'eval()': {
-    input: 'ITEM=eval("echo moo")',
+  'exec()': {
+    input: 'ITEM=exec("echo moo")',
     expected: { ITEM: 'moo' },
   },
   'ref()': {
@@ -51,30 +51,30 @@ describe('function calls', functionValueTests({
     },
   },
   'nested function calls': {
-    input: 'OTHERVAL=d\nITEM=concat("a", fallback("", "b"), eval("echo c"), ref(OTHERVAL))',
+    input: 'OTHERVAL=d\nITEM=concat("a", fallback("", "b"), exec("echo c"), ref(OTHERVAL))',
     expected: { ITEM: 'abcd' },
   },
 }));
 
 
-describe('eval expansion', functionValueTests({
-  'eval expansion - unquoted': {
+describe('exec expansion', functionValueTests({
+  'exec expansion - unquoted': {
     input: 'ITEM=$(echo foo)',
     expected: { ITEM: 'foo' },
   },
-  'eval expansion within quotes - double quotes': {
+  'exec expansion within quotes - double quotes': {
     input: 'ITEM="$(echo foo)"',
     expected: { ITEM: 'foo' },
   },
-  'eval expansion within quotes - backticks': {
+  'exec expansion within quotes - backticks': {
     input: 'ITEM=`$(echo foo)`',
     expected: { ITEM: 'foo' },
   },
-  'eval expansion within quotes - single quotes (NOT EXPANDED)': {
+  'exec expansion within quotes - single quotes (NOT EXPANDED)': {
     input: "ITEM='$(echo foo)'",
     expected: { ITEM: '$(echo foo)' },
   },
-  'eval expansion with quotes inside': {
+  'exec expansion with quotes inside': {
     input: 'ITEM=$(echo "foo bar")',
     expected: { ITEM: 'foo bar' },
   },

--- a/packages/varlock-website/src/content/docs/guides/schema.mdx
+++ b/packages/varlock-website/src/content/docs/guides/schema.mdx
@@ -21,7 +21,7 @@ Root level decorators are used to specify global settings for the environment va
 
 # override defaults flags
 # @required @sensitive
-REQ_SENS_VAR=eval("some cli command")
+REQ_SENS_VAR=exec("some cli command")
 ```
 
 > See the full reference of [root-level decorators](/reference/root-decorators) for more information.
@@ -95,8 +95,8 @@ MY_KEY=fallback("", undefined, "fallback-value") # outputs "fallback-value"
 # Concatenated value
 MY_KEY=concat("part1", "part2") # outputs "part1part2"
 
-# Eval to load a value from an external command
-MY_KEY=eval(`op read "op://dev test/${OP_VAULT}/credential"`)
+# Exec to load a value from an external cli command
+MY_KEY=exec(`op read "op://dev test/${OP_VAULT}/credential"`)
 
 # Reference another item
 MY_KEY=ref(“OTHER_KEY”) # equivalent to MY_KEY=${OTHER_KEY}

--- a/packages/varlock-website/src/content/docs/guides/secrets.mdx
+++ b/packages/varlock-website/src/content/docs/guides/secrets.mdx
@@ -26,12 +26,12 @@ We'll be adding support for cloud-based secret storage in the very near future.
 
 ## Using 3rd party tools
 
-`varlock` is compatible with any 3rd party tool that supports fetching secrets via a CLI. Using function syntax and `eval`, you can use any 3rd party tool to fetch secrets.
+`varlock` is compatible with any 3rd party tool that supports fetching secrets via a CLI. Using function syntax and `exec`, you can use any 3rd party tool to fetch secrets.
 
 Here's an example using 1Password:
 
 ```bash
 # A secret in 1Password
 # @sensitive @required
-MY_SECRET=eval(`op read "op://devTest/myVault/credential"`);
+MY_SECRET=exec(`op read "op://devTest/myVault/credential"`);
 ```

--- a/packages/varlock-website/src/content/docs/reference/functions.mdx
+++ b/packages/varlock-website/src/content/docs/reference/functions.mdx
@@ -61,12 +61,12 @@ API_URL=concat("https://", ref("DOMAIN"), "/api")
 CONFIG_PATH=concat("config/", ref("ENV"), "/", ref("REGION"), ".json")
 ```
 
-## eval()
+## exec()
 
-The `eval()` function executes a command and uses its output as the value. This is useful for integrating with external tools and services.
+The `exec()` function executes a command and uses its output as the value. This is useful for integrating with external tools and services.
 
 ```env-spec
-SECRET=eval(`op read "op://vault/item/credential"`)
+SECRET=exec(`op read "op://vault/item/credential"`)
 ```
 
 ### Arguments
@@ -75,10 +75,10 @@ SECRET=eval(`op read "op://vault/item/credential"`)
 ### Example
 ```env-spec
 # Using 1Password CLI
-API_KEY=eval(`op read "op://dev test/${OP_VAULT}/credential"`)
+API_KEY=exec(`op read "op://dev test/${OP_VAULT}/credential"`)
 
 # Using AWS CLI
-AWS_CREDENTIALS=eval(`aws sts get-session-token --profile prod`)
+AWS_CREDENTIALS=exec(`aws sts get-session-token --profile prod`)
 ```
 
 ## ref()
@@ -109,6 +109,6 @@ Functions can be composed together to create complex value resolution logic. Her
 # Using multiple functions together
 API_URL=concat("https://", ref("DOMAIN"), "/", ref("API_VERSION"))
 
-# Dynamic configuration with eval
-CONFIG=eval(`aws ssm get-parameter --name "/config/${ENV}" --with-decryption`)
+# Dynamic configuration with exec
+CONFIG=exec(`aws ssm get-parameter --name "/config/${ENV}" --with-decryption`)
 ```


### PR DESCRIPTION
- rename `eval` fn to `exec` (to avoid bad vibes of “eval” from JS)
- run exec commands in serial instead of parallel