### PR TITLE
fix: check bun version at call time instead of module-level constant

### DIFF
--- a/packages/varlock/src/lib/check-bun-version.ts
+++ b/packages/varlock/src/lib/check-bun-version.ts
@@ -1,5 +1,4 @@
 import semver from 'semver';
-import { isBun } from './detect-runtime';
 
 /**
  * Minimum Bun version required for varlock to work correctly.
@@ -14,16 +13,15 @@ export const MIN_BUN_VERSION = '1.3.3';
  * Throws an error if running on an unsupported Bun version.
  */
 export function checkBunVersion() {
-  if (!isBun) return;
-
   const bunVersion = process.versions.bun;
+  if (!bunVersion) return;
 
   if (!semver.gte(bunVersion, MIN_BUN_VERSION)) {
     throw new Error(
       `Varlock requires Bun >= ${MIN_BUN_VERSION}, but you are using Bun ${bunVersion}.\n`
-      + `Please upgrade Bun by running: \`bun upgrade\`\n`
+      + 'Please upgrade Bun by running: `bun upgrade`\n'
       + `Bun ${MIN_BUN_VERSION} introduced the \`--no-env-file\` flag which is required to prevent `
-      + `conflicts with varlock's own .env loading.`,
+      + 'conflicts with varlock\'s own .env loading.',
     );
   }
 }


### PR DESCRIPTION
## Summary
- Replaced module-level `isBun` constant with a direct `process.versions.bun` check at call time, fixing tests that mock the bun version
- Fixed lint errors (template literals without interpolation → single quotes)

## Test plan
- [x] `bun run lint` passes
- [x] `bun run --filter varlock test` — all 248 tests pass (including 6 bun version check tests that were previously failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)