### PR TITLE
new --path/-p flag to load from a specific path rather than assuming current directory

### DIFF
--- a/.changeset/add-path-flag.md
+++ b/.changeset/add-path-flag.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+Add `--path` / `-p` flag to `load` and `run` commands to specify a .env file or directory as the entry point

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -56,6 +56,7 @@ varlock load [options]
 - `--format`:     Format of output [pretty|json|env]
 - `--show-all`:   Shows all items, not just failing ones, when validation is failing
 - `--env`:        Set the default environment flag (e.g., `--env production`), only useful if not using `@currentEnv` in `.env.schema`
+- `--path` / `-p`: Path to a specific `.env` file or directory (with trailing slash) to use as the entry point
 
 **Examples:**
 ```bash
@@ -70,6 +71,12 @@ varlock load --format json
 
 # When validation is failing, will show all items, rather than just failing ones
 varlock load --show-all
+
+# Load from a specific .env file
+varlock load --path .env.prod
+
+# Load from a specific directory
+varlock load --path ./config/
 ```
 
 :::caution
@@ -89,11 +96,18 @@ varlock run -- <command>
 
 **Options:**
 - `--no-redact-stdout`: Disable stdout/stderr redaction to preserve TTY detection for interactive tools
+- `--path` / `-p`: Path to a specific `.env` file or directory (with trailing slash) to use as the entry point
 
 **Examples:**
 ```bash
 varlock run -- node app.js      # Run a Node.js application
 varlock run -- python script.py # Run a Python script
+
+# Use a specific .env file as entry point
+varlock run --path .env.prod -- node app.js
+
+# Use a specific directory as entry point
+varlock run --path ./config/ -- node app.js
 ```
 
 :::note[Shell expansion of env vars in commands]

--- a/packages/varlock/src/cli/commands/load.command.ts
+++ b/packages/varlock/src/cli/commands/load.command.ts
@@ -31,6 +31,11 @@ export const commandSpec = define({
       type: 'string',
       description: 'Set the environment (e.g., production, development, etc) - will be overridden by @currentEnv in the schema if present',
     },
+    path: {
+      type: 'string',
+      short: 'p',
+      description: 'Path to a specific .env file or directory (with trailing slash) to use as the entry point',
+    },
   },
   examples: `
 Loads and validates environment variables according to your .env files, and prints the results.
@@ -38,12 +43,11 @@ Useful for debugging locally, and in CI to print out a summary of env vars.
 
 Examples:
   varlock load                    # Load and validate with pretty output
-  varlock load --env production   # Load for a specific environment
   varlock load --format json      # Output in JSON format
   varlock load --show-all         # Show all items when validation fails
-
-⚠️ Note: Setting @currentEnv in your .env.schema will override the --env flag
-  `.trim(),
+  varlock load --path .env.prod   # Load from a specific .env file
+  varlock load --env production   # Load for a specific environment (⚠️ ignored if using @currentEnv!)
+`.trim(),
 });
 
 
@@ -52,6 +56,7 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
 
   const envGraph = await loadVarlockEnvGraph({
     currentEnvFallback: ctx.values.env,
+    entryFilePath: ctx.values.path,
   });
   checkForSchemaErrors(envGraph);
 

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -22,16 +22,23 @@ export const commandSpec = define({
       type: 'boolean',
       description: 'Disable stdout/stderr redaction to preserve TTY detection for interactive tools',
     },
+    path: {
+      type: 'string',
+      short: 'p',
+      description: 'Path to a specific .env file or directory (with trailing slash) to use as the entry point',
+    },
   },
   examples: `
 Executes a command in a child process, injecting your resolved and validated environment
 variables from your .env files. Useful when a code-level integration is not possible.
 
 Examples:
-  varlock run -- node app.js                 # Run a Node.js application
-  varlock run -- python script.py            # Run a Python script
-  varlock run -- sh -c 'echo $MY_VAR'        # Use shell expansion for env vars
-  varlock run --no-redact-stdout -- psql     # Preserve TTY for interactive tools
+  varlock run -- node app.js                    # Run a Node.js application
+  varlock run -- python script.py               # Run a Python script
+  varlock run -- sh -c 'echo $MY_VAR'           # Use shell expansion for env vars
+  varlock run --no-redact-stdout -- psql        # Preserve TTY for interactive tools
+  varlock run --path .env.prod -- node app.js   # Use a specific .env file
+  varlock run --path ./config/ -- node app.js   # Use a specific directory
 
 📍 Important: Use -- to separate varlock options from your command
 
@@ -67,7 +74,9 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   // console.log('running command', pathAwareCommand || rawCommand, commandArgsOnly);
 
 
-  const envGraph = await loadVarlockEnvGraph();
+  const envGraph = await loadVarlockEnvGraph({
+    entryFilePath: ctx.values.path,
+  });
   checkForSchemaErrors(envGraph);
   await envGraph.resolveEnvValues();
   checkForConfigErrors(envGraph);

--- a/packages/varlock/src/env-graph/lib/loader.ts
+++ b/packages/varlock/src/env-graph/lib/loader.ts
@@ -1,9 +1,11 @@
+import path from 'node:path';
 import _ from '@env-spec/utils/my-dash';
 import { EnvGraph } from './env-graph';
-import { DirectoryDataSource } from './data-source';
+import { DirectoryDataSource, DotEnvFileDataSource } from './data-source';
 
 export async function loadEnvGraph(opts?: {
   basePath?: string,
+  entryFilePath?: string,
   relativePaths?: Array<string>,
   checkGitIgnored?: boolean,
   excludeDirs?: Array<string>,
@@ -11,17 +13,28 @@ export async function loadEnvGraph(opts?: {
   afterInit?: (graph: EnvGraph) => Promise<void>,
 }) {
   const graph = new EnvGraph();
-  graph.basePath = opts?.basePath ?? process.cwd();
 
-  if (opts?.afterInit) {
-    await opts.afterInit(graph);
+  if (opts?.entryFilePath) {
+    const resolvedPath = path.resolve(opts.entryFilePath);
+    if (opts.entryFilePath.endsWith('/') || opts.entryFilePath.endsWith(path.sep)) {
+      // trailing slash means treat as directory
+      graph.basePath = resolvedPath;
+      if (opts?.afterInit) await opts.afterInit(graph);
+      if (opts?.currentEnvFallback) graph.envFlagFallback = opts.currentEnvFallback;
+      await graph.setRootDataSource(new DirectoryDataSource(resolvedPath));
+    } else {
+      graph.basePath = path.dirname(resolvedPath);
+      if (opts?.afterInit) await opts.afterInit(graph);
+      if (opts?.currentEnvFallback) graph.envFlagFallback = opts.currentEnvFallback;
+      await graph.setRootDataSource(new DotEnvFileDataSource(resolvedPath));
+    }
+  } else {
+    graph.basePath = opts?.basePath ?? process.cwd();
+    if (opts?.afterInit) await opts.afterInit(graph);
+    if (opts?.currentEnvFallback) graph.envFlagFallback = opts.currentEnvFallback;
+    await graph.setRootDataSource(new DirectoryDataSource(graph.basePath));
   }
 
-  if (opts?.currentEnvFallback) {
-    graph.envFlagFallback = opts.currentEnvFallback;
-  }
-
-  await graph.setRootDataSource(new DirectoryDataSource(graph.basePath));
   await graph.finishLoad();
 
   return graph;

--- a/packages/varlock/src/lib/load-graph.ts
+++ b/packages/varlock/src/lib/load-graph.ts
@@ -2,6 +2,7 @@ import { loadEnvGraph } from '../env-graph';
 
 export async function loadVarlockEnvGraph(opts?: {
   currentEnvFallback?: string,
+  entryFilePath?: string,
 }) {
   const envGraph = await loadEnvGraph({
     ...opts,


### PR DESCRIPTION
Adds a new `--path` / `-p` flag to `load` and `run` commands to specify a .env file or directory as the entry point