### PR TITLE
fix(cloudflare): ignore unchanged env watch events

### DIFF
--- a/packages/integrations/cloudflare/src/varlock-wrangler.ts
+++ b/packages/integrations/cloudflare/src/varlock-wrangler.ts
@@ -413,12 +413,19 @@ async function handleDev(args: Array<string>) {
 
   // watch env source files for changes and restart wrangler with fresh data
   let restartTimeout: ReturnType<typeof setTimeout> | undefined;
+  let cachedGraphJson = loaded.json;
   function scheduleRestart() {
     // debounce — multiple files may change at once
     if (restartTimeout) clearTimeout(restartTimeout);
     restartTimeout = setTimeout(() => {
       try {
         const freshLoaded = loadSerializedGraph();
+        if (freshLoaded.json === cachedGraphJson) {
+          restartTimeout = undefined;
+          return;
+        }
+        cachedGraphJson = freshLoaded.json;
+        loaded = freshLoaded;
         cachedContent = formatEnvFileContent(freshLoaded);
         handle.update(cachedContent);
         console.log('[varlock-wrangler] env changed, restarting wrangler...');


### PR DESCRIPTION
## Summary

- ignore `fs.watch()` events in `varlock-wrangler dev` when the resolved env graph is unchanged
- prevent restart loops caused by spurious env file watch events on macOS
- keep Wrangler restarts limited to real env changes

## Repro

On macOS, `varlock-wrangler dev` can receive repeated `fs.watch()` events for env source files even when their contents have not changed.

In our case this showed up under `portless` as repeated events for `apps/api/.env.schema`, causing `varlock-wrangler` to restart Wrangler in a loop.

## Root cause

`varlock-wrangler dev` currently restarts Wrangler on every watched env file event after re-resolving env.

That assumes every watch event represents a semantic env change, which is not always true on macOS.

## Fix

Cache the last resolved serialized env graph and compare it after each watch event.

Only restart Wrangler when the newly resolved env graph differs from the previous one.

## Why this is safe

This does not change how env is resolved.

It only skips restarts when the resolved env output is identical, so real env changes still trigger the existing restart path.