### PR TITLE
fix next integration dev reloading

### DIFF
--- a/.changeset/fifty-points-buy.md
+++ b/.changeset/fifty-points-buy.md
@@ -1,0 +1,5 @@
+---
+"@varlock/nextjs-integration": patch
+---
+
+fix dev reloading behaviour


### PR DESCRIPTION
Nextjs does not re-invoke the next.config file and its webpack modifications when .env files change, so the static replacements were getting stuck at their initial values when the user first starts the dev server.

Luckily we can get around this limitation by using a proxy object passed into `webpack.DefinePlugin`, so that when it is recompiling it will get the latest env values.