### PR TITLE
Leak detection fastify tweak

### DIFF
--- a/.changeset/dirty-weeks-boil.md
+++ b/.changeset/dirty-weeks-boil.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+adjust server response leak detection for no content type

--- a/.changeset/rich-flies-march.md
+++ b/.changeset/rich-flies-march.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+set defaultRequired to infer during varlock init

--- a/packages/varlock/src/cli/commands/init.command.ts
+++ b/packages/varlock/src/cli/commands/init.command.ts
@@ -97,7 +97,7 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
       '',
       // TODO: add env spec version? real links?
     ].join('\n'));
-    envSpecUpdater.setRootDecorator(parsedEnvSchemaFile, 'defaultRequired', 'false', { explicitTrue: true });
+    envSpecUpdater.setRootDecorator(parsedEnvSchemaFile, 'defaultRequired', 'infer', { explicitTrue: true });
     envSpecUpdater.setRootDecorator(parsedEnvSchemaFile, 'defaultSensitive', 'false', { explicitTrue: true });
     // TODO: detect js/ts project before adding this
     envSpecUpdater.setRootDecorator(parsedEnvSchemaFile, 'generateTypes', 'lang=ts, path=env.d.ts', { bareFnArgs: true });

--- a/packages/varlock/src/runtime/patch-console.ts
+++ b/packages/varlock/src/runtime/patch-console.ts
@@ -73,7 +73,3 @@ export function unpatchGlobalConsole() {
   globalThis.console[kWriteToConsoleSymbol] = (globalThis as any)._varlockOrigWriteToConsoleFn;
   delete (globalThis as any)._varlockOrigWriteToConsoleFn;
 }
-
-// ---
-
-// patchGlobalConsole();

--- a/packages/varlock/src/runtime/patch-server-response.ts
+++ b/packages/varlock/src/runtime/patch-server-response.ts
@@ -29,10 +29,10 @@ export function patchGlobalServerResponse(opts?: {
 
   // @ts-ignore
   ServerResponse.prototype.write = function varlockPatchedServerResponseWrite(...args) {
-    // console.log('⚡️ patched ServerResponse.write');
     // TODO: do we want to filter out some requests here? maybe based on the file type?
 
     const rawChunk = args[0];
+    // console.log('⚡️ patched ServerResponse.write', rawChunk);
 
     // for now, we only scan rendered html... may need to change this though for server components?
     // so we bail if it looks like this response does not contain html
@@ -41,6 +41,7 @@ export function patchGlobalServerResponse(opts?: {
     let runScan = (
       contentType.startsWith('text/')
       || contentType.startsWith('application/json')
+      || (!contentType && typeof rawChunk === 'string')
       // || contentType.startsWith('application/javascript')
     );
 
@@ -128,14 +129,12 @@ export function patchGlobalServerResponse(opts?: {
     return serverResponseWrite.apply(this, args);
   };
 
-
   // calling `res.json()` in the api routes on pages router calls `res.end` without called `res.write`
   const serverResponseEnd = ServerResponse.prototype.end;
   // @ts-ignore
   ServerResponse.prototype.end = function patchedServerResponseEnd(...args) {
     // console.log('⚡️ patched ServerResponse.end');
     const endChunk = args[0];
-    // console.log('patched ServerResponse.end', endChunk);
     // this just needs to work (so far) for nextjs sending json bodies, so does not need to handle all cases...
     if (endChunk && typeof endChunk === 'string') {
       // TODO: currently this throws the error and then things just hang... do we want to try to return an error type response instead?
@@ -146,5 +145,3 @@ export function patchGlobalServerResponse(opts?: {
   };
 }
 
-// ---
-// patchGlobalServerResponse();


### PR DESCRIPTION
fastify does some funky handling of content-type so the header is not set yet when we check it during leak detection. So we adjusted the logic to still run the leak scan if the body is a string and no content type is present