### PR TITLE
fix for next dev error logs

### DIFF
--- a/.changeset/rare-roses-invite.md
+++ b/.changeset/rare-roses-invite.md
@@ -1,0 +1,5 @@
+---
+"@varlock/nextjs-integration": patch
+---
+
+show error logs on first load

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -297,8 +297,7 @@ export function loadEnvConfig(
   try {
     loadCount++;
     const varlockLoadedEnvStr = execSyncVarlock(`load --format json-full --env ${envFromNextCommand}`, {
-      // in dev, there are 2 loads up front, so we dont show the first
-      showLogsOnError: !dev || loadCount > 1,
+      showLogsOnError: true,
       // in a build, we want to fail and exit, while in dev we can keep retrying when changes are detected
       exitOnError: !dev,
       env: initialEnv as any,

--- a/packages/varlock-website/src/content/docs/integrations/nextjs.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/nextjs.mdx
@@ -16,7 +16,7 @@ Varlock provides a huge upgrade over the [default Next.js environment variable t
 
 To integrate varlock into a Next.js application, you must use our [`@varlock/nextjs-integration`](https://www.npmjs.com/package/@varlock/nextjs-integration) package. This package provides a drop-in replacement for [`@next/env`](https://www.npmjs.com/package/@next/env), the internal package that handles .env loading, plus a small config plugin which injects our additional security features.
 
-:::note[Turbopack not yet supported]
+:::note[Turbopack supported, but not fully]
 [Turbopack](https://nextjs.org/docs/app/api-reference/turbopack) does not yet provide a plugin system, so using the config plugin is not supported. You can use the `@next/env` override only, but you will not get the additional security features.
 :::
 


### PR DESCRIPTION
Previously we had logic to hide error logs of varlock's first pass when running next dev, because it was displaying twice.

They must have changed something and now we are not seeing error logs if validation fails on a first run of `next dev`.

At the risk of sometimes probably showing it multiple times, we will now just make sure its visible regardless.

