### PR TITLE
support windows-style newlines

### DIFF
--- a/.changeset/plain-feet-unite.md
+++ b/.changeset/plain-feet-unite.md
@@ -1,0 +1,5 @@
+---
+"@env-spec/parser": patch
+---
+
+support \r\n newlines

--- a/packages/env-spec-parser/src/index.ts
+++ b/packages/env-spec-parser/src/index.ts
@@ -7,5 +7,5 @@ export * from './expand';
 import * as peggyParser from './grammar.js';
 
 export function parseEnvSpecDotEnvFile(source: string): ParsedEnvSpecFile {
-  return peggyParser.parse(source);
+  return peggyParser.parse(source.replaceAll('\r\n', '\n'));
 }

--- a/packages/env-spec-parser/test/general.test.ts
+++ b/packages/env-spec-parser/test/general.test.ts
@@ -1,0 +1,33 @@
+
+import { it, expect } from 'vitest';
+import { parseEnvSpecDotEnvFile } from '../src';
+import { simpleResolver } from '../src/simple-resolver';
+
+function generalTest(spec: {
+  input: string;
+  env?: Record<string, string>;
+  expected: Record<string, any> | Error
+}) {
+  return () => {
+    const { input, env, expected } = spec;
+
+    if (expected instanceof Error) {
+      // TODO: should prob split between parse error vs resolve error?
+      expect(() => parseEnvSpecDotEnvFile(input)).toThrow();
+    } else {
+      const parsedFile = parseEnvSpecDotEnvFile(input);
+      const resolved = simpleResolver(parsedFile, { env: env ?? {} });
+      for (const key in expected) {
+        expect(resolved[key]).toEqual(expected[key]);
+      }
+    }
+  };
+}
+
+it('supports \\r\\n style newlines', generalTest({
+  input: 'FOO=foo\r\nBAR=bar\r\n',
+  expected: {
+    FOO: 'foo',
+    BAR: 'bar',
+  },
+}));


### PR DESCRIPTION
very naive approach to supporting windows-style \r\n newlines...

we are just removing them before parsing.

This would potentially remove them from any multi-line values where they could have been there on purpose - but I think that should be somewhat rare. Will revisit if any bug reports come in.

fixes #155 