### PR TITLE
chore(varlock-wrangler): use exit-code if set from process to avoid silent fails

### DIFF
--- a/.changeset/slow-crabs-vanish.md
+++ b/.changeset/slow-crabs-vanish.md
@@ -1,0 +1,5 @@
+---
+"@varlock/cloudflare-integration": patch
+---
+
+pass through exit-code if set from process to avoid silent fails

--- a/packages/integrations/cloudflare/src/varlock-wrangler.ts
+++ b/packages/integrations/cloudflare/src/varlock-wrangler.ts
@@ -313,7 +313,7 @@ async function handleDeploy(args: Array<string>) {
   const secretCount = Object.keys(secretsObj).filter((k) => !k.startsWith('__VARLOCK_ENV')).length;
   console.log(`\x1b[36m✨ Deploying with varlock: ${varCount} var${varCount !== 1 ? 's' : ''}, ${secretCount} secret${secretCount !== 1 ? 's' : ''} 🧙🔒\x1b[0m`);
 
-  let exitCode = 0;
+  let exitCode = process.exitCode ?? 0;
   try {
     debug('deploy: spawning wrangler');
     exitCode = await spawnWrangler([...args, ...varFlags, '--secrets-file', tmp.filePath, '--keep-vars=false']);
@@ -348,7 +348,7 @@ async function handleTypes(args: Array<string>) {
   debug('types: starting FIFO serve');
   const handle = tmp.startServing(() => envFileLines.join('\n'));
 
-  let exitCode = 0;
+  let exitCode = process.exitCode ?? 0;
   try {
     debug('types: spawning wrangler');
     exitCode = await spawnWrangler([...args, '--env-file', tmp.filePath]);


### PR DESCRIPTION
The varlock-wrangler cli was silently exiting with 0, even though wrangler had errors. 

Currently, the wrangler CLI would throw an error like below, but because the wrapper code returns exit 0, the CI/CD actions would pass.
```
✘ [ERROR] A request to the Cloudflare API failed.
Authentication error [code: 10000]
```

This PR sets the exit code from the process if present (not null), otherwise it would fall back to 0.