### PR TITLE
fix varlock not found when running node directly

### DIFF
--- a/.changeset/tangy-numbers-nail.md
+++ b/.changeset/tangy-numbers-nail.md
@@ -1,0 +1,7 @@
+---
+"@varlock/nextjs-integration": patch
+"@varlock/vite-integration": patch
+"varlock": patch
+---
+
+fix issue with executable path when running directly instead of via package manager

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -10,6 +10,7 @@ import { execSync, type spawnSync } from 'child_process';
 import { type SerializedEnvGraph } from 'varlock';
 import { initVarlockEnv, resetRedactionMap } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
+import { execSyncVarlock } from 'varlock/exec-sync-varlock';
 
 export type Env = { [key: string]: string | undefined };
 export type LoadedEnvFiles = Array<{
@@ -284,7 +285,7 @@ export function loadEnvConfig(
   debug('Inferred env mode (to match @next/env):', envFromNextCommand);
 
   try {
-    const varlockLoadedEnvBuf = execSync(`varlock load --format json-full --env ${envFromNextCommand}`, {
+    const varlockLoadedEnvBuf = execSyncVarlock(`load --format json-full --env ${envFromNextCommand}`, {
       env: initialEnv as any,
     });
     varlockLoadedEnv = JSON.parse(varlockLoadedEnvBuf.toString());
@@ -292,7 +293,8 @@ export function loadEnvConfig(
     const { stdout, stderr } = err as ReturnType<typeof spawnSync>;
     const stdoutStr = stdout?.toString() || '';
     const stderrStr = stderr?.toString() || '';
-    if (stderrStr.includes('command not found')) {
+    // this error message comes from execSyncVarlock when it cannot find varlock
+    if (stderrStr.includes('Unable to find varlock executable')) {
       // eslint-disable-next-line no-console
       console.error([
         '',

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -6,7 +6,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { execSync, type spawnSync } from 'child_process';
+import { execSync } from 'child_process';
 import { type SerializedEnvGraph } from 'varlock';
 import { initVarlockEnv, resetRedactionMap } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
@@ -231,6 +231,8 @@ type LoadedEnvConfig = {
   loadedEnvFiles: LoadedEnvFiles
 };
 
+let loadCount = 0;
+
 export function loadEnvConfig(
   dir: string,
   dev?: boolean,
@@ -293,14 +295,20 @@ export function loadEnvConfig(
   debug('Inferred env mode (to match @next/env):', envFromNextCommand);
 
   try {
+    loadCount++;
     const varlockLoadedEnvStr = execSyncVarlock(`load --format json-full --env ${envFromNextCommand}`, {
+      // in dev, there are 2 loads up front, so we dont show the first
+      showLogsOnError: !dev || loadCount > 1,
+      // in a build, we want to fail and exit, while in dev we can keep retrying when changes are detected
+      exitOnError: !dev,
       env: initialEnv as any,
     });
+    if (loadCount >= 2) {
+      // eslint-disable-next-line no-console
+      console.log('✅ env reloaded and validated');
+    }
     varlockLoadedEnv = JSON.parse(varlockLoadedEnvStr);
   } catch (err) {
-    const { stdout, stderr } = err as ReturnType<typeof spawnSync>;
-    const stdoutStr = stdout?.toString() || '';
-    const stderrStr = stderr?.toString() || '';
     // this error message comes from execSyncVarlock when it cannot find varlock
     if ((err as any).message.includes('Unable to find varlock executable')) {
       // eslint-disable-next-line no-console
@@ -311,14 +319,8 @@ export function loadEnvConfig(
         '',
         'Please add varlock as a dependency to your project (e.g., `npm install varlock`)',
       ].join('\n'));
-      throw new Error('missing peer dependency - varlock');
+      process.exit(1);
     }
-
-    if (stdoutStr) console.log(stdoutStr); // eslint-disable-line no-console
-    if (stderrStr) console.error(stderrStr); // eslint-disable-line no-console
-
-    // in a build, we want to fail and exit, while in dev we can keep retrying when changes are detected
-    if (!dev) process.exit(1);
 
     // if we dont do this, we'll see an error that looks like `process.env.__VARLOCK_ENV is not set` which is misleading.
     // Ideally we would pass through an error of some kind and trigger the webpack runtime error popup

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 
-import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import type { Plugin } from 'vite';
 import Debug from 'debug';
@@ -64,14 +63,15 @@ let loadCount = 0;
 function reloadConfig() {
   debug('loading config - count =', ++loadCount);
   try {
-    const execResult = execSyncVarlock('load --format json-full', { env: originalProcessEnv });
+    const execResult = execSyncVarlock('load --format json-full', {
+      env: originalProcessEnv,
+      showLogsOnError: true,
+    });
     process.env.__VARLOCK_ENV = execResult;
     varlockLoadedEnv = JSON.parse(process.env.__VARLOCK_ENV) as SerializedEnvGraph;
     configIsValid = true;
   } catch (err) {
-    const errResult = err as ReturnType<typeof spawnSync>;
     configIsValid = false;
-    console.log(errResult.stdout.toString());
   }
 
   // initialize varlock and patch globals as necessary

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import { execSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import type { Plugin } from 'vite';
 import Debug from 'debug';
@@ -10,9 +10,11 @@ import { initVarlockEnv } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
 import { patchGlobalServerResponse } from 'varlock/patch-server-response';
 import { patchGlobalResponse } from 'varlock/patch-response';
-import { SerializedEnvGraph } from 'varlock';
+import { type SerializedEnvGraph } from 'varlock';
+import { execSyncVarlock } from 'varlock/exec-sync-varlock';
 
 import { createReplacerTransformFn } from './transform';
+
 
 // enables throwing when user accesses a bad key on ENV
 (globalThis as any).__varlockThrowOnMissingKeys = true;
@@ -62,7 +64,7 @@ let loadCount = 0;
 function reloadConfig() {
   debug('loading config - count =', ++loadCount);
   try {
-    const execResult = execSync('varlock load --format json-full', { env: originalProcessEnv });
+    const execResult = execSyncVarlock('load --format json-full', { env: originalProcessEnv });
     process.env.__VARLOCK_ENV = execResult.toString();
     varlockLoadedEnv = JSON.parse(process.env.__VARLOCK_ENV) as SerializedEnvGraph;
     configIsValid = true;

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -65,7 +65,7 @@ function reloadConfig() {
   debug('loading config - count =', ++loadCount);
   try {
     const execResult = execSyncVarlock('load --format json-full', { env: originalProcessEnv });
-    process.env.__VARLOCK_ENV = execResult.toString();
+    process.env.__VARLOCK_ENV = execResult;
     varlockLoadedEnv = JSON.parse(process.env.__VARLOCK_ENV) as SerializedEnvGraph;
     configIsValid = true;
   } catch (err) {

--- a/packages/utils/src/git-utils.ts
+++ b/packages/utils/src/git-utils.ts
@@ -7,7 +7,7 @@ export async function checkIsFileGitIgnored(path: string, warnIfNotGitRepo = fal
   } catch (err) {
     const stderr = (err as any).stderr as string;
     // git is not installed, so we don't know
-    if (stderr.includes('not found')) return undefined;
+    if ((err as any).status === 127 || stderr.includes('not found')) return undefined;
     // other file related issues could throw this
     if ((err as any).code === 'ENOENT') return undefined;
     // `git check-ignore -q` exits with code 1 but no other error if is not ignored

--- a/packages/varlock/package.json
+++ b/packages/varlock/package.json
@@ -61,6 +61,11 @@
       "types": "./dist/runtime/patch-server-response.d.ts",
       "default": "./dist/runtime/patch-server-response.js"
     },
+    "./exec-sync-varlock": {
+      "ts-src": "./src/lib/exec-sync-varlock.ts",
+      "types": "./dist/lib/exec-sync-varlock.d.ts",
+      "default": "./dist/lib/exec-sync-varlock.js"
+    },
     "./config": {
       "ts-src": "./src/config.ts",
       "types": "./dist/dotenv-compat.d.ts",

--- a/packages/varlock/src/auto-load.ts
+++ b/packages/varlock/src/auto-load.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execSyncVarlock } from './lib/exec-sync-varlock';
 
 import { initVarlockEnv } from './runtime/env';
 import { patchGlobalConsole } from './runtime/patch-console';
@@ -9,7 +9,7 @@ import { patchGlobalResponse } from './runtime/patch-response';
 // because even with top level await, we run into hoisting issues where things happen out of order
 // so we call out to the CLI using execSync
 // this also isolates the varlock loading process from the end user process
-const execResult = execSync('varlock load --format json-full');
+const execResult = execSyncVarlock('load --format json-full');
 process.env.__VARLOCK_ENV = execResult.toString();
 
 // initialize varlock and patch globals as necessary

--- a/packages/varlock/src/auto-load.ts
+++ b/packages/varlock/src/auto-load.ts
@@ -10,7 +10,7 @@ import { patchGlobalResponse } from './runtime/patch-response';
 // so we call out to the CLI using execSync
 // this also isolates the varlock loading process from the end user process
 const execResult = execSyncVarlock('load --format json-full');
-process.env.__VARLOCK_ENV = execResult.toString();
+process.env.__VARLOCK_ENV = execResult;
 
 // initialize varlock and patch globals as necessary
 initVarlockEnv();

--- a/packages/varlock/src/auto-load.ts
+++ b/packages/varlock/src/auto-load.ts
@@ -9,7 +9,12 @@ import { patchGlobalResponse } from './runtime/patch-response';
 // because even with top level await, we run into hoisting issues where things happen out of order
 // so we call out to the CLI using execSync
 // this also isolates the varlock loading process from the end user process
-const execResult = execSyncVarlock('load --format json-full');
+
+
+const execResult = execSyncVarlock('load --format json-full', {
+  exitOnError: true,
+  showLogsOnError: true,
+});
 process.env.__VARLOCK_ENV = execResult;
 
 // initialize varlock and patch globals as necessary

--- a/packages/varlock/src/cli/helpers/error-checks.ts
+++ b/packages/varlock/src/cli/helpers/error-checks.ts
@@ -62,23 +62,23 @@ export function checkForConfigErrors(envGraph: EnvGraph, opts?: {
 
   // TODO: use service.isValid?
   if (failingItems.length > 0) {
-    console.log(`\n🚨 🚨 🚨  ${ansis.bold.underline('Configuration is currently invalid ')}  🚨 🚨 🚨\n`);
-    console.log('Invalid items:\n');
+    console.error(`\n🚨 🚨 🚨  ${ansis.bold.underline('Configuration is currently invalid ')}  🚨 🚨 🚨\n`);
+    console.error('Invalid items:\n');
 
     _.each(failingItems, (item: ConfigItem) => {
-      console.log(getItemSummary(item));
-      console.log();
+      console.error(getItemSummary(item));
+      console.error();
     });
     if (opts?.showAll) {
-      console.log();
-      console.log(joinAndCompact([
+      console.error();
+      console.error(joinAndCompact([
         'Valid items:',
         ansis.italic.gray('(remove `--show-all` flag to hide)'),
       ]));
-      console.log();
+      console.error();
       const validItems = _.filter(_.values(envGraph.configSchema), (i: ConfigItem) => !!i.isValid);
       _.each(validItems, (item: ConfigItem) => {
-        console.log(getItemSummary(item));
+        console.error(getItemSummary(item));
       });
     }
 

--- a/packages/varlock/src/cli/helpers/js-package-manager-utils.ts
+++ b/packages/varlock/src/cli/helpers/js-package-manager-utils.ts
@@ -94,7 +94,11 @@ export function detectJsPackageManager(opts?: {
     }
     if (detectedPm) return JS_PACKAGE_MANAGERS[detectedPm];
 
-    cwd = path.join(cwd, '..');
+    // will break when we reach the root
+    const parentDir = path.dirname(cwd);
+    if (parentDir === cwd) break;
+    cwd = parentDir;
+
     if (opts?.workspaceRootPath) {
       if (opts.workspaceRootPath === cwd) {
         debug('> found workspace root');
@@ -107,7 +111,7 @@ export function detectJsPackageManager(opts?: {
         break;
       }
     }
-  } while (cwd && cwd !== '.' && cwd !== '/');
+  } while (cwd);
 
   // if we did not find a lockfile, we'll look at env vars for other hints
   if (process.env.npm_config_user_agent) {

--- a/packages/varlock/src/cli/helpers/telemetry.ts
+++ b/packages/varlock/src/cli/helpers/telemetry.ts
@@ -1,6 +1,6 @@
 import os from 'node:os';
 import crypto, { type BinaryLike, createHash } from 'node:crypto';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import {
   existsSync, readFileSync, writeFileSync,
   mkdirSync,
@@ -110,13 +110,16 @@ function getProjectGitRemoteUrl(): string | undefined {
     // Find the git directory by scanning upwards
     let gitDirPath: string | undefined;
     let currentDir = process.cwd();
-    while (currentDir && currentDir !== '/') {
+    while (currentDir) {
       const possibleGitDirPath = join(currentDir, '.git');
       if (existsSync(possibleGitDirPath)) {
         gitDirPath = possibleGitDirPath;
         break;
       }
-      currentDir = join(currentDir, '..');
+      // this will stop when we reach the root
+      const parentDir = dirname(currentDir);
+      if (parentDir === currentDir) break;
+      currentDir = parentDir;
     }
     if (!gitDirPath) return undefined;
     const gitConfigContents = readFileSync(join(gitDirPath, 'config'), 'utf-8');

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -1,0 +1,50 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+
+// weird tsup issue using `typeof execSync` from node:child_process
+// see https://github.com/egoist/tsup/issues/1367
+import type { execSync as execSyncType } from 'child_process';
+
+/**
+ * small helper to call execSync and call the varlock cli
+ *
+ * when end user runs via a package manager, it will inject node_modules/.bin into PATH
+ * but otherwise we may need to try to find that path ourselves
+ */
+export function execSyncVarlock(command: string, opts?: Parameters<typeof execSyncType>[1]) {
+  // in most cases, user will be running via their package manager
+  // and a package.json script (ie `pnpm run start`)
+  // which will inject node_modules/.bin into PATH
+  try {
+    return execSync(`varlock ${command}`, {
+      ...opts,
+      stdio: 'ignore', // we need to supress the output
+    });
+  } catch (err) {
+    // code 127 means not found
+    if ((err as any).status !== 127) throw err;
+  }
+
+  // if varlock was not found, it either means it is not installed
+  // or we must find the path to node_modules/.bin ourselves
+  // so we'll walk up the directory tree looking for it
+  let currentDir = process.cwd();
+  while (currentDir) {
+    const possibleBinPath = path.join(currentDir, 'node_modules', '.bin');
+    if (fs.existsSync(possibleBinPath)) {
+      const possibleVarlockPath = path.join(possibleBinPath, 'varlock');
+      if (fs.existsSync(possibleVarlockPath)) {
+        return execSync(`${possibleVarlockPath} ${command}`, opts);
+      } else {
+        throw new Error('Unable to find varlock executable');
+      }
+    }
+    // when we reach the root, it will stop
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) break;
+    currentDir = path.dirname(currentDir);
+  }
+
+  throw new Error('Unable to find varlock executable');
+}

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -12,42 +12,68 @@ import type { execSync as execSyncType } from 'child_process';
  * when end user runs via a package manager, it will inject node_modules/.bin into PATH
  * but otherwise we may need to try to find that path ourselves
  */
-export function execSyncVarlock(command: string, opts?: Parameters<typeof execSyncType>[1]) {
-  // in most cases, user will be running via their package manager
-  // and a package.json script (ie `pnpm run start`)
-  // which will inject node_modules/.bin into PATH
+export function execSyncVarlock(
+  command: string,
+  opts?: (Parameters<typeof execSyncType>[1] & {
+    exitOnError?: boolean,
+    showLogsOnError?: boolean,
+  }),
+) {
   try {
-    const result = execSync(`varlock ${command}`, {
-      ...opts,
-      // otherwise we will always see "varlock not found" error
-      stdio: 'pipe',
-    });
-    return result.toString();
-  } catch (err) {
-    // code 127 means not found
-    if ((err as any).status !== 127) throw err;
-  }
+    // in most cases, user will be running via their package manager
+    // and a package.json script (ie `pnpm run start`)
+    // which will inject node_modules/.bin into PATH
+    try {
+      const result = execSync(`varlock ${command}`, {
+        ...opts,
+        stdio: 'pipe',
+      });
+      return result.toString();
+    } catch (err) {
+      // code 127 means not found
+      if ((err as any).status !== 127) throw err;
+    }
 
-  // if varlock was not found, it either means it is not installed
-  // or we must find the path to node_modules/.bin ourselves
-  // so we'll walk up the directory tree looking for it
-  let currentDir = process.cwd();
-  while (currentDir) {
-    const possibleBinPath = path.join(currentDir, 'node_modules', '.bin');
-    if (fs.existsSync(possibleBinPath)) {
-      const possibleVarlockPath = path.join(possibleBinPath, 'varlock');
-      if (fs.existsSync(possibleVarlockPath)) {
-        const result = execSync(`${possibleVarlockPath} ${command}`, opts);
-        return result.toString();
-      } else {
-        throw new Error('Unable to find varlock executable');
+    // if varlock was not found, it either means it is not installed
+    // or we must find the path to node_modules/.bin ourselves
+    // so we'll walk up the directory tree looking for it
+    let currentDir = process.cwd();
+    while (currentDir) {
+      const possibleBinPath = path.join(currentDir, 'node_modules', '.bin');
+      if (fs.existsSync(possibleBinPath)) {
+        const possibleVarlockPath = path.join(possibleBinPath, 'varlock');
+        if (fs.existsSync(possibleVarlockPath)) {
+          const result = execSync(`${possibleVarlockPath} ${command}`, {
+            ...opts,
+            stdio: 'pipe',
+          });
+          // const commandArgs = command.split(' ').filter(Boolean);
+          // const result = execFileSync(possibleVarlockPath, commandArgs, opts);
+          return result.toString();
+        } else {
+          throw new Error('Unable to find varlock executable');
+        }
+      }
+      // when we reach the root, it will stop
+      const parentDir = path.dirname(currentDir);
+      if (parentDir === currentDir) break;
+      currentDir = path.dirname(currentDir);
+    }
+    throw new Error('Unable to find varlock executable');
+  } catch (err) {
+    const errAny = err as any;
+    if (opts?.showLogsOnError) {
+      /* eslint-disable no-console */
+      if (errAny.stdout) console.log(errAny.stdout.toString());
+      if (errAny.stderr) console.error(errAny.stderr.toString());
+
+      if (!errAny.stdout && !errAny.stderr) {
+        console.error(errAny);
       }
     }
-    // when we reach the root, it will stop
-    const parentDir = path.dirname(currentDir);
-    if (parentDir === currentDir) break;
-    currentDir = path.dirname(currentDir);
+    if (opts?.exitOnError) {
+      process.exit((err as any).status ?? 1);
+    }
+    throw err;
   }
-
-  throw new Error('Unable to find varlock executable');
 }

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -17,10 +17,12 @@ export function execSyncVarlock(command: string, opts?: Parameters<typeof execSy
   // and a package.json script (ie `pnpm run start`)
   // which will inject node_modules/.bin into PATH
   try {
-    return execSync(`varlock ${command}`, {
+    const result = execSync(`varlock ${command}`, {
       ...opts,
-      stdio: 'ignore', // we need to supress the output
+      // otherwise we will always see "varlock not found" error
+      stdio: 'pipe',
     });
+    return result.toString();
   } catch (err) {
     // code 127 means not found
     if ((err as any).status !== 127) throw err;
@@ -35,7 +37,8 @@ export function execSyncVarlock(command: string, opts?: Parameters<typeof execSy
     if (fs.existsSync(possibleBinPath)) {
       const possibleVarlockPath = path.join(possibleBinPath, 'varlock');
       if (fs.existsSync(possibleVarlockPath)) {
-        return execSync(`${possibleVarlockPath} ${command}`, opts);
+        const result = execSync(`${possibleVarlockPath} ${command}`, opts);
+        return result.toString();
       } else {
         throw new Error('Unable to find varlock executable');
       }

--- a/packages/varlock/tsup.config.ts
+++ b/packages/varlock/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
 
     'src/cli/lib/init-process.ts', // not actually used, but this helps make esbuild hoist this import to the top when it is used
     'src/cli/cli-executable.ts', // cli that gets run via `dmno` command
+    'src/lib/exec-sync-varlock.ts', // helper to call varlock cli from code
   ],
 
   noExternal: ['@env-spec/utils'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ catalogs:
       version: 4.1.12
     '@types/node':
       specifier: ^24.3.0
-      version: 24.3.0
+      version: 24.6.1
     ansis:
       specifier: ^4.1.0
       version: 4.1.0
@@ -29,7 +29,7 @@ catalogs:
       version: 8.5.0
     typescript:
       specifier: ^5.9.2
-      version: 5.9.2
+      version: 5.9.3
     vitest:
       specifier: ^3.2.4
       version: 3.2.4
@@ -67,7 +67,7 @@ importers:
         version: 2.20.1(eslint@9.32.0)
       eslint-plugin-n:
         specifier: ^17.21.3
-        version: 17.21.3(eslint@9.32.0)(typescript@5.9.2)
+        version: 17.21.3(eslint@9.32.0)(typescript@5.9.3)
       eslint-stylistic-airbnb:
         specifier: ^2.0.0
         version: 2.0.0(@stylistic/eslint-plugin@5.2.2(eslint@9.32.0))(eslint@9.32.0)
@@ -79,16 +79,16 @@ importers:
         version: 2.5.5
       typescript:
         specifier: 'catalog:'
-        version: 5.9.2
+        version: 5.9.3
       typescript-eslint:
         specifier: ^8.39.0
-        version: 8.39.0(eslint@9.32.0)(typescript@5.9.2)
+        version: 8.39.0(eslint@9.32.0)(typescript@5.9.3)
 
   packages/env-spec-parser:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 24.3.0
+        version: 24.6.1
       ansis:
         specifier: 'catalog:'
         version: 4.1.0
@@ -100,10 +100,10 @@ importers:
         version: 5.0.6
       tsup:
         specifier: 'catalog:'
-        version: 8.5.0(postcss@8.5.6)(typescript@5.9.2)
+        version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.6.1)
 
   packages/integrations/astro:
     dependencies:
@@ -116,22 +116,22 @@ importers:
         version: 4.1.12
       '@types/node':
         specifier: 'catalog:'
-        version: 24.3.0
+        version: 24.6.1
       '@varlock/vite-integration':
         specifier: workspace:*
         version: link:../vite
       astro:
         specifier: '>=5.12.8'
-        version: 5.12.8(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)
+        version: 5.12.8(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.0(postcss@8.5.6)(typescript@5.9.2)
+        version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)
       varlock:
         specifier: workspace:^
         version: link:../../varlock
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.6.1)
 
   packages/integrations/nextjs:
     dependencies:
@@ -141,16 +141,16 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 24.3.0
+        version: 24.6.1
       tsup:
         specifier: 'catalog:'
-        version: 8.5.0(postcss@8.5.6)(typescript@5.9.2)
+        version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)
       varlock:
         specifier: workspace:^
         version: link:../../varlock
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.6.1)
 
   packages/integrations/vite:
     dependencies:
@@ -163,7 +163,7 @@ importers:
         version: 4.1.12
       '@types/node':
         specifier: 'catalog:'
-        version: 24.3.0
+        version: 24.6.1
       ast-matcher:
         specifier: ^1.2.0
         version: 1.2.0
@@ -175,16 +175,16 @@ importers:
         version: 4.46.2
       tsup:
         specifier: 'catalog:'
-        version: 8.5.0(postcss@8.5.6)(typescript@5.9.2)
+        version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)
       varlock:
         specifier: workspace:^
         version: link:../../varlock
       vite:
         specifier: ^7.1.0
-        version: 7.1.0(@types/node@24.3.0)
+        version: 7.1.0(@types/node@24.6.1)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.6.1)
 
   packages/utils:
     dependencies:
@@ -194,13 +194,13 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 24.3.0
+        version: 24.6.1
       tsup:
         specifier: 'catalog:'
-        version: 8.5.0(postcss@8.5.6)(typescript@5.9.2)
+        version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.6.1)
 
   packages/varlock:
     dependencies:
@@ -234,7 +234,7 @@ importers:
         version: 4.1.12
       '@types/node':
         specifier: 'catalog:'
-        version: 24.3.0
+        version: 24.6.1
       '@types/which':
         specifier: ^3.0.4
         version: 3.0.4
@@ -270,16 +270,16 @@ importers:
         version: 0.8.0
       tsup:
         specifier: 'catalog:'
-        version: 8.5.0(postcss@8.5.6)(typescript@5.9.2)
+        version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.6.1)
 
   packages/varlock-website:
     dependencies:
       '@astrojs/mdx':
         specifier: ^4.3.1
-        version: 4.3.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2))
+        version: 4.3.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3))
       '@astrojs/partytown':
         specifier: ^2.1.4
         version: 2.1.4
@@ -288,16 +288,16 @@ importers:
         version: 3.4.2
       '@astrojs/starlight':
         specifier: ^0.35.1
-        version: 0.35.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2))
+        version: 0.35.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3))
       '@astrojs/vue':
         specifier: ^5.1.0
-        version: 5.1.0(@types/node@24.3.0)(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2))(rollup@4.46.2)(vue@3.5.18(typescript@5.9.2))
+        version: 5.1.0(@types/node@24.6.1)(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3))(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))
       astro:
         specifier: ^5.12.4
-        version: 5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)
+        version: 5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)
       astro-og-canvas:
         specifier: ^0.7.0
-        version: 0.7.0(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2))
+        version: 0.7.0(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3))
       astro-robots-txt:
         specifier: ^1.0.0
         version: 1.0.0
@@ -312,10 +312,10 @@ importers:
         version: 1.0.0
       starlight-llms-txt:
         specifier: ^0.5.1
-        version: 0.5.1(@astrojs/starlight@0.35.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)))(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2))
+        version: 0.5.1(@astrojs/starlight@0.35.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)))(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3))
       vue:
         specifier: ^3.5.18
-        version: 3.5.18(typescript@5.9.2)
+        version: 3.5.18(typescript@5.9.3)
     devDependencies:
       '@varlock/astro-integration':
         specifier: workspace:*
@@ -331,7 +331,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 24.3.0
+        version: 24.6.1
       '@types/vscode':
         specifier: ^1.102.0
         version: 1.102.0
@@ -343,7 +343,7 @@ importers:
         version: 0.10.5
       tsup:
         specifier: 'catalog:'
-        version: 8.5.0(postcss@8.5.6)(typescript@5.9.2)
+        version: 8.5.0(postcss@8.5.6)(typescript@5.9.3)
 
 packages:
 
@@ -2079,8 +2079,8 @@ packages:
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
 
-  '@types/node@24.3.0':
-    resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
+  '@types/node@24.6.1':
+    resolution: {integrity: sha512-ljvjjs3DNXummeIaooB4cLBKg2U6SPI6Hjra/9rRIy7CpM0HpLtG9HptkMKAb4HYWy5S7HUvJEuWgr/y0U8SHw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -5586,8 +5586,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  typescript@5.9.2:
-    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5610,8 +5610,8 @@ packages:
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
 
-  undici-types@7.10.0:
-    resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+  undici-types@7.13.0:
+    resolution: {integrity: sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==}
 
   undici@6.21.2:
     resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
@@ -6278,12 +6278,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2))':
+  '@astrojs/mdx@4.3.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.3
       '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
       acorn: 8.15.0
-      astro: 5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)
+      astro: 5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -6316,17 +6316,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.25.76
 
-  '@astrojs/starlight@0.35.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2))':
+  '@astrojs/starlight@0.35.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.1
-      '@astrojs/mdx': 4.3.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2))
+      '@astrojs/mdx': 4.3.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3))
       '@astrojs/sitemap': 3.4.2
       '@pagefind/default-ui': 1.3.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)
-      astro-expressive-code: 0.41.2(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2))
+      astro: 5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)
+      astro-expressive-code: 0.41.2(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -6361,15 +6361,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/vue@5.1.0(@types/node@24.3.0)(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2))(rollup@4.46.2)(vue@3.5.18(typescript@5.9.2))':
+  '@astrojs/vue@5.1.0(@types/node@24.6.1)(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3))(rollup@4.46.2)(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      '@vitejs/plugin-vue': 5.2.1(vite@6.3.5(@types/node@24.3.0))(vue@3.5.18(typescript@5.9.2))
-      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.3.5(@types/node@24.3.0))(vue@3.5.18(typescript@5.9.2))
+      '@vitejs/plugin-vue': 5.2.1(vite@6.3.5(@types/node@24.6.1))(vue@3.5.18(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.3.5(@types/node@24.6.1))(vue@3.5.18(typescript@5.9.3))
       '@vue/compiler-sfc': 3.5.18
-      astro: 5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)
-      vite: 6.3.5(@types/node@24.3.0)
-      vite-plugin-vue-devtools: 7.7.7(rollup@4.46.2)(vite@6.3.5(@types/node@24.3.0))(vue@3.5.18(typescript@5.9.2))
-      vue: 3.5.18(typescript@5.9.2)
+      astro: 5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)
+      vite: 6.3.5(@types/node@24.6.1)
+      vite-plugin-vue-devtools: 7.7.7(rollup@4.46.2)(vite@6.3.5(@types/node@24.6.1))(vue@3.5.18(typescript@5.9.3))
+      vue: 3.5.18(typescript@5.9.3)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@types/node'
@@ -8018,7 +8018,7 @@ snapshots:
 
   '@types/fontkit@2.0.8':
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 24.6.1
 
   '@types/hast@3.0.4':
     dependencies:
@@ -8048,9 +8048,9 @@ snapshots:
 
   '@types/node@17.0.45': {}
 
-  '@types/node@24.3.0':
+  '@types/node@24.6.1':
     dependencies:
-      undici-types: 7.10.0
+      undici-types: 7.13.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -8058,7 +8058,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 24.6.1
 
   '@types/unist@2.0.11': {}
 
@@ -8068,41 +8068,41 @@ snapshots:
 
   '@types/which@3.0.4': {}
 
-  '@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0)(typescript@5.9.2))(eslint@9.32.0)(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0)(typescript@5.9.3))(eslint@9.32.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.39.0(eslint@9.32.0)(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.39.0(eslint@9.32.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.39.0
-      '@typescript-eslint/type-utils': 8.39.0(eslint@9.32.0)(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0)(typescript@5.9.2)
+      '@typescript-eslint/type-utils': 8.39.0(eslint@9.32.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.39.0
       eslint: 9.32.0
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.39.0(eslint@9.32.0)(typescript@5.9.2)':
+  '@typescript-eslint/parser@8.39.0(eslint@9.32.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.39.0
       '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.39.0
       debug: 4.4.1
       eslint: 9.32.0
-      typescript: 5.9.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.39.0(typescript@5.9.2)':
+  '@typescript-eslint/project-service@8.39.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.39.0
       debug: 4.4.1
-      typescript: 5.9.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8111,28 +8111,28 @@ snapshots:
       '@typescript-eslint/types': 8.39.0
       '@typescript-eslint/visitor-keys': 8.39.0
 
-  '@typescript-eslint/tsconfig-utils@8.39.0(typescript@5.9.2)':
+  '@typescript-eslint/tsconfig-utils@8.39.0(typescript@5.9.3)':
     dependencies:
-      typescript: 5.9.2
+      typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.39.0(eslint@9.32.0)(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@8.39.0(eslint@9.32.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0)(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0)(typescript@5.9.3)
       debug: 4.4.1
       eslint: 9.32.0
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.39.0': {}
 
-  '@typescript-eslint/typescript-estree@8.39.0(typescript@5.9.2)':
+  '@typescript-eslint/typescript-estree@8.39.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.39.0(typescript@5.9.2)
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.9.2)
+      '@typescript-eslint/project-service': 8.39.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.39.0
       '@typescript-eslint/visitor-keys': 8.39.0
       debug: 4.4.1
@@ -8140,19 +8140,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.39.0(eslint@9.32.0)(typescript@5.9.2)':
+  '@typescript-eslint/utils@8.39.0(eslint@9.32.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0)
       '@typescript-eslint/scope-manager': 8.39.0
       '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.3)
       eslint: 9.32.0
-      typescript: 5.9.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8171,21 +8171,21 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.3.5(@types/node@24.3.0))(vue@3.5.18(typescript@5.9.2))':
+  '@vitejs/plugin-vue-jsx@4.2.0(vite@6.3.5(@types/node@24.6.1))(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
       '@rolldown/pluginutils': 1.0.0-beta.29
       '@vue/babel-plugin-jsx': 1.4.0(@babel/core@7.28.0)
-      vite: 6.3.5(@types/node@24.3.0)
-      vue: 3.5.18(typescript@5.9.2)
+      vite: 6.3.5(@types/node@24.6.1)
+      vue: 3.5.18(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.1(vite@6.3.5(@types/node@24.3.0))(vue@3.5.18(typescript@5.9.2))':
+  '@vitejs/plugin-vue@5.2.1(vite@6.3.5(@types/node@24.6.1))(vue@3.5.18(typescript@5.9.3))':
     dependencies:
-      vite: 6.3.5(@types/node@24.3.0)
-      vue: 3.5.18(typescript@5.9.2)
+      vite: 6.3.5(@types/node@24.6.1)
+      vue: 3.5.18(typescript@5.9.3)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -8195,13 +8195,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.0.6(@types/node@24.3.0))':
+  '@vitest/mocker@3.2.4(vite@7.0.6(@types/node@24.6.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.0.6(@types/node@24.3.0)
+      vite: 7.0.6(@types/node@24.6.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -8403,15 +8403,15 @@ snapshots:
       '@vue/compiler-dom': 3.5.18
       '@vue/shared': 3.5.18
 
-  '@vue/devtools-core@7.7.7(vite@6.3.5(@types/node@24.3.0))(vue@3.5.18(typescript@5.9.2))':
+  '@vue/devtools-core@7.7.7(vite@6.3.5(@types/node@24.6.1))(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       '@vue/devtools-kit': 7.7.7
       '@vue/devtools-shared': 7.7.7
       mitt: 3.0.1
       nanoid: 5.1.5
       pathe: 2.0.3
-      vite-hot-client: 2.0.4(vite@6.3.5(@types/node@24.3.0))
-      vue: 3.5.18(typescript@5.9.2)
+      vite-hot-client: 2.0.4(vite@6.3.5(@types/node@24.6.1))
+      vue: 3.5.18(typescript@5.9.3)
     transitivePeerDependencies:
       - vite
 
@@ -8445,11 +8445,11 @@ snapshots:
       '@vue/shared': 3.5.18
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@5.9.2))':
+  '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.18
       '@vue/shared': 3.5.18
-      vue: 3.5.18(typescript@5.9.2)
+      vue: 3.5.18(typescript@5.9.3)
 
   '@vue/shared@3.5.13': {}
 
@@ -8595,14 +8595,14 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.2(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)):
+  astro-expressive-code@0.41.2(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)):
     dependencies:
-      astro: 5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)
+      astro: 5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)
       rehype-expressive-code: 0.41.2
 
-  astro-og-canvas@0.7.0(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)):
+  astro-og-canvas@0.7.0(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)):
     dependencies:
-      astro: 5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)
+      astro: 5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)
       canvaskit-wasm: 0.39.1
       deterministic-object-hash: 2.0.2
       entities: 4.5.0
@@ -8612,7 +8612,7 @@ snapshots:
       valid-filename: 4.0.0
       zod: 3.24.3
 
-  astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2):
+  astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3):
     dependencies:
       '@astrojs/compiler': 2.12.2
       '@astrojs/internal-helpers': 0.6.1
@@ -8662,20 +8662,20 @@ snapshots:
       smol-toml: 1.4.1
       tinyexec: 0.3.2
       tinyglobby: 0.2.14
-      tsconfck: 3.1.5(typescript@5.9.2)
+      tsconfck: 3.1.5(typescript@5.9.3)
       ultrahtml: 1.6.0
       unifont: 0.5.2
       unist-util-visit: 5.0.0
       unstorage: 1.15.0(@azure/identity@4.10.1)
       vfile: 6.0.3
-      vite: 6.3.5(@types/node@24.3.0)
-      vitefu: 1.0.6(vite@6.3.5(@types/node@24.3.0))
+      vite: 6.3.5(@types/node@24.6.1)
+      vitefu: 1.0.6(vite@6.3.5(@types/node@24.6.1))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.2
       zod: 3.25.76
       zod-to-json-schema: 3.24.5(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@5.9.2)(zod@3.25.76)
+      zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
     optionalDependencies:
       sharp: 0.33.5
     transitivePeerDependencies:
@@ -8713,7 +8713,7 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@5.12.8(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2):
+  astro@5.12.8(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3):
     dependencies:
       '@astrojs/compiler': 2.12.2
       '@astrojs/internal-helpers': 0.7.1
@@ -8763,20 +8763,20 @@ snapshots:
       smol-toml: 1.4.1
       tinyexec: 0.3.2
       tinyglobby: 0.2.14
-      tsconfck: 3.1.5(typescript@5.9.2)
+      tsconfck: 3.1.5(typescript@5.9.3)
       ultrahtml: 1.6.0
       unifont: 0.5.2
       unist-util-visit: 5.0.0
       unstorage: 1.15.0(@azure/identity@4.10.1)
       vfile: 6.0.3
-      vite: 6.3.5(@types/node@24.3.0)
-      vitefu: 1.0.6(vite@6.3.5(@types/node@24.3.0))
+      vite: 6.3.5(@types/node@24.6.1)
+      vitefu: 1.0.6(vite@6.3.5(@types/node@24.6.1))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.2
       zod: 3.25.76
       zod-to-json-schema: 3.24.5(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@5.9.2)(zod@3.25.76)
+      zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
     optionalDependencies:
       sharp: 0.33.5
     transitivePeerDependencies:
@@ -9539,7 +9539,7 @@ snapshots:
     transitivePeerDependencies:
       - '@eslint/json'
 
-  eslint-plugin-n@17.21.3(eslint@9.32.0)(typescript@5.9.2):
+  eslint-plugin-n@17.21.3(eslint@9.32.0)(typescript@5.9.3):
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0)
       enhanced-resolve: 5.18.2
@@ -9550,7 +9550,7 @@ snapshots:
       globrex: 0.1.2
       ignore: 5.3.2
       semver: 7.7.2
-      ts-declaration-location: 1.0.7(typescript@5.9.2)
+      ts-declaration-location: 1.0.7(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
@@ -12300,13 +12300,13 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-llms-txt@0.5.1(@astrojs/starlight@0.35.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)))(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)):
+  starlight-llms-txt@0.5.1(@astrojs/starlight@0.35.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)))(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)):
     dependencies:
-      '@astrojs/mdx': 4.3.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2))
-      '@astrojs/starlight': 0.35.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2))
+      '@astrojs/mdx': 4.3.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3))
+      '@astrojs/starlight': 0.35.1(astro@5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3))
       '@types/hast': 3.0.4
       '@types/micromatch': 4.0.9
-      astro: 5.12.4(@azure/identity@4.10.1)(@types/node@24.3.0)(rollup@4.46.2)(typescript@5.9.2)
+      astro: 5.12.4(@azure/identity@4.10.1)(@types/node@24.6.1)(rollup@4.46.2)(typescript@5.9.3)
       github-slugger: 2.0.0
       hast-util-select: 6.0.4
       micromatch: 4.0.8
@@ -12562,24 +12562,24 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.1.0(typescript@5.9.2):
+  ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
-      typescript: 5.9.2
+      typescript: 5.9.3
 
-  ts-declaration-location@1.0.7(typescript@5.9.2):
+  ts-declaration-location@1.0.7(typescript@5.9.3):
     dependencies:
       picomatch: 4.0.3
-      typescript: 5.9.2
+      typescript: 5.9.3
 
   ts-interface-checker@0.1.13: {}
 
-  tsconfck@3.1.5(typescript@5.9.2):
+  tsconfck@3.1.5(typescript@5.9.3):
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 5.9.3
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(postcss@8.5.6)(typescript@5.9.2):
+  tsup@8.5.0(postcss@8.5.6)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.4)
       cac: 6.7.14
@@ -12600,7 +12600,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.6
-      typescript: 5.9.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -12685,18 +12685,18 @@ snapshots:
       tunnel: 0.0.6
       underscore: 1.13.7
 
-  typescript-eslint@8.39.0(eslint@9.32.0)(typescript@5.9.2):
+  typescript-eslint@8.39.0(eslint@9.32.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0)(typescript@5.9.2))(eslint@9.32.0)(typescript@5.9.2)
-      '@typescript-eslint/parser': 8.39.0(eslint@9.32.0)(typescript@5.9.2)
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0)(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0)(typescript@5.9.3))(eslint@9.32.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.39.0(eslint@9.32.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0)(typescript@5.9.3)
       eslint: 9.32.0
-      typescript: 5.9.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.2: {}
+  typescript@5.9.3: {}
 
   uc.micro@2.1.0: {}
 
@@ -12715,7 +12715,7 @@ snapshots:
 
   underscore@1.13.7: {}
 
-  undici-types@7.10.0: {}
+  undici-types@7.13.0: {}
 
   undici@6.21.2: {}
 
@@ -12878,17 +12878,17 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-hot-client@2.0.4(vite@6.3.5(@types/node@24.3.0)):
+  vite-hot-client@2.0.4(vite@6.3.5(@types/node@24.6.1)):
     dependencies:
-      vite: 6.3.5(@types/node@24.3.0)
+      vite: 6.3.5(@types/node@24.6.1)
 
-  vite-node@3.2.4(@types/node@24.3.0):
+  vite-node@3.2.4(@types/node@24.6.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.0(@types/node@24.3.0)
+      vite: 7.1.0(@types/node@24.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -12903,7 +12903,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-inspect@0.8.9(rollup@4.46.2)(vite@6.3.5(@types/node@24.3.0)):
+  vite-plugin-inspect@0.8.9(rollup@4.46.2)(vite@6.3.5(@types/node@24.6.1)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.4(rollup@4.46.2)
@@ -12914,28 +12914,28 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.1
-      vite: 6.3.5(@types/node@24.3.0)
+      vite: 6.3.5(@types/node@24.6.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-vue-devtools@7.7.7(rollup@4.46.2)(vite@6.3.5(@types/node@24.3.0))(vue@3.5.18(typescript@5.9.2)):
+  vite-plugin-vue-devtools@7.7.7(rollup@4.46.2)(vite@6.3.5(@types/node@24.6.1))(vue@3.5.18(typescript@5.9.3)):
     dependencies:
-      '@vue/devtools-core': 7.7.7(vite@6.3.5(@types/node@24.3.0))(vue@3.5.18(typescript@5.9.2))
+      '@vue/devtools-core': 7.7.7(vite@6.3.5(@types/node@24.6.1))(vue@3.5.18(typescript@5.9.3))
       '@vue/devtools-kit': 7.7.7
       '@vue/devtools-shared': 7.7.7
       execa: 9.6.0
       sirv: 3.0.1
-      vite: 6.3.5(@types/node@24.3.0)
-      vite-plugin-inspect: 0.8.9(rollup@4.46.2)(vite@6.3.5(@types/node@24.3.0))
-      vite-plugin-vue-inspector: 5.3.1(vite@6.3.5(@types/node@24.3.0))
+      vite: 6.3.5(@types/node@24.6.1)
+      vite-plugin-inspect: 0.8.9(rollup@4.46.2)(vite@6.3.5(@types/node@24.6.1))
+      vite-plugin-vue-inspector: 5.3.1(vite@6.3.5(@types/node@24.6.1))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - rollup
       - supports-color
       - vue
 
-  vite-plugin-vue-inspector@5.3.1(vite@6.3.5(@types/node@24.3.0)):
+  vite-plugin-vue-inspector@5.3.1(vite@6.3.5(@types/node@24.6.1)):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.10)
@@ -12946,11 +12946,11 @@ snapshots:
       '@vue/compiler-dom': 3.5.13
       kolorist: 1.8.0
       magic-string: 0.30.17
-      vite: 6.3.5(@types/node@24.3.0)
+      vite: 6.3.5(@types/node@24.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.3.5(@types/node@24.3.0):
+  vite@6.3.5(@types/node@24.6.1):
     dependencies:
       esbuild: 0.25.4
       fdir: 6.4.6(picomatch@4.0.3)
@@ -12959,10 +12959,10 @@ snapshots:
       rollup: 4.46.2
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 24.3.0
+      '@types/node': 24.6.1
       fsevents: 2.3.3
 
-  vite@7.0.6(@types/node@24.3.0):
+  vite@7.0.6(@types/node@24.6.1):
     dependencies:
       esbuild: 0.25.2
       fdir: 6.4.6(picomatch@4.0.3)
@@ -12971,10 +12971,10 @@ snapshots:
       rollup: 4.46.2
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 24.3.0
+      '@types/node': 24.6.1
       fsevents: 2.3.3
 
-  vite@7.1.0(@types/node@24.3.0):
+  vite@7.1.0(@types/node@24.6.1):
     dependencies:
       esbuild: 0.25.4
       fdir: 6.4.6(picomatch@4.0.3)
@@ -12983,18 +12983,18 @@ snapshots:
       rollup: 4.46.2
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 24.3.0
+      '@types/node': 24.6.1
       fsevents: 2.3.3
 
-  vitefu@1.0.6(vite@6.3.5(@types/node@24.3.0)):
+  vitefu@1.0.6(vite@6.3.5(@types/node@24.6.1)):
     optionalDependencies:
-      vite: 6.3.5(@types/node@24.3.0)
+      vite: 6.3.5(@types/node@24.6.1)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.6.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.0.6(@types/node@24.3.0))
+      '@vitest/mocker': 3.2.4(vite@7.0.6(@types/node@24.6.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13012,12 +13012,12 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.6(@types/node@24.3.0)
-      vite-node: 3.2.4(@types/node@24.3.0)
+      vite: 7.0.6(@types/node@24.6.1)
+      vite-node: 3.2.4(@types/node@24.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 24.3.0
+      '@types/node': 24.6.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -13032,15 +13032,15 @@ snapshots:
       - tsx
       - yaml
 
-  vue@3.5.18(typescript@5.9.2):
+  vue@3.5.18(typescript@5.9.3):
     dependencies:
       '@vue/compiler-dom': 3.5.18
       '@vue/compiler-sfc': 3.5.18
       '@vue/runtime-dom': 3.5.18
-      '@vue/server-renderer': 3.5.18(vue@3.5.18(typescript@5.9.2))
+      '@vue/server-renderer': 3.5.18(vue@3.5.18(typescript@5.9.3))
       '@vue/shared': 3.5.18
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 5.9.3
 
   web-namespaces@2.0.1: {}
 
@@ -13250,9 +13250,9 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-ts@1.2.0(typescript@5.9.2)(zod@3.25.76):
+  zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
     dependencies:
-      typescript: 5.9.2
+      typescript: 5.9.3
       zod: 3.25.76
 
   zod@3.22.3: {}


### PR DESCRIPTION
Received reports of `varlock not found` - meaning our executable was not found by our library code which was trying to invoke it to load env vars.

This was due to `execSync('varlock ...')` not being able to find varlock in the PATH. This was surprising because this works in most cases. Tracked it down to the difference between running via a package manager vs directly. The package managers automatically inject `./node_modules/.bin` into the PATH.

This PR adjusts things so that if varlock is not found, we walk up the ancestor directories looking for node_modules, and when found, we try to use the full path.

Along the way, also improved handling of all code that handles not finding an executable, and all code that walks up directories to the root.