### PR TITLE
fix preview release action

### DIFF
--- a/packages/env-spec-parser/package.json
+++ b/packages/env-spec-parser/package.json
@@ -2,6 +2,11 @@
   "name": "@env-spec/parser",
   "version": "0.0.1",
   "description": "Parser for @env-spec enabled dotenv files",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dmno-dev/varlock.git",
+    "directory": "packages/env-spec-parser"
+  },
   "files": ["dist"],
   "exports": {
     ".": {

--- a/packages/varlock/package.json
+++ b/packages/varlock/package.json
@@ -6,6 +6,11 @@
   "type": "module",
   "author": "dmno-dev",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dmno-dev/varlock.git",
+    "directory": "packages/varlock"
+  },
   "scripts": {
     "build": "tsup",
     "build:sea": "tsup --config tsup-sea.config.ts",

--- a/scripts/release-preview.js
+++ b/scripts/release-preview.js
@@ -1,34 +1,63 @@
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const MONOREPO_ROOT = path.resolve(path.dirname(__filename), '..');
 
 let err;
 try {
   const workspacePackagesInfoRaw = execSync('pnpm m ls --json --depth=-1');
   const workspacePackagesInfo = JSON.parse(workspacePackagesInfoRaw);
 
-  // generate summary of changed (publishable) modules according to changesets
-  // only has option to output to a file
-  execSync('pnpm exec changeset status --output=changesets-summary.json');
+  // Check if we're on changeset-release/main branch
+  const currentBranch = execSync('git branch --show-current').toString().trim();
+  let releasePackagePaths;
 
-  const changeSetsSummaryRaw = fs.readFileSync('./changesets-summary.json', 'utf8');
-  const changeSetsSummary = JSON.parse(changeSetsSummaryRaw);
-  // console.log(changeSetsSummary);
+  if (currentBranch === 'changeset-release/main') {
+    // On changeset-release/main branch, find modified package.json files
+    console.log('Running on changeset-release/main branch, finding modified package.json files...');
+    const gitDiff = execSync('git diff origin/main --name-only').toString();
+    const modifiedPackageJsons = gitDiff
+      .split('\n')
+      .filter((filePath) => filePath !== 'package.json') // skip root package.json
+      .filter((filePath) => filePath.endsWith('package.json'));
+
+    if (!modifiedPackageJsons.length) {
+      console.log('No modified package.json files found!');
+      process.exit(0);
+    }
+
+    // Get the workspace paths for modified packages
+    releasePackagePaths = modifiedPackageJsons
+      .map((filePath) => `${MONOREPO_ROOT}/${filePath.replace('/package.json', '')}`)
+      .filter((filePath) => workspacePackagesInfo.some((p) => p.path === filePath));
+  } else {
+    // Regular changeset-based logic
+    // generate summary of changed (publishable) modules according to changesets
+    execSync('pnpm exec changeset status --output=changesets-summary.json');
+
+    const changeSetsSummaryRaw = fs.readFileSync('./changesets-summary.json', 'utf8');
+    const changeSetsSummary = JSON.parse(changeSetsSummaryRaw);
+
+    releasePackagePaths = changeSetsSummary.releases
+      .filter((r) => r.newVersion !== r.oldVersion)
+      .map((r) => workspacePackagesInfo.find((p) => p.name === r.name))
+      .map((p) => p.path);
+  }
 
   // filter out vscode extension which is not released via npm
-  changeSetsSummary.releases = changeSetsSummary.releases.filter((r) => r.name !== 'env-spec-language');
+  releasePackagePaths = releasePackagePaths.filter((p) => !p.endsWith('packages/vscode-plugin'));
 
-  if (!changeSetsSummary.releases.length) {
-    console.log('No preview packages to release!');
+  if (!releasePackagePaths.length) {
+    console.log('No packages to release!');
     process.exit(0);
   }
 
-  const releasePackagePaths = changeSetsSummary.releases
-    .filter((r) => r.newVersion !== r.oldVersion)
-    .map((r) => workspacePackagesInfo.find((p) => p.name === r.name))
-    .map((p) => p.path);
+  console.log('Updated packages to release:', releasePackagePaths);
 
-  // TODO: put back --compact once repo is public?
-  const publishResult = execSync(`pnpm dlx pkg-pr-new publish --pnpm ${releasePackagePaths.join(' ')}`);
+  const publishResult = execSync(`pnpm dlx pkg-pr-new publish --pnpm --compact ${releasePackagePaths.join(' ')}`);
   console.log('published preview packages!');
   console.log(publishResult);
 } catch (_err) {
@@ -36,5 +65,9 @@ try {
   console.error('preview release failed');
   console.error(_err);
 }
-fs.unlinkSync('./changesets-summary.json');
+
+// Only clean up changesets-summary.json if it exists (only created in changeset case)
+if (fs.existsSync('./changesets-summary.json')) {
+  fs.unlinkSync('./changesets-summary.json');
+}
 process.exit(err ? 1 : 0);


### PR DESCRIPTION
our github action for pkg.pr.new releases was is not working for our versioned release PRs. Changesets is not able to detect which packages to release in the PRs where we are removing all the changeset files.

Instead we detect that this is a versioned release branch, and then look for updated package.json files.