### PR TITLE
fix: explicit per-item decorators take priority over defaults

### DIFF
--- a/.bumpy/decorator-priority-fix.md
+++ b/.bumpy/decorator-priority-fix.md
@@ -1,0 +1,5 @@
+---
+varlock: major
+---
+
+fix: explicit per-item decorators now take priority over @defaultSensitive/@defaultRequired from other files

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -317,62 +317,62 @@ export class ConfigItem {
 
   private async processRequired() {
     try {
+      // Pass 1: explicit per-item @required / @optional decorators take highest priority
       for (const def of this.defs) {
         const requiredDecs = def.itemDef.decorators?.filter((d) => d.name === 'required' || d.name === 'optional') || [];
-        // NOTE - checks for duplicates and using required+optional together are already handled more generally
         const requiredDec = requiredDecs[0];
+        if (!requiredDec) continue;
 
-        // Explicit per-item decorators
-        if (requiredDec) {
-          const usingOptional = requiredDec.name === 'optional';
+        const usingOptional = requiredDec.name === 'optional';
 
-          // need to track if required-ness is dynamic
-          // NOTE - if any other resolver ever has a static value, we'll need to change this
-          if (requiredDec.decValueResolver?.fnName !== '\0static') {
-            this._isRequiredDynamic = true;
-          }
-
-          const requiredDecoratorVal = await requiredDec.resolve();
-          // if we got an error, we'll bail and the error will be checked later
-          if (requiredDec.schemaErrors.length) {
-            // but we mark as not required so we don't _also_ get required error
-            this._isRequired = false;
-            return;
-          }
-          if (![true, false, undefined].includes(requiredDecoratorVal)) {
-            throw new SchemaError('@required/@optional must resolve to a boolean or undefined');
-          }
-          if (requiredDecoratorVal !== undefined) {
-            this._isRequired = usingOptional ? !requiredDecoratorVal : requiredDecoratorVal;
-            return;
-          }
+        // need to track if required-ness is dynamic
+        // NOTE - if any other resolver ever has a static value, we'll need to change this
+        if (requiredDec.decValueResolver?.fnName !== '\0static') {
+          this._isRequiredDynamic = true;
         }
 
-        // Root-level @defaultRequired (skip for defs without a source, e.g. builtins)
-        const defaultRequiredDec = def.source?.getRootDec('defaultRequired');
-        if (defaultRequiredDec) {
-          const defaultRequiredVal = await defaultRequiredDec.resolve();
-          // @defaultRequired = true/false
-          if (_.isBoolean(defaultRequiredVal)) {
-            this._isRequired = defaultRequiredVal;
-            return;
+        const requiredDecoratorVal = await requiredDec.resolve();
+        // if we got an error, we'll bail and the error will be checked later
+        if (requiredDec.schemaErrors.length) {
+          // but we mark as not required so we don't _also_ get required error
+          this._isRequired = false;
+          return;
+        }
+        if (![true, false, undefined].includes(requiredDecoratorVal)) {
+          throw new SchemaError('@required/@optional must resolve to a boolean or undefined');
+        }
+        if (requiredDecoratorVal !== undefined) {
+          this._isRequired = usingOptional ? !requiredDecoratorVal : requiredDecoratorVal;
+          return;
+        }
+      }
 
-          // @defaultRequired = infer
-          // we infer based on if a value is set in this source
-          } else if (defaultRequiredVal === 'infer') {
-            if (def.itemDef.resolver) {
-              if (def.itemDef.resolver instanceof StaticValueResolver) {
-                this._isRequired = def.itemDef.resolver.staticValue !== undefined && def.itemDef.resolver.staticValue !== '';
-              } else {
-                this._isRequired = true;
-              }
+      // Pass 2: @defaultRequired from source files
+      for (const def of this.defs) {
+        const defaultRequiredDec = def.source?.getRootDec('defaultRequired');
+        if (!defaultRequiredDec) continue;
+
+        const defaultRequiredVal = await defaultRequiredDec.resolve();
+        // @defaultRequired = true/false
+        if (_.isBoolean(defaultRequiredVal)) {
+          this._isRequired = defaultRequiredVal;
+          return;
+
+        // @defaultRequired = infer
+        // we infer based on if a value is set in this source
+        } else if (defaultRequiredVal === 'infer') {
+          if (def.itemDef.resolver) {
+            if (def.itemDef.resolver instanceof StaticValueResolver) {
+              this._isRequired = def.itemDef.resolver.staticValue !== undefined && def.itemDef.resolver.staticValue !== '';
             } else {
-              this._isRequired = false;
+              this._isRequired = true;
             }
-            return;
           } else {
-            throw new SchemaError('@defaultRequired must resolve to a boolean or "infer"');
+            this._isRequired = false;
           }
+          return;
+        } else {
+          throw new SchemaError('@defaultRequired must resolve to a boolean or "infer"');
         }
       }
     } catch (err) {
@@ -384,43 +384,39 @@ export class ConfigItem {
 
 
   _isSensitive: boolean = true;
+  _sensitiveExplicitlySet = false;
   get isSensitive(): boolean {
     return this._isSensitive;
   }
   private async processSensitive() {
     const sensitiveFromDataType = this.dataType?.isSensitive;
+
+    // Pass 1: explicit per-item @sensitive / @public decorators take highest priority
     for (const def of this.defs) {
       const sensitiveDecs = def.itemDef.decorators?.filter((d) => d.name === 'sensitive' || d.name === 'public') || [];
-      // NOTE - checks for duplicates and using sensitive+public together are already handled more generally
       const sensitiveDec = sensitiveDecs[0];
+      if (!sensitiveDec) continue;
 
-      // Explicit per-item decorators
-      if (sensitiveDec) {
-        const usingPublic = sensitiveDec.name === 'public';
-
-        const sensitiveDecValue = await sensitiveDec.resolve();
-        // can bail if the decorator value resolution failed
-        if (sensitiveDec.schemaErrors.length) {
-          return;
-        }
-        if (![true, false, undefined].includes(sensitiveDecValue)) {
-          throw new SchemaError('@sensitive/@public must resolve to a boolean or undefined');
-        }
-        if (sensitiveDecValue !== undefined) {
-          this._isSensitive = usingPublic ? !sensitiveDecValue : sensitiveDecValue;
-          return;
-        }
+      const usingPublic = sensitiveDec.name === 'public';
+      const sensitiveDecValue = await sensitiveDec.resolve();
+      if (sensitiveDec.schemaErrors.length) return;
+      if (![true, false, undefined].includes(sensitiveDecValue)) {
+        throw new SchemaError('@sensitive/@public must resolve to a boolean or undefined');
       }
+      if (sensitiveDecValue !== undefined) {
+        this._isSensitive = usingPublic ? !sensitiveDecValue : sensitiveDecValue;
+        this._sensitiveExplicitlySet = true;
+        return;
+      }
+    }
 
-      // we skip `defaultSensitive` behaviour if the data type specifies sensitivity
-      if (sensitiveFromDataType !== undefined) continue;
-
-      // skip for defs without a source (e.g. builtins)
-      const defaultSensitiveDec = def.source?.getRootDec('defaultSensitive');
-      if (defaultSensitiveDec) {
+    // Pass 2: @defaultSensitive from source files (skipped if data type specifies sensitivity)
+    if (sensitiveFromDataType === undefined) {
+      for (const def of this.defs) {
+        const defaultSensitiveDec = def.source?.getRootDec('defaultSensitive');
+        if (!defaultSensitiveDec) continue;
         if (!defaultSensitiveDec.decValueResolver) throw new Error('expected defaultSensitive to have a value resolver');
-        // special case for inferFromPrefix()
-        // TODO: formalize this pattern of a root decorator running a function _within the context of an item_
+
         if (defaultSensitiveDec.decValueResolver.fnName === 'inferFromPrefix') {
           const prefix = defaultSensitiveDec.decValueResolver.arrArgs![0].staticValue;
           if (!_.isString(prefix)) {
@@ -440,6 +436,7 @@ export class ConfigItem {
         }
       }
     }
+
     if (sensitiveFromDataType !== undefined) this._isSensitive = sensitiveFromDataType;
   }
 

--- a/packages/varlock/src/env-graph/test/required-decorators.test.ts
+++ b/packages/varlock/src/env-graph/test/required-decorators.test.ts
@@ -223,6 +223,85 @@ describe('required decorators', () => {
       },
     }));
   });
+  describe('explicit @required overrides @defaultRequired from other files', () => {
+    test('@required in schema wins over @defaultRequired=false in local', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @required
+          ITEM_A=
+        `,
+        '.env.local': outdent`
+          # @defaultRequired=false
+          # ---
+          ITEM_A=value
+        `,
+      },
+      expectRequired: { ITEM_A: true },
+    }));
+
+    test('@optional in schema wins over @defaultRequired=true in local', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @optional
+          ITEM_A=
+        `,
+        '.env.local': outdent`
+          # @defaultRequired=true
+          # ---
+          ITEM_A=value
+        `,
+      },
+      expectRequired: { ITEM_A: false },
+    }));
+
+    test('@required in local wins over @defaultRequired=false in schema', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @defaultRequired=false
+          # ---
+          ITEM_A=
+        `,
+        '.env.local': outdent`
+          # @required
+          ITEM_A=value
+        `,
+      },
+      expectRequired: { ITEM_A: true },
+    }));
+
+    test('@required in schema wins over @defaultRequired=infer in local', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @required
+          ITEM_A=
+        `,
+        '.env.local': outdent`
+          # @defaultRequired=infer
+          # ---
+          ITEM_A=
+        `,
+      },
+      expectRequired: { ITEM_A: true },
+    }));
+
+    test('items without explicit decorator still follow @defaultRequired', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @required
+          EXPLICIT_REQUIRED=
+          NO_DECORATOR=
+        `,
+        '.env.local': outdent`
+          # @defaultRequired=false
+          # ---
+          EXPLICIT_REQUIRED=value
+          NO_DECORATOR=value
+        `,
+      },
+      expectRequired: { EXPLICIT_REQUIRED: true, NO_DECORATOR: false },
+    }));
+  });
+
   describe('dynamic @required based on other items', () => {
     test('dynamic @required works', envFilesTest({
       files: {

--- a/packages/varlock/src/env-graph/test/sensitive-decorator.test.ts
+++ b/packages/varlock/src/env-graph/test/sensitive-decorator.test.ts
@@ -1,6 +1,11 @@
-import { describe, test } from 'vitest';
+import {
+  describe, test, expect, vi,
+} from 'vitest';
+import path from 'node:path';
 import outdent from 'outdent';
 import { envFilesTest } from './helpers/generic-test';
+import { EnvGraph, DotEnvFileDataSource } from '../index';
+import { createEnvGraphDataType } from '../lib/data-types';
 
 describe('@sensitive and @defaultSensitive tests', () => {
   test('no @defaultSensitive set - sensitive by default, can override', envFilesTest({
@@ -152,8 +157,186 @@ describe('@sensitive and @defaultSensitive tests', () => {
     }));
   });
 
-  test.todo('data type sensitive can set sensitivity');
-  test.todo('data type sensitive is not overridden by item decorators');
+  describe('explicit @sensitive overrides @defaultSensitive from other files', () => {
+    test('@sensitive in schema wins over @defaultSensitive=false in local', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @sensitive
+          ITEM_A=
+        `,
+        '.env.local': outdent`
+          # @defaultSensitive=false
+          # ---
+          ITEM_A=secret
+        `,
+      },
+      expectSensitive: { ITEM_A: true },
+    }));
+
+    test('@sensitive=false in schema wins over @defaultSensitive=true in local', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @sensitive=false
+          ITEM_A=
+        `,
+        '.env.local': outdent`
+          # @defaultSensitive=true
+          # ---
+          ITEM_A=value
+        `,
+      },
+      expectSensitive: { ITEM_A: false },
+    }));
+
+    test('@public in schema wins over @defaultSensitive=true in local', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @public
+          ITEM_A=
+        `,
+        '.env.local': outdent`
+          # @defaultSensitive=true
+          # ---
+          ITEM_A=value
+        `,
+      },
+      expectSensitive: { ITEM_A: false },
+    }));
+
+    test('@sensitive in local wins over @defaultSensitive=false in schema', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @defaultSensitive=false
+          # ---
+          ITEM_A=
+        `,
+        '.env.local': outdent`
+          # @sensitive
+          ITEM_A=secret
+        `,
+      },
+      expectSensitive: { ITEM_A: true },
+    }));
+
+    test('@sensitive in schema wins over inferFromPrefix in local', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @sensitive
+          PUBLIC_ITEM=
+        `,
+        '.env.local': outdent`
+          # @defaultSensitive=inferFromPrefix(PUBLIC_)
+          # ---
+          PUBLIC_ITEM=value
+        `,
+      },
+      expectSensitive: { PUBLIC_ITEM: true },
+    }));
+
+    test('items without explicit decorator still follow @defaultSensitive', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @sensitive
+          EXPLICIT_SENSITIVE=
+          NO_DECORATOR=
+        `,
+        '.env.local': outdent`
+          # @defaultSensitive=false
+          # ---
+          EXPLICIT_SENSITIVE=secret
+          NO_DECORATOR=value
+        `,
+      },
+      expectSensitive: { EXPLICIT_SENSITIVE: true, NO_DECORATOR: false },
+    }));
+  });
+
+  describe('data type with sensitive flag', () => {
+    function dataTypeSensitiveTest(spec: {
+      envFile: string;
+      sensitiveDataType: boolean;
+      expectSensitive: Record<string, boolean>;
+    }) {
+      return async () => {
+        const currentDir = path.dirname(expect.getState().testPath!);
+        vi.spyOn(process, 'cwd').mockReturnValue(currentDir);
+
+        const g = new EnvGraph();
+        g.registerDataType(createEnvGraphDataType({
+          name: 'secret-token',
+          sensitive: spec.sensitiveDataType,
+        }));
+        const source = new DotEnvFileDataSource('.env.schema', { overrideContents: spec.envFile });
+        await g.setRootDataSource(source);
+        await g.finishLoad();
+        await g.resolveEnvValues();
+
+        for (const [key, expected] of Object.entries(spec.expectSensitive)) {
+          const item = g.configSchema[key];
+          expect(item.isSensitive, `expected ${key} to be ${expected ? 'sensitive' : 'NOT sensitive'}`).toBe(expected);
+        }
+      };
+    }
+
+    test('data type sensitive=true makes items sensitive', dataTypeSensitiveTest({
+      sensitiveDataType: true,
+      envFile: outdent`
+        TYPED=      # @type=secret-token
+        UNTYPED=
+      `,
+      expectSensitive: { TYPED: true, UNTYPED: true },
+    }));
+
+    test('data type sensitive=false makes items not sensitive (overrides default)', dataTypeSensitiveTest({
+      sensitiveDataType: false,
+      envFile: outdent`
+        TYPED=      # @type=secret-token
+        UNTYPED=
+      `,
+      expectSensitive: { TYPED: false, UNTYPED: true },
+    }));
+
+    test('data type sensitive skips @defaultSensitive', dataTypeSensitiveTest({
+      sensitiveDataType: true,
+      envFile: outdent`
+        # @defaultSensitive=false
+        # ---
+        TYPED=      # @type=secret-token
+        UNTYPED=
+      `,
+      expectSensitive: { TYPED: true, UNTYPED: false },
+    }));
+
+    test('explicit @sensitive=false overrides data type sensitive=true', dataTypeSensitiveTest({
+      sensitiveDataType: true,
+      envFile: outdent`
+        # @sensitive=false
+        TYPED=      # @type=secret-token
+        UNTYPED=
+      `,
+      expectSensitive: { TYPED: false, UNTYPED: true },
+    }));
+
+    test('explicit @public overrides data type sensitive=true', dataTypeSensitiveTest({
+      sensitiveDataType: true,
+      envFile: outdent`
+        # @public
+        TYPED=      # @type=secret-token
+        UNTYPED=
+      `,
+      expectSensitive: { TYPED: false, UNTYPED: true },
+    }));
+
+    test('explicit @sensitive=true overrides data type sensitive=false', dataTypeSensitiveTest({
+      sensitiveDataType: false,
+      envFile: outdent`
+        # @sensitive
+        TYPED=      # @type=secret-token
+        UNTYPED=
+      `,
+      expectSensitive: { TYPED: true, UNTYPED: true },
+    }));
+  });
 });
 
 // maybe not the right spot, but it is related to sensitivity and decorators


### PR DESCRIPTION
## Summary

- Explicit per-item `@sensitive`/`@public` and `@required`/`@optional` decorators now always take priority over `@defaultSensitive`/`@defaultRequired` from other files
- Previously, if a `.env.local` had `@defaultSensitive=false`, it could override an explicit `@sensitive` in `.env.schema` due to definition source ordering
- Refactored `processSensitive()` and `processRequired()` to use a two-pass approach: scan all defs for explicit per-item decorators first, then fall through to defaults
- Added 17 new tests covering cross-file priority and data type sensitivity interactions

## Breaking change

This changes the precedence of decorator resolution. Projects relying on `@defaultSensitive`/`@defaultRequired` in override files to override explicit per-item decorators in schema files will see different behavior.

## Test plan

- [x] All existing sensitive/required decorator tests pass
- [x] New cross-file priority tests for @sensitive vs @defaultSensitive
- [x] New cross-file priority tests for @required vs @defaultRequired  
- [x] New data type sensitive flag interaction tests
- [x] Full typecheck passes