### PR TITLE
feat: add reset=true arg to @generateTypes

### DIFF
--- a/.changeset/generate-types-reset-flag.md
+++ b/.changeset/generate-types-reset-flag.md
@@ -1,0 +1,7 @@
+---
+"varlock": minor
+---
+
+Add `reset=true` argument to `@generateTypes` decorator.
+
+When set, the generated `env.d.ts` adds a `[key: string]: unknown` index signature to both `ProcessEnv` and `ImportMetaEnv`, making TypeScript flag accesses to undeclared env variables as `unknown` rather than implicitly allowing them.

--- a/.changeset/generate-types-reset-flag.md
+++ b/.changeset/generate-types-reset-flag.md
@@ -2,6 +2,6 @@
 "varlock": minor
 ---
 
-Add `reset=true` argument to `@generateTypes` decorator.
+Add `strict=true` argument to `@generateTypes` decorator.
 
 When set, the generated `env.d.ts` adds a `[key: string]: unknown` index signature to both `ProcessEnv` and `ImportMetaEnv`, making TypeScript flag accesses to undeclared env variables as `unknown` rather than implicitly allowing them.

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -449,8 +449,8 @@ export class EnvGraph {
     return _.some(_.values(this.configSchema), (i) => !i.isValid);
   }
 
-  async generateTypes(lang: string, outputPath: string, reset?: boolean) {
-    await generateTypes(this, lang, outputPath, reset);
+  async generateTypes(lang: string, outputPath: string, strict?: boolean) {
+    await generateTypes(this, lang, outputPath, strict);
   }
 
   /**
@@ -485,7 +485,7 @@ export class EnvGraph {
         ? path.resolve(generateTypesDec.dataSource.fullPath, '..', typeGenSettings.obj.path)
         : typeGenSettings.obj.path;
 
-      await this.generateTypes(typeGenSettings.obj.lang, outputPath, typeGenSettings.obj.reset === true);
+      await this.generateTypes(typeGenSettings.obj.lang, outputPath, typeGenSettings.obj.strict === true);
       generatedCount++;
     }
     return generatedCount;

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -449,8 +449,8 @@ export class EnvGraph {
     return _.some(_.values(this.configSchema), (i) => !i.isValid);
   }
 
-  async generateTypes(lang: string, outputPath: string) {
-    await generateTypes(this, lang, outputPath);
+  async generateTypes(lang: string, outputPath: string, reset?: boolean) {
+    await generateTypes(this, lang, outputPath, reset);
   }
 
   /**
@@ -485,7 +485,7 @@ export class EnvGraph {
         ? path.resolve(generateTypesDec.dataSource.fullPath, '..', typeGenSettings.obj.path)
         : typeGenSettings.obj.path;
 
-      await this.generateTypes(typeGenSettings.obj.lang, outputPath);
+      await this.generateTypes(typeGenSettings.obj.lang, outputPath, typeGenSettings.obj.reset === true);
       generatedCount++;
     }
     return generatedCount;

--- a/packages/varlock/src/env-graph/lib/type-generation.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation.ts
@@ -157,7 +157,7 @@ export async function getTsDefinitionForItem(info: TypeGenItemInfo, indentLevel 
   return _.map(itemSrc, (line) => `${i}${line}`);
 }
 
-export async function generateTsTypesSrc(items: Array<TypeGenItemInfo>, reset?: boolean) {
+export async function generateTsTypesSrc(items: Array<TypeGenItemInfo>, strict?: boolean) {
   // TODO: first check if schema is valid - we dont care if values are invalid
 
   const tsSrc = [
@@ -207,7 +207,7 @@ export type EnvSchemaAsStrings = {
   const importMetaEnvTypes = true;
   const processEnvTypes = true;
 
-  const IMPORT_META_AUGMENTATION = reset
+  const IMPORT_META_AUGMENTATION = strict
     ? `
   // add types for global import.meta.env
   interface ImportMetaEnv extends EnvSchemaAsStrings {
@@ -222,7 +222,7 @@ export type EnvSchemaAsStrings = {
   interface ImportMeta {
     readonly env: ImportMetaEnv;
   }`;
-  const PROCESS_ENV_AUGMENTATION = reset
+  const PROCESS_ENV_AUGMENTATION = strict
     ? `
   // add types for global process.env
   namespace NodeJS {
@@ -247,7 +247,7 @@ export type EnvSchemaAsStrings = {
   return tsSrc.join('\n');
 }
 
-export async function generateTypes(graph: EnvGraph, lang: string, typesPath: string, reset?: boolean) {
+export async function generateTypes(graph: EnvGraph, lang: string, typesPath: string, strict?: boolean) {
   if (lang !== 'ts') throw new Error(`Unsupported @generateTypes lang: ${lang}`);
 
   // Compute type gen info from non-env-specific definitions only
@@ -259,6 +259,6 @@ export async function generateTypes(graph: EnvGraph, lang: string, typesPath: st
     items.push(await configItem.getTypeGenInfo());
   }
 
-  const tsSrc = await generateTsTypesSrc(items, reset);
+  const tsSrc = await generateTsTypesSrc(items, strict);
   await fs.promises.writeFile(typesPath, tsSrc, 'utf-8');
 }

--- a/packages/varlock/src/env-graph/lib/type-generation.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation.ts
@@ -157,7 +157,7 @@ export async function getTsDefinitionForItem(info: TypeGenItemInfo, indentLevel 
   return _.map(itemSrc, (line) => `${i}${line}`);
 }
 
-export async function generateTsTypesSrc(items: Array<TypeGenItemInfo>) {
+export async function generateTsTypesSrc(items: Array<TypeGenItemInfo>, reset?: boolean) {
   // TODO: first check if schema is valid - we dont care if values are invalid
 
   const tsSrc = [
@@ -207,13 +207,30 @@ export type EnvSchemaAsStrings = {
   const importMetaEnvTypes = true;
   const processEnvTypes = true;
 
-  const IMPORT_META_AUGMENTATION = `
+  const IMPORT_META_AUGMENTATION = reset
+    ? `
+  // add types for global import.meta.env
+  interface ImportMetaEnv extends EnvSchemaAsStrings {
+    [key: string]: unknown
+  }
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }`
+    : `
   // add types for global import.meta.env
   interface ImportMetaEnv extends EnvSchemaAsStrings {}
   interface ImportMeta {
     readonly env: ImportMetaEnv;
   }`;
-  const PROCESS_ENV_AUGMENTATION = `
+  const PROCESS_ENV_AUGMENTATION = reset
+    ? `
+  // add types for global process.env
+  namespace NodeJS {
+    interface ProcessEnv extends EnvSchemaAsStrings {
+      [key: string]: unknown
+    }
+  }`
+    : `
   // add types for global process.env
   namespace NodeJS {
     interface ProcessEnv extends EnvSchemaAsStrings {}
@@ -230,7 +247,7 @@ export type EnvSchemaAsStrings = {
   return tsSrc.join('\n');
 }
 
-export async function generateTypes(graph: EnvGraph, lang: string, typesPath: string) {
+export async function generateTypes(graph: EnvGraph, lang: string, typesPath: string, reset?: boolean) {
   if (lang !== 'ts') throw new Error(`Unsupported @generateTypes lang: ${lang}`);
 
   // Compute type gen info from non-env-specific definitions only
@@ -242,6 +259,6 @@ export async function generateTypes(graph: EnvGraph, lang: string, typesPath: st
     items.push(await configItem.getTypeGenInfo());
   }
 
-  const tsSrc = await generateTsTypesSrc(items);
+  const tsSrc = await generateTsTypesSrc(items, reset);
   await fs.promises.writeFile(typesPath, tsSrc, 'utf-8');
 }

--- a/packages/varlock/src/env-graph/test/type-generation.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation.test.ts
@@ -598,7 +598,7 @@ describe('type generation', () => {
       expect(src).toContain("Pick<CoercedEnvSchema, 'DB_HOST' | 'DB_PORT' | 'DEBUG' | 'APP_ENV'>");
     });
 
-    test('reset=false (default) does not add index signature to ProcessEnv or ImportMetaEnv', async () => {
+    test('strict=false (default) does not add index signature to ProcessEnv or ImportMetaEnv', async () => {
       const g = await loadGraph({
         envFile: outdent`
           ITEM1=val
@@ -612,7 +612,7 @@ describe('type generation', () => {
       expect(src).not.toContain('[key: string]: unknown');
     });
 
-    test('reset=true adds [key: string]: unknown index signature to ProcessEnv and ImportMetaEnv', async () => {
+    test('strict=true adds [key: string]: unknown index signature to ProcessEnv and ImportMetaEnv', async () => {
       const g = await loadGraph({
         envFile: outdent`
           ITEM1=val

--- a/packages/varlock/src/env-graph/test/type-generation.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation.test.ts
@@ -598,6 +598,36 @@ describe('type generation', () => {
       expect(src).toContain("Pick<CoercedEnvSchema, 'DB_HOST' | 'DB_PORT' | 'DEBUG' | 'APP_ENV'>");
     });
 
+    test('reset=false (default) does not add index signature to ProcessEnv or ImportMetaEnv', async () => {
+      const g = await loadGraph({
+        envFile: outdent`
+          ITEM1=val
+        `,
+      });
+      const items: Array<TypeGenItemInfo> = [];
+      for (const key of g.sortedConfigKeys) {
+        items.push(await g.configSchema[key].getTypeGenInfo());
+      }
+      const src = await generateTsTypesSrc(items);
+      expect(src).not.toContain('[key: string]: unknown');
+    });
+
+    test('reset=true adds [key: string]: unknown index signature to ProcessEnv and ImportMetaEnv', async () => {
+      const g = await loadGraph({
+        envFile: outdent`
+          ITEM1=val
+        `,
+      });
+      const items: Array<TypeGenItemInfo> = [];
+      for (const key of g.sortedConfigKeys) {
+        items.push(await g.configSchema[key].getTypeGenInfo());
+      }
+      const src = await generateTsTypesSrc(items, true);
+      // should appear twice: once in ProcessEnv, once in ImportMetaEnv
+      const matches = src.match(/\[key: string\]: unknown/g);
+      expect(matches).toHaveLength(2);
+    });
+
     test('type gen output is the same regardless of current environment', async () => {
       const schemaFile = outdent`
         # @currentEnv=$APP_ENV @defaultRequired=false @defaultSensitive=false


### PR DESCRIPTION
## Summary
- Adds a `strict=true` argument to the `@generateTypes` decorator
- When set, the generated `env.d.ts` adds a `[key: string]: unknown` index signature to both `ProcessEnv` and `ImportMetaEnv`, making TypeScript flag accesses to undeclared env variables as `unknown` rather than implicitly allowing them
- Usage: `@generateTypes(lang=ts, path=env.d.ts, strict=true)`