### PR TITLE
add charset to content-type header

### DIFF
--- a/packages/varlock-website/public/_headers
+++ b/packages/varlock-website/public/_headers
@@ -1,0 +1,4 @@
+# Set charset=utf-8 for .txt files to ensure proper encoding
+/*.txt
+  Content-Type: text/plain; charset=utf-8
+


### PR DESCRIPTION
UTF8 chars in lllms-*.txt weren't being rendered properly

see discussion here https://github.com/delucis/starlight-llms-txt/issues/44