### PR TITLE
Add varlock explain command and override indicators

### DIFF
--- a/.changeset/cli-explain-and-override-indicator.md
+++ b/.changeset/cli-explain-and-override-indicator.md
@@ -1,0 +1,9 @@
+---
+"varlock": minor
+---
+
+Add `varlock explain ITEM_KEY` command and override indicators in `varlock load` output.
+
+**Override indicators**: When a config item's value comes from a `process.env` override rather than its file-based definitions, `varlock load` now shows a yellow indicator on that item. This helps users understand why their resolver functions (e.g. `op()`) are not being called.
+
+**`varlock explain` command**: Shows detailed information about how a single config item is resolved, including all definitions and sources in priority order, which source is active, whether a process.env override is in effect (and what would be used without it), decorators, type info, and documentation links.

--- a/packages/varlock/src/cli/cli-executable.ts
+++ b/packages/varlock/src/cli/cli-executable.ts
@@ -18,6 +18,7 @@ import { commandSpec as printenvCommandSpec } from './commands/printenv.command'
 // import { commandSpec as doctorCommandSpec } from './commands/doctor.command';
 import { commandSpec as helpCommandSpec } from './commands/help.command';
 import { commandSpec as telemetryCommandSpec } from './commands/telemetry.command';
+import { commandSpec as explainCommandSpec } from './commands/explain.command';
 import { commandSpec as scanCommandSpec } from './commands/scan.command';
 import { commandSpec as typegenCommandSpec } from './commands/typegen.command';
 // import { commandSpec as loginCommandSpec } from './commands/login.command';
@@ -51,6 +52,7 @@ subCommands.set('run', buildLazyCommand(runCommandSpec, async () => await import
 subCommands.set('printenv', buildLazyCommand(printenvCommandSpec, async () => await import('./commands/printenv.command')));
 // subCommands.set('encrypt', buildLazyCommand(encryptCommandSpec, async () => await import('./commands/encrypt.command')));
 // subCommands.set('doctor', buildLazyCommand(doctorCommandSpec, async () => await import('./commands/doctor.command')));
+subCommands.set('explain', buildLazyCommand(explainCommandSpec, async () => await import('./commands/explain.command')));
 subCommands.set('help', buildLazyCommand(helpCommandSpec, async () => await import('./commands/help.command')));
 subCommands.set('telemetry', buildLazyCommand(telemetryCommandSpec, async () => await import('./commands/telemetry.command')));
 subCommands.set('scan', buildLazyCommand(scanCommandSpec, async () => await import('./commands/scan.command')));

--- a/packages/varlock/src/cli/commands/explain.command.ts
+++ b/packages/varlock/src/cli/commands/explain.command.ts
@@ -1,0 +1,198 @@
+import ansis from 'ansis';
+import { define } from 'gunshi';
+import { gracefulExit } from 'exit-hook';
+
+import { loadVarlockEnvGraph } from '../../lib/load-graph';
+import { formattedValue } from '../../lib/formatting';
+import { redactString } from '../../runtime/lib/redaction';
+import {
+  checkForSchemaErrors, checkForNoEnvFiles,
+} from '../helpers/error-checks';
+import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
+import { CliExitError } from '../helpers/exit-error';
+import { StaticValueResolver } from '../../env-graph/lib/resolver';
+import _ from '@env-spec/utils/my-dash';
+
+export const commandSpec = define({
+  name: 'explain',
+  description: 'Show detailed information about how a config item is resolved',
+  args: {
+    env: {
+      type: 'string',
+      description: 'Set the environment (e.g., production, development, etc)',
+    },
+    path: {
+      type: 'string',
+      short: 'p',
+      description: 'Path to a specific .env file or directory to use as the entry point',
+    },
+  },
+  examples: `
+Shows detailed information about all definitions, sources, and overrides
+that feed into a single config item. Useful for debugging why a value
+is not what you expect.
+
+Examples:
+  varlock explain DATABASE_URL          # Explain how DATABASE_URL is resolved
+  varlock explain --env production API_KEY  # Explain in production context
+`.trim(),
+});
+
+function describeResolver(resolver: any, indent = ''): string {
+  if (resolver instanceof StaticValueResolver) {
+    return `${indent}static value`;
+  }
+  const fnName = resolver.fnName;
+  if (fnName && !fnName.startsWith('\0')) {
+    return `${indent}${fnName}()`;
+  }
+  return `${indent}(resolver)`;
+}
+
+export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
+  const positionals = (ctx.positionals ?? []).slice(ctx.commandPath?.length ?? 0);
+  if (!positionals.length) {
+    throw new CliExitError('Missing required argument: variable name', {
+      suggestion: 'Run `varlock explain MY_VAR` to explain a config item',
+    });
+  }
+  const varName = positionals[0];
+
+  const envGraph = await loadVarlockEnvGraph({
+    currentEnvFallback: ctx.values.env,
+    entryFilePath: ctx.values.path,
+  });
+
+  checkForSchemaErrors(envGraph);
+  checkForNoEnvFiles(envGraph);
+
+  if (!(varName in envGraph.configSchema)) {
+    throw new CliExitError(`Variable "${varName}" not found in schema`);
+  }
+
+  await envGraph.resolveEnvValues();
+
+  const item = envGraph.configSchema[varName];
+  const isSensitive = item.isSensitive;
+
+  // Header
+  console.log('');
+  console.log(ansis.bold.cyan(`  ${item.key}`));
+  console.log('');
+
+  // Description
+  if (item.description) {
+    console.log(`  ${ansis.gray('Description:')} ${item.description}`);
+  }
+
+  // Type info
+  if (item.dataType) {
+    console.log(`  ${ansis.gray('Type:')} ${item.dataType.name}`);
+  }
+
+  // Properties
+  const props = [];
+  if (item.isRequired) props.push('required');
+  else props.push('optional');
+  if (isSensitive) props.push('sensitive');
+  else props.push('public');
+  console.log(`  ${ansis.gray('Properties:')} ${props.join(', ')}`);
+
+  // Resolved value
+  console.log('');
+  console.log(ansis.bold('  Resolved value'));
+  if (item.validationState === 'error') {
+    console.log(`  ${ansis.red('  (resolution failed)')}`);
+    for (const err of item.errors) {
+      console.log(`  ${ansis.red(`  - ${err.message}`)}`);
+    }
+  } else {
+    let valStr = formattedValue(item.resolvedValue, true);
+    if (isSensitive && item.resolvedValue && _.isString(item.resolvedValue)) {
+      valStr = redactString(item.resolvedValue)!;
+    }
+    console.log(`    ${valStr}`);
+    if (item.isCoerced) {
+      let rawStr = formattedValue(item.resolvedRawValue, true);
+      if (isSensitive && item.resolvedRawValue && _.isString(item.resolvedRawValue)) {
+        rawStr = redactString(item.resolvedRawValue)!;
+      }
+      console.log(`    ${ansis.gray.italic(`coerced from ${rawStr}`)}`);
+    }
+  }
+
+  // Value source
+  console.log('');
+  console.log(ansis.bold('  Value source'));
+
+  if (item.isOverridden) {
+    console.log(`    ${ansis.yellow('⚡ process.env override')} ${ansis.yellow.bold('(active)')}`);
+    const activeValueDef = item.activeValueDef;
+    if (activeValueDef) {
+      const sourceLabel = activeValueDef.source?.label || 'internal';
+      const resolverDesc = activeValueDef.itemDef.resolver
+        ? describeResolver(activeValueDef.itemDef.resolver)
+        : 'no value';
+      console.log(`    ${ansis.gray('└')} ${ansis.gray.italic(`would use ${resolverDesc} from ${sourceLabel} without override`)}`);
+    }
+  } else {
+    const activeValueDef = item.activeValueDef;
+    if (activeValueDef) {
+      const sourceLabel = activeValueDef.source?.label || 'internal';
+      const resolverDesc = activeValueDef.itemDef.resolver
+        ? describeResolver(activeValueDef.itemDef.resolver)
+        : 'no value';
+      console.log(`    ${resolverDesc} from ${ansis.cyan(sourceLabel)}`);
+    } else {
+      console.log(`    ${ansis.gray('(no value set)')}`);
+    }
+  }
+
+  // All definitions
+  const defs = item.defs;
+  if (defs.length) {
+    console.log('');
+    console.log(ansis.bold('  All definitions') + ansis.gray(` (${defs.length} source${defs.length > 1 ? 's' : ''}, highest priority first)`));
+
+    for (let i = 0; i < defs.length; i++) {
+      const def = defs[i];
+      const sourceLabel = def.source?.label || 'internal (builtin)';
+      const sourceType = def.source?.type || 'builtin';
+
+      const isActiveSource = !item.isOverridden && def === item.activeValueDef;
+      const marker = isActiveSource ? ansis.green(' ← active') : '';
+
+      console.log(`    ${ansis.gray(`${i + 1}.`)} ${ansis.cyan(sourceLabel)} ${ansis.gray(`(${sourceType})`)}${marker}`);
+
+      // Show resolver info
+      if (def.itemDef.resolver) {
+        console.log(`       ${ansis.gray('value:')} ${describeResolver(def.itemDef.resolver)}`);
+      } else {
+        console.log(`       ${ansis.gray('value:')} ${ansis.gray.italic('(none - decorators only)')}`);
+      }
+
+      // Show decorators from this definition
+      const decNames = def.itemDef.decorators?.map((d) => `@${d.name}`).join(', ');
+      if (decNames) {
+        console.log(`       ${ansis.gray('decorators:')} ${ansis.magenta(decNames)}`);
+      }
+    }
+  }
+
+  // Docs links
+  const docsLinks = item.docsLinks;
+  if (docsLinks.length) {
+    console.log('');
+    console.log(ansis.bold('  Documentation'));
+    for (const link of docsLinks) {
+      const label = link.description ? `${link.description}: ` : '';
+      console.log(`    ${label}${ansis.underline(link.url)}`);
+    }
+  }
+
+  console.log('');
+
+  if (item.validationState === 'error') {
+    gracefulExit(1);
+  }
+};

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -114,9 +114,35 @@ export class ConfigItem {
     return links;
   }
 
+  /** Whether the resolved value came from a process.env override rather than file definitions */
+  get isOverridden() {
+    return this.key in this.envGraph.overrideValues;
+  }
+
+  /**
+   * Returns the definition+source that would provide the value resolver
+   * (i.e. the "winning" definition), or undefined if no definition has a resolver.
+   * This is useful for explaining where a value comes from regardless of overrides.
+   */
+  get activeValueDef(): ConfigItemDefAndSource | undefined {
+    const hasInternalResolver = this._internalDefs.some((d) => d.itemDef.resolver);
+    for (const def of this.defs) {
+      if (def.itemDef.resolver) {
+        if (
+          hasInternalResolver
+          && def.itemDef.resolver instanceof StaticValueResolver
+          && !def.itemDef.resolver.staticValue
+        ) {
+          continue;
+        }
+        return def;
+      }
+    }
+  }
+
   get valueResolver() {
     // special case for process.env overrides - always return the static value
-    if (this.key in this.envGraph.overrideValues) {
+    if (this.isOverridden) {
       return new StaticValueResolver(this.envGraph.overrideValues[this.key]);
     }
 

--- a/packages/varlock/src/lib/formatting.ts
+++ b/packages/varlock/src/lib/formatting.ts
@@ -118,13 +118,9 @@ export function getItemSummary(item: ConfigItem) {
     ),
   ]));
 
-  // if (item.overrides?.length) {
-  //   const activeOverride = item.overrides[0];
-  //   let overrideNote = ansis.gray.italic('value set via override: ');
-  //   overrideNote += ansis.gray(activeOverride.sourceType);
-  //   if (activeOverride.sourceLabel) overrideNote += ansis.gray(` - ${activeOverride.sourceLabel}`);
-  //   summary.push(`      ${overrideNote}`);
-  // }
+  if (item.isOverridden) {
+    summary.push(`   🟡 ${ansis.yellow.italic('set via process.env override')}`);
+  }
 
   itemErrors?.forEach((err) => {
     summary.push(ansis[err.isWarning ? 'yellow' : 'red'](`   - ${err.isWarning ? '[WARNING] ' : ''}${err.message}`));


### PR DESCRIPTION
## Summary

- **Override indicators in varlock load**: When a config item value comes from a process.env override rather than its file-based definitions, the pretty output now shows a yellow indicator. This helps users understand why their resolver functions (e.g. op()) are not being called.
- **New varlock explain ITEM_KEY command**: Shows detailed information about how a single config item is resolved - all definitions/sources in priority order, which is active, whether a process.env override is in effect (and what would be used without it), type info, decorators, and documentation links.

## Motivation

Users were getting confused when setting a config item via op() but the function was never invoked because a process.env override was silently taking precedence.

## Test plan

- [ ] Run varlock load with a process.env override set - verify the override indicator appears
- [ ] Run varlock explain ITEM_KEY for items with/without overrides
- [ ] Run varlock explain ITEM_KEY for items with multiple definitions
- [ ] Run varlock explain NONEXISTENT - verify clear error message
- [ ] Existing tests pass (329 passed, 0 failed)

## Screenshots
override indicators
<img width="624" height="170" alt="image" src="https://github.com/user-attachments/assets/9d987582-d53a-4d44-a518-cbd097dd7622" />

explain output
<img width="649" height="271" alt="image" src="https://github.com/user-attachments/assets/a8c3757e-4e88-4168-924b-3b1d65d83f99" />

Not 100% set on either of these, but probably a good start and can improve later



Generated with [Claude Code](https://claude.com/claude-code)