### PR TITLE
fix: resolve workspace/catalog versions before changeset publish

### DIFF
--- a/.changeset/fix-publish-workspace-versions.md
+++ b/.changeset/fix-publish-workspace-versions.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix publishing pipeline to resolve `workspace:` and `catalog:` version protocols before `changeset publish`. These were previously resolved automatically by pnpm during publish, but after switching to Bun, `changeset publish` falls back to `npm publish` which doesn't understand these protocols.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "changeset:add": "changeset add",
     "changeset:empty": "changeset add --empty",
     "changeset:version": "changeset version && bun run lint:fix",
-    "changeset:publish": "bun run build:libs && changeset publish",
+    "changeset:publish": "bun run build:libs && bun run scripts/resolve-workspace-versions.ts && changeset publish",
     "release:create-missing-tags": "node scripts/create-missing-release-tags.js"
   },
   "devDependencies": {

--- a/scripts/resolve-workspace-versions.ts
+++ b/scripts/resolve-workspace-versions.ts
@@ -1,0 +1,125 @@
+/**
+ * Resolves `workspace:` and `catalog:` version protocols in all workspace package.json files.
+ *
+ * This is needed because `changeset publish` calls `npm publish` under the hood (when not using pnpm),
+ * and npm doesn't understand these protocols. Previously pnpm handled this automatically during publish.
+ *
+ * - `workspace:*` → resolved version (e.g. "0.3.0")
+ * - `workspace:^` → `^{version}` (e.g. "^0.3.0")
+ * - `workspace:~` → `~{version}` (e.g. "~0.3.0")
+ * - `catalog:` or `catalog:default` → version from root package.json `catalog` field
+ * - `catalog:{name}` → version from root package.json `catalogs.{name}` field
+ *
+ * See: https://github.com/changesets/changesets/issues/1376
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { listWorkspaces } from './list-workspaces.ts';
+
+const dryRun = process.argv.includes('--dry-run');
+const monorepoRoot = path.resolve(import.meta.dirname, '..');
+
+// Load root package.json to get catalog definitions
+const rootPkgJson = JSON.parse(fs.readFileSync(path.join(monorepoRoot, 'package.json'), 'utf-8'));
+
+// Build catalog lookup: { catalogName: { packageName: version } }
+// `catalog:` (no name) or `catalog:default` maps to root `catalog` field
+// `catalog:{name}` maps to root `catalogs.{name}` field
+const catalogs: Record<string, Record<string, string>> = {};
+if (rootPkgJson.catalog) {
+  catalogs.default = rootPkgJson.catalog;
+}
+if (rootPkgJson.catalogs) {
+  for (const [name, entries] of Object.entries(rootPkgJson.catalogs)) {
+    catalogs[name] = entries as Record<string, string>;
+  }
+}
+
+// Build workspace version lookup: { packageName: version }
+const workspaces = await listWorkspaces(monorepoRoot);
+const workspaceVersions: Record<string, string> = {};
+for (const ws of workspaces) {
+  workspaceVersions[ws.name] = ws.version;
+}
+
+const DEP_TYPES = ['dependencies', 'peerDependencies', 'optionalDependencies', 'devDependencies'] as const;
+
+let totalResolved = 0;
+
+for (const ws of workspaces) {
+  const pkgJsonPath = path.join(ws.path, 'package.json');
+  const raw = fs.readFileSync(pkgJsonPath, 'utf-8');
+  const pkgJson = JSON.parse(raw);
+
+  // skip private packages - they don't get published
+  if (pkgJson.private) continue;
+
+  let modified = false;
+
+  for (const depType of DEP_TYPES) {
+    const deps = pkgJson[depType];
+    if (!deps) continue;
+
+    for (const [depName, depVersion] of Object.entries(deps) as Array<[string, string]>) {
+      if (typeof depVersion !== 'string') continue;
+
+      let resolved: string | undefined;
+
+      // Handle workspace: protocol
+      if (depVersion.startsWith('workspace:')) {
+        const range = depVersion.slice('workspace:'.length);
+        const actualVersion = workspaceVersions[depName];
+        if (!actualVersion) {
+          console.error(`ERROR: Cannot resolve ${depType}.${depName}: "${depVersion}" - package not found in workspace`);
+          process.exit(1);
+        }
+
+        if (range === '*') {
+          resolved = actualVersion;
+        } else if (range === '^') {
+          resolved = `^${actualVersion}`;
+        } else if (range === '~') {
+          resolved = `~${actualVersion}`;
+        } else {
+          // For workspace:^1.0.0 style ranges, keep the semver range as-is
+          resolved = range;
+        }
+      }
+
+      // Handle catalog: protocol
+      if (depVersion.startsWith('catalog:')) {
+        const catalogName = depVersion.slice('catalog:'.length) || 'default';
+        const catalog = catalogs[catalogName];
+        if (!catalog) {
+          console.error(`ERROR: Cannot resolve ${depType}.${depName}: "${depVersion}" - catalog "${catalogName}" not found`);
+          process.exit(1);
+        }
+        const catalogVersion = catalog[depName];
+        if (!catalogVersion) {
+          console.error(`ERROR: Cannot resolve ${depType}.${depName}: "${depVersion}" - package not found in catalog "${catalogName}"`);
+          process.exit(1);
+        }
+        resolved = catalogVersion;
+      }
+
+      if (resolved !== undefined) {
+        console.log(`  ${pkgJson.name}: ${depType}.${depName} "${depVersion}" → "${resolved}"`);
+        deps[depName] = resolved;
+        modified = true;
+        totalResolved++;
+      }
+    }
+  }
+
+  if (modified && !dryRun) {
+    // Preserve original formatting (indentation) by detecting it from the raw file
+    const indent = raw.match(/^(\s+)/m)?.[1] || '  ';
+    fs.writeFileSync(pkgJsonPath, `${JSON.stringify(pkgJson, null, indent)}\n`);
+  }
+}
+
+if (totalResolved > 0) {
+  console.log(`\n✓ ${dryRun ? '[DRY RUN] Would resolve' : 'Resolved'} ${totalResolved} workspace/catalog version(s)`);
+} else {
+  console.log('No workspace: or catalog: versions found in publishable packages');
+}


### PR DESCRIPTION
## Problem

After switching from pnpm to Bun (#313), published packages started shipping with unresolved `workspace:` and `catalog:` version protocols in their package.json (e.g. `"varlock": "workspace:^"` instead of `"varlock": "^0.3.0"`).

**Working (v0.2.1):** https://www.npmjs.com/package/@varlock/vite-integration/v/0.2.1?activeTab=code
**Broken (v0.2.2):** https://www.npmjs.com/package/@varlock/vite-integration/v/0.2.2?activeTab=code

### Root cause

`changeset publish` uses `package-manager-detector` to choose the publish tool. With pnpm, it called `pnpm publish` which auto-resolves `workspace:` and `catalog:` protocols. With Bun, detection falls back to `npm publish`, which doesn't understand these protocols and publishes them as-is.

See: https://github.com/changesets/changesets/issues/1376

## Fix

Added `scripts/resolve-workspace-versions.ts` — a pre-publish script that resolves all `workspace:` and `catalog:` protocols to real versions in non-private package.json files. It runs in CI before `changeset publish`, and the file changes are transient (never committed).

Handles:
- `workspace:*` → exact version (e.g. `0.3.0`)
- `workspace:^` → caret range (e.g. `^0.3.0`)
- `workspace:~` → tilde range (e.g. `~0.3.0`)
- `catalog:` / `catalog:default` → version from root `catalog` field
- `catalog:{name}` → version from root `catalogs.{name}` field