### PR TITLE
Specify `--transport http` for Claude Code MCP instructions

### DIFF
--- a/packages/varlock-website/src/content/docs/guides/mcp.mdx
+++ b/packages/varlock-website/src/content/docs/guides/mcp.mdx
@@ -533,7 +533,7 @@ See below for tool-specific setup instructions.
   <TabItem label="Claude">
   To add a server in Claude Code, run the following command:
   ```bash
-  claude mcp add varlock-docs-mcp https://docs.mcp.varlock.dev/mcp
+  claude mcp add --transport http varlock-docs-mcp https://docs.mcp.varlock.dev/mcp
   ```
 
   See [Claude's documentation](https://docs.claude.com/en/docs/claude-code/mcp#option-1%3A-add-a-remote-http-server) for more information.


### PR DESCRIPTION
If you don't specify `--transport http`, it still works, but you get this warning message which is unpleasant:

```
Warning: The command "https://docs.mcp.varlock.dev/mcp" looks like a URL, but is being interpreted as a stdio server as --transport was not specified.
If this is an HTTP server, use: claude mcp add --transport http varlock-docs-mcp https://docs.mcp.varlock.dev/mcp
If this is an SSE server, use: claude mcp add --transport sse varlock-docs-mcp https://docs.mcp.varlock.dev/mcp
Added stdio MCP server varlock-docs-mcp with command: https://docs.mcp.varlock.dev/mcp  to local config
```

After this patch the warning drops and you just get:

```
Added HTTP MCP server varlock-docs-mcp with URL: https://docs.mcp.varlock.dev/mcp to local config
```