### PR TITLE
fix: monorepo typegen conflicts in env.d.ts

### DIFF
--- a/.changeset/fix-monorepo-typegen-conflicts.md
+++ b/.changeset/fix-monorepo-typegen-conflicts.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+Fix `declare module 'varlock/env'` type augmentation breaking in monorepo setups where multiple packages each have their own `.env.schema` and generated `env.d.ts`. Use unique type aliases per schema so that `CoercedEnvSchema` and `EnvSchemaAsStrings` names don't collide when multiple `env.d.ts` files are in the same TypeScript compilation.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:fix": "eslint . --fix",
     "changeset:add": "changeset add",
     "changeset:empty": "changeset add --empty",
-    "changeset:version": "changeset version && bun run lint:fix",
+    "changeset:version": "changeset version && bun install && bun run lint:fix",
     "changeset:publish": "bun run build:libs && bun run scripts/resolve-workspace-versions.ts && changeset publish",
     "release:create-missing-tags": "node scripts/create-missing-release-tags.js"
   },

--- a/packages/varlock/src/env-graph/lib/type-generation.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import _ from '@env-spec/utils/my-dash';
 import type { EnvGraph } from './env-graph';
@@ -72,6 +73,24 @@ async function fetchIconSvg(
 }
 
 
+/** Compute the TS type string for an item (extracted for reuse in augmentation blocks) */
+function getItemTsType(info: TypeGenItemInfo): string {
+  const dataType = info.dataType;
+  const dataTypeName = dataType?.name;
+
+  if (dataType) {
+    if (dataTypeName === 'number' || dataTypeName === 'port') return 'number';
+    if (dataTypeName === 'boolean') return 'boolean';
+    if (dataTypeName === 'simple-object') return 'Record<string, any>';
+    if (dataTypeName === 'enum') {
+      const rawEnumOptions = (dataType._rawDef as any)._rawEnumOptions;
+      if (!rawEnumOptions?.length) return 'never';
+      return _.map(rawEnumOptions, JSON.stringify).join(' | ');
+    }
+  }
+  return 'string';
+}
+
 export async function getTsDefinitionForItem(info: TypeGenItemInfo, indentLevel = 0) {
   const i = _.times(indentLevel, () => '  ').join('');
   const itemSrc = [];
@@ -120,37 +139,7 @@ export async function getTsDefinitionForItem(info: TypeGenItemInfo, indentLevel 
     ]);
   }
 
-  // TODO: logic should probably be within the Item class(es) and we still need to figure out how to identify these types...
-  const dataType = info.dataType;
-  const dataTypeName = dataType?.name;
-
-  let itemTsType = 'string';
-  if (dataType) {
-    if (dataTypeName === 'number' || dataTypeName === 'port') {
-      itemTsType = 'number';
-    } else if (dataTypeName === 'boolean') {
-      itemTsType = 'boolean';
-    } else if (dataTypeName === 'simple-object') {
-      itemTsType = 'Record<string, any>';
-    } else if (dataTypeName === 'enum') {
-      // enums have several different formats we need to handle
-      const rawEnumOptions = (dataType._rawDef as any)._rawEnumOptions;
-      let enumOptions = [] as Array<any>;
-      enumOptions = rawEnumOptions;
-
-      // TODO: we'll likely add other formats later where enum options can have attached descriptions
-
-      if (!enumOptions.length) {
-        itemTsType = 'never'; // should it be any instead?
-      } else {
-        // we could spit out descriptions in comments here, although currently it does nothing
-        // see https://github.com/microsoft/TypeScript/issues/38106
-        itemTsType = _.map(enumOptions, JSON.stringify).join(' | ');
-      }
-    }
-    // TODO: eventually handle objects, arrays, dictionaries
-  }
-
+  const itemTsType = getItemTsType(info);
   const isRequired = info.isRequired && !info.isRequiredDynamic;
   itemSrc.push(`${info.key}${isRequired ? '' : '?'}: ${itemTsType};`);
   itemSrc.push('');
@@ -168,23 +157,35 @@ export async function generateTsTypesSrc(items: Array<TypeGenItemInfo>) {
     'export type CoercedEnvSchema = {',
   ];
 
-  const exposedKeys: Array<string> = [];
-  const exposedNonSensitiveKeys: Array<string> = [];
   for (const info of items) {
     // generate the TS type for the item in the full schema
     tsSrc.push(...await getTsDefinitionForItem(info, 1));
-
-    // TODO: we will want the ability to keep some items internal and not exposed in the schema
-    exposedKeys.push(info.key);
-    if (!info.isSensitive) exposedNonSensitiveKeys.push(info.key);
   }
 
   tsSrc.push('};\n');
 
+  // Generate a unique type alias so that `declare module` and `declare global` blocks
+  // reference a file-scoped name that won't collide across packages in a monorepo.
+  // Without this, multiple env.d.ts files exporting the same `CoercedEnvSchema` /
+  // `EnvSchemaAsStrings` names can confuse TS when both are in the same compilation.
+  const schemaHash = crypto.createHash('md5')
+    .update(items.map((i) => i.key).sort().join(','))
+    .digest('hex')
+    .slice(0, 8);
+  const schemaAlias = `_CoercedEnvSchema_${schemaHash}`;
+  const stringsAlias = `_EnvSchemaAsStrings_${schemaHash}`;
+
+  tsSrc.push(`type ${schemaAlias} = CoercedEnvSchema;`);
+
+  const exposedNonSensitiveKeys: Array<string> = [];
+  for (const info of items) {
+    if (!info.isSensitive) exposedNonSensitiveKeys.push(info.key);
+  }
+
   tsSrc.push(`
 declare module 'varlock/env' {
-  export interface TypedEnvSchema extends Readonly<CoercedEnvSchema> {}
-  export interface PublicTypedEnvSchema extends Readonly<Pick<CoercedEnvSchema, '${exposedNonSensitiveKeys.join("' | '")}'>> {}
+  export interface TypedEnvSchema extends Readonly<${schemaAlias}> {}
+  export interface PublicTypedEnvSchema extends Readonly<Pick<${schemaAlias}, '${exposedNonSensitiveKeys.join("' | '")}'>> {}
 }
 `);
 
@@ -201,6 +202,8 @@ export type EnvSchemaAsStrings = {
 };
 `);
 
+  tsSrc.push(`type ${stringsAlias} = EnvSchemaAsStrings;`);
+
   // TODO: allow user to pass in options to control this?
   // although because we add the @generateTypes decorator an init time
   // we may need our integrations to specify what settings they prefer
@@ -209,14 +212,14 @@ export type EnvSchemaAsStrings = {
 
   const IMPORT_META_AUGMENTATION = `
   // add types for global import.meta.env
-  interface ImportMetaEnv extends EnvSchemaAsStrings {}
+  interface ImportMetaEnv extends ${stringsAlias} {}
   interface ImportMeta {
     readonly env: ImportMetaEnv;
   }`;
   const PROCESS_ENV_AUGMENTATION = `
   // add types for global process.env
   namespace NodeJS {
-    interface ProcessEnv extends EnvSchemaAsStrings {}
+    interface ProcessEnv extends ${stringsAlias} {}
   }`;
 
   // TODO: should add an option to enable/disable

--- a/packages/varlock/src/env-graph/test/type-generation.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation.test.ts
@@ -621,8 +621,8 @@ describe('type generation', () => {
       expect(src).toContain('PublicTypedEnvSchema');
       expect(src).toContain('EnvSchemaAsStrings');
 
-      // verify sensitive items are excluded from public schema
-      expect(src).toContain("Pick<CoercedEnvSchema, 'DB_HOST' | 'DB_PORT' | 'DEBUG' | 'APP_ENV'>");
+      // verify sensitive items are excluded from public schema (uses unique alias, not bare CoercedEnvSchema)
+      expect(src).toMatch(/Pick<_CoercedEnvSchema_[0-9a-f]+, 'DB_HOST' \| 'DB_PORT' \| 'DEBUG' \| 'APP_ENV'>/);
     });
 
     test('type gen output is the same regardless of current environment', async () => {

--- a/smoke-tests/smoke-test-monorepo/packages/pkg-a/.env.schema
+++ b/smoke-tests/smoke-test-monorepo/packages/pkg-a/.env.schema
@@ -1,0 +1,6 @@
+# @defaultSensitive=false
+# @generateTypes(lang="ts", path="env.d.ts")
+# ---
+
+PORT=3000
+REDIS_URL=redis://localhost:6379

--- a/smoke-tests/smoke-test-monorepo/packages/pkg-a/package.json
+++ b/smoke-tests/smoke-test-monorepo/packages/pkg-a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@smoke/pkg-a",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/smoke-tests/smoke-test-monorepo/packages/pkg-a/src/index.ts
+++ b/smoke-tests/smoke-test-monorepo/packages/pkg-a/src/index.ts
@@ -1,0 +1,12 @@
+import { ENV } from 'varlock/env';
+
+// Use pkg-a's env vars
+export function getPort(): number {
+  return ENV.PORT;
+}
+
+export function getRedisUrl(): string {
+  return ENV.REDIS_URL;
+}
+
+export type SharedConfig = { port: number; redisUrl: string };

--- a/smoke-tests/smoke-test-monorepo/packages/pkg-a/tsconfig.json
+++ b/smoke-tests/smoke-test-monorepo/packages/pkg-a/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true
+  },
+  "include": ["src", "env.d.ts"]
+}

--- a/smoke-tests/smoke-test-monorepo/packages/pkg-b/.env.schema
+++ b/smoke-tests/smoke-test-monorepo/packages/pkg-b/.env.schema
@@ -1,0 +1,6 @@
+# @defaultSensitive=false
+# @generateTypes(lang="ts", path="env.d.ts")
+# ---
+
+API_KEY=test-api-key
+LOG_LEVEL=debug

--- a/smoke-tests/smoke-test-monorepo/packages/pkg-b/package.json
+++ b/smoke-tests/smoke-test-monorepo/packages/pkg-b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@smoke/pkg-b",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@smoke/pkg-a": "workspace:*"
+  }
+}

--- a/smoke-tests/smoke-test-monorepo/packages/pkg-b/src/index.ts
+++ b/smoke-tests/smoke-test-monorepo/packages/pkg-b/src/index.ts
@@ -1,0 +1,12 @@
+import { ENV } from 'varlock/env';
+import type { SharedConfig } from '@smoke/pkg-a';
+
+// Use pkg-b's env vars
+export function getApiKey(): string {
+  return ENV.API_KEY;
+}
+
+// Import a type from pkg-a to trigger tsc following into pkg-a's source
+export function makeConfig(shared: SharedConfig): SharedConfig & { apiKey: string } {
+  return { ...shared, apiKey: ENV.API_KEY };
+}

--- a/smoke-tests/smoke-test-monorepo/packages/pkg-b/tsconfig.json
+++ b/smoke-tests/smoke-test-monorepo/packages/pkg-b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "declaration": true
+  },
+  "include": ["src", "env.d.ts"]
+}

--- a/smoke-tests/smoke-test-monorepo/pnpm-lock.yaml
+++ b/smoke-tests/smoke-test-monorepo/pnpm-lock.yaml
@@ -1,0 +1,15 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  packages/pkg-a: {}
+
+  packages/pkg-b:
+    dependencies:
+      '@smoke/pkg-a':
+        specifier: workspace:*
+        version: link:../pkg-a

--- a/smoke-tests/smoke-test-monorepo/pnpm-workspace.yaml
+++ b/smoke-tests/smoke-test-monorepo/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/smoke-tests/smoke-test-monorepo/tsconfig.json
+++ b/smoke-tests/smoke-test-monorepo/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "paths": {
+      "@smoke/pkg-a": ["./packages/pkg-a/src/index.ts"]
+    }
+  },
+  "include": [
+    "packages/pkg-a/src",
+    "packages/pkg-a/env.d.ts",
+    "packages/pkg-b/src",
+    "packages/pkg-b/env.d.ts"
+  ]
+}

--- a/smoke-tests/tests/monorepo-typegen.test.ts
+++ b/smoke-tests/tests/monorepo-typegen.test.ts
@@ -1,0 +1,82 @@
+import {
+  describe, test, expect, beforeAll,
+} from 'vitest';
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { varlockLoad } from '../helpers/run-varlock.js';
+
+const MONOREPO_DIR = join(import.meta.dirname, '..', 'smoke-test-monorepo');
+const PKG_A_DIR = join(MONOREPO_DIR, 'packages', 'pkg-a');
+const PKG_B_DIR = join(MONOREPO_DIR, 'packages', 'pkg-b');
+
+function tsc(cwd: string) {
+  try {
+    const output = execSync('npx tsc --noEmit', {
+      cwd,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+    return { exitCode: 0, output };
+  } catch (error: any) {
+    return {
+      exitCode: error.status || 1,
+      output: (error.stdout || '') + (error.stderr || ''),
+    };
+  }
+}
+
+describe('monorepo type generation', () => {
+  beforeAll(() => {
+    // Clean and regenerate env.d.ts for both packages
+    const envDtsA = join(PKG_A_DIR, 'env.d.ts');
+    const envDtsB = join(PKG_B_DIR, 'env.d.ts');
+    if (existsSync(envDtsA)) rmSync(envDtsA);
+    if (existsSync(envDtsB)) rmSync(envDtsB);
+
+    const resultA = varlockLoad({ cwd: 'smoke-test-monorepo/packages/pkg-a' });
+    expect(resultA.exitCode).toBe(0);
+    expect(existsSync(envDtsA)).toBe(true);
+
+    const resultB = varlockLoad({ cwd: 'smoke-test-monorepo/packages/pkg-b' });
+    expect(resultB.exitCode).toBe(0);
+    expect(existsSync(envDtsB)).toBe(true);
+  });
+
+  test('pkg-a type-checks successfully on its own', () => {
+    const result = tsc(PKG_A_DIR);
+    expect(result.output).toBe('');
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('monorepo root tsconfig type-checks with both packages env.d.ts visible', () => {
+    // When a root tsconfig includes all packages (common in monorepos),
+    // both env.d.ts augmentations are visible to tsc. The inlined interface
+    // properties must merge additively without conflicting.
+    const result = tsc(MONOREPO_DIR);
+    expect(result.output).not.toContain("Property 'PORT' does not exist");
+    expect(result.output).not.toContain("Property 'REDIS_URL' does not exist");
+    expect(result.output).not.toContain("Property 'API_KEY' does not exist");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('generated env.d.ts uses unique type aliases to avoid cross-package collisions', () => {
+    const envDtsA = readFileSync(join(PKG_A_DIR, 'env.d.ts'), 'utf-8');
+    const envDtsB = readFileSync(join(PKG_B_DIR, 'env.d.ts'), 'utf-8');
+
+    // Should NOT reference CoercedEnvSchema or EnvSchemaAsStrings directly in augmentation blocks
+    expect(envDtsA).not.toContain('extends Readonly<CoercedEnvSchema>');
+    expect(envDtsB).not.toContain('extends Readonly<CoercedEnvSchema>');
+    expect(envDtsA).not.toContain('extends EnvSchemaAsStrings');
+    expect(envDtsB).not.toContain('extends EnvSchemaAsStrings');
+
+    // Should use unique hashed aliases instead
+    expect(envDtsA).toMatch(/_CoercedEnvSchema_[0-9a-f]+/);
+    expect(envDtsB).toMatch(/_CoercedEnvSchema_[0-9a-f]+/);
+
+    // The two packages should have different hashes (different schemas)
+    const hashA = envDtsA.match(/_CoercedEnvSchema_([0-9a-f]+)/)![1];
+    const hashB = envDtsB.match(/_CoercedEnvSchema_([0-9a-f]+)/)![1];
+    expect(hashA).not.toBe(hashB);
+  });
+});


### PR DESCRIPTION
## Summary
- Generated `env.d.ts` files now use unique hashed type aliases (`_CoercedEnvSchema_<hash>`, `_EnvSchemaAsStrings_<hash>`) instead of referencing the bare `CoercedEnvSchema` / `EnvSchemaAsStrings` names inside `declare module` and `declare global` blocks
- This prevents type name collisions when multiple packages in a monorepo each have their own generated `env.d.ts` and both are visible to the same TypeScript compilation
- The exported `CoercedEnvSchema` and `EnvSchemaAsStrings` types remain unchanged for user-facing API compatibility
- JSDoc intellisense on `ENV.XXX` is preserved since the `extends Readonly<...>` pattern is kept

Closes #582

## Test plan
- [x] New `smoke-test-monorepo` fixture with two packages (pkg-a, pkg-b) where pkg-b imports from pkg-a
- [x] New `monorepo-typegen.test.ts` verifying both packages type-check together via a root tsconfig
- [x] Assertion that generated files use unique hashed aliases and different hashes per schema
- [x] All existing CLI smoke tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)