### PR TITLE
pass through USER/HOME to op cli

### DIFF
--- a/.changeset/bold-trees-relate.md
+++ b/.changeset/bold-trees-relate.md
@@ -1,0 +1,5 @@
+---
+"@varlock/1password-plugin": patch
+---
+
+pass through USER and HOME to op cli calls

--- a/packages/plugins/1password/src/cli-helper.ts
+++ b/packages/plugins/1password/src/cli-helper.ts
@@ -202,11 +202,12 @@ async function executeReadBatch(batchToExecute: NonNullable<typeof opReadBatch>)
   // because otherwise we'll have trouble dealing with values that contain newlines
   await spawnAsync('op', `run --no-masking ${lockCliToOpAccount ? `--account ${lockCliToOpAccount} ` : ''}-- env -0`.split(' '), {
     env: {
-      // have to pass through at least path so it can find `op`
-      // and in some scenarios we need USER/HOME (homebrew on multi-user system)
+      // have to pass a few things through at least path so it can find `op` and related config files
+      // (encountered some errors on a homebrew multi-user system)
       PATH: process.env.PATH!,
-      USER: process.env.USER,
-      HOME: process.env.HOME,
+      ...process.env.USER && { USER: process.env.USER },
+      ...process.env.HOME && { HOME: process.env.HOME },
+      ...process.env.XDG_CONFIG_HOME && { XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
       ...envMap,
     },
   })

--- a/packages/plugins/1password/src/cli-helper.ts
+++ b/packages/plugins/1password/src/cli-helper.ts
@@ -202,9 +202,11 @@ async function executeReadBatch(batchToExecute: NonNullable<typeof opReadBatch>)
   // because otherwise we'll have trouble dealing with values that contain newlines
   await spawnAsync('op', `run --no-masking ${lockCliToOpAccount ? `--account ${lockCliToOpAccount} ` : ''}-- env -0`.split(' '), {
     env: {
-      // have to pass through at least path so it can find `op`, but might need other items too?
+      // have to pass through at least path so it can find `op`
+      // and in some scenarios we need USER/HOME (homebrew on multi-user system)
       PATH: process.env.PATH!,
-      // ...process.env as any,
+      USER: process.env.USER,
+      HOME: process.env.HOME,
       ...envMap,
     },
   })

--- a/packages/plugins/1password/src/cli-helper.ts
+++ b/packages/plugins/1password/src/cli-helper.ts
@@ -203,11 +203,13 @@ async function executeReadBatch(batchToExecute: NonNullable<typeof opReadBatch>)
   await spawnAsync('op', `run --no-masking ${lockCliToOpAccount ? `--account ${lockCliToOpAccount} ` : ''}-- env -0`.split(' '), {
     env: {
       // have to pass a few things through at least path so it can find `op` and related config files
-      // (encountered some errors on a homebrew multi-user system)
       PATH: process.env.PATH!,
       ...process.env.USER && { USER: process.env.USER },
       ...process.env.HOME && { HOME: process.env.HOME },
       ...process.env.XDG_CONFIG_HOME && { XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
+      // this setting actually just enables the CLI + Desktop App integration
+      // which in some cases op has a hard time detecting via app setting
+      OP_BIOMETRIC_UNLOCK_ENABLED: 'true',
       ...envMap,
     },
   })


### PR DESCRIPTION
passes through USER and HOME env vars to op cli calls within 1password plugin. This is to fix op plugin behaviour on machines where op is installed via brew in a multi-user setup.