### PR TITLE
set up trusted publishing for npm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC
+      contents: write
+      packages: write
+      pull-requests: write
+      issues: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -31,6 +37,11 @@ jobs:
       - name: Enable turborepo build cache
         uses: rharkor/caching-for-turbo@v2.3.2
       
+      # Ensure npm 11.5.1 or later is installed (for trusted publishing)
+      # (pnpm publish calls npm under the hood)
+      - name: Update npm
+        run: npm install -g npm@latest
+
       # ------------------------------------------------------------
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
Enable trusted publishing for github -> npm. This removes the need for using tokens at all.
This may not be right yet - need to test...

