### PR TITLE
matej/vscode-header-context-parsing

### DIFF
--- a/.changeset/calm-ravens-smile.md
+++ b/.changeset/calm-ravens-smile.md
@@ -1,0 +1,4 @@
+---
+---
+
+No publishable package changes. This PR only fixes VS Code extension header-context completion behavior.

--- a/packages/vscode-plugin/src/completion-core.ts
+++ b/packages/vscode-plugin/src/completion-core.ts
@@ -5,8 +5,8 @@ type LineDocument = {
   lineAt(line: number): { text: string };
 };
 
-const HEADER_SEPARATOR_PATTERN = /^\s*#\s*---+\s*$/;
-const ENV_ASSIGNMENT_PATTERN = /^\s*[A-Za-z_][A-Za-z0-9_]*\s*=/;
+const CONFIG_ITEM_PATTERN = /^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_.-]*\s*=/;
+const DIVIDER_PATTERN = /^\s*#\s*(?:---+|===+)(?:\s|$)/;
 const DECORATOR_PATTERN = /@([A-Za-z][\w-]*)/g;
 const INCOMPATIBLE_DECORATORS = new Map<string, Set<string>>([
   ['required', new Set(['optional'])],
@@ -61,47 +61,24 @@ function splitArgs(input: string) {
   return parts;
 }
 
-function getFirstConfigItemLine(document: LineDocument) {
-  for (let line = 0; line < document.lineCount; line += 1) {
-    if (ENV_ASSIGNMENT_PATTERN.test(document.lineAt(line).text)) return line;
+export function isInHeader(document: LineDocument, lineNumber: number) {
+  for (let line = lineNumber + 1; line < document.lineCount; line += 1) {
+    const text = document.lineAt(line).text.trim();
+    if (!text) break;
+    if (DIVIDER_PATTERN.test(text)) break;
+    if (CONFIG_ITEM_PATTERN.test(text)) return false;
+    if (!text.startsWith('#')) break;
   }
 
-  return -1;
-}
-
-function getAttachedCommentBlockRange(document: LineDocument, firstConfigItemLine: number) {
-  if (firstConfigItemLine <= 0) return undefined;
-
-  const lastCommentLine = firstConfigItemLine - 1;
-  const lastCommentText = document.lineAt(lastCommentLine).text.trim();
-  if (!lastCommentText.startsWith('#') || HEADER_SEPARATOR_PATTERN.test(lastCommentText)) {
-    return undefined;
+  for (let line = 0; line < lineNumber; line += 1) {
+    if (CONFIG_ITEM_PATTERN.test(document.lineAt(line).text)) return false;
   }
 
-  let start = lastCommentLine;
-  while (start > 0) {
-    const previousText = document.lineAt(start - 1).text.trim();
-    if (!previousText.startsWith('#') || HEADER_SEPARATOR_PATTERN.test(previousText)) break;
-    start -= 1;
-  }
-
-  return { start, end: lastCommentLine };
+  return true;
 }
 
 export function getCommentScope(document: LineDocument, lineNumber: number) {
-  const firstConfigItemLine = getFirstConfigItemLine(document);
-  if (firstConfigItemLine === -1 || lineNumber >= firstConfigItemLine) return 'item';
-
-  const attachedCommentBlock = getAttachedCommentBlockRange(document, firstConfigItemLine);
-  if (attachedCommentBlock && lineNumber >= attachedCommentBlock.start && lineNumber <= attachedCommentBlock.end) {
-    return 'item';
-  }
-
-  return 'header';
-}
-
-export function isInHeader(document: LineDocument, lineNumber: number) {
-  return getCommentScope(document, lineNumber) === 'header';
+  return isInHeader(document, lineNumber) ? 'header' : 'item';
 }
 
 export function getExistingDecoratorNames(
@@ -111,11 +88,24 @@ export function getExistingDecoratorNames(
 ) {
   const names = new Set<string>();
 
-  for (let line = lineNumber - 1; line >= 0; line -= 1) {
-    const text = document.lineAt(line).text.trim();
-    if (!text.startsWith('#')) break;
-    for (const match of text.matchAll(DECORATOR_PATTERN)) {
-      names.add(match[1]);
+  if (isInHeader(document, lineNumber)) {
+    for (let line = 0; line < lineNumber; line += 1) {
+      const text = document.lineAt(line).text.trim();
+      if (CONFIG_ITEM_PATTERN.test(text)) break;
+      if (!text.startsWith('#')) continue;
+
+      for (const match of text.matchAll(DECORATOR_PATTERN)) {
+        names.add(match[1]);
+      }
+    }
+  } else {
+    for (let line = lineNumber - 1; line >= 0; line -= 1) {
+      const text = document.lineAt(line).text.trim();
+      if (!text.startsWith('#')) break;
+
+      for (const match of text.matchAll(DECORATOR_PATTERN)) {
+        names.add(match[1]);
+      }
     }
   }
 

--- a/packages/vscode-plugin/test/completion-core.test.ts
+++ b/packages/vscode-plugin/test/completion-core.test.ts
@@ -2,30 +2,76 @@ import { describe, expect, it } from 'vitest';
 
 import {
   filterAvailableDecorators,
-  getCommentScope,
   getEnumValuesFromPrecedingComments,
   getExistingDecoratorNames,
   getTypeOptionDataType,
   isInHeader,
 } from '../src/completion-core';
 import { createLineDocument } from '../src/document-lines';
-import { DATA_TYPES, ITEM_DECORATORS } from '../src/intellisense-catalog';
+import { DATA_TYPES, ITEM_DECORATORS, ROOT_DECORATORS } from '../src/intellisense-catalog';
 
 describe('completion-core', () => {
-  it('detects root header vs item sections', () => {
+  it('treats divider-separated comments directly above the first item as item scope', () => {
     const document = createLineDocument([
-      '# header',
-      '',
+      '# @defaultRequired=false',
+      '# ---',
+      '# @currentEnv=$APP_ENV',
+      'APP_ENV=staging',
+      '# @required',
+      'ITEM=',
+    ]);
+
+    expect(isInHeader(document, 0)).toBe(true);
+    expect(isInHeader(document, 2)).toBe(false);
+    expect(isInHeader(document, 4)).toBe(false);
+  });
+
+  it('treats free-floating comment blocks before the first item as header', () => {
+    const document = createLineDocument([
       '# @defaultRequired=false',
       '',
+      '# @currentEnv=$APP_ENV',
+      '',
       '# @required',
-      'APP_ENV=',
     ]);
 
     expect(isInHeader(document, 0)).toBe(true);
     expect(isInHeader(document, 2)).toBe(true);
-    expect(isInHeader(document, 4)).toBe(false);
-    expect(getCommentScope(document, 4)).toBe('item');
+    expect(isInHeader(document, 4)).toBe(true);
+  });
+
+  it('treats the comment block directly above the first item as item scope', () => {
+    const document = createLineDocument([
+      '# @defaultRequired=false',
+      '# @generateTypes(lang=ts, path=./env.d.ts)',
+      '',
+      '# @required',
+      'MY_VAR=',
+    ]);
+
+    expect(isInHeader(document, 3)).toBe(false);
+    expect(getExistingDecoratorNames(document, 3, ' @required @')).toEqual(new Set(['required']));
+    expect(
+      filterAvailableDecorators(ITEM_DECORATORS, getExistingDecoratorNames(document, 3, ' @required @')).map(
+        (decorator) => decorator.name,
+      ),
+    ).not.toContain('required');
+  });
+
+  it('keeps divider-separated free-floating blocks before the first item in header scope', () => {
+    const document = createLineDocument([
+      '# @defaultRequired=false',
+      '# @generateTypes(lang=ts, path=./env.d.ts)',
+      '# ---',
+      '# @',
+    ]);
+
+    expect(isInHeader(document, 3)).toBe(true);
+    expect(
+      filterAvailableDecorators(ROOT_DECORATORS, getExistingDecoratorNames(document, 3, ' @')).map(
+        (decorator) => decorator.name,
+      ),
+    ).not.toContain('defaultRequired');
   });
 
   it('collects decorators already used in the current block', () => {
@@ -37,6 +83,49 @@ describe('completion-core', () => {
     expect(
       getExistingDecoratorNames(document, 1, ' @required @type=enum(prod, dev) @'),
     ).toEqual(new Set(['docs', 'required', 'type']));
+  });
+
+  it('keeps root duplicate filtering across divider-less header blocks', () => {
+    const document = createLineDocument([
+      '# @defaultRequired=false',
+      '',
+      '# @currentEnv=$APP_ENV',
+      '',
+      '# @',
+    ]);
+
+    const existingDecoratorNames = getExistingDecoratorNames(document, 4, ' @');
+
+    expect(existingDecoratorNames).toEqual(new Set(['defaultRequired', 'currentEnv']));
+    expect(
+      filterAvailableDecorators(ROOT_DECORATORS, existingDecoratorNames).map((decorator) => decorator.name),
+    ).not.toContain('defaultRequired');
+  });
+
+  it('ends header scope after exported config items', () => {
+    const document = createLineDocument([
+      '# @defaultRequired=false',
+      'export APP_ENV=staging',
+      '# @',
+    ]);
+
+    expect(isInHeader(document, 2)).toBe(false);
+  });
+
+  it('ends header scope after dotted and hyphenated config item keys', () => {
+    const dottedDocument = createLineDocument([
+      '# @defaultRequired=false',
+      'APP.ENV=staging',
+      '# @',
+    ]);
+    const hyphenDocument = createLineDocument([
+      '# @defaultRequired=false',
+      'APP-ENV=staging',
+      '# @',
+    ]);
+
+    expect(isInHeader(dottedDocument, 2)).toBe(false);
+    expect(isInHeader(hyphenDocument, 2)).toBe(false);
   });
 
   it('filters duplicate and incompatible decorators but keeps repeatable ones', () => {

--- a/packages/vscode-plugin/test/diagnostics-provider.test.ts
+++ b/packages/vscode-plugin/test/diagnostics-provider.test.ts
@@ -34,7 +34,7 @@ vi.mock('vscode', () => ({
 let validateDocument: typeof import('../src/diagnostics-provider').validateDocument;
 
 beforeAll(async () => {
-  ({ validateDocument } = await import('../src/diagnostics-provider'));
+  ({ validateDocument } = await import('../src/diagnostics-provider.js'));
 });
 
 function createTestDocument(lines: Array<string>) {
@@ -44,7 +44,7 @@ function createTestDocument(lines: Array<string>) {
     lineAt(line: number) {
       return { text: lines[line] };
     },
-  };
+  } as Parameters<typeof validateDocument>[0];
 }
 
 describe('diagnostics-provider', () => {


### PR DESCRIPTION
## Summary
- align VS Code header detection with current `@env-spec` semantics by treating all comment blocks before the first config item as header scope
- stop relying on `# ---` when deciding whether decorator completion should use root or item decorators
- add focused completion-core tests for divider-separated and divider-less header blocks, including duplicate filtering across header scope

## Test plan
- [x] `bun test packages/vscode-plugin/test/completion-core.test.ts`
- [x] `bun run --filter env-spec-language test:ci`
- [x] `bun run lint:fix`

Note: `bun run lint:fix` completed, but it still reports unrelated pre-existing warnings in `packages/varlock/src/lib/load-graph.ts`.

Examples:
1. Header block before the first item stays root-scoped

![01](https://github.com/user-attachments/assets/895a2ced-34e5-4927-b94f-425f6f7a4214)

2. First attached block becomes item scope

![02](https://github.com/user-attachments/assets/9e0f2525-8ec0-4cd1-b509-3c2c8960fe48)

3. Later item blocks still behave normally

<img width="812" height="791" alt="03" src="https://github.com/user-attachments/assets/b2d00c3f-142e-440f-b6fd-15f1d4e7cafc" />

4. Parser-valid item syntax ends header scope too

<img width="812" height="791" alt="04" src="https://github.com/user-attachments/assets/6ccbf30e-83a1-4033-9c29-f206b0de88aa" />
