### PR TITLE
feat: Convex integration — sync env vars to Convex deployments

### DIFF
--- a/.changeset/convex-integration-initial.md
+++ b/.changeset/convex-integration-initial.md
@@ -1,0 +1,5 @@
+---
+"@varlock/convex-integration": minor
+---
+
+Initial release of the Convex integration for varlock. Sync environment variables from your `.env.schema` to a Convex deployment using the `@syncTarget(convex)` decorator.

--- a/.changeset/convex-sync-targets.md
+++ b/.changeset/convex-sync-targets.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+Add `syncTargets` field to `SerializedEnvGraph` config items, populated from `@syncTarget()` function-call decorators. Also guard against missing global `Buffer` in runtimes like Convex's serverless environment.

--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,23 @@
         "varlock": "workspace:^",
       },
     },
+    "packages/integrations/convex": {
+      "name": "@varlock/convex-integration",
+      "version": "0.0.1",
+      "bin": {
+        "varlock-convex-sync": "./dist/cli.js",
+      },
+      "devDependencies": {
+        "@types/node": "catalog:",
+        "tsup": "catalog:",
+        "varlock": "workspace:^",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "convex": ">=1.0",
+        "varlock": "workspace:^",
+      },
+    },
     "packages/integrations/nextjs": {
       "name": "@varlock/nextjs-integration",
       "version": "0.2.3",
@@ -1183,6 +1200,8 @@
 
     "@varlock/ci-env-info": ["@varlock/ci-env-info@workspace:packages/ci-env-info"],
 
+    "@varlock/convex-integration": ["@varlock/convex-integration@workspace:packages/integrations/convex"],
+
     "@varlock/google-secret-manager-plugin": ["@varlock/google-secret-manager-plugin@workspace:packages/plugins/google-secret-manager"],
 
     "@varlock/infisical-plugin": ["@varlock/infisical-plugin@workspace:packages/plugins/infisical"],
@@ -1476,6 +1495,8 @@
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "convex": ["convex@1.33.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-mRhR1XqZPLhgJsUepecM/kOgQVRCWKJtHHtyEX/XYY4zmzfItG0D1GNh5fjNEkuO5+72X4PCkzbEFA6327rxog=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -2485,7 +2506,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
@@ -3249,7 +3270,11 @@
 
     "@changesets/apply-release-plan/outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
 
+    "@changesets/apply-release-plan/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+
     "@changesets/cli/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
+
+    "@changesets/write/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
@@ -3355,6 +3380,8 @@
 
     "cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
+    "convex/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
     "dir-glob/path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
@@ -3392,8 +3419,6 @@
     "is-ci/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
-
-    "json-schema-to-typescript/prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "jsonc-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
@@ -3738,6 +3763,58 @@
     "astro/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "convex/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "convex/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "convex/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "convex/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "convex/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "convex/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "convex/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "convex/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "convex/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "convex/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "convex/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "convex/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "convex/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "convex/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "convex/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "convex/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "convex/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "convex/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "convex/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "convex/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "convex/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "convex/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "convex/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "convex/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "convex/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "convex/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 

--- a/packages/integrations/convex/package.json
+++ b/packages/integrations/convex/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@varlock/convex-integration",
+  "description": "Varlock integration for syncing environment variables to Convex deployments",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dmno-dev/varlock.git",
+    "directory": "packages/integrations/convex"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./plugin": "./dist/plugin.js"
+  },
+  "bin": {
+    "varlock-convex-sync": "./dist/cli.js"
+  },
+  "files": ["dist"],
+  "scripts": {
+    "dev": "tsup --watch",
+    "build": "tsup",
+    "test": "vitest"
+  },
+  "keywords": [
+    "varlock",
+    "convex",
+    "env",
+    ".env",
+    "environment variables",
+    "env vars",
+    "config",
+    "sync",
+    "deploy",
+    "varlock-integration"
+  ],
+  "author": "dmno-dev",
+  "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
+  "peerDependencies": {
+    "varlock": "workspace:^",
+    "convex": ">=1.0"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsup": "catalog:",
+    "varlock": "workspace:^",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/integrations/convex/src/cli.ts
+++ b/packages/integrations/convex/src/cli.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+/**
+ * CLI for syncing varlock-resolved environment variables to a Convex deployment.
+ *
+ * Usage:
+ *   varlock-convex-sync [options]
+ *
+ * Options:
+ *   --deploy-key <key>   Convex deploy key (or set CONVEX_DEPLOY_KEY env var)
+ *   --env <name>         Environment name (e.g., production, staging)
+ *   --path <path>        Path to .env.schema or project directory
+ *   --prod               Use --prod flag for Convex CLI
+ *   --no-blob            Skip pushing the __VARLOCK_ENV blob
+ *   --no-individual      Skip pushing individual env vars
+ *   --dry-run            Preview changes without pushing
+ *   --help               Show this help message
+ */
+
+import { syncToConvex } from './index.js';
+
+function printHelp() {
+  console.log(`
+varlock-convex-sync - Sync varlock-resolved env vars to a Convex deployment
+
+Usage:
+  varlock-convex-sync [options]
+
+Options:
+  --deploy-key <key>   Convex deploy key (or set CONVEX_DEPLOY_KEY env var)
+  --env <name>         Environment name (e.g., production, staging)
+  --path <path>        Path to .env.schema or project directory
+  --prod               Use --prod flag for Convex CLI
+  --no-blob            Skip pushing the __VARLOCK_ENV blob
+  --no-individual      Skip pushing individual env vars
+  --dry-run            Preview changes without pushing
+  --help               Show this help message
+
+Environment Variables:
+  CONVEX_DEPLOY_KEY    Convex deploy key (alternative to --deploy-key)
+
+Examples:
+  # Sync to dev deployment
+  varlock-convex-sync --deploy-key $CONVEX_DEPLOY_KEY
+
+  # Sync to production
+  varlock-convex-sync --deploy-key $CONVEX_DEPLOY_KEY --env production --prod
+
+  # Preview what would be synced
+  varlock-convex-sync --dry-run
+
+  # In CI/deploy pipeline
+  npx convex deploy --cmd "varlock-convex-sync"
+`.trim());
+}
+
+function parseArgs(argv: Array<string>) {
+  const args: Record<string, string | boolean> = {};
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+    } else if (arg === '--dry-run') {
+      args.dryRun = true;
+    } else if (arg === '--prod') {
+      args.prod = true;
+    } else if (arg === '--no-blob') {
+      args.noBlob = true;
+    } else if (arg === '--no-individual') {
+      args.noIndividual = true;
+    } else if (arg === '--deploy-key' && i + 1 < argv.length) {
+      args.deployKey = argv[++i];
+    } else if (arg === '--env' && i + 1 < argv.length) {
+      args.env = argv[++i];
+    } else if (arg === '--path' && i + 1 < argv.length) {
+      args.path = argv[++i];
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      printHelp();
+      process.exit(1);
+    }
+    i++;
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  try {
+    const result = await syncToConvex({
+      deployKey: typeof args.deployKey === 'string' ? args.deployKey : undefined,
+      schemaPath: typeof args.path === 'string' ? args.path : undefined,
+      env: typeof args.env === 'string' ? args.env : undefined,
+      prod: !!args.prod,
+      pushBlob: !args.noBlob,
+      pushIndividual: !args.noIndividual,
+      dryRun: !!args.dryRun,
+    });
+
+    if (result.dryRun) {
+      process.exit(0);
+    }
+
+    if (result.variables.length === 0) {
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error('Failed to sync to Convex:', (err as Error).message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/integrations/convex/src/index.ts
+++ b/packages/integrations/convex/src/index.ts
@@ -1,0 +1,207 @@
+/**
+ * Core sync logic for pushing varlock-resolved environment variables to a Convex deployment.
+ *
+ * Uses the Convex CLI (`npx convex env set`) as the transport mechanism.
+ */
+
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { SerializedEnvGraph } from 'varlock';
+import { execSyncVarlock } from 'varlock/exec-sync-varlock';
+
+export type { SerializedEnvGraph };
+
+export type SerializedConfig = SerializedEnvGraph['config'];
+
+export type SyncOptions = {
+  /** Convex deploy key. Falls back to CONVEX_DEPLOY_KEY env var. */
+  deployKey?: string;
+
+  /** Path to .env.schema or project directory. Passed to varlock load --path. */
+  schemaPath?: string;
+
+  /** Environment name (e.g., 'production'). Passed to varlock load --env. */
+  env?: string;
+
+  /** Push the __VARLOCK_ENV blob for `import { ENV } from 'varlock/env'` support. Default: true. */
+  pushBlob?: boolean;
+
+  /** Push individual env vars for `process.env.KEY` access. Default: true. */
+  pushIndividual?: boolean;
+
+  /** Preview changes without pushing. */
+  dryRun?: boolean;
+
+  /** Use --prod flag when calling Convex CLI. */
+  prod?: boolean;
+};
+
+export type SyncResult = {
+  /** Variables that were synced (or would be synced in dry-run mode). */
+  variables: Array<{ name: string; sensitive: boolean }>;
+  /** Whether the __VARLOCK_ENV blob was included. */
+  blobPushed: boolean;
+  /** Total bytes of the __VARLOCK_ENV blob (if pushed). */
+  blobSize?: number;
+  /** Whether this was a dry run. */
+  dryRun: boolean;
+};
+
+/**
+ * Resolve env vars via varlock and filter to items tagged with @syncTarget(convex).
+ */
+export function resolveAndFilter(options: Pick<SyncOptions, 'schemaPath' | 'env'>): {
+  graph: SerializedEnvGraph;
+  convexItems: Array<{ key: string; value: any; isSensitive: boolean }>;
+} {
+  const args = ['load', '--format', 'json-full', '--compact'];
+  if (options.schemaPath) args.push('--path', options.schemaPath);
+  if (options.env) args.push('--env', options.env);
+
+  const result = execSyncVarlock(args.join(' '), {
+    showLogsOnError: true,
+  });
+
+  const graph: SerializedEnvGraph = JSON.parse(result);
+
+  // filter to items with @syncTarget(convex)
+  const convexItems: Array<{ key: string; value: any; isSensitive: boolean }> = [];
+  for (const [key, item] of Object.entries(graph.config)) {
+    if (item.syncTargets?.includes('convex')) {
+      convexItems.push({ key, value: item.value, isSensitive: item.isSensitive });
+    }
+  }
+
+  return { graph, convexItems };
+}
+
+/**
+ * Build a minimal __VARLOCK_ENV blob containing only the Convex-targeted items.
+ * Strips basePath and sources (not needed at runtime).
+ */
+export function buildConvexBlob(
+  graph: SerializedEnvGraph,
+  convexItems: Array<{ key: string; value: any; isSensitive: boolean }>,
+): string {
+  const minimalGraph: Omit<SerializedEnvGraph, 'basePath' | 'sources'> = {
+    settings: graph.settings,
+    config: {},
+  };
+  for (const item of convexItems) {
+    minimalGraph.config[item.key] = {
+      value: item.value,
+      isSensitive: item.isSensitive,
+    };
+  }
+  return JSON.stringify(minimalGraph);
+}
+
+/**
+ * Push resolved env vars to a Convex deployment using the Convex CLI.
+ */
+export async function syncToConvex(options: SyncOptions = {}): Promise<SyncResult> {
+  const pushBlob = options.pushBlob ?? true;
+  const pushIndividual = options.pushIndividual ?? true;
+  const dryRun = options.dryRun ?? false;
+  const deployKey = options.deployKey ?? process.env.CONVEX_DEPLOY_KEY;
+
+  // resolve and filter
+  const { graph, convexItems } = resolveAndFilter({
+    schemaPath: options.schemaPath,
+    env: options.env,
+  });
+
+  if (convexItems.length === 0) {
+    console.warn('No variables with @syncTarget(convex) found. Nothing to sync.');
+    return { variables: [], blobPushed: false, dryRun };
+  }
+
+  const result: SyncResult = {
+    variables: convexItems.map((i) => ({ name: i.key, sensitive: i.isSensitive })),
+    blobPushed: pushBlob,
+    dryRun,
+  };
+
+  if (dryRun) {
+    console.log('Dry run - would sync the following variables to Convex:');
+    for (const item of convexItems) {
+      const label = item.isSensitive ? ' [sensitive]' : '';
+      console.log(`  ${item.key}${label}`);
+    }
+    if (pushBlob) {
+      const blob = buildConvexBlob(graph, convexItems);
+      result.blobSize = Buffer.byteLength(blob, 'utf-8');
+      console.log(`  __VARLOCK_ENV (blob, ${result.blobSize} bytes)`);
+      if (result.blobSize > 8192) {
+        console.warn(`  WARNING: blob exceeds Convex's 8KB env var limit (${result.blobSize} bytes)`);
+        console.warn('  Consider using --no-blob and relying on individual vars only');
+      }
+    }
+    return result;
+  }
+
+  // build convex CLI env with deploy key
+  const convexEnv = { ...process.env };
+  if (deployKey) {
+    convexEnv.CONVEX_DEPLOY_KEY = deployKey;
+  }
+
+  const convexFlags = options.prod ? ' --prod' : '';
+
+  // push individual vars via a temp .env file
+  if (pushIndividual) {
+    const envFileLines: Array<string> = [];
+    for (const item of convexItems) {
+      const value = item.value === undefined ? '' : String(item.value);
+      // escape double quotes and newlines for .env format
+      const escaped = value.replace(/"/g, '\\"').replace(/\n/g, '\\n');
+      envFileLines.push(`${item.key}="${escaped}"`);
+    }
+
+    const tmpFile = path.join(os.tmpdir(), `varlock-convex-sync-${Date.now()}.env`);
+    try {
+      fs.writeFileSync(tmpFile, envFileLines.join('\n'), { encoding: 'utf-8', mode: 0o600 });
+      execSync(`npx convex env set --from-file "${tmpFile}" --force${convexFlags}`, {
+        env: convexEnv,
+        stdio: 'inherit',
+      });
+    } finally {
+      // clean up temp file
+      try {
+        fs.unlinkSync(tmpFile);
+      } catch { /* ignore */ }
+    }
+  }
+
+  // push __VARLOCK_ENV blob
+  if (pushBlob) {
+    const blob = buildConvexBlob(graph, convexItems);
+    result.blobSize = Buffer.byteLength(blob, 'utf-8');
+
+    if (result.blobSize > 8192) {
+      console.warn(`WARNING: __VARLOCK_ENV blob is ${result.blobSize} bytes, exceeding Convex's 8KB limit.`);
+      console.warn('Skipping blob push. Use --no-blob or reduce the number of synced variables.');
+      result.blobPushed = false;
+    } else {
+      // write blob to temp file and use --from-file to avoid shell escaping issues
+      const tmpFile = path.join(os.tmpdir(), `varlock-convex-blob-${Date.now()}.env`);
+      try {
+        fs.writeFileSync(tmpFile, `__VARLOCK_ENV=${blob}`, { encoding: 'utf-8', mode: 0o600 });
+        execSync(`npx convex env set --from-file "${tmpFile}" --force${convexFlags}`, {
+          env: convexEnv,
+          stdio: 'inherit',
+        });
+      } finally {
+        try {
+          fs.unlinkSync(tmpFile);
+        } catch { /* ignore */ }
+      }
+    }
+  }
+
+  console.log(`Synced ${convexItems.length} variables to Convex${pushBlob && result.blobPushed ? ' (+ __VARLOCK_ENV blob)' : ''}`);
+  return result;
+}

--- a/packages/integrations/convex/src/plugin.ts
+++ b/packages/integrations/convex/src/plugin.ts
@@ -1,0 +1,51 @@
+/**
+ * Varlock plugin for Convex integration.
+ *
+ * Registers the @syncTarget(convex) item decorator, which marks environment variables
+ * for syncing to a Convex deployment.
+ *
+ * Usage in .env.schema:
+ *   # @plugin(@varlock/convex-integration)
+ *   DATABASE_URL=string @syncTarget(convex) @sensitive
+ *   API_KEY=op("op://vault/item/key") @syncTarget(convex) @sensitive
+ */
+
+// side-effect import: declares the global `plugin` variable
+import 'varlock/plugin-lib';
+
+const CONVEX_ICON = 'simple-icons:convex';
+
+plugin.name = 'convex';
+plugin.icon = CONVEX_ICON;
+
+const { debug } = plugin;
+debug('init - version =', plugin.version);
+
+// Register the @syncTarget(targetName) item decorator
+// This is a function-style decorator: @syncTarget(convex), @syncTarget(vercel), etc.
+// Multiple can be used on the same item: @syncTarget(convex) @syncTarget(vercel)
+plugin.registerItemDecorator({
+  name: 'syncTarget',
+  isFunction: true,
+  useFnArgsResolver: true,
+  // No process() needed -- the resolved value of the decorator (e.g., "convex")
+  // is automatically available via decorator.resolvedValue after resolution.
+  // The serialization in getSerializedGraph() reads it from getDecFns('syncTarget').
+});
+
+// Register a convex deploy key data type for validation
+plugin.registerDataType({
+  name: 'convexDeployKey',
+  typeDescription: 'A Convex deploy key',
+  icon: CONVEX_ICON,
+  sensitive: true,
+  validate(value: string) {
+    if (typeof value !== 'string') return new Error('expected a string');
+    // Deploy keys have format: prod:name|token, preview:team:project|token, dev:name|token
+    if (!/^(prod|preview|dev):[\w:-]+\|.+$/.test(value)) {
+      return new Error('invalid Convex deploy key format (expected prod:name|token, preview:team:project|token, or dev:name|token)');
+    }
+    return true;
+  },
+  docs: [{ url: 'https://docs.convex.dev/cli/deploy-key-types', description: 'Convex deploy key types' }],
+});

--- a/packages/integrations/convex/test/sync.test.ts
+++ b/packages/integrations/convex/test/sync.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for the Convex integration sync logic.
+ *
+ * These test the filtering and blob building logic with mocked varlock output.
+ * They don't require a real Convex deployment.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { buildConvexBlob, type SerializedEnvGraph } from '../src/index.js';
+
+// -- helpers --
+
+function makeGraph(
+  config: SerializedEnvGraph['config'],
+  settings?: SerializedEnvGraph['settings'],
+): SerializedEnvGraph {
+  return {
+    basePath: '/fake/project',
+    sources: [
+      { label: '.env.schema', enabled: true, path: '.env.schema' },
+      { label: '.env', enabled: true, path: '.env' },
+    ],
+    settings: settings ?? { redactLogs: true, preventLeaks: true },
+    config,
+  };
+}
+
+// -- tests --
+
+describe('buildConvexBlob', () => {
+  test('strips basePath and sources from the blob', () => {
+    const graph = makeGraph({
+      DATABASE_URL: { value: 'postgres://localhost', isSensitive: true, syncTargets: ['convex'] },
+    });
+    const items = [{ key: 'DATABASE_URL', value: 'postgres://localhost', isSensitive: true }];
+
+    const blob = buildConvexBlob(graph, items);
+    const parsed = JSON.parse(blob);
+
+    expect(parsed.basePath).toBeUndefined();
+    expect(parsed.sources).toBeUndefined();
+    expect(parsed.settings).toEqual({ redactLogs: true, preventLeaks: true });
+    expect(parsed.config.DATABASE_URL).toEqual({ value: 'postgres://localhost', isSensitive: true });
+  });
+
+  test('only includes convex-targeted items in the blob', () => {
+    const graph = makeGraph({
+      DATABASE_URL: { value: 'postgres://localhost', isSensitive: true, syncTargets: ['convex'] },
+      OP_TOKEN: { value: 'ops_abc123', isSensitive: true },
+      DEBUG: { value: 'false', isSensitive: false },
+    });
+    const convexItems = [{ key: 'DATABASE_URL', value: 'postgres://localhost', isSensitive: true }];
+
+    const blob = buildConvexBlob(graph, convexItems);
+    const parsed = JSON.parse(blob);
+
+    expect(Object.keys(parsed.config)).toEqual(['DATABASE_URL']);
+    expect(parsed.config.OP_TOKEN).toBeUndefined();
+    expect(parsed.config.DEBUG).toBeUndefined();
+  });
+
+  test('blob size is reasonable for typical projects', () => {
+    const config: SerializedEnvGraph['config'] = {};
+    const items: Array<{ key: string; value: any; isSensitive: boolean }> = [];
+    for (let i = 0; i < 20; i++) {
+      const key = `ENV_VAR_${i}`;
+      const value = `value-${i}-${'x'.repeat(50)}`;
+      config[key] = { value, isSensitive: i % 3 === 0, syncTargets: ['convex'] };
+      items.push({ key, value, isSensitive: i % 3 === 0 });
+    }
+    const graph = makeGraph(config);
+
+    const blob = buildConvexBlob(graph, items);
+    const size = Buffer.byteLength(blob, 'utf-8');
+
+    // 20 vars with ~60-byte values should be well under 8KB
+    expect(size).toBeLessThan(8192);
+  });
+});
+
+describe('filtering logic', () => {
+  test('regular flow: only @syncTarget(convex) items are included', () => {
+    const graph = makeGraph({
+      DATABASE_URL: { value: 'postgres://localhost:5432/mydb', isSensitive: false, syncTargets: ['convex'] },
+      PORT: { value: 3000, isSensitive: false, syncTargets: ['convex'] },
+      NODE_ENV: { value: 'production', isSensitive: false, syncTargets: ['convex'] },
+      INTERNAL_DEBUG: { value: false, isSensitive: false },
+    });
+
+    const convexItems: Array<{ key: string; value: any; isSensitive: boolean }> = [];
+    for (const [key, item] of Object.entries(graph.config)) {
+      if (item.syncTargets?.includes('convex')) {
+        convexItems.push({ key, value: item.value, isSensitive: item.isSensitive });
+      }
+    }
+
+    expect(convexItems).toHaveLength(3);
+    expect(convexItems.map((i) => i.key)).toEqual(['DATABASE_URL', 'PORT', 'NODE_ENV']);
+  });
+
+  test('secret-zero flow: plugin auth tokens are excluded', () => {
+    const graph = makeGraph({
+      OP_TOKEN: { value: 'ops_secret_token_value', isSensitive: true },
+      DATABASE_URL: { value: 'postgres://resolved-from-1password', isSensitive: true, syncTargets: ['convex'] },
+      STRIPE_KEY: { value: 'sk_live_resolved', isSensitive: true, syncTargets: ['convex'] },
+      PUBLIC_APP_URL: { value: 'https://myapp.com', isSensitive: false, syncTargets: ['convex'] },
+    });
+
+    const convexItems: Array<{ key: string; value: any; isSensitive: boolean }> = [];
+    for (const [key, item] of Object.entries(graph.config)) {
+      if (item.syncTargets?.includes('convex')) {
+        convexItems.push({ key, value: item.value, isSensitive: item.isSensitive });
+      }
+    }
+
+    // OP_TOKEN should NOT be in the list (no @syncTarget(convex))
+    expect(convexItems.map((i) => i.key)).not.toContain('OP_TOKEN');
+
+    // All @syncTarget(convex) items should be present
+    expect(convexItems).toHaveLength(3);
+    expect(convexItems.map((i) => i.key)).toEqual(['DATABASE_URL', 'STRIPE_KEY', 'PUBLIC_APP_URL']);
+
+    // Sensitive flags preserved
+    expect(convexItems.find((i) => i.key === 'DATABASE_URL')?.isSensitive).toBe(true);
+    expect(convexItems.find((i) => i.key === 'PUBLIC_APP_URL')?.isSensitive).toBe(false);
+  });
+
+  test('multi-target: items can target both convex and vercel', () => {
+    const graph = makeGraph({
+      SHARED_KEY: { value: 'shared', isSensitive: true, syncTargets: ['convex', 'vercel'] },
+      CONVEX_ONLY: { value: 'convex-val', isSensitive: false, syncTargets: ['convex'] },
+      VERCEL_ONLY: { value: 'vercel-val', isSensitive: false, syncTargets: ['vercel'] },
+    });
+
+    const convexItems: Array<{ key: string; value: any; isSensitive: boolean }> = [];
+    for (const [key, item] of Object.entries(graph.config)) {
+      if (item.syncTargets?.includes('convex')) {
+        convexItems.push({ key, value: item.value, isSensitive: item.isSensitive });
+      }
+    }
+
+    expect(convexItems).toHaveLength(2);
+    expect(convexItems.map((i) => i.key)).toEqual(['SHARED_KEY', 'CONVEX_ONLY']);
+  });
+
+  test('blob preserves isSensitive flags for redaction', () => {
+    const graph = makeGraph({
+      SECRET: { value: 'secret-value', isSensitive: true, syncTargets: ['convex'] },
+      PUBLIC: { value: 'public-value', isSensitive: false, syncTargets: ['convex'] },
+    });
+    const items = [
+      { key: 'SECRET', value: 'secret-value', isSensitive: true },
+      { key: 'PUBLIC', value: 'public-value', isSensitive: false },
+    ];
+
+    const blob = buildConvexBlob(graph, items);
+    const parsed = JSON.parse(blob);
+
+    expect(parsed.config.SECRET.isSensitive).toBe(true);
+    expect(parsed.config.PUBLIC.isSensitive).toBe(false);
+  });
+});
+
+describe('edge cases', () => {
+  test('empty syncTargets - no items synced', () => {
+    const graph = makeGraph({
+      VAR_A: { value: 'a', isSensitive: false },
+      VAR_B: { value: 'b', isSensitive: false },
+    });
+
+    const convexItems: Array<{ key: string; value: any; isSensitive: boolean }> = [];
+    for (const [key, item] of Object.entries(graph.config)) {
+      if (item.syncTargets?.includes('convex')) {
+        convexItems.push({ key, value: item.value, isSensitive: item.isSensitive });
+      }
+    }
+
+    expect(convexItems).toHaveLength(0);
+  });
+
+  test('undefined values are handled', () => {
+    const graph = makeGraph({
+      OPTIONAL_VAR: { value: undefined, isSensitive: false, syncTargets: ['convex'] },
+    });
+    const items = [{ key: 'OPTIONAL_VAR', value: undefined, isSensitive: false }];
+
+    const blob = buildConvexBlob(graph, items);
+    const parsed = JSON.parse(blob);
+
+    // undefined properties are omitted by JSON.stringify
+    expect(parsed.config.OPTIONAL_VAR.value).toBeUndefined();
+  });
+
+  test('blob exceeding 8KB triggers warning', () => {
+    const config: SerializedEnvGraph['config'] = {};
+    const items: Array<{ key: string; value: any; isSensitive: boolean }> = [];
+    // Create items with very long values to exceed 8KB
+    for (let i = 0; i < 30; i++) {
+      const key = `LONG_VALUE_VAR_${i}`;
+      const value = 'x'.repeat(300); // 300 bytes each * 30 = 9KB+
+      config[key] = { value, isSensitive: false, syncTargets: ['convex'] };
+      items.push({ key, value, isSensitive: false });
+    }
+    const graph = makeGraph(config);
+
+    const blob = buildConvexBlob(graph, items);
+    const size = Buffer.byteLength(blob, 'utf-8');
+
+    expect(size).toBeGreaterThan(8192);
+  });
+});

--- a/packages/integrations/convex/tsconfig.json
+++ b/packages/integrations/convex/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": false,
+    "customConditions": ["ts-src"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/integrations/convex/tsup.config.ts
+++ b/packages/integrations/convex/tsup.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: [
+    'src/index.ts',
+    'src/plugin.ts',
+    'src/cli.ts',
+  ],
+
+  dts: true,
+
+  sourcemap: true,
+  treeshake: true,
+
+  clean: true,
+  outDir: 'dist',
+
+  format: ['esm'],
+  splitting: false,
+  target: 'esnext',
+  external: ['varlock'],
+});

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -34,6 +34,7 @@ export type SerializedEnvGraph = {
   config: Record<string, {
     value: any;
     isSensitive: boolean;
+    syncTargets?: Array<string>;
   }>;
 };
 
@@ -427,10 +428,21 @@ export class EnvGraph {
     }
     for (const itemKey of this.sortedConfigKeys) {
       const item = this.configSchema[itemKey];
-      serializedGraph.config[itemKey] = {
+      const serializedItem: SerializedEnvGraph['config'][string] = {
         value: item.resolvedValue,
         isSensitive: item.isSensitive,
       };
+
+      // collect sync targets from @syncTarget decorators (e.g., @syncTarget(convex))
+      // resolvedValue for function-call decorators is { arr: [...], obj: {} }
+      const syncTargetDecs = item.getDecFns('syncTarget');
+      if (syncTargetDecs.length > 0) {
+        serializedItem.syncTargets = syncTargetDecs
+          .map((d) => d.resolvedValue?.arr?.[0])
+          .filter((v): v is string => typeof v === 'string');
+      }
+
+      serializedGraph.config[itemKey] = serializedItem;
     }
 
     // expose a few root level settings

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -158,7 +158,7 @@ export function scanForLeaks(
   if (isString(toScan)) {
     scanStrForLeaks(toScan as string);
     return toScan;
-  } else if (toScan instanceof Buffer) {
+  } else if (typeof Buffer !== 'undefined' && toScan instanceof Buffer) {
     scanStrForLeaks(toScan.toString());
     return toScan;
   // scan a ReadableStream by piping it through a scanner

--- a/smoke-tests/smoke-test-convex/.env.schema
+++ b/smoke-tests/smoke-test-convex/.env.schema
@@ -1,0 +1,21 @@
+# @defaultSensitive=false
+# @plugin(@varlock/convex-integration)
+# ---
+
+# Variables tagged for Convex sync
+# @syncTarget(convex)
+DATABASE_URL=postgres://localhost:5432/testdb
+
+# @syncTarget(convex)
+PORT=3000
+
+# @syncTarget(convex)
+NODE_ENV=production
+
+# Not synced to Convex (no @syncTarget)
+INTERNAL_DEBUG=false
+
+# Sensitive var synced to Convex
+# @sensitive
+# @syncTarget(convex)
+API_KEY=test-api-key-12345

--- a/smoke-tests/smoke-test-convex/package.json
+++ b/smoke-tests/smoke-test-convex/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "smoke-test-convex",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@varlock/convex-integration": "link:../../packages/integrations/convex",
+    "varlock": "link:../../packages/varlock"
+  }
+}

--- a/smoke-tests/tests/convex.test.ts
+++ b/smoke-tests/tests/convex.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect } from 'vitest';
+import { varlockLoad } from '../helpers/run-varlock.js';
+
+describe('Convex Integration', () => {
+  const CWD = 'smoke-test-convex';
+
+  test('varlock load succeeds with convex plugin', () => {
+    const result = varlockLoad({ cwd: CWD });
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('varlock load --format json-full includes syncTargets', () => {
+    const result = varlockLoad({ cwd: CWD, format: 'json-full' });
+    expect(result.exitCode).toBe(0);
+
+    const graph = JSON.parse(result.stdout);
+
+    // Items with @syncTarget(convex) should have syncTargets populated
+    expect(graph.config.DATABASE_URL.syncTargets).toEqual(['convex']);
+    expect(graph.config.PORT.syncTargets).toEqual(['convex']);
+    expect(graph.config.NODE_ENV.syncTargets).toEqual(['convex']);
+    expect(graph.config.API_KEY.syncTargets).toEqual(['convex']);
+
+    // Item without @syncTarget should NOT have syncTargets
+    expect(graph.config.INTERNAL_DEBUG.syncTargets).toBeUndefined();
+  });
+
+  test('sensitive flags are preserved in serialized output', () => {
+    const result = varlockLoad({ cwd: CWD, format: 'json-full' });
+    expect(result.exitCode).toBe(0);
+
+    const graph = JSON.parse(result.stdout);
+
+    expect(graph.config.API_KEY.isSensitive).toBe(true);
+    expect(graph.config.DATABASE_URL.isSensitive).toBe(false);
+    expect(graph.config.PORT.isSensitive).toBe(false);
+  });
+
+  test('resolved values are correct', () => {
+    const result = varlockLoad({ cwd: CWD, format: 'json' });
+    expect(result.exitCode).toBe(0);
+
+    const envObj = JSON.parse(result.stdout);
+
+    expect(envObj.DATABASE_URL).toBe('postgres://localhost:5432/testdb');
+    expect(envObj.PORT).toBe(3000);
+    // NODE_ENV may be overridden by the test runner (vitest sets NODE_ENV=test)
+    expect(envObj.NODE_ENV).toBeDefined();
+    expect(envObj.INTERNAL_DEBUG).toBe(false);
+    expect(envObj.API_KEY).toBe('test-api-key-12345');
+  });
+
+  test('filtering: only convex-targeted items are selected', () => {
+    const result = varlockLoad({ cwd: CWD, format: 'json-full' });
+    expect(result.exitCode).toBe(0);
+
+    const graph = JSON.parse(result.stdout);
+
+    // Count items with convex sync target
+    const convexItems = Object.entries(graph.config)
+      .filter(([, item]: [string, any]) => item.syncTargets?.includes('convex'));
+
+    // Should be 4: DATABASE_URL, PORT, NODE_ENV, API_KEY
+    // INTERNAL_DEBUG should NOT be included
+    expect(convexItems).toHaveLength(4);
+
+    const convexKeys = convexItems.map(([key]: [string, any]) => key);
+    expect(convexKeys).toContain('DATABASE_URL');
+    expect(convexKeys).toContain('PORT');
+    expect(convexKeys).toContain('NODE_ENV');
+    expect(convexKeys).toContain('API_KEY');
+    expect(convexKeys).not.toContain('INTERNAL_DEBUG');
+  });
+
+  test('blob building: stripped graph fits under 8KB', () => {
+    const result = varlockLoad({ cwd: CWD, format: 'json-full' });
+    expect(result.exitCode).toBe(0);
+
+    const graph = JSON.parse(result.stdout);
+
+    // Build a minimal blob (strip basePath and sources)
+    const minimalGraph = {
+      settings: graph.settings,
+      config: {} as Record<string, any>,
+    };
+    for (const [key, item] of Object.entries(graph.config) as Array<[string, any]>) {
+      if (item.syncTargets?.includes('convex')) {
+        minimalGraph.config[key] = {
+          value: item.value,
+          isSensitive: item.isSensitive,
+        };
+      }
+    }
+
+    const blob = JSON.stringify(minimalGraph);
+    const blobSize = Buffer.byteLength(blob, 'utf-8');
+
+    // This small fixture should be well under 8KB
+    expect(blobSize).toBeLessThan(8192);
+    // And should contain only convex-targeted items
+    expect(Object.keys(minimalGraph.config)).toHaveLength(4);
+  });
+
+  test('secret-zero flow simulation: auth vars excluded from sync', () => {
+    // This test simulates the secret-zero pattern where OP_TOKEN is used
+    // for 1Password auth but should NOT be synced to Convex.
+    // Since we can't use real 1Password in smoke tests, we verify the
+    // filtering logic works by checking that items WITHOUT @syncTarget(convex)
+    // are excluded from the sync set.
+    const result = varlockLoad({ cwd: CWD, format: 'json-full' });
+    expect(result.exitCode).toBe(0);
+
+    const graph = JSON.parse(result.stdout);
+
+    // INTERNAL_DEBUG simulates an auth-only var (no @syncTarget)
+    const allKeys = Object.keys(graph.config).filter((k) => !k.startsWith('VARLOCK_'));
+    const convexKeys = allKeys.filter((k) => graph.config[k].syncTargets?.includes('convex'));
+    const excludedKeys = allKeys.filter((k) => !graph.config[k].syncTargets?.includes('convex'));
+
+    expect(convexKeys).not.toHaveLength(0);
+    expect(excludedKeys).not.toHaveLength(0);
+    expect(excludedKeys).toContain('INTERNAL_DEBUG');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `@varlock/convex-integration`, a new integration package that syncs varlock-resolved environment variables to Convex deployments.

## What this enables

Users can tag specific env vars in their `.env.schema` with `@syncTarget(convex)` to selectively push them to a Convex backend — keeping auth-only secrets (like 1Password tokens) out of the sync.

### User experience

**1. Install and configure** — add the plugin to your `.env.schema`:

```bash
# @plugin(@varlock/convex-integration)
# ---

# These get synced to Convex
# @syncTarget(convex)
DATABASE_URL=postgres://localhost:5432/mydb

# @sensitive
# @syncTarget(convex)
API_KEY=op("op://vault/item/key")

# This stays local (no @syncTarget)
OP_TOKEN=ops_my_1password_token
```

**2. Preview what will be synced:**

```bash
varlock-convex-sync --dry-run
# Dry run - would sync the following variables to Convex:
#   DATABASE_URL
#   API_KEY [sensitive]
#   __VARLOCK_ENV (blob, 299 bytes)
```

**3. Push to Convex:**

```bash
CONVEX_DEPLOY_KEY=prod:my-project|token varlock-convex-sync
# ✔ Successfully set 2 environment variables (on deployment my-project)
# ✔ Successfully set __VARLOCK_ENV blob
# Synced 2 variables to Convex (+ __VARLOCK_ENV blob)
```

**4. In CI/deploy pipelines:**

```bash
npx convex deploy --cmd "varlock-convex-sync"
```

### What gets pushed

- **Individual env vars** via `npx convex env set --from-file` (for `process.env.KEY` access)
- **`__VARLOCK_ENV` blob** containing a minimal graph (for `import { ENV } from 'varlock/env'` support in Convex functions)
- Items without `@syncTarget(convex)` are excluded from both

### CLI options

| Flag | Description |
|------|-------------|
| `--deploy-key <key>` | Convex deploy key (or use `CONVEX_DEPLOY_KEY` env var) |
| `--env <name>` | Environment name (e.g., `production`) |
| `--path <path>` | Path to `.env.schema` or project directory |
| `--prod` | Pass `--prod` flag to Convex CLI |
| `--no-blob` | Skip pushing the `__VARLOCK_ENV` blob |
| `--no-individual` | Skip pushing individual env vars |
| `--dry-run` | Preview changes without pushing |

## Changes

### New package: `@varlock/convex-integration`
- **Plugin** (`src/plugin.ts`) — registers `@syncTarget` item decorator and `convexDeployKey` data type
- **Sync logic** (`src/index.ts`) — resolves env graph, filters by `@syncTarget(convex)`, builds minimal blob, pushes via Convex CLI
- **CLI** (`src/cli.ts`) — `varlock-convex-sync` binary with dry-run, `--prod`, `--no-blob` support
- **Unit tests** (10 tests) — blob building, filtering, edge cases
- **Smoke tests** (7 tests) — end-to-end serialization, `syncTargets` population, sensitivity flags

### Core changes (`varlock`)
- **`env-graph.ts`** — add `syncTargets?: Array<string>` to `SerializedEnvGraph` config items, populated from `@syncTarget()` function-call decorators during serialization
- **`runtime/env.ts`** — guard `Buffer` access with `typeof Buffer !== 'undefined'` for serverless runtimes (Convex) that lack a global `Buffer`

## Test results

- 10/10 unit tests passing (`packages/integrations/convex/test/sync.test.ts`)
- 7/7 smoke tests passing (`smoke-tests/tests/convex.test.ts`)
- Tested live sync against a real Convex dev deployment