### PR TITLE
Dont assume process exists in runtime code

### DIFF
--- a/.changeset/slimy-women-wink.md
+++ b/.changeset/slimy-women-wink.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+fix runtime env code to not assume process (or shim) exists - for sveltekit

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -202,11 +202,12 @@ let varlockInjectedProcessEnvKeys: Array<string> | undefined;
 export function initVarlockEnv(opts?: {
   allowFail?: boolean,
 }) {
-  debug('⚡️ INIT VARLOCK ENV!', initializedEnv, !!(globalThis as any).__varlockLoadedEnv, processExists && !!process.env.__VARLOCK_ENV);
+  debug('⚡️ INIT VARLOCK ENV!', initializedEnv, !!(globalThis as any).__varlockLoadedEnv, !!globalThis.process?.env.__VARLOCK_ENV);
 
   // normally we can just bail if we detect we are in the browser
   // however when front-end related tests, it may appear that we are in the browser but it is not
-  if (isBrowser && !process.env.__VARLOCK_ENV) {
+  // also some frameworks inject a process polyfill, others do not
+  if (isBrowser && !globalThis.process?.env.__VARLOCK_ENV) {
     initializedEnv = true;
     return;
   }

--- a/packages/varlock/src/runtime/lib/debug.ts
+++ b/packages/varlock/src/runtime/lib/debug.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
 export function debug(...args: Array<any>) {
-  if (!process.env.DEBUG_VARLOCK) return;
+  if (!globalThis.process?.env.DEBUG_VARLOCK) return;
   console.log(...args);
 }


### PR DESCRIPTION
sveltekit does not inject a `process.env` shim in the browser, so certain cases where we should have gotten nice error messages were not working.