### PR TITLE
fix for cf + vite during local dev

### DIFF
--- a/.changeset/curvy-pillows-act.md
+++ b/.changeset/curvy-pillows-act.md
@@ -1,0 +1,5 @@
+---
+"@varlock/vite-integration": patch
+---
+
+fix for local dev with cloudflare+vite

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -208,11 +208,6 @@ export function varlockVitePlugin(
           // default to injecting varlock init code only
           ssrInjectMode ??= 'init-only';
 
-          // in dev mode, we only need to inject init code
-          // because we'll already have the resolved env available
-          // from the vite plugin itself already loading it
-          if (isDevEnv) ssrInjectMode = 'init-only';
-
           debug('ssrInjectMode =', ssrInjectMode);
           if (ssrInjectMode === 'auto-load') {
             injectCode.push(


### PR DESCRIPTION
Small for fix vite integration when used in conjunction with the cloudflare plugin.

In other frameworks, during local development, varlocks loaded env lives in the global scope and seems to make its way into the running code's scope. Because of this, we assumed that during local dev, the resolved env was already available. However with the cloudflare plugin, this does not seem to be the case. So instead we just dont assume the env is loaded already and inject it again if necessary.