### PR TITLE
fix(nextjs): bundle varlock into next-env-compat for Vercel

### DIFF
--- a/.bumpy/fix-nextjs-vercel-584.md
+++ b/.bumpy/fix-nextjs-vercel-584.md
@@ -1,0 +1,5 @@
+---
+"@varlock/nextjs-integration": patch
+---
+
+bundle varlock into next-env-compat to fix Vercel module resolution

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/packages/integrations/nextjs/package.json
+++ b/packages/integrations/nextjs/package.json
@@ -12,8 +12,7 @@
   "exports": {
     ".": "./dist/next-env-compat.js",
     "./plugin": "./dist/plugin.js",
-    "./loader": "./dist/loader.js",
-    "./varlock-env-inline": "./dist/varlock-env-inline.js"
+    "./loader": "./dist/loader.js"
   },
   "files": ["dist"],
   "scripts": {

--- a/packages/integrations/nextjs/tsup.config.ts
+++ b/packages/integrations/nextjs/tsup.config.ts
@@ -1,24 +1,42 @@
 import { defineConfig } from 'tsup';
 
-export default defineConfig({
-  entry: [ // Entry point(s)
-    'src/next-env-compat.ts',
-    'src/plugin.ts',
+export default defineConfig([
+  // next-env-compat is the @next/env replacement and runs at both build time AND runtime.
+  // On Vercel, the bundled server inlines @next/env so its dependencies (varlock) are not
+  // traced into the serverless function. Bundle varlock modules directly to avoid runtime
+  // "Cannot find module 'varlock'" errors.
+  // See: https://github.com/dmno-dev/varlock/issues/584
+  {
+    entry: ['src/next-env-compat.ts'],
 
-    'src/edge-env.ts',
-    'src/loader.ts',
-  ],
+    noExternal: [/^varlock/],
 
-  dts: true,
+    dts: true,
+    sourcemap: true,
+    treeshake: true,
 
-  // minify: true, // Minify output
-  sourcemap: true, // Generate sourcemaps
-  treeshake: true, // Remove unused code
+    clean: true,
+    outDir: 'dist',
 
-  clean: true,
-  outDir: 'dist', // Output directory
+    // ! we are exporting cjs to match @next/env
+    format: ['cjs'],
+    splitting: false,
+  },
+  // Other entry points only run at build time where varlock is always available.
+  {
+    entry: [
+      'src/plugin.ts',
+      'src/loader.ts',
+    ],
 
-  // ! we are exporting cjs to match @next/env
-  format: ['cjs'], // Output format(s)
-  splitting: false,
-});
+    dts: true,
+    sourcemap: true,
+    treeshake: true,
+
+    clean: false, // don't clean - first config already cleaned
+    outDir: 'dist',
+
+    format: ['cjs'],
+    splitting: false,
+  },
+]);


### PR DESCRIPTION
## Summary
- Bundle varlock runtime modules directly into `next-env-compat.js` via `noExternal: [/^varlock/]` in the tsup config, eliminating external `require('varlock')` calls at runtime
- Vercel's builder now always uses the bundled server path (PR vercel/vercel#15688), which inlines `@next/env` into `server.runtime.prod.js`. This means `@vercel/nft` no longer traces through the external `@next/env` package's dependencies, so `varlock` is missing from the serverless function at runtime
- Cleaned up stale exports (`varlock-env-inline`, `edge-env`) referencing non-existent files

Fixes #584

## Test plan
- [x] `bun run --filter @varlock/nextjs-integration build` succeeds
- [x] `next-env-compat.js` output contains no external `require('varlock')` calls
- [x] Build-time entries (`plugin.js`, `loader.js`) still externalize varlock (only needed at build time)
- [x] Typecheck passes across all packages
- [x] All 412 varlock unit tests pass
- [ ] Verify on Vercel with Next.js 16.2+ (needs user confirmation from #584)