### PR TITLE
fix: dynamic @required incorrectly resolved after type generation runs

### DIFF
--- a/.changeset/fix-dynamic-required-type-gen-cache.md
+++ b/.changeset/fix-dynamic-required-type-gen-cache.md
@@ -1,0 +1,9 @@
+---
+"varlock": patch
+---
+
+Fix dynamic `@required` being incorrectly resolved after type generation runs.
+
+When `generateTypesIfNeeded()` ran before `resolveEnvValues()` (as it does in the CLI), `getTypeGenInfo()` would call `resolve()` on dynamic decorators like `@required=eq($OTHER, foo)` before their dependencies were resolved. This cached a stale result on the decorator, causing `processRequired()` to return the wrong value when env values were later resolved.
+
+The fix skips calling `resolve()` for dynamic decorators in `getTypeGenInfo()` — their runtime value is irrelevant for type generation anyway (dynamic required items are always typed as optional).

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -597,6 +597,10 @@ export class ConfigItem {
           const usingOptional = requiredDec.name === 'optional';
           if (requiredDec.decValueResolver?.fnName !== '\0static') {
             isRequiredDynamic = true;
+            // Dynamic decorators depend on runtime values not yet resolved here.
+            // Skip resolve() to avoid caching a stale result that would corrupt
+            // the later processRequired() call during resolveEnvValues().
+            break;
           }
 
           const requiredDecoratorVal = await requiredDec.resolve();
@@ -646,6 +650,8 @@ export class ConfigItem {
 
         if (sensitiveDec) {
           const usingPublic = sensitiveDec.name === 'public';
+          // Skip dynamic decorators to avoid caching a stale result (same as @required fix above)
+          if (sensitiveDec.decValueResolver?.fnName !== '\0static') break;
           const sensitiveDecValue = await sensitiveDec.resolve();
           if (sensitiveDec.schemaErrors.length) break;
           if (![true, false, undefined].includes(sensitiveDecValue)) break;

--- a/packages/varlock/src/env-graph/test/helpers/generic-test.ts
+++ b/packages/varlock/src/env-graph/test/helpers/generic-test.ts
@@ -25,6 +25,12 @@ export function envFilesTest(spec: {
   expectRequiredIsDynamic?: Record<string, boolean>;
   expectSensitive?: Record<string, boolean | Constructor<Error>>;
   expectSerializedMatches?: any;
+  /**
+   * Simulate calling getTypeGenInfo() on all items before resolveEnvValues(),
+   * which mirrors what the CLI does (generateTypesIfNeeded before resolveEnvValues).
+   * This is used to reproduce bugs where early type-gen resolution corrupts cached state.
+   */
+  runTypeGeneration?: boolean;
 }) {
   return async () => {
     // mock process.cwd to be the current test file
@@ -82,6 +88,13 @@ export function envFilesTest(spec: {
         firstLoadingError,
         `Expected no loading errors, but got - ${firstLoadingError?.message}`,
       ).toBeFalsy();
+
+      // Simulate calling getTypeGenInfo() before resolveEnvValues(), as the CLI does
+      if (spec.runTypeGeneration) {
+        for (const key of Object.keys(g.configSchema)) {
+          await g.configSchema[key].getTypeGenInfo();
+        }
+      }
 
       await g.resolveEnvValues();
 

--- a/packages/varlock/src/env-graph/test/required-decorators.test.ts
+++ b/packages/varlock/src/env-graph/test/required-decorators.test.ts
@@ -241,6 +241,20 @@ describe('required decorators', () => {
         REQ_IF_F: false,
       },
     }));
+    test('dynamic @required works (with type gen running first)', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @generateTypes(lang=ts, path=env.d.ts)
+          # ---
+          OTHER=foo
+          REQ_IF_FOO= # @required=eq($OTHER, foo)
+        `,
+      },
+      runTypeGeneration: true,
+      expectRequired: {
+        REQ_IF_FOO: true,
+      },
+    }));
     test('ensure @required isDynamic is correct (affects type generation)', envFilesTest({
       files: {
         '.env.schema': outdent`


### PR DESCRIPTION
## Summary

- `generateTypesIfNeeded()` runs before `resolveEnvValues()` in the CLI, which caused `getTypeGenInfo()` to call `resolve()` on dynamic decorators (e.g. `@required=eq($OTHER, foo)`) before their dependencies were resolved
- This cached a stale result on the decorator, so when `processRequired()` / `processSensitive()` later called `resolve()` during `resolveEnvValues()`, they got the wrong cached value
- Fix: skip calling `resolve()` for any non-static `@required`, `@optional`, `@sensitive`, or `@public` decorator in `getTypeGenInfo()` — their runtime values are irrelevant for type generation anyway (dynamic required → typed as optional; dynamic sensitive is not a supported pattern)
- Root decorators (`@defaultRequired`, `@defaultSensitive`) and string decorators (`@icon`, `@docs`) are always static so they're unaffected

## Test plan

- [x] Added `runTypeGeneration?: boolean` option to `envFilesTest` helper — when set, calls `getTypeGenInfo()` on all items between `finishLoad()` and `resolveEnvValues()`, mirroring the real CLI flow
- [x] Updated existing test (`dynamic @required works (with type gen running first)`) to use `runTypeGeneration: true` — fails before the fix, passes after
- [x] All 16 tests in `required-decorators.test.ts` pass
- [x] All 25 tests in `type-generation.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)