### PR TITLE
Feature: add folding region support for VSCode extension

### DIFF
--- a/packages/vscode-plugin/language/language-configuration.json
+++ b/packages/vscode-plugin/language/language-configuration.json
@@ -31,5 +31,11 @@
     ["`", "`"],
     ["(", ")"],
     ["{", "}"]
-  ]
+  ],
+  "folding": {
+    "markers": {
+      "start": "^\\s*#?region\\b",
+      "end": "^\\s*#?endregion\\b"
+    }
+  },
 }


### PR DESCRIPTION
Add support for folding regions using the `#region` and `#endregion` markers.

This is based on the [API docs for language extensions](https://code.visualstudio.com/api/language-extensions/language-configuration-guide#folding).

Reference for the feature in VSCode: https://code.visualstudio.com/docs/editing/codebasics#_folding