### PR TITLE
fix: work around Windows libuv crash on process exit

### DIFF
--- a/packages/varlock/src/cli/cli-executable.ts
+++ b/packages/varlock/src/cli/cli-executable.ts
@@ -115,6 +115,14 @@ subCommands.set('install-plugin', buildLazyCommand(installPluginCommandSpec, asy
         return VARLOCK_BANNER_COLOR;
       },
     });
+    // Short delay before exit to work around a libuv bug on Windows where
+    // uv_async_send is called after uv_close during shutdown, causing a crash.
+    // See: https://github.com/nodejs/node/issues/56645
+    if (process.platform === 'win32') {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 100);
+      });
+    }
     gracefulExit();
   } catch (error) {
     if (error instanceof Error && error.message.startsWith('Command not found: ')) {
@@ -132,6 +140,12 @@ subCommands.set('install-plugin', buildLazyCommand(installPluginCommandSpec, asy
       throw error;
     }
 
+    // Same Windows libuv workaround as the success path above
+    if (process.platform === 'win32') {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 100);
+      });
+    }
     gracefulExit(1);
   }
 }());

--- a/packages/varlock/src/env-graph/lib/type-generation.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation.ts
@@ -44,10 +44,7 @@ async function fetchIconSvg(
     iconInMemoryCache[iconPath] = svgSrc;
   } else {
     try {
-      const iconSvg = await fetch(`https://api.iconify.design/${iconifyName.replace(':', '/')}.svg?height=${ICON_SIZE}`, {
-        // On Windows, lingering keep-alive connections cause a libuv assertion crash on process exit
-        keepalive: process.platform !== 'win32',
-      });
+      const iconSvg = await fetch(`https://api.iconify.design/${iconifyName.replace(':', '/')}.svg?height=${ICON_SIZE}`);
       svgSrc = await iconSvg.text();
     } catch (err) {
       return;


### PR DESCRIPTION
## Summary
- Adds a 100ms delay before `gracefulExit()` on Windows to prevent a libuv assertion failure (`uv_async_send` called after `uv_close`) during process shutdown — a known libuv bug ([nodejs/node#56645](https://github.com/nodejs/node/issues/56645)) that also affects Bun
- Removes the now-superseded `keepalive: false` workaround in `type-generation.ts` since this fix addresses the root timing issue

## Test plan
- [ ] Verify Windows smoke tests pass (specifically `monorepo-typegen.test.ts`)
- [ ] Verify macOS/Linux CI unaffected (delay is Windows-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)