### PR TITLE
patch changesets to allow minor bumps without bumping deps

### DIFF
--- a/.changeset/cli-allow-multiple-paths.md
+++ b/.changeset/cli-allow-multiple-paths.md
@@ -1,5 +1,5 @@
 ---
-"varlock": minor
+"varlock": minor-isolated
 ---
 
 Added support for specifying multiple `--path` / `-p` flags from the CLI (e.g. `varlock load -p ./envs -p ./overrides`). Later paths take higher precedence. This brings the CLI to parity with the existing `package.json` `varlock.loadPath` array support.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,6 +102,9 @@ bun run changeset:publish # Build and publish packages
 ```
 **🚨 CRITICAL**: Always add a changeset for package changes that affect users!
 
+#### Isolated bump types
+This repo supports custom `minor-isolated` and `patch-isolated` bump types via patched `@changesets/*` packages. These suppress dependency propagation — the package gets bumped but dependents are not automatically bumped. Use **`minor-isolated`** for minor bumps that don't affect the library API consumed by dependents (e.g., CLI-only features in `varlock`). This is the most common use case — because all packages are still on `0.x`, `^0.y.z` ranges treat minor bumps as out-of-range, which would otherwise cascade bumps to all dependents. `patch-isolated` exists but is rarely needed since patch bumps stay within `^` ranges on `0.x`. `major-isolated` is not supported — major bumps must propagate to keep semver ranges valid.
+
 ## Coding Standards
 
 ### 🚨 MANDATORY PRE-COMPLETION CHECKLIST

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,17 @@
 - Smoke tests live in `smoke-tests/` and test the CLI end-to-end
 - Binary-specific tests in `smoke-tests/tests/binary.test.ts` require the SEA binary to be built first
 
+## Changesets & versioning
+
+- This monorepo uses **changesets** for version management
+- Changeset files live in `.changeset/` and are created with `bunx changeset add`
+- Standard bump types: `major`, `minor`, `patch`, `none`
+- **Custom isolated bump types**: `minor-isolated` and `patch-isolated` are supported via patched `@changesets/*` packages
+  - These suppress dependency propagation — the package itself gets bumped but dependents are **not** automatically bumped
+  - Use **`minor-isolated`** for minor bumps that don't affect the library API consumed by dependents (e.g., CLI-only features in `varlock` that plugins/integrations don't depend on). This is the most common use case — because all packages are still on `0.x`, `^0.y.z` ranges treat minor bumps as out-of-range, which would otherwise cascade bumps to all dependents.
+  - `patch-isolated` exists but is rarely needed — patch bumps on `0.x` stay within `^` ranges and don't cascade
+  - `major-isolated` is intentionally **not** supported (major bumps must propagate to keep semver ranges valid)
+
 ## Linting
 
 - Run **`bun run lint:fix`** from the repo root after completing a significant chunk of work (new feature, refactor, bug fix, etc.)

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "packages/ci-env-info": {
       "name": "@varlock/ci-env-info",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "devDependencies": {
         "@types/node": "catalog:",
         "tsup": "catalog:",
@@ -116,7 +116,7 @@
     },
     "packages/integrations/nextjs": {
       "name": "@varlock/nextjs-integration",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "devDependencies": {
         "@types/node": "catalog:",
         "tsup": "catalog:",
@@ -130,7 +130,7 @@
     },
     "packages/integrations/vite": {
       "name": "@varlock/vite-integration",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "devDependencies": {
         "@types/node": "catalog:",
         "ast-matcher": "^1.2.0",
@@ -148,7 +148,7 @@
     },
     "packages/plugins/1password": {
       "name": "@varlock/1password-plugin",
-      "version": "0.3.2",
+      "version": "0.3.5",
       "devDependencies": {
         "@1password/sdk": "0.4.1-beta.1",
         "@1password/sdk-core": "0.4.1-beta.1",
@@ -355,7 +355,7 @@
     },
     "packages/varlock": {
       "name": "varlock",
-      "version": "0.7.1",
+      "version": "0.7.4",
       "bin": {
         "varlock": "./bin/cli.js",
       },
@@ -439,6 +439,9 @@
   },
   "patchedDependencies": {
     "@changesets/assemble-release-plan@6.0.9": "patches/@changesets%2Fassemble-release-plan@6.0.9.patch",
+    "@changesets/parse@0.4.3": "patches/@changesets%2Fparse@0.4.3.patch",
+    "@changesets/apply-release-plan@7.1.0": "patches/@changesets%2Fapply-release-plan@7.1.0.patch",
+    "@changesets/types@6.1.0": "patches/@changesets%2Ftypes@6.1.0.patch",
   },
   "overrides": {
     "form-data": "4.0.5",
@@ -3168,7 +3171,7 @@
 
     "workerd": ["workerd@1.20260317.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260317.1", "@cloudflare/workerd-darwin-arm64": "1.20260317.1", "@cloudflare/workerd-linux-64": "1.20260317.1", "@cloudflare/workerd-linux-arm64": "1.20260317.1", "@cloudflare/workerd-windows-64": "1.20260317.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g=="],
 
-    "wrangler": ["wrangler@4.75.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.15.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260317.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260317.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260317.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-Efk1tcnm4eduBYpH1sSjMYydXMnIFPns/qABI3+fsbDrUk5GksNYX8nYGVP4sFygvGPO7kJc36YJKB5ooA7JAg=="],
+    "wrangler": ["wrangler@4.78.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260317.3", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260317.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260317.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-He/vUhk4ih0D0eFmtNnlbT6Od8j+BEokaSR+oYjbVsH0SWIrIch+eHqfLRSBjBQaOoh6HCNxcafcIkBm2u0Hag=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
@@ -3251,8 +3254,6 @@
     "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@changesets/apply-release-plan/outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
-
-    "@cloudflare/vite-plugin/wrangler": ["wrangler@4.78.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260317.3", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260317.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260317.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-He/vUhk4ih0D0eFmtNnlbT6Od8j+BEokaSR+oYjbVsH0SWIrIch+eHqfLRSBjBQaOoh6HCNxcafcIkBm2u0Hag=="],
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
@@ -3476,11 +3477,7 @@
 
     "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
-    "wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.15.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw=="],
-
     "wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
-
-    "wrangler/miniflare": ["miniflare@4.20260317.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.4", "workerd": "1.20260317.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-xuwk5Kjv+shi5iUBAdCrRl9IaWSGnTU8WuTQzsUS2GlSDIMCJuu8DiF/d9ExjMXYiQG5ml+k9SVKnMj8cRkq0w=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
@@ -3583,8 +3580,6 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "@expressive-code/core/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -3985,58 +3980,6 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
-
-    "@cloudflare/vite-plugin/wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
     "@infisical/sdk/@aws-sdk/credential-providers/@aws-sdk/client-cognito-identity/@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.993.0", "", { "dependencies": { "@aws-sdk/types": "^3.973.1", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-endpoints": "^3.2.8", "tslib": "^2.6.2" } }, "sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw=="],
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
     "vitest": "^4.0.18"
   },
   "patchedDependencies": {
-    "@changesets/assemble-release-plan@6.0.9": "patches/@changesets%2Fassemble-release-plan@6.0.9.patch"
+    "@changesets/types@6.1.0": "patches/@changesets%2Ftypes@6.1.0.patch",
+    "@changesets/parse@0.4.3": "patches/@changesets%2Fparse@0.4.3.patch",
+    "@changesets/assemble-release-plan@6.0.9": "patches/@changesets%2Fassemble-release-plan@6.0.9.patch",
+    "@changesets/apply-release-plan@7.1.0": "patches/@changesets%2Fapply-release-plan@7.1.0.patch"
   }
 }

--- a/patches/@changesets%2Fapply-release-plan@7.1.0.patch
+++ b/patches/@changesets%2Fapply-release-plan@7.1.0.patch
@@ -1,0 +1,72 @@
+diff --git a/dist/changesets-apply-release-plan.cjs.js b/dist/changesets-apply-release-plan.cjs.js
+index 2e57ca5e53b45a05c637766852336ad1353bbe9f..7cd68d3310c1aa9d32d484b2d43a34557b3e9515 100644
+--- a/dist/changesets-apply-release-plan.cjs.js
++++ b/dist/changesets-apply-release-plan.cjs.js
+@@ -100,15 +100,15 @@ function _objectSpread2(e) {
+ /**
+  * Shared utility functions and business logic
+  */
+-const bumpTypes = ["none", "patch", "minor", "major"];
+-
+ /* Converts a bump type into a numeric level to indicate order */
+ function getBumpLevel(type) {
+-  const level = bumpTypes.indexOf(type);
+-  if (level < 0) {
+-    throw new Error(`Unrecognised bump type ${type}`);
++  switch (type) {
++    case "major": return 3;
++    case "minor": case "minor-isolated": return 2;
++    case "patch": case "patch-isolated": return 1;
++    case "none": return 0;
++    default: throw new Error(`Unrecognised bump type ${type}`);
+   }
+-  return level;
+ }
+ function shouldUpdateDependencyBasedOnConfig(release, {
+   depVersionRange,
+@@ -156,7 +156,8 @@ async function getChangelogEntry(release, releases, changesets, changelogFuncs,
+   changesets.forEach(cs => {
+     const rls = cs.releases.find(r => r.name === release.name);
+     if (rls && rls.type !== "none") {
+-      changelogLines[rls.type].push(changelogFuncs.getReleaseLine(cs, rls.type, changelogOpts));
++      const changelogType = rls.type === "minor-isolated" ? "minor" : rls.type === "patch-isolated" ? "patch" : rls.type;
++      changelogLines[changelogType].push(changelogFuncs.getReleaseLine(cs, rls.type, changelogOpts));
+     }
+   });
+   let dependentReleases = releases.filter(rel => {
+diff --git a/dist/changesets-apply-release-plan.esm.js b/dist/changesets-apply-release-plan.esm.js
+index f010f14fd5770c2e2f0af613beda3f817036aab4..c99fff927b5beedd395aac19a9b432114958905a 100644
+--- a/dist/changesets-apply-release-plan.esm.js
++++ b/dist/changesets-apply-release-plan.esm.js
+@@ -63,15 +63,15 @@ function _objectSpread2(e) {
+ /**
+  * Shared utility functions and business logic
+  */
+-const bumpTypes = ["none", "patch", "minor", "major"];
+-
+ /* Converts a bump type into a numeric level to indicate order */
+ function getBumpLevel(type) {
+-  const level = bumpTypes.indexOf(type);
+-  if (level < 0) {
+-    throw new Error(`Unrecognised bump type ${type}`);
++  switch (type) {
++    case "major": return 3;
++    case "minor": case "minor-isolated": return 2;
++    case "patch": case "patch-isolated": return 1;
++    case "none": return 0;
++    default: throw new Error(`Unrecognised bump type ${type}`);
+   }
+-  return level;
+ }
+ function shouldUpdateDependencyBasedOnConfig(release, {
+   depVersionRange,
+@@ -119,7 +119,8 @@ async function getChangelogEntry(release, releases, changesets, changelogFuncs,
+   changesets.forEach(cs => {
+     const rls = cs.releases.find(r => r.name === release.name);
+     if (rls && rls.type !== "none") {
+-      changelogLines[rls.type].push(changelogFuncs.getReleaseLine(cs, rls.type, changelogOpts));
++      const changelogType = rls.type === "minor-isolated" ? "minor" : rls.type === "patch-isolated" ? "patch" : rls.type;
++      changelogLines[changelogType].push(changelogFuncs.getReleaseLine(cs, rls.type, changelogOpts));
+     }
+   });
+   let dependentReleases = releases.filter(rel => {

--- a/patches/@changesets%2Fassemble-release-plan@6.0.9.patch
+++ b/patches/@changesets%2Fassemble-release-plan@6.0.9.patch
@@ -1,8 +1,45 @@
+diff --git a/node_modules/@changesets/assemble-release-plan/.bun-tag-7a691b1c0127e905 b/.bun-tag-7a691b1c0127e905
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
-index e07ba6e793021b6cfdec898afca517e293386ddb..c286051e952d78d4dc6cda5832ba4226d63295c5 100644
+index e07ba6e793021b6cfdec898afca517e293386ddb..036463cd3da0e89c9a5566b92b431288cbc190b4 100644
 --- a/dist/changesets-assemble-release-plan.cjs.js
 +++ b/dist/changesets-assemble-release-plan.cjs.js
-@@ -317,6 +317,9 @@ function shouldBumpMajor({
+@@ -74,9 +74,13 @@ function getHighestReleaseType(releases) {
+       case "major":
+         return "major";
+       case "minor":
+-        highestReleaseType = "minor";
++      case "minor-isolated":
++        if (highestReleaseType !== "minor") {
++          highestReleaseType = "minor";
++        }
+         break;
+       case "patch":
++      case "patch-isolated":
+         if (highestReleaseType === "none") {
+           highestReleaseType = "patch";
+         }
+@@ -145,7 +149,8 @@ function incrementVersion(release, preInfo) {
+   if (release.type === "none") {
+     return release.oldVersion;
+   }
+-  let version = semverInc__default["default"](release.oldVersion, release.type);
++  const semverType = release.type === "minor-isolated" ? "minor" : release.type === "patch-isolated" ? "patch" : release.type;
++  let version = semverInc__default["default"](release.oldVersion, semverType);
+   if (preInfo !== undefined && preInfo.state.mode !== "exit") {
+     let preVersion = preInfo.preVersions.get(release.name);
+     if (preVersion === undefined) {
+@@ -204,7 +209,7 @@ function determineDependents({
+           depType,
+           versionRange
+         } of dependencyVersionRanges) {
+-          if (nextRelease.type === "none") {
++          if (nextRelease.type === "none" || nextRelease.type === "minor-isolated" || nextRelease.type === "patch-isolated") {
+             continue;
+           } else if (shouldBumpMajor({
+             dependent,
+@@ -317,6 +322,9 @@ function shouldBumpMajor({
    preInfo,
    onlyUpdatePeerDependentsWhenOutOfRange
  }) {
@@ -12,11 +49,74 @@ index e07ba6e793021b6cfdec898afca517e293386ddb..c286051e952d78d4dc6cda5832ba4226
    // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
    return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && (
    // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+@@ -327,6 +335,17 @@ function shouldBumpMajor({
+ }
+ 
+ // This function takes in changesets and returns one release per
++function getBumpLevel$1(type) {
++  switch (type) {
++    case "major": return 3;
++    case "minor": case "minor-isolated": return 2;
++    case "patch": case "patch-isolated": return 1;
++    default: return 0;
++  }
++}
++function isIsolated(type) {
++  return type === "minor-isolated" || type === "patch-isolated";
++}
+ function flattenReleases(changesets, packagesByName, config) {
+   let releases = new Map();
+   changesets.forEach(changeset => {
+@@ -355,7 +374,9 @@ function flattenReleases(changesets, packagesByName, config) {
+           changesets: [changeset.id]
+         };
+       } else {
+-        if (type === "major" || (release.type === "patch" || release.type === "none") && (type === "minor" || type === "patch")) {
++        const newLevel = getBumpLevel$1(type);
++        const existingLevel = getBumpLevel$1(release.type);
++        if (newLevel > existingLevel || newLevel === existingLevel && isIsolated(release.type) && !isIsolated(type)) {
+           release.type = type;
+         }
+         // Check whether the bumpType will change
 diff --git a/dist/changesets-assemble-release-plan.esm.js b/dist/changesets-assemble-release-plan.esm.js
-index ea2be567403c4ef94a65f3218ccb683cf5cb4bc1..0f5ac121649f1ac0a2b2e9704079474e360761e9 100644
+index ea2be567403c4ef94a65f3218ccb683cf5cb4bc1..417273c7b4faab122e32db0cd8c38bdd906909be 100644
 --- a/dist/changesets-assemble-release-plan.esm.js
 +++ b/dist/changesets-assemble-release-plan.esm.js
-@@ -306,6 +306,9 @@ function shouldBumpMajor({
+@@ -63,9 +63,13 @@ function getHighestReleaseType(releases) {
+       case "major":
+         return "major";
+       case "minor":
+-        highestReleaseType = "minor";
++      case "minor-isolated":
++        if (highestReleaseType !== "minor") {
++          highestReleaseType = "minor";
++        }
+         break;
+       case "patch":
++      case "patch-isolated":
+         if (highestReleaseType === "none") {
+           highestReleaseType = "patch";
+         }
+@@ -134,7 +138,8 @@ function incrementVersion(release, preInfo) {
+   if (release.type === "none") {
+     return release.oldVersion;
+   }
+-  let version = semverInc(release.oldVersion, release.type);
++  const semverType = release.type === "minor-isolated" ? "minor" : release.type === "patch-isolated" ? "patch" : release.type;
++  let version = semverInc(release.oldVersion, semverType);
+   if (preInfo !== undefined && preInfo.state.mode !== "exit") {
+     let preVersion = preInfo.preVersions.get(release.name);
+     if (preVersion === undefined) {
+@@ -193,7 +198,7 @@ function determineDependents({
+           depType,
+           versionRange
+         } of dependencyVersionRanges) {
+-          if (nextRelease.type === "none") {
++          if (nextRelease.type === "none" || nextRelease.type === "minor-isolated" || nextRelease.type === "patch-isolated") {
+             continue;
+           } else if (shouldBumpMajor({
+             dependent,
+@@ -306,6 +311,9 @@ function shouldBumpMajor({
    preInfo,
    onlyUpdatePeerDependentsWhenOutOfRange
  }) {
@@ -26,6 +126,35 @@ index ea2be567403c4ef94a65f3218ccb683cf5cb4bc1..0f5ac121649f1ac0a2b2e9704079474e
    // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
    return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && (
    // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+@@ -316,6 +324,17 @@ function shouldBumpMajor({
+ }
+ 
+ // This function takes in changesets and returns one release per
++function getBumpLevel$1(type) {
++  switch (type) {
++    case "major": return 3;
++    case "minor": case "minor-isolated": return 2;
++    case "patch": case "patch-isolated": return 1;
++    default: return 0;
++  }
++}
++function isIsolated(type) {
++  return type === "minor-isolated" || type === "patch-isolated";
++}
+ function flattenReleases(changesets, packagesByName, config) {
+   let releases = new Map();
+   changesets.forEach(changeset => {
+@@ -344,7 +363,9 @@ function flattenReleases(changesets, packagesByName, config) {
+           changesets: [changeset.id]
+         };
+       } else {
+-        if (type === "major" || (release.type === "patch" || release.type === "none") && (type === "minor" || type === "patch")) {
++        const newLevel = getBumpLevel$1(type);
++        const existingLevel = getBumpLevel$1(release.type);
++        if (newLevel > existingLevel || newLevel === existingLevel && isIsolated(release.type) && !isIsolated(type)) {
+           release.type = type;
+         }
+         // Check whether the bumpType will change
 diff --git a/src/determine-dependents.ts b/src/determine-dependents.ts
 index 47e32b6f09310d3ed03ab46b2d342d032f9014df..4edccca93152b1c8df59391b35e5f72de7ab8c05 100644
 --- a/src/determine-dependents.ts

--- a/patches/@changesets%2Fassemble-release-plan@6.0.9.patch
+++ b/patches/@changesets%2Fassemble-release-plan@6.0.9.patch
@@ -2,7 +2,7 @@ diff --git a/node_modules/@changesets/assemble-release-plan/.bun-tag-7a691b1c012
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
-index e07ba6e793021b6cfdec898afca517e293386ddb..036463cd3da0e89c9a5566b92b431288cbc190b4 100644
+index e07ba6e793021b6cfdec898afca517e293386ddb..1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b 100644
 --- a/dist/changesets-assemble-release-plan.cjs.js
 +++ b/dist/changesets-assemble-release-plan.cjs.js
 @@ -74,9 +74,13 @@ function getHighestReleaseType(releases) {
@@ -78,8 +78,18 @@ index e07ba6e793021b6cfdec898afca517e293386ddb..036463cd3da0e89c9a5566b92b431288
            release.type = type;
          }
          // Check whether the bumpType will change
+@@ -545,7 +566,9 @@ function assembleReleasePlan(changesets, packages, config,
+   return {
+     changesets: relevantChangesets,
+     releases: [...releases.values()].map(incompleteRelease => {
++      const normalizedType = incompleteRelease.type === "minor-isolated" ? "minor" : incompleteRelease.type === "patch-isolated" ? "patch" : incompleteRelease.type;
+       return _objectSpread2(_objectSpread2({}, incompleteRelease), {}, {
++        type: normalizedType,
+         newVersion: snapshotSuffix ? getSnapshotVersion(incompleteRelease, preInfo, refinedConfig.snapshot.useCalculatedVersion, snapshotSuffix) : getNewVersion(incompleteRelease, preInfo)
+       });
+     }),
 diff --git a/dist/changesets-assemble-release-plan.esm.js b/dist/changesets-assemble-release-plan.esm.js
-index ea2be567403c4ef94a65f3218ccb683cf5cb4bc1..417273c7b4faab122e32db0cd8c38bdd906909be 100644
+index ea2be567403c4ef94a65f3218ccb683cf5cb4bc1..517273c7b4faab122e32db0cd8c38bdd906909be 100644
 --- a/dist/changesets-assemble-release-plan.esm.js
 +++ b/dist/changesets-assemble-release-plan.esm.js
 @@ -63,9 +63,13 @@ function getHighestReleaseType(releases) {
@@ -155,6 +165,16 @@ index ea2be567403c4ef94a65f3218ccb683cf5cb4bc1..417273c7b4faab122e32db0cd8c38bdd
            release.type = type;
          }
          // Check whether the bumpType will change
+@@ -534,7 +555,9 @@ function assembleReleasePlan(changesets, packages, config,
+   return {
+     changesets: relevantChangesets,
+     releases: [...releases.values()].map(incompleteRelease => {
++      const normalizedType = incompleteRelease.type === "minor-isolated" ? "minor" : incompleteRelease.type === "patch-isolated" ? "patch" : incompleteRelease.type;
+       return _objectSpread2(_objectSpread2({}, incompleteRelease), {}, {
++        type: normalizedType,
+         newVersion: snapshotSuffix ? getSnapshotVersion(incompleteRelease, preInfo, refinedConfig.snapshot.useCalculatedVersion, snapshotSuffix) : getNewVersion(incompleteRelease, preInfo)
+       });
+     }),
 diff --git a/src/determine-dependents.ts b/src/determine-dependents.ts
 index 47e32b6f09310d3ed03ab46b2d342d032f9014df..4edccca93152b1c8df59391b35e5f72de7ab8c05 100644
 --- a/src/determine-dependents.ts

--- a/patches/@changesets%2Fparse@0.4.3.patch
+++ b/patches/@changesets%2Fparse@0.4.3.patch
@@ -1,0 +1,52 @@
+diff --git a/dist/changesets-parse.cjs.js b/dist/changesets-parse.cjs.js
+index 336185245c3f809adcda1fb1c3e038730bf4232b..e144c3065cc1852f6e1d5bf14fffbf446e1b4944 100644
+--- a/dist/changesets-parse.cjs.js
++++ b/dist/changesets-parse.cjs.js
+@@ -10,7 +10,7 @@ var yaml__default = /*#__PURE__*/_interopDefault(yaml);
+ 
+ const mdRegex = /\s*---([^]*?)\n\s*---(\s*(?:\n|$)[^]*)/;
+ const EXAMPLE_FORMAT = `---\n"package-name": patch\n---`;
+-const validVersionTypes = ["major", "minor", "patch", "none"];
++const validVersionTypes = ["major", "minor", "minor-isolated", "patch", "patch-isolated", "none"];
+ function truncate(s, max = 200) {
+   return s.length > max ? s.slice(0, max) + "..." : s;
+ }
+@@ -23,7 +23,11 @@ function validateReleases(releases, contents) {
+       throw new Error(`could not parse changeset - invalid release type for package "${release.name}".\n` + `Expected a string for release type, but got: ${typeof release.type}\n` + `Changeset contents:\n${truncate(contents)}`);
+     }
+     if (!validVersionTypes.includes(release.type)) {
+-      throw new Error(`could not parse changeset - invalid version type ${JSON.stringify(release.type)} for package "${release.name}".\n` + `Valid version types are: ${validVersionTypes.join(", ")}\n` + `Changeset contents:\n${truncate(contents)}`);
++      const errorPrefix = `could not parse changeset - invalid version type ${JSON.stringify(release.type)} for package "${release.name}".`;
++      if (release.type === "major-isolated") {
++        throw new Error(`${errorPrefix}\n` + `"major-isolated" is not supported because a major bump would leave dependents with incompatible semver ranges.\n` + `Use "major" instead, which will correctly update dependent packages.\n` + `Changeset contents:\n${truncate(contents)}`);
++      }
++      throw new Error(`${errorPrefix}\n` + `Valid version types are: ${validVersionTypes.join(", ")}\n` + `Changeset contents:\n${truncate(contents)}`);
+     }
+   }
+ }
+diff --git a/dist/changesets-parse.esm.js b/dist/changesets-parse.esm.js
+index f7f055bc695e92dd68078371e645ade914195c59..f87c423cab45c1840bfb0c013fdbdcd99201392d 100644
+--- a/dist/changesets-parse.esm.js
++++ b/dist/changesets-parse.esm.js
+@@ -2,7 +2,7 @@ import yaml from 'js-yaml';
+ 
+ const mdRegex = /\s*---([^]*?)\n\s*---(\s*(?:\n|$)[^]*)/;
+ const EXAMPLE_FORMAT = `---\n"package-name": patch\n---`;
+-const validVersionTypes = ["major", "minor", "patch", "none"];
++const validVersionTypes = ["major", "minor", "minor-isolated", "patch", "patch-isolated", "none"];
+ function truncate(s, max = 200) {
+   return s.length > max ? s.slice(0, max) + "..." : s;
+ }
+@@ -15,7 +15,11 @@ function validateReleases(releases, contents) {
+       throw new Error(`could not parse changeset - invalid release type for package "${release.name}".\n` + `Expected a string for release type, but got: ${typeof release.type}\n` + `Changeset contents:\n${truncate(contents)}`);
+     }
+     if (!validVersionTypes.includes(release.type)) {
+-      throw new Error(`could not parse changeset - invalid version type ${JSON.stringify(release.type)} for package "${release.name}".\n` + `Valid version types are: ${validVersionTypes.join(", ")}\n` + `Changeset contents:\n${truncate(contents)}`);
++      const errorPrefix = `could not parse changeset - invalid version type ${JSON.stringify(release.type)} for package "${release.name}".`;
++      if (release.type === "major-isolated") {
++        throw new Error(`${errorPrefix}\n` + `"major-isolated" is not supported because a major bump would leave dependents with incompatible semver ranges.\n` + `Use "major" instead, which will correctly update dependent packages.\n` + `Changeset contents:\n${truncate(contents)}`);
++      }
++      throw new Error(`${errorPrefix}\n` + `Valid version types are: ${validVersionTypes.join(", ")}\n` + `Changeset contents:\n${truncate(contents)}`);
+     }
+   }
+ }

--- a/patches/@changesets%2Ftypes@6.1.0.patch
+++ b/patches/@changesets%2Ftypes@6.1.0.patch
@@ -1,0 +1,11 @@
+diff --git a/dist/declarations/src/index.d.ts b/dist/declarations/src/index.d.ts
+index df6e0869a794df65f3754f8f7f4e5c36c0750860..fc8087573eb9001d8a8166d13933ed8dd30ec098 100644
+--- a/dist/declarations/src/index.d.ts
++++ b/dist/declarations/src/index.d.ts
+@@ -1,5 +1,5 @@
+ declare const DEPENDENCY_TYPES: readonly ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
+-export type VersionType = "major" | "minor" | "patch" | "none";
++export type VersionType = "major" | "minor" | "minor-isolated" | "patch" | "patch-isolated" | "none";
+ export type DependencyType = typeof DEPENDENCY_TYPES[number];
+ export type AccessType = "public" | "restricted";
+ export type Release = {


### PR DESCRIPTION
## Summary

- Patches `@changesets/parse`, `@changesets/types`, `@changesets/assemble-release-plan`, and `@changesets/apply-release-plan` to support `minor-isolated` and `patch-isolated` bump types
- These new bump types allow a package to receive a minor/patch version bump **without** forcing dependent packages to also bump — useful for changes that don't affect the public API consumed by dependents
- Updates existing changeset (`cli-allow-multiple-paths`) to use `minor-isolated` for the varlock package

## Context

By default, changesets propagates version bumps to all dependent packages. This is correct for breaking changes but overly aggressive for internal-only changes (e.g., CLI-only features that don't affect the library API). The `isolated` variants let us cut releases for individual packages without triggering unnecessary cascading bumps across the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)