### PR TITLE
feat: support $XDG_CONFIG_HOME for user config directory

### DIFF
--- a/.changeset/warm-keys-play.md
+++ b/.changeset/warm-keys-play.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+Support XDG Base Directory Specification for user config directory. Varlock now respects `$XDG_CONFIG_HOME` and defaults to `~/.config/varlock` instead of `~/.varlock` for new installations, while maintaining backwards compatibility with existing `~/.varlock` directories.

--- a/packages/varlock-website/src/content/docs/guides/telemetry.mdx
+++ b/packages/varlock-website/src/content/docs/guides/telemetry.mdx
@@ -28,7 +28,7 @@ Run the following command to permanently opt out:
 
 <ExecCommandWidget command="varlock telemetry disable" />
 
-This will create/update a configuration file saving your preference at `~/.varlock/config.json`.
+This will create/update a configuration file saving your preference at `$XDG_CONFIG_HOME/varlock/config.json` (defaults to `~/.config/varlock/config.json`).
 
 _You may re-enable telemetry by running `varlock telemetry enable`_
 

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -250,7 +250,7 @@ varlock typegen --path .env.prod
 <div>
 ### `varlock telemetry` ||telemetry||
 
-Opts in/out of anonymous usage analytics. This command creates/updates a configuration file at `~/.varlock/config.json` saving your preference.
+Opts in/out of anonymous usage analytics. This command creates/updates a configuration file at `$XDG_CONFIG_HOME/varlock/config.json` (defaults to `~/.config/varlock/config.json`) saving your preference.
 
 ```bash
 varlock telemetry disable

--- a/packages/varlock/install.sh
+++ b/packages/varlock/install.sh
@@ -14,8 +14,17 @@ OS=""
 ARCH=""
 VERSION=""
 LATEST_VERSION=""
-INSTALL_DIR="${HOME}/.varlock/bin"
-INSTALL_DIR_UNEXPANDED="~/.varlock/bin"
+# Resolve the varlock config directory respecting XDG Base Directory Spec
+if [ -n "${XDG_CONFIG_HOME}" ]; then
+  VARLOCK_CONFIG_DIR="${XDG_CONFIG_HOME}/varlock"
+elif [ -d "${HOME}/.varlock" ]; then
+  VARLOCK_CONFIG_DIR="${HOME}/.varlock"
+else
+  VARLOCK_CONFIG_DIR="${HOME}/.config/varlock"
+fi
+
+INSTALL_DIR="${VARLOCK_CONFIG_DIR}/bin"
+INSTALL_DIR_UNEXPANDED="\${XDG_CONFIG_HOME:-~/.config}/varlock/bin"
 REINSTALL=""
 FORCE_NO_BREW="false"
 

--- a/packages/varlock/src/cli/commands/login.command.ts
+++ b/packages/varlock/src/cli/commands/login.command.ts
@@ -138,8 +138,8 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     publicKey?: string;
   };
 
-  // TODO: if app exists, pass off login info to it instead of storing in home folder
-  // otherwise save login info in ~/.varlock/identity.json
+  // TODO: if app exists, pass off login info to it instead of storing in config folder
+  // otherwise save login info in the user varlock config dir (e.g. ~/.config/varlock/identity.json)
   // also save it along with a new keypair if necessary, and send the public key to the api
 
   console.log(`✅ Logged in as ${authRes.user.githubUsername} (${authRes.user.name})!`);

--- a/packages/varlock/src/cli/commands/telemetry.command.ts
+++ b/packages/varlock/src/cli/commands/telemetry.command.ts
@@ -1,4 +1,3 @@
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { mkdir, writeFile, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
@@ -7,6 +6,7 @@ import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { gracefulExit } from 'exit-hook';
 import { fmt } from '../helpers/pretty-format';
 import { CliExitError } from '../helpers/exit-error';
+import { getUserVarlockDir } from '../../lib/user-config-dir';
 
 
 export const commandSpec = define({
@@ -20,7 +20,8 @@ export const commandSpec = define({
   },
   examples: `
 Opts in/out of anonymous usage analytics. This command creates/updates a configuration
-file at ~/.varlock/config.json saving your preference.
+file at $XDG_CONFIG_HOME/varlock/config.json (or ~/.config/varlock/config.json) saving
+your preference.
 
 Examples:
   varlock telemetry disable    # Opt out of telemetry
@@ -39,7 +40,7 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     });
   }
 
-  const configDir = join(homedir(), '.varlock');
+  const configDir = getUserVarlockDir();
   const configPath = join(configDir, 'config.json');
 
   try {

--- a/packages/varlock/src/cli/helpers/telemetry.ts
+++ b/packages/varlock/src/cli/helpers/telemetry.ts
@@ -15,6 +15,7 @@ import isWSL from 'is-wsl';
 import packageJson from '../../../package.json';
 
 import { CONFIG } from '../../config';
+import { getUserVarlockDir } from '../../lib/user-config-dir';
 
 
 const debug = createDebug('varlock:telemetry');
@@ -22,7 +23,7 @@ const debug = createDebug('varlock:telemetry');
 const TRUE_ENV_VAR_VALUES = ['true', '1', 't'];
 
 
-const userVarlockDirPath = join(os.homedir(), '.varlock');
+const userVarlockDirPath = getUserVarlockDir();
 const userVarlockConfigFilePath = join(userVarlockDirPath, 'config.json');
 let userVarlockConfig: Record<string, any> | undefined;
 let projectVarlockConfig: Record<string, any> | undefined;
@@ -79,7 +80,7 @@ function findProjectDirs() {
 function loadVarlockConfig() {
   if (mergedVarlockConfigFileContents) return mergedVarlockConfigFileContents;
 
-  // load user config file - ~/.varlock/config.json
+  // load user config file - $XDG_CONFIG_HOME/varlock/config.json (or ~/.config/varlock/config.json)
   try {
     const userConfigStr = readFileSync(userVarlockConfigFilePath, 'utf-8');
     userVarlockConfig = userConfigStr.trim() ? JSON.parse(userConfigStr) : undefined;
@@ -123,7 +124,7 @@ function loadVarlockConfig() {
 
   return mergedVarlockConfigFileContents;
 }
-// we will identify users using a random UUID stored in the `~/.varlock/config.json` file
+// we will identify users using a random UUID stored in the user varlock config dir
 let cachedAnonymousId: string | undefined;
 function getAnonymousId() {
   if (cachedAnonymousId) return cachedAnonymousId;
@@ -134,7 +135,7 @@ function getAnonymousId() {
     return varlockConfig.anonymousId;
   }
 
-  // generate new anon ID and save in ~/.varlock/config.json
+  // generate new anon ID and save in user varlock config
   const newAnonymousId = `${isCI ? 'ci-' : ''}${crypto.randomUUID()}`;
 
   try {
@@ -160,9 +161,9 @@ function getAnonymousId() {
       ].join('\n'));
     } else {
       console.error([
-        'There was a problem writing to the ~/.varlock folder',
+        `There was a problem writing to the varlock config folder (${userVarlockDirPath})`,
         (err as Error).message,
-        'Please ensure your home folder (or at least the ~/.varlock folder) is writable',
+        `Please ensure the varlock config folder (${userVarlockDirPath}) is writable`,
       ].join('\n'));
     }
     gracefulExit(1);

--- a/packages/varlock/src/env-graph/lib/plugins.ts
+++ b/packages/varlock/src/env-graph/lib/plugins.ts
@@ -2,7 +2,6 @@ import path from 'node:path';
 import { exec as execCb } from 'node:child_process';
 import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
-import os from 'node:os';
 import { promisify } from 'node:util';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
@@ -12,6 +11,7 @@ import vm from 'node:vm';
 import semver from 'semver';
 import _ from '@env-spec/utils/my-dash';
 import { pathExists } from '@env-spec/utils/fs-utils';
+import { getUserVarlockDir } from '../../lib/user-config-dir';
 
 
 import { FileBasedDataSource, type EnvGraphDataSource } from './data-source';
@@ -342,7 +342,7 @@ async function registerPluginInGraph(graph: EnvGraph, plugin: VarlockPlugin, plu
 
 async function downloadPlugin(url: string) {
   const exec = promisify(execCb);
-  const cacheDir = path.join(os.homedir(), '.varlock', 'plugins-cache');
+  const cacheDir = path.join(getUserVarlockDir(), 'plugins-cache');
   const indexPath = path.join(cacheDir, 'index.json');
   await fs.mkdir(cacheDir, { recursive: true });
 
@@ -534,7 +534,7 @@ export async function processPluginInstallDecorators(dataSource: EnvGraphDataSou
               throw new Error(`Failed to find tarball URL for plugin "${moduleName}@${versionDescriptor}" from npm`);
             }
 
-            // downloads into local cache folder (~/.varlock/plugins-cache/)
+            // downloads into local cache folder (user varlock config dir / plugins-cache/)
             const downloadedPluginPath = await downloadPlugin(tarballUrl);
             pluginSrcPath = downloadedPluginPath;
           }

--- a/packages/varlock/src/lib/user-config-dir.ts
+++ b/packages/varlock/src/lib/user-config-dir.ts
@@ -1,0 +1,31 @@
+import os from 'node:os';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+
+/**
+ * Resolves the user-level varlock config directory, respecting the XDG Base Directory Specification.
+ *
+ * Resolution order:
+ * 1. If `$XDG_CONFIG_HOME` is set → `$XDG_CONFIG_HOME/varlock`
+ * 2. If legacy `~/.varlock` exists → `~/.varlock` (backwards compatibility)
+ * 3. Otherwise → `~/.config/varlock` (XDG default)
+ *
+ * @see https://specifications.freedesktop.org/basedir/latest/
+ */
+export function getUserVarlockDir(): string {
+  const home = os.homedir();
+
+  // If XDG_CONFIG_HOME is explicitly set, always respect it
+  if (process.env.XDG_CONFIG_HOME) {
+    return join(process.env.XDG_CONFIG_HOME, 'varlock');
+  }
+
+  // Backwards compatibility: if legacy ~/.varlock exists, keep using it
+  const legacyDir = join(home, '.varlock');
+  if (existsSync(legacyDir)) {
+    return legacyDir;
+  }
+
+  // Default to XDG standard location: ~/.config/varlock
+  return join(home, '.config', 'varlock');
+}


### PR DESCRIPTION
Closes #348

Adds support for the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/) for the user-level varlock config directory.

### Resolution order
1. If `$XDG_CONFIG_HOME` is set → `$XDG_CONFIG_HOME/varlock`
2. If legacy `~/.varlock` exists → `~/.varlock` (backwards compatibility)
3. Otherwise → `~/.config/varlock` (XDG default)

### Changes
- **New**: `packages/varlock/src/lib/user-config-dir.ts` — shared utility for resolving the user config dir
- **Updated**: `telemetry.ts`, `telemetry.command.ts`, `plugins.ts` — use the new utility instead of hardcoded `~/.varlock`
- **Updated**: `install.sh` — mirrors the same XDG resolution logic in shell
- **Updated**: docs and error messages to reference the new paths
- **Updated**: `login.command.ts` — updated TODO comments