### PR TITLE
fix: defer plugin auth errors and prefix resolution errors

### DIFF
--- a/.changeset/fix-plugin-deferred-auth-errors.md
+++ b/.changeset/fix-plugin-deferred-auth-errors.md
@@ -1,0 +1,7 @@
+---
+"@varlock/bitwarden-plugin": patch
+"@varlock/infisical-plugin": patch
+"varlock": patch
+---
+
+fix: defer plugin auth errors until resolver is actually used, and prefix resolution errors with resolver function name for clearer error messages

--- a/packages/plugins/bitwarden/src/plugin.ts
+++ b/packages/plugins/bitwarden/src/plugin.ts
@@ -56,11 +56,11 @@ class BitwardenPluginInstance {
   ) {}
 
   setAuth(
-    accessToken: string,
+    accessToken: any,
     apiUrl?: string,
     identityUrl?: string,
   ) {
-    this.accessToken = accessToken;
+    if (accessToken && typeof accessToken === 'string') this.accessToken = accessToken;
     if (apiUrl) {
       this.apiUrl = apiUrl;
     }
@@ -338,11 +338,9 @@ plugin.registerRootDecorator({
     identityUrl,
     accessTokenResolver,
   }) {
+    // even if the token is empty, we can't throw errors yet
+    // in case the instance is never actually used
     const accessTokenValue = await accessTokenResolver?.resolve();
-
-    if (!accessTokenValue || typeof accessTokenValue !== 'string') {
-      throw new SchemaError('accessToken must resolve to a string');
-    }
 
     pluginInstances[id].setAuth(
       accessTokenValue,

--- a/packages/plugins/infisical/src/plugin.ts
+++ b/packages/plugins/infisical/src/plugin.ts
@@ -29,17 +29,17 @@ class InfisicalPluginInstance {
   ) {}
 
   setAuth(
-    projectId: string,
-    environment: string,
-    clientId: string,
-    clientSecret: string,
+    projectId: any,
+    environment: any,
+    clientId: any,
+    clientSecret: any,
     siteUrl?: string,
     secretPath?: string,
   ) {
-    this.projectId = projectId;
-    this.environment = environment;
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
+    if (projectId && typeof projectId === 'string') this.projectId = projectId;
+    if (environment && typeof environment === 'string') this.environment = environment;
+    if (clientId && typeof clientId === 'string') this.clientId = clientId;
+    if (clientSecret && typeof clientSecret === 'string') this.clientSecret = clientSecret;
     this.siteUrl = siteUrl;
     this.secretPath = secretPath;
     debug('infisical instance', this.id, 'set auth - projectId:', projectId, 'environment:', environment);
@@ -283,23 +283,12 @@ plugin.registerRootDecorator({
     clientIdResolver,
     clientSecretResolver,
   }) {
+    // even if these are empty, we can't throw errors yet
+    // in case the instance is never actually used
     const projectId = await projectIdResolver?.resolve();
     const environment = await environmentResolver?.resolve();
     const clientId = await clientIdResolver?.resolve();
     const clientSecret = await clientSecretResolver?.resolve();
-
-    if (!projectId || typeof projectId !== 'string') {
-      throw new SchemaError('projectId must resolve to a string');
-    }
-    if (!environment || typeof environment !== 'string') {
-      throw new SchemaError('environment must resolve to a string');
-    }
-    if (!clientId || typeof clientId !== 'string') {
-      throw new SchemaError('clientId must resolve to a string');
-    }
-    if (!clientSecret || typeof clientSecret !== 'string') {
-      throw new SchemaError('clientSecret must resolve to a string');
-    }
 
     pluginInstances[id].setAuth(
       projectId,

--- a/packages/varlock/src/env-graph/lib/resolver.ts
+++ b/packages/varlock/src/env-graph/lib/resolver.ts
@@ -171,12 +171,20 @@ export class Resolver {
       const resolvedValue = await this.def.resolve.call(this, this.meta);
       return resolvedValue;
     } catch (err) {
-      // enrich errors with location info from the parsed node if available
-      if (err instanceof VarlockError && !err.more?.location && this._parsedNode && this.dataSource) {
-        const location = getErrorLocation(this.dataSource, this._parsedNode);
-        if (location) {
-          (err as any).more ??= {};
-          (err as any).more.location = location;
+      if (err instanceof VarlockError) {
+        // prefix error message with resolver function name (matching schema error behavior)
+        // only prefix if the error wasn't already prefixed by a child resolver
+        if (!this.def.name.startsWith('\0') && !(err as any)._resolverPrefixed) {
+          err.message = `${this.def.name}(): ${err.message}`;
+          (err as any)._resolverPrefixed = true;
+        }
+        // enrich errors with location info from the parsed node if available
+        if (!err.more?.location && this._parsedNode && this.dataSource) {
+          const location = getErrorLocation(this.dataSource, this._parsedNode);
+          if (location) {
+            (err as any).more ??= {};
+            (err as any).more.location = location;
+          }
         }
       }
       throw err;


### PR DESCRIPTION
## Summary
- **Bitwarden & Infisical plugins**: Defer auth credential validation from the `execute` phase to when a resolver actually uses the plugin instance. This allows plugins to be configured with empty/missing credentials without causing errors, as long as no resolver function actually needs them.
- **Resolver error prefixing**: Resolution errors thrown during `resolve()` are now automatically prefixed with the resolver function name (e.g., `bitwarden(): Access token not configured`), matching the existing behavior for schema errors. A `_resolverPrefixed` flag prevents double-prefixing in nested resolver chains.

## Test plan
- [ ] Configure a Bitwarden or Infisical plugin with an empty access token and verify no error is thrown at startup
- [ ] Use a resolver from that plugin and verify the error message now includes the resolver function name
- [ ] Verify nested resolvers (e.g., `fallback(bitwarden(...), ...)`) don't double-prefix errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)