### PR TITLE
fix(1password): fix duplicate refs silently failing in SDK batch mode

### DIFF
--- a/.changeset/fix-1password-sdk-duplicate-batch.md
+++ b/.changeset/fix-1password-sdk-duplicate-batch.md
@@ -1,0 +1,5 @@
+---
+"@varlock/1password-plugin": patch
+---
+
+Fix duplicate 1Password references silently failing when using SDK (service account token) - batch entries were being overwritten instead of deduplicated, and improve error handling in batch resolution

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -284,7 +284,7 @@ class OpPluginInstance {
           triggerBatch = true;
         }
         // add item to batch, with deferred promise
-        this.readBatch[opReference] = { defers: [] };
+        this.readBatch[opReference] ||= { defers: [] };
         const deferred = createDeferredPromise();
         this.readBatch[opReference].defers.push(deferred);
         if (triggerBatch) {
@@ -350,9 +350,11 @@ class OpPluginInstance {
       const result = await opClient.secrets.resolveAll(opReferences);
 
       for (const ref in batch) {
+        const itemResponse = result.individualResponses[ref];
         for (const dp of batch[ref].defers) {
-          const itemResponse = result.individualResponses[ref];
-          if (itemResponse.error) {
+          if (!itemResponse) {
+            dp.reject(new ResolutionError(`1Password error - no response returned for reference: ${ref}`));
+          } else if (itemResponse.error) {
             const errMsg = itemResponse.error.message || itemResponse.error.type || '';
             const isNotFound = /not.?found|does.?not.?exist|no.?such/i.test(errMsg);
             dp.reject(new ResolutionError(`1Password error - ${errMsg}`, {
@@ -376,9 +378,9 @@ class OpPluginInstance {
 
       for (const ref in batch) {
         for (const dp of batch[ref].defers) {
-          const wrappedErr = new Error(`1Password error - ${commonErr.message}`);
+          const wrappedErr = new ResolutionError(`1Password error - ${commonErr.message}`);
           (wrappedErr as any).cause = commonErr;
-          dp.reject(err);
+          dp.reject(wrappedErr);
         }
       }
     }


### PR DESCRIPTION
## Summary
- Fix duplicate 1Password secret references silently hanging when using service account token (SDK mode) — batch entries were overwritten, losing the first caller's deferred promise
- Fix catch block rejecting with raw error instead of wrapped `ResolutionError`
- Add guard for missing individual responses from SDK `resolveAll`

## Test plan
- [x] Verified `bunx varlock load` resolves duplicate refs (`OP_1` and `OP_2` pointing to same secret) successfully
- [x] Verified bad item reference surfaces clear `itemNotFound` error
- [x] Verified malformed reference triggers catch block with proper `ResolutionError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)