### PR TITLE
fix varlock executable finding logic on windows

### DIFF
--- a/.changeset/nine-hoops-cough.md
+++ b/.changeset/nine-hoops-cough.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+fix logic around finding the varlock executable to work with windows .cmd files

--- a/packages/utils/src/git-utils.ts
+++ b/packages/utils/src/git-utils.ts
@@ -6,8 +6,15 @@ export async function checkIsFileGitIgnored(path: string, warnIfNotGitRepo = fal
     return true;
   } catch (err) {
     const stderr = (err as any).stderr as string;
-    // git is not installed, so we don't know
-    if ((err as any).status === 127 || stderr.includes('not found')) return undefined;
+    // git is not installed, so we can't check
+    if (
+      (err as any).status === 127
+      || stderr.includes('not found')
+      || stderr.includes('not recognized') // windows
+    ) {
+      return undefined;
+    }
+
     // other file related issues could throw this
     if ((err as any).code === 'ENOENT') return undefined;
     // `git check-ignore -q` exits with code 1 but no other error if is not ignored


### PR DESCRIPTION
small fix for how we look for the varlock executable to work with windows - which creates .cmd files.

This is necessary when the varlock cli is invoked by our helper libraries (like `import 'varlock/auto-load'`) and the command has not been invoked via a package manager.

Fixes #198 (hopefully)