### PR TITLE
fix(1password): forward proxy env vars in batch read subprocess

### DIFF
--- a/.bumpy/fix-1password-proxy-env-653.md
+++ b/.bumpy/fix-1password-proxy-env-653.md
@@ -1,0 +1,5 @@
+---
+"@varlock/1password-plugin": patch
+---
+
+Forward proxy environment variables (`http_proxy`, `https_proxy`, `ALL_PROXY`, `NO_PROXY` and case variants) to the `op` subprocess in the batch read path. Fixes secret resolution failures in proxied environments (corporate proxies, Claude Code sandbox, Docker, CI runners behind proxies).

--- a/packages/plugins/1password/src/cli-helper.ts
+++ b/packages/plugins/1password/src/cli-helper.ts
@@ -12,10 +12,14 @@ const OP_CLI_CACHE: Record<string, any> = {};
 /** Proxy env vars that must be forwarded so `op` can reach 1Password through HTTP/SOCKS proxies
  * (e.g. corporate proxies, container networks, sandboxed dev tools like Claude Code). */
 const PROXY_ENV_KEYS = [
-  'http_proxy', 'HTTP_PROXY',
-  'https_proxy', 'HTTPS_PROXY',
-  'all_proxy', 'ALL_PROXY',
-  'no_proxy', 'NO_PROXY',
+  'http_proxy',
+  'HTTP_PROXY',
+  'https_proxy',
+  'HTTPS_PROXY',
+  'all_proxy',
+  'ALL_PROXY',
+  'no_proxy',
+  'NO_PROXY',
 ] as const;
 
 function pickProxyEnv(): Record<string, string> {

--- a/packages/plugins/1password/src/cli-helper.ts
+++ b/packages/plugins/1password/src/cli-helper.ts
@@ -9,6 +9,23 @@ const ENABLE_BATCHING = true;
 
 const OP_CLI_CACHE: Record<string, any> = {};
 
+/** Proxy env vars that must be forwarded so `op` can reach 1Password through HTTP/SOCKS proxies
+ * (e.g. corporate proxies, container networks, sandboxed dev tools like Claude Code). */
+const PROXY_ENV_KEYS = [
+  'http_proxy', 'HTTP_PROXY',
+  'https_proxy', 'HTTPS_PROXY',
+  'all_proxy', 'ALL_PROXY',
+  'no_proxy', 'NO_PROXY',
+] as const;
+
+function pickProxyEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of PROXY_ENV_KEYS) {
+    if (process.env[key]) env[key] = process.env[key]!;
+  }
+  return env;
+}
+
 // for now we'll just use a single 1pass account for all requests
 // but we'll likely want to support multiple accounts in the future
 // note that the SDK does not currently support this - but service accounts are already limited to an account
@@ -207,6 +224,8 @@ async function executeReadBatch(batchToExecute: NonNullable<typeof opReadBatch>)
       ...process.env.USER && { USER: process.env.USER },
       ...process.env.HOME && { HOME: process.env.HOME },
       ...process.env.XDG_CONFIG_HOME && { XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
+      // proxy env vars so `op` can connect through HTTP/SOCKS proxies
+      ...pickProxyEnv(),
       // this setting actually just enables the CLI + Desktop App integration
       // which in some cases op has a hard time detecting via app setting
       OP_BIOMETRIC_UNLOCK_ENABLED: 'true',


### PR DESCRIPTION
## Problem

The `executeReadBatch` function in the 1Password plugin spawns `op run` with a minimal, hand-picked environment (just `PATH`, `USER`, `HOME`, `XDG_CONFIG_HOME`, and `OP_BIOMETRIC_UNLOCK_ENABLED`). This intentionally avoids leaking secrets into the subprocess — but it also strips `http_proxy` / `https_proxy` / `ALL_PROXY` / `NO_PROXY` and their case variants.

In any proxied environment, this causes `op` to bypass the proxy and attempt a direct connection, which fails:

```
error resolving value: Error: 1Password CLI error - error initializing client:
  Get "https://my-team.1password.com/api/v2/account/keysets":
  dial tcp: lookup my-team.1password.com: no such host
```

Environments affected:

- **Claude Code** — routes all sandboxed traffic through a localhost HTTP/SOCKS proxy; without proxy vars, DNS resolution itself fails
- **Corporate HTTP proxies** — common in enterprise environments
- **Docker / container networks** — when proxy vars are set for outbound access
- **CI runners behind proxies**

Note: the single-command path (`execOpCliCommand`) already preserves proxy vars because it uses `{ OP_SERVICE_ACCOUNT_TOKEN: _, ...cleanEnv } = process.env`. This PR brings the batch read path into parity.

## Fix

Add a `pickProxyEnv()` helper that selectively forwards the 8 standard proxy environment variables (both lowercase and uppercase forms) when present. Spread it into the `env` object alongside the existing passthrough vars.

## Testing

Verified in Claude Code's sandbox environment:
- **Before**: `varlock run --path varlock.schema -- echo test` fails with DNS error on `my-subdomain.1password.com`
- **After**: resolves the 1Password secret successfully, `op` connects through the proxy
- **Without proxy**: no behavior change — `pickProxyEnv()` returns `{}` when no proxy vars are set