### PR TITLE
fix import path issue

### DIFF
--- a/.changeset/all-zebras-grow.md
+++ b/.changeset/all-zebras-grow.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+fix import relative path issues

--- a/packages/varlock/env-graph/lib/data-source.ts
+++ b/packages/varlock/env-graph/lib/data-source.ts
@@ -243,7 +243,7 @@ export abstract class EnvGraphDataSource {
               await this.addChild(source, { isImport: true, importKeys });
             }
           } else {
-            const fsStat = await tryCatch(async () => fs.stat(importPath), (_err) => {
+            const fsStat = await tryCatch(async () => fs.stat(fullImportPath), (_err) => {
               // TODO: work through possible error types here
             });
 
@@ -541,10 +541,6 @@ export class DirectoryDataSource extends EnvGraphDataSource {
   get label() { return `directory - ${this.basePath}`; }
 
   schemaDataSource?: DotEnvFileDataSource;
-
-  get loadingError() {
-    return this._loadingError || this.schemaDataSource?.loadingError;
-  }
 
   constructor(
     readonly basePath: string,

--- a/packages/varlock/src/cli/helpers/error-checks.ts
+++ b/packages/varlock/src/cli/helpers/error-checks.ts
@@ -14,13 +14,10 @@ export function checkForSchemaErrors(envGraph: EnvGraph) {
 
     // TODO: use a formatting helper to show the error - which will include location/stack/etc appropriately
     if (source.loadingError) {
-      console.log(`🚨 Error encountered while loading ${source.label}`);
-      console.log(source.loadingError.message);
+      console.log(`🚨 Error encountered while loading ${source.label}\n`);
 
       // Check if the error has a location property (like EnvSourceParseError)
       if ('location' in source.loadingError) {
-        console.log((source.loadingError as EnvSourceParseError).location);
-
         const errLoc = (source.loadingError as EnvSourceParseError).location;
 
         const errPreview = [
@@ -28,9 +25,11 @@ export function checkForSchemaErrors(envGraph: EnvGraph) {
           `${ansis.gray('-'.repeat(errLoc.colNumber - 1))}${ansis.red('^')}`,
         ].join('\n');
 
-        console.log('Error parsing .env file');
-        console.log(` ${errLoc.path}:${errLoc.lineNumber}:${errLoc.colNumber}`);
+        console.log('Error parsing .env file: ', source.loadingError.message);
+        console.log(`📂 ${errLoc.path}:${errLoc.lineNumber}:${errLoc.colNumber}`);
         console.log(errPreview);
+      } else {
+        console.log(source.loadingError.message);
       }
 
       return gracefulExit(1);


### PR DESCRIPTION
fixes path issue related to imports. It was not causing problems in most situations, but when there are chains of multiple imports, it can create a problem. Hard to test this one, because in our test suite, we mock the file loading using virtual files and follow a different code path. In the future we could think about mocking fs methods, but its likely not worth the effort.