### PR TITLE
fix: Make execSyncVarlock work in a shell-less environment

### DIFF
--- a/.changeset/chatty-beans-refuse.md
+++ b/.changeset/chatty-beans-refuse.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+Fix execSyncVarlock not working in a shell-less environment

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -74,7 +74,8 @@ export function execSyncVarlock(
       return result.toString();
     } catch (err) {
       // code 127 means not found (on linux only)
-      if (!isWindows && (err as any).status !== 127) throw err;
+      // ENOENT from execSync means that a shell was not found
+      if (!isWindows && (err as any).status !== 127 && (err as any).code !== 'ENOENT') throw err;
       // on windows, we'll just do the extra checks anyway
     }
 


### PR DESCRIPTION
execSyncVarlock's initial execution, trying to find varlock on PATH, fails in a hardened environment where there is no shell installed with an ENOENT error.

Given that the ENOENT error from execSync is unique to when the shell itself is not found (ie: A missing varlock binary triggers a different error), capturing the ENOENT error and allowing a fallthrough to the rest of the function mitigates against this.