### PR TITLE
chore: add lefthook for pre-commit eslint and pre-push typecheck

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "eslint-plugin-n": "^17.24.0",
         "eslint-stylistic-airbnb": "^2.0.1",
         "globals": "^17.3.0",
+        "lefthook": "^2.1.6",
         "turbo": "^2.8.12",
         "typescript": "catalog:",
         "typescript-eslint": "^8.56.1",
@@ -149,12 +150,30 @@
     "packages/plugins/1password": {
       "name": "@varlock/1password-plugin",
       "version": "0.3.5",
+      "bin": {
+        "varlock-op-bridge": "./dist/bridge-cli.cjs",
+      },
       "devDependencies": {
         "@1password/sdk": "0.4.1-beta.1",
         "@1password/sdk-core": "0.4.1-beta.1",
         "@env-spec/utils": "workspace:^",
         "@types/node": "catalog:",
         "import-meta-resolve": "^4.2.0",
+        "tsup": "catalog:",
+        "varlock": "workspace:^",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "varlock": "workspace:^",
+      },
+    },
+    "packages/plugins/akeyless": {
+      "name": "@varlock/akeyless-plugin",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@env-spec/utils": "workspace:^",
+        "@types/node": "catalog:",
+        "ky": "catalog:",
         "tsup": "catalog:",
         "varlock": "workspace:^",
         "vitest": "catalog:",
@@ -219,6 +238,21 @@
         "@env-spec/utils": "workspace:^",
         "@types/node": "catalog:",
         "outdent": "catalog:",
+        "tsup": "catalog:",
+        "varlock": "workspace:^",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "varlock": "workspace:^",
+      },
+    },
+    "packages/plugins/doppler": {
+      "name": "@varlock/doppler-plugin",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@env-spec/utils": "workspace:^",
+        "@types/node": "catalog:",
+        "ky": "catalog:",
         "tsup": "catalog:",
         "varlock": "workspace:^",
         "vitest": "catalog:",
@@ -1293,6 +1327,8 @@
 
     "@varlock/1password-plugin": ["@varlock/1password-plugin@workspace:packages/plugins/1password"],
 
+    "@varlock/akeyless-plugin": ["@varlock/akeyless-plugin@workspace:packages/plugins/akeyless"],
+
     "@varlock/astro-integration": ["@varlock/astro-integration@workspace:packages/integrations/astro"],
 
     "@varlock/aws-secrets-plugin": ["@varlock/aws-secrets-plugin@workspace:packages/plugins/aws-secrets"],
@@ -1308,6 +1344,8 @@
     "@varlock/cloudflare-integration": ["@varlock/cloudflare-integration@workspace:packages/integrations/cloudflare"],
 
     "@varlock/dashlane-plugin": ["@varlock/dashlane-plugin@workspace:packages/plugins/dashlane"],
+
+    "@varlock/doppler-plugin": ["@varlock/doppler-plugin@workspace:packages/plugins/doppler"],
 
     "@varlock/expo-integration": ["@varlock/expo-integration@workspace:packages/integrations/expo"],
 
@@ -2250,6 +2288,28 @@
     "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
 
     "ky": ["ky@1.14.3", "", {}, "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw=="],
+
+    "lefthook": ["lefthook@2.1.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.6", "lefthook-darwin-x64": "2.1.6", "lefthook-freebsd-arm64": "2.1.6", "lefthook-freebsd-x64": "2.1.6", "lefthook-linux-arm64": "2.1.6", "lefthook-linux-x64": "2.1.6", "lefthook-openbsd-arm64": "2.1.6", "lefthook-openbsd-x64": "2.1.6", "lefthook-windows-arm64": "2.1.6", "lefthook-windows-x64": "2.1.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.6", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.6", "", { "os": "linux", "cpu": "x64" }, "sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.6", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.6", "", { "os": "openbsd", "cpu": "x64" }, "sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,12 @@
+pre-commit:
+  parallel: true
+  jobs:
+    - name: eslint
+      glob: "*.{js,jsx,ts,tsx,mjs,cjs,json,jsonc}"
+      run: bunx eslint --fix --no-warn-ignored {staged_files}
+      stage_fixed: true
+
+pre-push:
+  jobs:
+    - name: typecheck
+      run: bun run typecheck

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "changeset:empty": "changeset add --empty",
     "changeset:version": "changeset version && bun install && bun run lint:fix",
     "changeset:publish": "bun run build:libs && bun run scripts/resolve-workspace-versions.ts && changeset publish",
-    "release:create-missing-tags": "node scripts/create-missing-release-tags.js"
+    "release:create-missing-tags": "node scripts/create-missing-release-tags.js",
+    "prepare": "lefthook install"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
@@ -37,9 +38,9 @@
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.56.1",
     "@varlock/changeset-changelog": "workspace:*",
-    "@varlock/tsconfig": "workspace:*",
     "@varlock/cloudflare-integration": "workspace:*",
     "@varlock/keepass-plugin": "workspace:*",
+    "@varlock/tsconfig": "workspace:*",
     "eslint": "^10.0.2",
     "eslint-plugin-es-x": "^9.5.0",
     "eslint-plugin-fix-disabled-rules": "^0.0.2",
@@ -47,6 +48,7 @@
     "eslint-plugin-n": "^17.24.0",
     "eslint-stylistic-airbnb": "^2.0.1",
     "globals": "^17.3.0",
+    "lefthook": "^2.1.6",
     "turbo": "^2.8.12",
     "typescript": "catalog:",
     "typescript-eslint": "^8.56.1"


### PR DESCRIPTION
## Summary

- Adds [lefthook](https://lefthook.dev) as a dev dependency for managing git hooks
- **pre-commit**: runs `eslint --fix` on staged JS/TS/JSON files and re-stages fixes (fast — only staged files, not the whole repo)
- **pre-push**: runs `bun run typecheck` to catch type errors before they hit CI
- `prepare` script auto-installs hooks after `bun install` so teammates don't need a manual setup step

Bypass on a one-off emergency: `LEFTHOOK=0 git commit ...` or `git commit --no-verify`.

## Test plan

- [x] `bunx lefthook run pre-commit --all-files` — executes eslint against all files
- [x] `bunx lefthook run pre-push` — executes typecheck successfully
- [x] Pre-commit fired on this branch's own commit (no JS/TS changes, passed clean)
- [x] Pre-push fired on `git push` (typecheck passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)