### PR TITLE
fix: improve framework test detection for release PRs

### DIFF
--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       force-all:
-        description: 'Run all framework tests regardless of changesets'
+        description: 'Run all framework tests regardless of changes'
         type: boolean
         default: false
 
@@ -27,14 +27,16 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Detect changed integrations from changesets
+      - name: Detect changed integrations
         id: detect
         run: |
+          ARGS=""
           if [[ "${{ github.event.inputs.force-all }}" == "true" ]] || [[ "${{ contains(github.event.pull_request.labels.*.name, 'framework-tests') }}" == "true" ]]; then
-            bun run scripts/detect-changed-integrations.ts --all
-          else
-            bun run scripts/detect-changed-integrations.ts
+            ARGS="--all"
+          elif [[ "${{ github.head_ref }}" == "changeset-release/main" ]]; then
+            ARGS="--release-pr"
           fi
+          bun run scripts/detect-changed-integrations.ts $ARGS
 
   build:
     name: Build Libraries

--- a/scripts/detect-changed-integrations.ts
+++ b/scripts/detect-changed-integrations.ts
@@ -1,7 +1,14 @@
 #!/usr/bin/env bun
 /**
- * Uses `changeset status` to detect which integration packages have pending changes,
- * then outputs GitHub Actions flags for which framework tests should run.
+ * Detects which integration packages have changes, then outputs GitHub Actions
+ * flags for which framework tests should run.
+ *
+ * On normal PRs: uses `changeset status` to detect pending changesets.
+ * On release PRs (changeset-release/main): uses `git diff origin/main` to find
+ * modified package.json files — same approach as release-preview.ts.
+ *
+ * When the core `varlock` package changes, all integration tests are triggered
+ * only on release PRs since core changes are frequent and framework tests are slow.
  *
  * To add a new integration, add an entry to INTEGRATION_PACKAGES below
  * and create the corresponding test directory in framework-tests/frameworks/.
@@ -12,18 +19,19 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 
-// Map integration test directory names to their package names in changesets.
-// Add new integrations here as they are created.
-// Changes to `varlock` (core) trigger all integration tests.
+// Map integration test directory names to their package names.
+// Dependencies are expressed by listing all triggering packages — e.g. cloudflare
+// tests run when vite-integration changes because cloudflare depends on it.
 const INTEGRATION_PACKAGES: Record<string, Array<string>> = {
   nextjs: ['@varlock/nextjs-integration'],
   cloudflare: ['@varlock/cloudflare-integration', '@varlock/vite-integration'],
   expo: ['@varlock/expo-integration'],
-  // astro: ['@varlock/astro-integration'],
+  // astro: ['@varlock/astro-integration', '@varlock/vite-integration'],
 };
 
 const ALL_INTEGRATIONS = Object.keys(INTEGRATION_PACKAGES);
 const forceAll = process.argv.includes('--all');
+const isReleasePR = process.argv.includes('--release-pr');
 
 function writeGithubOutputs(outputs: Record<string, string>) {
   if (!process.env.GITHUB_OUTPUT) return;
@@ -43,7 +51,7 @@ function writeResults(integrations: Array<string>) {
     integrations: JSON.stringify(integrations),
   });
   if (!process.env.GITHUB_OUTPUT) {
-    console.log('Integrations to test:', integrations);
+    console.log('Integrations to test:', integrations.length > 0 ? integrations : '(none)');
   }
 }
 
@@ -53,48 +61,94 @@ if (forceAll) {
   process.exit(0);
 }
 
-// Use changeset CLI to get the list of changed packages (same pattern as release-preview.ts)
-try {
-  execSync(`bunx changeset status --output=${STATUS_FILE}`, {
-    cwd: REPO_ROOT,
-    stdio: 'pipe',
-  });
-} catch {
-  // changeset status can fail when there are no changesets or no base branch
+// Detect changed packages using the appropriate strategy
+let changedPackages: Set<string>;
+
+if (isReleasePR) {
+  // On changeset-release/main, changesets has already bumped versions in package.json
+  // files. Detect which packages changed by diffing package.json files vs origin/main,
+  // same approach as release-preview.ts.
+  console.log('Release PR detected — finding modified package.json files vs origin/main...');
+  let gitDiff: string;
+  try {
+    execSync('git fetch origin main --depth=1', { stdio: 'pipe' });
+    gitDiff = execSync('git diff origin/main --name-only', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (e) {
+    console.error('Failed to diff against origin/main:', e);
+    writeResults(ALL_INTEGRATIONS);
+    process.exit(0);
+  }
+
+  const modifiedPackageJsons = gitDiff
+    .split('\n')
+    .filter((filePath) => filePath !== 'package.json') // skip root package.json
+    .filter((filePath) => filePath.endsWith('package.json'));
+
+  // Read each modified package.json to get the package name
+  changedPackages = new Set<string>();
+  for (const pkgJsonPath of modifiedPackageJsons) {
+    const fullPath = join(REPO_ROOT, pkgJsonPath);
+    if (!existsSync(fullPath)) continue;
+    try {
+      const pkg = JSON.parse(readFileSync(fullPath, 'utf-8'));
+      if (pkg.name) changedPackages.add(pkg.name);
+    } catch {
+      // skip unparseable package.json
+    }
+  }
+  console.log('Changed packages (from modified package.json):', [...changedPackages]);
+} else {
+  // Normal PR: use changeset CLI to get pending changesets
+  try {
+    execSync(`bunx changeset status --output=${STATUS_FILE}`, {
+      cwd: REPO_ROOT,
+      stdio: 'pipe',
+    });
+  } catch {
+    // changeset status can fail when there are no changesets or no base branch
+  }
+
+  if (!existsSync(statusFilePath)) {
+    console.log('No changesets found');
+    writeResults([]);
+    process.exit(0);
+  }
+
+  let status: any;
+  try {
+    status = JSON.parse(readFileSync(statusFilePath, 'utf-8'));
+  } finally {
+    unlinkSync(statusFilePath);
+  }
+
+  changedPackages = new Set<string>(
+    status.releases
+      ?.filter((r: { type: string }) => r.type !== 'none')
+      .map((r: { name: string }) => r.name) ?? [],
+  );
+  if (!process.env.GITHUB_OUTPUT) {
+    console.log('Changed packages (from changesets):', [...changedPackages]);
+  }
 }
 
-if (!existsSync(statusFilePath)) {
-  console.log('No changesets found');
-  writeResults([]);
-  process.exit(0);
-}
-
-let status: any;
-try {
-  status = JSON.parse(readFileSync(statusFilePath, 'utf-8'));
-} finally {
-  unlinkSync(statusFilePath);
-}
-
-// Collect all package names from changeset releases
-const changedPackages = new Set<string>(
-  status.releases
-    ?.filter((r: { type: string }) => r.type !== 'none')
-    .map((r: { name: string }) => r.name) ?? [],
-);
-
-// Changes to core varlock package trigger all integration tests
+// Changes to core varlock package trigger all integration tests,
+// but only on release PRs (core changes are frequent, framework tests are slow)
 if (changedPackages.has('varlock')) {
-  writeResults(ALL_INTEGRATIONS);
-  process.exit(0);
+  if (isReleasePR) {
+    console.log('Core varlock package changed on release PR — running all integration tests');
+    writeResults(ALL_INTEGRATIONS);
+    process.exit(0);
+  } else {
+    console.log('Core varlock package changed but not a release PR — skipping core-triggered tests');
+  }
 }
 
-// Otherwise, only test integrations whose packages changed
+// Match changed packages to integration test suites
 const integrationsList = Object.entries(INTEGRATION_PACKAGES)
   .filter(([, packages]) => packages.some((pkg) => changedPackages.has(pkg)))
   .map(([name]) => name);
 
-if (!process.env.GITHUB_OUTPUT) {
-  console.log('Changed packages:', [...changedPackages]);
-}
 writeResults(integrationsList);


### PR DESCRIPTION
## Summary
- **Normal PRs**: Continue using `changeset status` to detect which integration packages need testing
- **Release PRs** (`changeset-release/main`): Use `git diff origin/main` to find modified `package.json` files — same approach as `release-preview.ts`, since changesets has already bumped versions
- **Core varlock gating**: When `varlock` core changes, all framework tests only trigger on release PRs (too slow for every PR since core changes frequently)
- Integration dependency tracking preserved (e.g. vite changes trigger cloudflare tests)

## Test plan
- [ ] Verify normal PR with integration changesets triggers correct framework tests
- [ ] Verify release PR (`changeset-release/main`) detects changed packages via git diff
- [ ] Verify core-only changes on normal PRs don't trigger all framework tests
- [ ] Verify `--all` flag and `framework-tests` label still force all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)