### PR TITLE
apply redaction to stdout

### DIFF
--- a/.changeset/some-candles-repair.md
+++ b/.changeset/some-candles-repair.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+apply redaction to stdout and sterr in `varlock run`

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,5 +3,6 @@
     "pflannery.vscode-versionlens",
     "antfu.pnpm-catalog-lens",
     "allemandinstable.colorful-comments-refreshed",
+    "dbaeumer.vscode-eslint",
   ]
 }


### PR DESCRIPTION
Applies redaction to both stdout and stderr when running `varlock run`

fixes #251

