### PR TITLE
chore: dogfood varlock-action v1.0.1 in CI docs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,18 @@ jobs:
           node-version: "22.x"
       - name: Install js deps (w/ bun)
         run: bun install
+      - name: Dogfood varlock-action
+        id: varlock
+        uses: dmno-dev/varlock-action@v1.0.1
+        with:
+          working-directory: smoke-tests/smoke-test-basic
+          show-summary: 'false'
+          fail-on-error: 'true'
+          output-format: 'json'
+      - name: Verify varlock-action output
+        run: |
+          test -n "${{ steps.varlock.outputs.json-env }}"
+          echo "Varlock action output is present"
       - name: Enable turborepo build cache
         uses: rharkor/caching-for-turbo@v2.3.11
 

--- a/packages/varlock-github-action/README.md
+++ b/packages/varlock-github-action/README.md
@@ -1,6 +1,6 @@
 # Varlock GitHub Action
 
-Use `dmno-dev/varlock-action@v1` in your workflows to load and validate environment variables with varlock.
+Use `dmno-dev/varlock-action@v1.0.1` in your workflows to load and validate environment variables with varlock.
 
 See [Varlock GitHub Action docs](https://varlock.dev/integrations/github-action/) for full documentation.
 

--- a/packages/varlock-website/src/content/docs/integrations/github-action.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/github-action.mdx
@@ -75,7 +75,7 @@ If you do not have a `.env.schema` file, the action will only load `.env`, since
            uses: actions/checkout@v4
 
          - name: Load environment variables
-           uses: dmno-dev/varlock-action@v1
+           uses: dmno-dev/varlock-action@v1.0.1
    ```
 
 </Steps>
@@ -120,7 +120,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Load environment variables
-        uses: dmno-dev/varlock-action@v1
+        uses: dmno-dev/varlock-action@v1.0.1
 
       - name: Use environment variables
         run: |
@@ -152,7 +152,7 @@ jobs:
 
       - name: Load environment variables as JSON
         id: varlock
-        uses: dmno-dev/varlock-action@v1
+        uses: dmno-dev/varlock-action@v1.0.1
         with:
           show-summary: false
           output-format: 'json'
@@ -226,7 +226,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Load environment variables
-        uses: dmno-dev/varlock-action@v1
+        uses: dmno-dev/varlock-action@v1.0.1
         env:
           # Set environment-specific values
           APP_ENV: ${{ github.ref_name == 'main' && 'production' || github.ref_name == 'staging' && 'staging' || 'development' }}
@@ -266,7 +266,7 @@ jobs:
 
       - name: Load environment variables
         id: varlock
-        uses: dmno-dev/varlock-action@v1
+        uses: dmno-dev/varlock-action@v1.0.1
         with:
           fail-on-error: false  # Don't fail on validation errors
 


### PR DESCRIPTION
Point CI and integration docs to varlock-action v1.0.1 so the monorepo validates and documents the same released action version.

Merge https://github.com/dmno-dev/varlock-action/pull/13 first !! 