### PR TITLE
undo major version bump

### DIFF
--- a/.changeset/lemon-parrots-deny.md
+++ b/.changeset/lemon-parrots-deny.md
@@ -1,0 +1,8 @@
+---
+"@varlock/nextjs-integration": patch
+"@varlock/astro-integration": patch
+"@varlock/vite-integration": patch
+"@varlock/1password-plugin": patch
+---
+
+undo major version bump caused by changesets peer dep logic, using minor instead

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -16,7 +16,6 @@
   "license": "ISC",
   "dependencies": {
     "dotenv": "link:../../packages/varlock",
-    "openai": "^5.10.2",
     "varlock": "workspace:*"
   },
   "packageManager": "pnpm@10.14.0",

--- a/packages/integrations/astro/package.json
+++ b/packages/integrations/astro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@varlock/astro-integration",
   "description": "Astro integration to use varlock for .env file loading - adds validation, type-safety, and extra security features",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/dmno-dev/varlock.git",

--- a/packages/integrations/nextjs/package.json
+++ b/packages/integrations/nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@varlock/nextjs-integration",
   "description": "drop-in replacement for @next/env that uses varlock to load .env files with validation and extra security features",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/dmno-dev/varlock.git",

--- a/packages/integrations/vite/package.json
+++ b/packages/integrations/vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@varlock/vite-integration",
   "description": "Vite plugin to use varlock for .env file loading - adds validation, type-safety, and extra security features",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/dmno-dev/varlock.git",

--- a/packages/plugins/1password/package.json
+++ b/packages/plugins/1password/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@varlock/1password-plugin",
   "description": "Varlock plugin to pull data from 1password",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,9 +131,6 @@ importers:
       dotenv:
         specifier: link:../../packages/varlock
         version: link:../../packages/varlock
-      openai:
-        specifier: ^5.10.2
-        version: 5.23.2(ws@8.18.0)(zod@3.25.76)
       varlock:
         specifier: workspace:*
         version: link:../../packages/varlock
@@ -6251,18 +6248,6 @@ packages:
   open@10.1.1:
     resolution: {integrity: sha512-zy1wx4+P3PfhXSEPJNtZmJXfhkkIaxU1VauWIrDZw1O7uJRDRJtKr9n3Ic4NgbA16KyOxOXO2ng9gYwCdXuSXA==}
     engines: {node: '>=18'}
-
-  openai@5.23.2:
-    resolution: {integrity: sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -15595,11 +15580,6 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
-
-  openai@5.23.2(ws@8.18.0)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.18.0
-      zod: 3.25.76
 
   optionator@0.9.4:
     dependencies:


### PR DESCRIPTION
changesets caused an unexpected major version bump due to the minor  vesion bump in varlock core.

see https://github.com/changesets/changesets/issues/1011

Attempting to undo this for now… will need to figure out a better  strategy next time