### PR TITLE
allow setting envFlag from imported file

### DIFF
--- a/.changeset/early-rockets-do.md
+++ b/.changeset/early-rockets-do.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+allow setting envFlag from an imported file

--- a/packages/varlock/env-graph/lib/env-graph.ts
+++ b/packages/varlock/env-graph/lib/env-graph.ts
@@ -261,7 +261,7 @@ export class EnvGraph {
     for (const s of sources) {
       if (s.disabled) continue;
       // we skip root decorators if the file was being _partially_ imported
-      if (s.importKeys) continue;
+      if (s.isPartialImport) continue;
       const decs = s.getRootDecorators(decoratorName);
       if (decs.length) return decs[0].simplifiedValue;
     }
@@ -273,7 +273,7 @@ export class EnvGraph {
     for (const source of sources) {
       if (source.disabled) continue;
       // we skip root decorators if the file was being _partially_ imported
-      if (source.importKeys) continue;
+      if (source.isPartialImport) continue;
       const decs = source.getRootDecorators(decoratorName);
       combinedDecsWithSources.push([source, decs]);
     }

--- a/packages/varlock/env-graph/test/import.test.ts
+++ b/packages/varlock/env-graph/test/import.test.ts
@@ -61,7 +61,7 @@ describe('@import', () => {
         ITEM1=value-from-.env.schema
       `,
       'dir/.env.schema': outdent`
-        ITEM1=value-from-dir/.env.schema   
+        ITEM1=value-from-dir/.env.schema
         ITEM2=value-from-dir/.env.schema
         ITEM3=value-from-dir/.env.schema
       `,
@@ -75,48 +75,6 @@ describe('@import', () => {
       ITEM2: 'value-from-dir/.env.schema',
       ITEM3: 'value-from-dir/.env.local',
       ITEM4: 'value-from-dir/.env.local',
-    },
-  }));
-
-  test('imported directory can reuse the existing envFlag', envFilesTest({
-    overrideValues: { APP_ENV: 'dev' },
-    files: {
-      '.env.schema': outdent`
-        # @envFlag=APP_ENV
-        # @import(./dir/)
-        # ---
-        APP_ENV=dev
-      `,
-      'dir/.env.dev': outdent`
-        IMPORTED_ITEM=foo
-      `,
-    },
-    expectValues: {
-      IMPORTED_ITEM: 'foo',
-    },
-  }));
-  test('imported directory can use a different envFlag', envFilesTest({
-    files: {
-      '.env.schema': outdent`
-        # @envFlag=APP_ENV
-        # @import(./dir/)
-        # ---
-        APP_ENV=dev
-      `,
-      'dir/.env.schema': outdent`
-        # @envFlag=APP_ENV2
-        # ---
-        APP_ENV2=prod
-      `,
-      'dir/.env.dev': outdent`
-        IMPORTED_ITEM=dev
-      `,
-      'dir/.env.prod': outdent`
-        IMPORTED_ITEM=prod
-      `,
-    },
-    expectValues: {
-      IMPORTED_ITEM: 'prod',
     },
   }));
 


### PR DESCRIPTION
We now allow setting envFlag via an imported file.

This is useful if you had many services and wanted to import that common setting from a single place.

To make this happen, when we encounter an `@envFlag` decorator, we now set the envFlag on the data source itself, and walk up the parent chain setting it if it is empty. We also (still) walk up the parent chain when checking for an envFlag.