### PR TITLE
fix: warning errors no longer block plugin loading

### DIFF
--- a/.changeset/fix-warning-errors-blocking.md
+++ b/.changeset/fix-warning-errors-blocking.md
@@ -1,0 +1,7 @@
+---
+"varlock": patch
+---
+
+fix: warning-level schema errors no longer block plugin loading or item resolution
+
+Warning errors (e.g., deprecated syntax warnings) were incorrectly treated as hard errors in several places, causing early bail-outs that prevented plugins from loading and items from resolving. Fixed `isValid`, `finishLoad`, and decorator `resolve` checks to filter out warnings.

--- a/packages/varlock/src/env-graph/lib/data-source.ts
+++ b/packages/varlock/src/env-graph/lib/data-source.ts
@@ -478,7 +478,7 @@ export abstract class EnvGraphDataSource {
   }
 
   get isValid() {
-    return !this.loadingError && !this.schemaErrors.length && !this.resolutionErrors.length;
+    return !this.loadingError && !this.schemaErrors.some((e) => !e.isWarning) && !this.resolutionErrors.length;
   }
 
   configItemDefs: Record<string, ConfigItemDef> = {};

--- a/packages/varlock/src/env-graph/lib/decorators.ts
+++ b/packages/varlock/src/env-graph/lib/decorators.ts
@@ -126,8 +126,8 @@ export abstract class DecoratorInstance {
 
     await this.process();
     if (!this.decValueResolver) {
-      // process() already recorded schema errors, don't throw again
-      if (this._schemaErrors.length > 0) return;
+      // process() already recorded schema errors, don't throw again (warnings don't block)
+      if (this._schemaErrors.some((e) => !e.isWarning)) return;
       throw new Error('expected decorator to have a value resolver');
     }
     try {
@@ -468,4 +468,14 @@ export const builtInItemDecorators: Array<ItemDecoratorDef<any>> = [
   {
     name: 'icon',
   },
+
+  // test-only decorators — dropped in release builds
+  ...__VARLOCK_BUILD_TYPE__ === 'test' ? [
+    {
+      name: 'warn',
+      process() {
+        throw new SchemaError('test warning', { isWarning: true });
+      },
+    },
+  ] as Array<ItemDecoratorDef<any>> : [],
 ];

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -252,7 +252,7 @@ export class EnvGraph {
     for (const itemKey in this.configSchema) {
       const item = this.configSchema[itemKey];
       await item.process();
-      if (item.errors.length) processingError = true;
+      if (item.errors.some((e) => !e.isWarning)) processingError = true;
     }
 
     if (processingError) return;

--- a/packages/varlock/src/env-graph/test/plugins.test.ts
+++ b/packages/varlock/src/env-graph/test/plugins.test.ts
@@ -73,4 +73,25 @@ describe('plugins ', () => {
     `,
     earlyError: true,
   }));
+
+  test('warning on item does not block plugin resolver on same item', envFilesTest({
+    envFile: outdent`
+      # @plugin(./plugins/test-plugin/)
+      # ---
+      # @warn
+      PLUGIN_RESOLVER_TEST=test(foo)
+    `,
+    expectValues: { PLUGIN_RESOLVER_TEST: 'foo' },
+  }));
+
+  test('warning on one item does not block other items', envFilesTest({
+    envFile: outdent`
+      # @plugin(./plugins/test-plugin/)
+      # ---
+      # @warn
+      WARNED_ITEM=some_value
+      OTHER_ITEM=test(bar)
+    `,
+    expectValues: { WARNED_ITEM: 'some_value', OTHER_ITEM: 'bar' },
+  }));
 });

--- a/packages/varlock/src/globals.d.ts
+++ b/packages/varlock/src/globals.d.ts
@@ -4,4 +4,4 @@
 declare const __VARLOCK_SEA_BUILD__: boolean;
 
 // detect if this is a published release or not (currently used to disable telemetry)
-declare const __VARLOCK_BUILD_TYPE__: 'dev' | 'preview' | 'release';
+declare const __VARLOCK_BUILD_TYPE__: 'dev' | 'preview' | 'release' | 'test';

--- a/packages/varlock/vitest.config.ts
+++ b/packages/varlock/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  define: {
+    __VARLOCK_BUILD_TYPE__: JSON.stringify('test'),
+    __VARLOCK_SEA_BUILD__: 'false',
+  },
+});


### PR DESCRIPTION
## Summary
- Warning-level `SchemaError`s were incorrectly treated as hard errors in 3 places, causing early bail-outs that prevented plugins from loading and items from resolving
- Fixed `data-source.isValid`, `env-graph.finishLoad` item error check, and `decorator.resolve` bail check to filter out warnings
- Added `vitest.config.ts` with `__VARLOCK_BUILD_TYPE__` define, enabling test-only built-in decorators (like `@warn`) that are stripped from release builds

## Test plan
- [x] Added test: warning on item does not block plugin resolver on same item
- [x] Added test: warning on one item does not block other items
- [x] All 290 existing tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)