### PR TITLE
dedupe env file labels on nextjs

### DIFF
--- a/.changeset/clear-experts-buy.md
+++ b/.changeset/clear-experts-buy.md
@@ -1,0 +1,5 @@
+---
+"@varlock/nextjs-integration": patch
+---
+
+dedupe loaded env files labels

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -34,20 +34,23 @@ let rootDir: string | undefined;
 // @next/env exports this info and currently it is only used to display
 // a list of filenames loaded, for example: `Environments: .env, .env.development`
 function getVarlockSourcesAsLoadedEnvFiles(): LoadedEnvFiles {
-  const envFiles = varlockLoadedEnv.sources
+  const envFilesLabels = varlockLoadedEnv.sources
     // TODO expose more info so we can filter out disabled sources
     // and maybe show relative paths
     .filter((s) => s.enabled && !s.label.startsWith('directory -'))
-    .map((s) => ({
-      path: s.label,
-      contents: '',
-      env: {},
-    }));
-  if (envFiles.length) {
+    .map((s) => s.label);
+  if (envFilesLabels.length) {
     // this adds an additional line, below the list of files
-    envFiles.push({ path: '\n                   ✨ loaded by varlock ✨', contents: '', env: {} });
+    envFilesLabels.push('\n                   ✨ loaded by varlock ✨');
   }
-  return envFiles;
+  // files can be imported multiple times, so we deduplicate the labels here
+  const uniqueLabels = [...new Set(envFilesLabels)];
+  // Next.js expects an array of objects, even though it is not used for anything
+  return uniqueLabels.map((label) => ({
+    path: label,
+    contents: '',
+    env: {},
+  }));
 }
 
 const IS_WORKER = !!process.env.NEXT_PRIVATE_WORKER;


### PR DESCRIPTION
When using explicit imports, a single file may exist multiple times in the list of datasources. Eventually we may want to try to dedupe them at the data-source level, but this may be quite complex. Currently there is additional metadata about which keys are imported, and the ordering of the item definitions is very significant. For now, we can just leave it as is, but dedupe how the labels appear in the Next.js startup logs.

