### PR TITLE
add project-level config file to allow telemetry opt-out

### DIFF
--- a/.changeset/giant-cameras-unite.md
+++ b/.changeset/giant-cameras-unite.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+add project-level config file

--- a/packages/varlock-website/src/content/docs/guides/telemetry.mdx
+++ b/packages/varlock-website/src/content/docs/guides/telemetry.mdx
@@ -15,9 +15,11 @@ We track general usage information, and the environment in which `varlock` is be
 - General system/machine information
 - Anonymous user + project ID
 
+**We will never collect any of your config files or environment variables.**
+
 ## How to Opt Out
 
-You can opt out of analytics in two ways:
+You can opt out of analytics in three ways:
 
 ### Using the CLI
 
@@ -38,7 +40,17 @@ You can also opt out temporarily by setting the `VARLOCK_TELEMETRY_DISABLED` env
 export VARLOCK_TELEMETRY_DISABLED=true
 ```
 
-This will disable analytics for the current session only, which is useful in CI/CD pipelines, or while running a specific command.
+This could be set in a specific terminal session, while running a specific command, in a Dockerfile, or in a CI/CD pipeline.
+
+### With a project config file
+
+You can also opt out at the project level by creating a `.varlock/config.json` file in your project root with the following content:
+
+```json title="my-app/.varlock/config.json"
+{
+  "telemetryDisabled": true
+}
+```
 
 ## Privacy
 


### PR DESCRIPTION
previously we checked the user's home folder for a `.varlock/config.json` file. This file can contain a `"disableTelemetry": true` to let the user opt out of telemetry.

We now also look for a project-level config file - by walking up the directory tree. These 2 config files will be merged, with project settings overriding user settings.

This allows a telemetry opt-out to live within the repo, and persist across team members.