### PR TITLE
load using execSync to avoid esm hoisting issues

### DIFF
--- a/example-repo/src/example-autoload.ts
+++ b/example-repo/src/example-autoload.ts
@@ -1,16 +1,11 @@
 import 'varlock/auto-load';
 import { VarlockRedactor } from 'varlock';
 
+// console.log('loading varlock env');
+// await load();
 VarlockRedactor.patchConsole();
 
 import { logEnv } from './log-env.ts';
-
-
-// import { load } from 'varlock';
-
-// await load({
-//   global: MY_CONFIG,
-// });
 
 if (!process.env.SENSITIVE_ITEM) {
   throw new Error('no env vars have been loaded :( auto-load is not working');

--- a/example-repo/src/log-env.ts
+++ b/example-repo/src/log-env.ts
@@ -1,13 +1,22 @@
-import { ENV, PUBLIC_ENV } from 'varlock';
+import { ENV } from 'varlock';
+
+// import OpenAI from 'openai';
+
+// const client = new OpenAI({
+//   apiKey: ENV.OPENAI_API_KEY
+// });
+
+console.log(process.env.OPENAI_API_KEY);
 
 export function logEnv() {
+  console.log(process.env.OPENAI_API_KEY);
   console.log({
     'process.env.APP_ENV': process.env.APP_ENV,
     'process.env.SOME_VAR': process.env.SOME_VAR,
     'process.env.NOT_SENSITIVE_ITEM': process.env.NOT_SENSITIVE_ITEM,
     'process.env.SENSITIVE_ITEM': process.env.SENSITIVE_ITEM,
     'ENV.SENSITIVE_ITEM': ENV.SENSITIVE_ITEM,
-    'PUBLIC_ENV.NOT_SENSITIVE_ITEM': PUBLIC_ENV.NOT_SENSITIVE_ITEM,
+    // 'PUBLIC_ENV.NOT_SENSITIVE_ITEM': PUBLIC_ENV.NOT_SENSITIVE_ITEM,
     // these trigger errors - uncomment to test
     // 'ENV.BAD_KEY': ENV.BAD_KEY,
     // 'PUBLIC_ENV.SENSITIVE_ITEM': PUBLIC_ENV.SENSITIVE_ITEM,

--- a/packages/env-graph/src/index.ts
+++ b/packages/env-graph/src/index.ts
@@ -1,6 +1,6 @@
 export { loadEnvGraph } from './lib/loader';
 
-export { EnvGraph } from './lib/env-graph';
+export { EnvGraph, SerializedEnvGraph } from './lib/env-graph';
 export { EnvSourceParseError, FileBasedDataSource, DotEnvFileDataSource } from './lib/data-source';
 export { Resolver } from './lib/resolver';
 export {

--- a/packages/env-graph/src/lib/env-graph.ts
+++ b/packages/env-graph/src/lib/env-graph.ts
@@ -10,6 +10,13 @@ import { findGraphCycles, GraphAdjacencyList } from './graph-utils';
 import { ResolutionError, SchemaError } from './errors';
 import { generateTypes } from './type-generation';
 
+export type SerializedEnvGraph = {
+  config: Record<string, {
+    value: any;
+    isSensitive: boolean;
+  }>;
+}
+
 /** container of the overall graph and current resolution attempt / values */
 export class EnvGraph {
   // TODO: not sure if this should be the graph of _everything_ in a workspace/project
@@ -260,6 +267,20 @@ export class EnvGraph {
       envObject[itemKey] = item.resolvedValue;
     }
     return envObject;
+  }
+
+  getSerializedGraph(): SerializedEnvGraph {
+    const serializedGraph: SerializedEnvGraph = {
+      config: {},
+    };
+    for (const itemKey in this.configSchema) {
+      const item = this.configSchema[itemKey];
+      serializedGraph.config[itemKey] = {
+        value: item.resolvedValue,
+        isSensitive: item.isSensitive,
+      };
+    }
+    return serializedGraph;
   }
 
   get isInvalid() {

--- a/packages/varlock/src/auto-load.ts
+++ b/packages/varlock/src/auto-load.ts
@@ -1,4 +1,6 @@
-import { load } from './index';
+import { execSync } from 'node:child_process';
+import { loadFromSerializedGraph } from './index';
 
-// eslint-disable-next-line es-x/no-top-level-await
-await load();
+const execResult = execSync('varlock load --format json-full');
+const serializedGraph = JSON.parse(execResult.toString());
+loadFromSerializedGraph(serializedGraph);

--- a/packages/varlock/src/cli/commands/load.command.ts
+++ b/packages/varlock/src/cli/commands/load.command.ts
@@ -53,8 +53,9 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
       console.log(getItemSummary(item));
     }
   } else if (format === 'json') {
-    const resolvedEnv = envGraph.getResolvedEnvObject();
-    console.log(JSON.stringify(resolvedEnv, null, 2));
+    console.log(JSON.stringify(envGraph.getResolvedEnvObject(), null, 2));
+  } else if (format === 'json-full') {
+    console.log(JSON.stringify(envGraph.getSerializedGraph(), null, 2));
   } else if (format === 'env') {
     const resolvedEnv = envGraph.getResolvedEnvObject();
     for (const key in resolvedEnv) {

--- a/packages/varlock/src/lib/redaction-helpers.ts
+++ b/packages/varlock/src/lib/redaction-helpers.ts
@@ -1,4 +1,4 @@
-import { EnvGraph } from '@env-spec/env-graph';
+import { EnvGraph, SerializedEnvGraph } from '@env-spec/env-graph';
 import _ from '@env-spec/utils/my-dash';
 
 const UNMASK_STR = '👁';
@@ -33,15 +33,15 @@ let sensitiveSecretsMap: Record<string, string> = {};
 type ReplaceFn = (match: string, pre: string, val: string, post: string) => string;
 let redactorFindReplace: undefined | { find: RegExp, replace: ReplaceFn };
 
-export function resetRedactionMap(graph: EnvGraph) {
+export function resetRedactionMap(graph: SerializedEnvGraph) {
   // reset map of { [sensitive] => redacted }
   sensitiveSecretsMap = {};
-  for (const itemKey in graph.configSchema) {
-    const item = graph.configSchema[itemKey];
-    if (item.isSensitive && item.resolvedValue && _.isString(item.resolvedValue)) {
+  for (const itemKey in graph.config) {
+    const item = graph.config[itemKey];
+    if (item.isSensitive && item.value && _.isString(item.value)) {
       // TODO: we want to respect masking settings from the schema (once added)
-      const redacted = redactString(item.resolvedValue);
-      if (redacted) sensitiveSecretsMap[item.resolvedValue] = redacted;
+      const redacted = redactString(item.value);
+      if (redacted) sensitiveSecretsMap[item.value] = redacted;
     }
   }
 


### PR DESCRIPTION
calling load via top level await means we run into hoisting issues with esm imports.

to avoid this, we must make the loading process synchronous. Because the loading logic is async,  we have to load in another process via `execSync`