### PR TITLE
@required - env() helper

### DIFF
--- a/.changeset/thin-parents-lick.md
+++ b/.changeset/thin-parents-lick.md
@@ -2,4 +2,4 @@
 "varlock": patch
 ---
 
-add new `env()` helper for @required decorator, to allow dynamically setting required-ness based on current env
+add new `forEnv()` helper for @required decorator, to allow dynamically setting required-ness based on current env flag

--- a/.changeset/thin-parents-lick.md
+++ b/.changeset/thin-parents-lick.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+add new `env()` helper for @required decorator, to allow dynamically setting required-ness based on current env

--- a/packages/varlock/env-graph/lib/config-item.ts
+++ b/packages/varlock/env-graph/lib/config-item.ts
@@ -151,69 +151,73 @@ export class ConfigItem {
   _isRequiredDynamic: boolean = false;
 
   private processRequired() {
-    for (const def of this.defs) {
-      const defDecorators = def.itemDef.decorators || {};
+    try {
+      for (const def of this.defs) {
+        const defDecorators = def.itemDef.decorators || {};
 
-      // Explicit per-item decorators
-      if ('required' in defDecorators || 'optional' in defDecorators) {
-        // cannot use both @required and @optional at same time
-        if ('required' in defDecorators && 'optional' in defDecorators) {
-          this.schemaErrors.push(new SchemaError('@required and @optional cannot both be set'));
+        // Explicit per-item decorators
+        if ('required' in defDecorators || 'optional' in defDecorators) {
+          // cannot use both @required and @optional at same time
+          if ('required' in defDecorators && 'optional' in defDecorators) {
+            throw new SchemaError('@required and @optional cannot both be set');
+          }
+
+          const requiredDecoratorVal = defDecorators.required?.value || defDecorators.optional?.value;
+          const usingOptional = 'optional' in defDecorators;
+          // static value of  `true` or `false`
+          if (requiredDecoratorVal instanceof ParsedEnvSpecStaticValue) {
+            const staticVal = requiredDecoratorVal.value;
+            if (_.isBoolean(staticVal)) {
+              this._isRequired = usingOptional ? !staticVal : staticVal;
+            } else {
+              throw new SchemaError('@required/@optional can only be set to true/false if using a static value');
+            }
+
+          // dynamic / function value - setting based on other values
+          } else if (requiredDecoratorVal instanceof ParsedEnvSpecFunctionCall) {
+            this._isRequiredDynamic = true;
+            const requiredFnName = requiredDecoratorVal.name;
+            const requiredFnArgs = requiredDecoratorVal.simplifiedArgs;
+
+            // set required based on current envFlag
+            if (requiredFnName === 'forEnv') {
+              const currentEnv = this.#envGraph.envFlagValue;
+              if (!currentEnv) {
+                throw new SchemaError('Cannot set @required using forEnv() because environment flag is not set');
+              }
+              const envMatches = requiredFnArgs.includes(currentEnv);
+              this._isRequired = usingOptional ? !envMatches : envMatches;
+            }
+          }
           return;
         }
 
-        const requiredDecoratorVal = defDecorators.required?.value || defDecorators.optional?.value;
-        const usingOptional = 'optional' in defDecorators;
-        // static value of  `true` or `false`
-        if (requiredDecoratorVal instanceof ParsedEnvSpecStaticValue) {
-          const staticVal = requiredDecoratorVal.value;
-          if (_.isBoolean(staticVal)) {
-            this._isRequired = usingOptional ? !staticVal : staticVal;
-          } else {
-            this.schemaErrors.push(new SchemaError('@required/@optional can only be set to true/false if using a static value'));
-          }
-
-        // dynamic / function value - setting based on other values
-        } else if (requiredDecoratorVal instanceof ParsedEnvSpecFunctionCall) {
-          this._isRequiredDynamic = true;
-          const requiredFnName = requiredDecoratorVal.name;
-          const requiredFnArgs = requiredDecoratorVal.simplifiedArgs;
-
-          // set required based on current envFlag
-          if (requiredFnName === 'env') {
-            const currentEnv = this.#envGraph.envFlagValue;
-            if (!currentEnv) {
-              this.schemaErrors.push(new SchemaError('Cannot set @required using env() because current env is not set'));
-            }
-            const envMatches = requiredFnArgs.includes(currentEnv);
-            this._isRequired = usingOptional ? !envMatches : envMatches;
-          }
-        }
-        return;
-      }
-
-      // Root-level @defaultRequired
-      if ('defaultRequired' in def.source.decorators) {
-        const val = def.source.decorators.defaultRequired.simplifiedValue;
-        if (val === 'infer') {
-          // Only apply infer logic for schema source
-          if (def.source.type === 'schema') {
-            const resolver = def.itemDef.resolver;
-            if (resolver instanceof StaticValueResolver) {
-              this._isRequired = resolver.staticValue !== undefined && resolver.staticValue !== '';
+        // Root-level @defaultRequired
+        if ('defaultRequired' in def.source.decorators) {
+          const val = def.source.decorators.defaultRequired.simplifiedValue;
+          if (val === 'infer') {
+            // Only apply infer logic for schema source
+            // ? not sure about this - we could probably still apply it for other sources?
+            if (def.source.type === 'schema') {
+              const resolver = def.itemDef.resolver;
+              if (resolver instanceof StaticValueResolver) {
+                this._isRequired = resolver.staticValue !== undefined && resolver.staticValue !== '';
+              } else {
+                this._isRequired = true;
+              }
+              return;
             } else {
-              this._isRequired = true;
+              // Not schema source, skip this def and continue
+              continue;
             }
-            return;
-          } else {
-            // Not schema source, skip this def and continue
-            continue;
           }
+          // explicit true or false
+          this._isRequired = val;
+          return;
         }
-        // explicit true or false
-        this._isRequired = val;
-        return;
       }
+    } catch (err) {
+      this.schemaErrors.push(err instanceof SchemaError ? err : new SchemaError(err as Error));
     }
   }
   get isRequired() { return this._isRequired; }

--- a/packages/varlock/env-graph/lib/type-generation.ts
+++ b/packages/varlock/env-graph/lib/type-generation.ts
@@ -157,7 +157,8 @@ export async function getTsDefinitionForItem(item: ConfigItem, indentLevel = 0) 
     // TODO: eventually handle objects, arrays, dictionaries
   }
 
-  itemSrc.push(`readonly ${item.key}${item.isRequired ? '' : '?'}: ${itemTsType};`);
+  const isRequired = item.isRequired && !item.isRequiredDynamic;
+  itemSrc.push(`readonly ${item.key}${isRequired ? '' : '?'}: ${itemTsType};`);
   itemSrc.push('');
   return _.map(itemSrc, (line) => `${i}${line}`);
 }

--- a/packages/varlock/env-graph/test/required-decorators.test.ts
+++ b/packages/varlock/env-graph/test/required-decorators.test.ts
@@ -191,7 +191,7 @@ describe('required decorators', requiredDecoratorTests([
       ERROR1= # @required=123
       ERROR2= # @required="true"
       ERROR3= # @optional=123
-      ERROR4= # @optional="false"
+      ERROR4= # @optional=undefined
     `,
     expected: {
       ERROR1: SchemaError,
@@ -201,15 +201,14 @@ describe('required decorators', requiredDecoratorTests([
     },
   },
   {
-    label: '@required can use `env()` helper to be set based on current envFlag',
+    label: '@required can use `forEnv()` helper to be set based on current envFlag',
     envSchema: outdent`
-      # @envFlag=APP_ENV
+      # @envFlag=APP_ENV @defaultRequired=false
       # ---
       APP_ENV=staging
-      REQ_FOR_DEV=      # @required=env(dev)
-      REQ_FOR_STAGING=  # @required=env(staging)
-      REQ_FOR_MULTIPLE= # @required=env(staging, prod)
-      OPTIONAL_FOR_STAGING=  # @optional=env(staging)
+      REQ_FOR_DEV=      # @required=forEnv(dev)
+      REQ_FOR_STAGING=  # @required=forEnv(staging)
+      REQ_FOR_MULTIPLE= # @required=forEnv(staging, prod)
     `,
     expected: {
       REQ_FOR_DEV: false,
@@ -218,9 +217,25 @@ describe('required decorators', requiredDecoratorTests([
     },
   },
   {
-    label: '`env()` helper is not usable if no envFlag is set',
+    label: '@optional can also use `forEnv()`',
     envSchema: outdent`
-      REQ_FOR_DEV=      # @required=env(dev)
+      # @envFlag=APP_ENV @defaultRequired=true
+      # ---
+      APP_ENV=staging
+      OPT_FOR_DEV=      # @optional=forEnv(dev)
+      OPT_FOR_STAGING=  # @optional=forEnv(staging)
+      OPT_FOR_MULTIPLE= # @optional=forEnv(staging, prod)
+    `,
+    expected: {
+      OPT_FOR_DEV: true,
+      OPT_FOR_STAGING: false,
+      OPT_FOR_MULTIPLE: false,
+    },
+  },
+  {
+    label: '`forEnv()` helper is not usable if no envFlag is set',
+    envSchema: outdent`
+      REQ_FOR_DEV=      # @required=forEnv(dev)
     `,
     expected: {
       REQ_FOR_DEV: SchemaError,

--- a/packages/varlock/env-graph/test/resolvers.test.ts
+++ b/packages/varlock/env-graph/test/resolvers.test.ts
@@ -12,6 +12,7 @@ import { outdent } from 'outdent';
 import { DotEnvFileDataSource, EnvGraph } from '../index';
 import { ResolutionError, SchemaError } from '../lib/errors';
 import { Resolver } from '../lib/resolver';
+import type { Constructor } from '@env-spec/utils/type-utils';
 
 // define special increment resolver used only for tests
 class IncrementResolver extends Resolver {
@@ -28,7 +29,7 @@ function functionValueTests(
   tests: Record<string, {
     input: string;
     env?: Record<string, string>;
-    expected: Record<string, any> | Error
+    expected: Record<string, any | Constructor<Error>>
   }>,
 ) {
   return () => {


### PR DESCRIPTION
First steps towards https://github.com/dmno-dev/varlock/issues/119

This adds a new helper to set item required-ness based on the current env (as set by @envFlag)

Some notes:
- not sure about the `env()` name, could be `ifEnv` `isEnv` `forEnv`
- value can be a single env, or multiple
- works for both `@required` and `@optional`
- if the value is dynamic, we must respect that in type generation

In an ideal world, we'd handle any arbitrary logic here, and likely unify our resolver functions (which are used for item values) with our decorator values. However this introduces a lot of complexity, because now items can be dependent on each other in new ways, and the resolution process would need to handle that.

For now, we are using a much more limited subset. Using the envFlag is totally safe, because we always resolve that up front, so it does not introduce any new ordering / dependency issues. We likely want to add a few more helpers here, but they will likely have additional limitations, which will allow us to keep things a bit simpler.
