### PR TITLE
fix: skip notarization/native builds when not publishing

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -32,29 +32,34 @@ jobs:
         with:
           category: ${{ matrix.language }}
 
-  check-swift:
-    name: Check Swift changes
+  check-native-changes:
+    name: Check native source changes
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.check.outputs.changed }}
+      swift-changed: ${{ steps.check.outputs.swift-changed }}
+      rust-changed: ${{ steps.check.outputs.rust-changed }}
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-          elif git diff --name-only origin/main...HEAD 2>/dev/null | grep -q '^packages/encryption-binary-swift/'; then
-            echo "changed=true" >> $GITHUB_OUTPUT
+          FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --paginate --jq '.[].filename')
+          if echo "$FILES" | grep -q '^packages/encryption-binary-swift/'; then
+            echo "swift-changed=true" >> $GITHUB_OUTPUT
           else
-            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "swift-changed=false" >> $GITHUB_OUTPUT
+          fi
+          if echo "$FILES" | grep -q '^packages/encryption-binary-rust/'; then
+            echo "rust-changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "rust-changed=false" >> $GITHUB_OUTPUT
           fi
 
   analyze-swift:
     name: Analyze Swift
-    needs: check-swift
-    if: needs.check-swift.outputs.changed == 'true'
+    needs: check-native-changes
+    if: always() && (github.event_name != 'pull_request' || needs.check-native-changes.outputs.swift-changed == 'true')
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -72,29 +77,10 @@ jobs:
         with:
           category: swift
 
-  check-rust:
-    name: Check Rust changes
-    runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.check.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - id: check
-        run: |
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-          elif git diff --name-only origin/main...HEAD 2>/dev/null | grep -q '^packages/encryption-binary-rust/'; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
-
   analyze-rust:
     name: Analyze Rust
-    needs: check-rust
-    if: needs.check-rust.outputs.changed == 'true'
+    needs: check-native-changes
+    if: always() && (github.event_name != 'pull_request' || needs.check-native-changes.outputs.rust-changed == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,109 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # weekly scan — Sundays at 4am UTC
+    - cron: '0 4 * * 0'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze-js:
+    name: Analyze JavaScript/TypeScript + Actions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [javascript-typescript, actions]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: ${{ matrix.language }}
+
+  check-swift:
+    name: Check Swift changes
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: check
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          elif git diff --name-only origin/main...HEAD 2>/dev/null | grep -q '^packages/encryption-binary-swift/'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+  analyze-swift:
+    name: Analyze Swift
+    needs: check-swift
+    if: needs.check-swift.outputs.changed == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: swift
+          config-file: ./.github/codeql/codeql-config.yml
+      - name: Build Swift binary
+        run: |
+          cd packages/encryption-binary-swift
+          swift build
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: swift
+
+  check-rust:
+    name: Check Rust changes
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: check
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          elif git diff --name-only origin/main...HEAD 2>/dev/null | grep -q '^packages/encryption-binary-rust/'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+  analyze-rust:
+    name: Analyze Rust
+    needs: check-rust
+    if: needs.check-rust.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+          config-file: ./.github/codeql/codeql-config.yml
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: rust

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,11 +8,38 @@ on:
 permissions:
   contents: read
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: bumpy-release
+  cancel-in-progress: false
 
 jobs:
+  # Determine what bumpy will do — only run expensive build/notarize when publishing
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.plan.outputs.mode }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Cache bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+      - name: Install node deps
+        run: bun install
+      - id: plan
+        run: bunx @varlock/bumpy ci plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   # Build and sign the macOS native binary (cache hit if already built in CI)
   build-native-macos:
+    needs: plan
+    if: needs.plan.outputs.mode == 'publish'
     uses: ./.github/workflows/build-native-macos.yaml
     with:
       mode: release
@@ -22,7 +49,8 @@ jobs:
 
   # Notarize for production npm distribution
   notarize-native-macos:
-    needs: build-native-macos
+    needs: [plan, build-native-macos]
+    if: needs.plan.outputs.mode == 'publish'
     uses: ./.github/workflows/notarize-native-macos.yaml
     with:
       source-artifact-name: native-bin-macos-signed
@@ -32,13 +60,16 @@ jobs:
 
   # Build Rust native binaries for Linux and Windows
   build-native-rust:
+    needs: plan
+    if: needs.plan.outputs.mode == 'publish'
     uses: ./.github/workflows/build-native-rust.yaml
     with:
       artifact-name: native-bin-rust
 
   release:
     name: Release
-    needs: [notarize-native-macos, build-native-rust]
+    needs: [plan, notarize-native-macos, build-native-rust]
+    if: always() && !failure() && !cancelled()
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # Required for OIDC
@@ -77,30 +108,36 @@ jobs:
 
       # Download signed macOS native binary so it's included in the npm package
       - name: Download macOS native binary
+        if: needs.plan.outputs.mode == 'publish'
         uses: actions/download-artifact@v8
         with:
           name: native-bin-macos-npm
           path: packages/varlock/native-bins/darwin/VarlockEnclave.app
       - name: Restore native binary execute permission
+        if: needs.plan.outputs.mode == 'publish'
         run: chmod +x packages/varlock/native-bins/darwin/VarlockEnclave.app/Contents/MacOS/varlock-local-encrypt
 
       # Download Rust native binaries for Linux and Windows
       - name: Download Linux x64 native binary
+        if: needs.plan.outputs.mode == 'publish'
         uses: actions/download-artifact@v8
         with:
           name: native-bin-rust-linux-x64
           path: packages/varlock/native-bins/linux-x64
       - name: Download Linux arm64 native binary
+        if: needs.plan.outputs.mode == 'publish'
         uses: actions/download-artifact@v8
         with:
           name: native-bin-rust-linux-arm64
           path: packages/varlock/native-bins/linux-arm64
       - name: Download Windows x64 native binary
+        if: needs.plan.outputs.mode == 'publish'
         uses: actions/download-artifact@v8
         with:
           name: native-bin-rust-win32-x64
           path: packages/varlock/native-bins/win32-x64
       - name: Restore Rust binary execute permissions
+        if: needs.plan.outputs.mode == 'publish'
         run: |
           chmod +x packages/varlock/native-bins/linux-x64/varlock-local-encrypt
           chmod +x packages/varlock/native-bins/linux-arm64/varlock-local-encrypt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       mode: ${{ steps.plan.outputs.mode }}
-      packages: ${{ steps.plan.outputs.packages }}
-      includes-varlock: ${{ steps.check-varlock.outputs.result }}
+      includes-varlock: ${{ contains(fromJSON(steps.plan.outputs.json).packageNames, 'varlock') }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup Bun
@@ -37,14 +36,6 @@ jobs:
         run: bunx @varlock/bumpy ci plan
         env:
           GH_TOKEN: ${{ github.token }}
-      - id: check-varlock
-        run: |
-          # packages output is comma-separated — check for exact "varlock" entry
-          if echo ",${{ steps.plan.outputs.packages }}," | grep -q ',varlock,'; then
-            echo "result=true" >> $GITHUB_OUTPUT
-          else
-            echo "result=false" >> $GITHUB_OUTPUT
-          fi
 
   # Build and sign the macOS native binary (cache hit if already built in CI)
   build-native-macos:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,15 +23,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-      - name: Cache bun dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
-      - name: Install node deps
-        run: bun install
       - id: plan
         run: bunx @varlock/bumpy ci plan
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       mode: ${{ steps.plan.outputs.mode }}
+      packages: ${{ steps.plan.outputs.packages }}
+      includes-varlock: ${{ steps.check-varlock.outputs.result }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup Bun
@@ -35,11 +37,19 @@ jobs:
         run: bunx @varlock/bumpy ci plan
         env:
           GH_TOKEN: ${{ github.token }}
+      - id: check-varlock
+        run: |
+          # packages output is comma-separated — check for exact "varlock" entry
+          if echo ",${{ steps.plan.outputs.packages }}," | grep -q ',varlock,'; then
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
 
   # Build and sign the macOS native binary (cache hit if already built in CI)
   build-native-macos:
     needs: plan
-    if: needs.plan.outputs.mode == 'publish'
+    if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
     uses: ./.github/workflows/build-native-macos.yaml
     with:
       mode: release
@@ -50,7 +60,7 @@ jobs:
   # Notarize for production npm distribution
   notarize-native-macos:
     needs: [plan, build-native-macos]
-    if: needs.plan.outputs.mode == 'publish'
+    if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
     uses: ./.github/workflows/notarize-native-macos.yaml
     with:
       source-artifact-name: native-bin-macos-signed
@@ -61,7 +71,7 @@ jobs:
   # Build Rust native binaries for Linux and Windows
   build-native-rust:
     needs: plan
-    if: needs.plan.outputs.mode == 'publish'
+    if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
     uses: ./.github/workflows/build-native-rust.yaml
     with:
       artifact-name: native-bin-rust
@@ -108,36 +118,36 @@ jobs:
 
       # Download signed macOS native binary so it's included in the npm package
       - name: Download macOS native binary
-        if: needs.plan.outputs.mode == 'publish'
+        if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
         uses: actions/download-artifact@v8
         with:
           name: native-bin-macos-npm
           path: packages/varlock/native-bins/darwin/VarlockEnclave.app
       - name: Restore native binary execute permission
-        if: needs.plan.outputs.mode == 'publish'
+        if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
         run: chmod +x packages/varlock/native-bins/darwin/VarlockEnclave.app/Contents/MacOS/varlock-local-encrypt
 
       # Download Rust native binaries for Linux and Windows
       - name: Download Linux x64 native binary
-        if: needs.plan.outputs.mode == 'publish'
+        if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
         uses: actions/download-artifact@v8
         with:
           name: native-bin-rust-linux-x64
           path: packages/varlock/native-bins/linux-x64
       - name: Download Linux arm64 native binary
-        if: needs.plan.outputs.mode == 'publish'
+        if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
         uses: actions/download-artifact@v8
         with:
           name: native-bin-rust-linux-arm64
           path: packages/varlock/native-bins/linux-arm64
       - name: Download Windows x64 native binary
-        if: needs.plan.outputs.mode == 'publish'
+        if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
         uses: actions/download-artifact@v8
         with:
           name: native-bin-rust-win32-x64
           path: packages/varlock/native-bins/win32-x64
       - name: Restore Rust binary execute permissions
-        if: needs.plan.outputs.mode == 'publish'
+        if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
         run: |
           chmod +x packages/varlock/native-bins/linux-x64/varlock-local-encrypt
           chmod +x packages/varlock/native-bins/linux-arm64/varlock-local-encrypt

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@types/node": "catalog:",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.56.1",
-        "@varlock/bumpy": "^1.5.1",
+        "@varlock/bumpy": "^1.7.0",
         "@varlock/cloudflare-integration": "workspace:*",
         "@varlock/keepass-plugin": "workspace:*",
         "@varlock/tsconfig": "workspace:*",
@@ -1332,7 +1332,7 @@
 
     "@varlock/bitwarden-plugin": ["@varlock/bitwarden-plugin@workspace:packages/plugins/bitwarden"],
 
-    "@varlock/bumpy": ["@varlock/bumpy@1.5.1", "", { "bin": { "bumpy": "dist/cli.mjs" } }, "sha512-oSGpOR7OIDJ4UXyX8ZosUAQYYgvBR3BOdNj+WHYXY0DSEWyC4Lzh09iVC9pGflo3vpZ+OtyemGSyL2nWhz/Qdw=="],
+    "@varlock/bumpy": ["@varlock/bumpy@1.7.0", "", { "bin": { "bumpy": "dist/cli.mjs" } }, "sha512-FYsjPJlnQufwkfstMVh2G2bvaa7bctX97Qgisc3NyC063U3AtPT05sGAEESf45DS+3jT7IXuEjeUsxXNAFtatA=="],
 
     "@varlock/ci-env-info": ["@varlock/ci-env-info@workspace:packages/ci-env-info"],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prepare": "lefthook install"
   },
   "devDependencies": {
-    "@varlock/bumpy": "^1.5.1",
+    "@varlock/bumpy": "^1.7.0",
     "@cloudflare/vite-plugin": "^1.30.1",
     "@eslint/js": "^10.0.1",
     "@stylistic/eslint-plugin": "^5.9.0",

--- a/scripts/check-release-packages.ts
+++ b/scripts/check-release-packages.ts
@@ -37,7 +37,7 @@ if (bumpyStatusRaw) {
   if (jsonMatch) {
     const bumpyStatus = JSON.parse(jsonMatch[0]);
     const bumpyReleases = bumpyStatus.releases
-      .filter((r: any) => r.publishTargets?.includes('npm'));
+      .filter((r: any) => r.publishTargets?.some((t: any) => t.type === 'npm'));
     releasePackagePaths = bumpyReleases
       .map((r: any) => path.resolve(MONOREPO_ROOT, r.dir));
   }


### PR DESCRIPTION
## Summary
- Adds a `bumpy ci plan` preflight job to the release workflow to determine whether bumpy will publish or just create/update a version PR
- Gates the expensive macOS build, notarization, and Rust native binary build jobs so they only run when `mode == 'publish'`
- Fixes concurrency control to use a static `bumpy-release` group with `cancel-in-progress: false` (queues rather than cancels, per bumpy docs)
- Updates `@varlock/bumpy` from ^1.5.1 to ^1.7.0 for `ci plan` support
- Fixes `publishTargets` filter in `check-release-packages.ts` for the new object shape (`{ type: 'npm' }` instead of `'npm'`)

## Test plan
- [ ] Merge a normal commit to main → verify plan reports `version-pr` or `nothing`, and build/notarize jobs are skipped
- [ ] Merge a release PR to main → verify plan reports `publish`, build/notarize jobs run, and publish succeeds