### PR TITLE
feat: add --summary-stderr/--summary-file to varlock load, improve execSyncVarlock API

### DIFF
--- a/.bumpy/load-summary-stderr.md
+++ b/.bumpy/load-summary-stderr.md
@@ -1,0 +1,9 @@
+---
+varlock: minor
+"@varlock/vite-integration": minor
+"@varlock/nextjs-integration": minor
+"@varlock/expo-integration": minor
+"@varlock/cloudflare-integration": minor
+---
+
+Add --summary-stderr/--summary-file flags to varlock load and fullResult option to execSyncVarlock

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-      
+
       # this caching step is kind of a wash
       # downloading the cache adds a few seconds and then installing is a bit faster
       - name: Cache bun dependencies

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -81,7 +81,7 @@ export function varlockCloudflareVitePlugin(
     if (!isDevMode) return userResult;
 
     // Single CLI call for the full graph, then extract individual vars.
-    const serializedGraph = execSyncVarlock('load --format json-full --compact');
+    const { stdout: serializedGraph } = execSyncVarlock('load --format json-full --compact', { fullResult: true });
     let graph: { config: Record<string, { value: unknown }> };
     try {
       graph = JSON.parse(serializedGraph);

--- a/packages/integrations/cloudflare/src/varlock-wrangler.ts
+++ b/packages/integrations/cloudflare/src/varlock-wrangler.ts
@@ -48,8 +48,7 @@ function spawnWrangler(args: Array<string>): Promise<number> {
 }
 
 function loadSerializedGraph() {
-  const { stdout, stderr } = execSyncVarlock('load --format json-full --compact --summary-stderr', { fullResult: true });
-  if (stderr) process.stderr.write(stderr);
+  const { stdout } = execSyncVarlock('load --format json-full --compact', { fullResult: true });
   return {
     json: stdout,
     graph: JSON.parse(stdout) as {

--- a/packages/integrations/cloudflare/src/varlock-wrangler.ts
+++ b/packages/integrations/cloudflare/src/varlock-wrangler.ts
@@ -48,12 +48,11 @@ function spawnWrangler(args: Array<string>): Promise<number> {
 }
 
 function loadSerializedGraph() {
-  const serializedGraphJson = execSyncVarlock('load --format json-full --compact', {
-    showLogsOnError: true,
-  });
+  const { stdout, stderr } = execSyncVarlock('load --format json-full --compact --summary-stderr', { fullResult: true });
+  if (stderr) process.stderr.write(stderr);
   return {
-    json: serializedGraphJson,
-    graph: JSON.parse(serializedGraphJson) as {
+    json: stdout,
+    graph: JSON.parse(stdout) as {
       basePath?: string,
       sources: Array<{ label: string, enabled: boolean, path?: string }>,
       config: Record<string, { value: unknown, isSensitive: boolean }>,

--- a/packages/integrations/expo/src/babel-plugin.ts
+++ b/packages/integrations/expo/src/babel-plugin.ts
@@ -14,11 +14,10 @@ let configIsValid = true;
 function loadVarlockConfig() {
   debug('loading varlock config for expo babel plugin');
   try {
-    const { stdout, stderr } = execSyncVarlock('load --format json-full --summary-stderr', {
+    const { stdout } = execSyncVarlock('load --format json-full', {
       fullResult: true,
       env: originalProcessEnv,
     });
-    if (stderr) process.stderr.write(stderr);
     process.env.__VARLOCK_ENV = stdout;
     varlockLoadedEnv = JSON.parse(stdout) as SerializedEnvGraph;
     configIsValid = true;

--- a/packages/integrations/expo/src/babel-plugin.ts
+++ b/packages/integrations/expo/src/babel-plugin.ts
@@ -1,4 +1,4 @@
-import { execSyncVarlock } from 'varlock/exec-sync-varlock';
+import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 import { initVarlockEnv } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
 import { createDebug, type SerializedEnvGraph } from 'varlock';
@@ -14,12 +14,13 @@ let configIsValid = true;
 function loadVarlockConfig() {
   debug('loading varlock config for expo babel plugin');
   try {
-    const execResult = execSyncVarlock('load --format json-full', {
+    const { stdout, stderr } = execSyncVarlock('load --format json-full --summary-stderr', {
+      fullResult: true,
       env: originalProcessEnv,
-      showLogsOnError: true,
     });
-    process.env.__VARLOCK_ENV = execResult;
-    varlockLoadedEnv = JSON.parse(process.env.__VARLOCK_ENV) as SerializedEnvGraph;
+    if (stderr) process.stderr.write(stderr);
+    process.env.__VARLOCK_ENV = stdout;
+    varlockLoadedEnv = JSON.parse(stdout) as SerializedEnvGraph;
     configIsValid = true;
 
     // Make the loaded env available on globalThis so that any module instance
@@ -31,7 +32,10 @@ function loadVarlockConfig() {
     initVarlockEnv();
     // this will be a no-op if disabled by settings
     patchGlobalConsole();
-  } catch (_err) {
+  } catch (err) {
+    if (err instanceof VarlockExecError && err.stderr) {
+      process.stderr.write(err.stderr);
+    }
     configIsValid = false;
   }
 }

--- a/packages/integrations/expo/src/metro-config.ts
+++ b/packages/integrations/expo/src/metro-config.ts
@@ -1,5 +1,5 @@
 import { resolve, dirname } from 'node:path';
-import { execSyncVarlock } from 'varlock/exec-sync-varlock';
+import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 import { initVarlockEnv } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
 import type { SerializedEnvGraph } from 'varlock';
@@ -76,17 +76,19 @@ export function withVarlockMetroConfig<T extends Record<string, any>>(config: T)
   if (process.env.__VARLOCK_ENV) return config;
 
   try {
-    const execResult = execSyncVarlock('load --format json-full', {
-      showLogsOnError: true,
-    });
-    process.env.__VARLOCK_ENV = execResult;
+    const { stdout, stderr } = execSyncVarlock('load --format json-full --summary-stderr', { fullResult: true });
+    if (stderr) process.stderr.write(stderr);
+    process.env.__VARLOCK_ENV = stdout;
 
-    const parsed = JSON.parse(execResult) as SerializedEnvGraph;
+    const parsed = JSON.parse(stdout) as SerializedEnvGraph;
     (globalThis as any).__varlockLoadedEnv = parsed;
 
     initVarlockEnv();
     patchGlobalConsole();
   } catch (err) {
+    if (err instanceof VarlockExecError && err.stderr) {
+      process.stderr.write(err.stderr);
+    }
     throw new Error(
       '@varlock/expo-integration: Failed to initialize varlock in Metro config.\n'
       + 'Your .env.schema may have syntax errors or failing validation.\n'

--- a/packages/integrations/expo/src/metro-config.ts
+++ b/packages/integrations/expo/src/metro-config.ts
@@ -76,8 +76,7 @@ export function withVarlockMetroConfig<T extends Record<string, any>>(config: T)
   if (process.env.__VARLOCK_ENV) return config;
 
   try {
-    const { stdout, stderr } = execSyncVarlock('load --format json-full --summary-stderr', { fullResult: true });
-    if (stderr) process.stderr.write(stderr);
+    const { stdout } = execSyncVarlock('load --format json-full', { fullResult: true });
     process.env.__VARLOCK_ENV = stdout;
 
     const parsed = JSON.parse(stdout) as SerializedEnvGraph;

--- a/packages/integrations/expo/test/babel-plugin.test.ts
+++ b/packages/integrations/expo/test/babel-plugin.test.ts
@@ -32,7 +32,8 @@ const FIXTURE_ENV_GRAPH = vi.hoisted(async () => {
 // are in place when the module-level `loadVarlockConfig()` runs.
 // ---------------------------------------------------------------------------
 vi.mock('varlock/exec-sync-varlock', async () => ({
-  execSyncVarlock: vi.fn().mockReturnValue(JSON.stringify(await FIXTURE_ENV_GRAPH)),
+  execSyncVarlock: vi.fn().mockReturnValue({ stdout: JSON.stringify(await FIXTURE_ENV_GRAPH), stderr: '' }),
+  VarlockExecError: class VarlockExecError extends Error {},
 }));
 
 vi.mock('varlock/env', () => ({

--- a/packages/integrations/expo/test/metro-config.test.ts
+++ b/packages/integrations/expo/test/metro-config.test.ts
@@ -61,7 +61,7 @@ describe('withVarlockMetroConfig', () => {
   it('calls execSyncVarlock to load config', () => {
     withVarlockMetroConfig({});
     expect(mockExecSyncVarlock).toHaveBeenCalledOnce();
-    expect(mockExecSyncVarlock).toHaveBeenCalledWith('load --format json-full --summary-stderr', { fullResult: true });
+    expect(mockExecSyncVarlock).toHaveBeenCalledWith('load --format json-full', { fullResult: true });
   });
 
   it('sets process.env.__VARLOCK_ENV with the JSON result', () => {

--- a/packages/integrations/expo/test/metro-config.test.ts
+++ b/packages/integrations/expo/test/metro-config.test.ts
@@ -10,6 +10,7 @@ const { mockExecSyncVarlock, mockInitVarlockEnv, mockPatchGlobalConsole } = vi.h
 
 vi.mock('varlock/exec-sync-varlock', () => ({
   execSyncVarlock: mockExecSyncVarlock,
+  VarlockExecError: class VarlockExecError extends Error {},
 }));
 
 vi.mock('varlock/env', () => ({
@@ -39,7 +40,7 @@ describe('withVarlockMetroConfig', () => {
     delete process.env.__VARLOCK_ENV;
     delete (globalThis as any).__varlockLoadedEnv;
     vi.clearAllMocks();
-    mockExecSyncVarlock.mockReturnValue(JSON.stringify(FAKE_ENV_GRAPH));
+    mockExecSyncVarlock.mockReturnValue({ stdout: JSON.stringify(FAKE_ENV_GRAPH), stderr: '' });
   });
 
   afterEach(() => {
@@ -60,9 +61,7 @@ describe('withVarlockMetroConfig', () => {
   it('calls execSyncVarlock to load config', () => {
     withVarlockMetroConfig({});
     expect(mockExecSyncVarlock).toHaveBeenCalledOnce();
-    expect(mockExecSyncVarlock).toHaveBeenCalledWith('load --format json-full', {
-      showLogsOnError: true,
-    });
+    expect(mockExecSyncVarlock).toHaveBeenCalledWith('load --format json-full --summary-stderr', { fullResult: true });
   });
 
   it('sets process.env.__VARLOCK_ENV with the JSON result', () => {

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -328,11 +328,10 @@ export function loadEnvConfig(
     // strip DEBUG_VARLOCK from env to prevent debug output from contaminating JSON stdout
     const cleanEnv = { ...initialEnv };
     delete cleanEnv.DEBUG_VARLOCK;
-    const { stdout, stderr } = execSyncVarlock(`load --format json-full --summary-stderr --env ${envFromNextCommand}`, {
+    const { stdout } = execSyncVarlock(`load --format json-full --env ${envFromNextCommand}`, {
       fullResult: true,
       env: cleanEnv as any,
     });
-    if (stderr) process.stderr.write(stderr);
     if (loadCount >= 2) {
       // eslint-disable-next-line no-console
       console.log('✅ env reloaded and validated');

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -10,7 +10,7 @@ import { execSync } from 'child_process';
 import { type SerializedEnvGraph } from 'varlock';
 import { initVarlockEnv, resetRedactionMap } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
-import { execSyncVarlock } from 'varlock/exec-sync-varlock';
+import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 
 export type Env = { [key: string]: string | undefined };
 export type LoadedEnvFiles = Array<{
@@ -328,18 +328,16 @@ export function loadEnvConfig(
     // strip DEBUG_VARLOCK from env to prevent debug output from contaminating JSON stdout
     const cleanEnv = { ...initialEnv };
     delete cleanEnv.DEBUG_VARLOCK;
-    const varlockLoadedEnvStr = execSyncVarlock(`load --format json-full --env ${envFromNextCommand}`, {
-      // We handle all error display and exit logic ourselves in the catch block
-      // so we can silently defer on serverless platforms where the binary is missing.
-      showLogsOnError: false,
-      exitOnError: false,
+    const { stdout, stderr } = execSyncVarlock(`load --format json-full --summary-stderr --env ${envFromNextCommand}`, {
+      fullResult: true,
       env: cleanEnv as any,
     });
+    if (stderr) process.stderr.write(stderr);
     if (loadCount >= 2) {
       // eslint-disable-next-line no-console
       console.log('✅ env reloaded and validated');
     }
-    varlockLoadedEnv = JSON.parse(varlockLoadedEnvStr);
+    varlockLoadedEnv = JSON.parse(stdout);
   } catch (err) {
     if ((err as any).message.includes('Unable to find varlock executable')) {
       // In production the binary may not exist — e.g., on serverless platforms
@@ -363,16 +361,15 @@ export function loadEnvConfig(
     }
 
     // For real errors (validation failures, etc.) show the CLI output
-    /* eslint-disable no-console */
-    const errAny = err as any;
-    if (errAny.stdout) console.log(errAny.stdout.toString());
-    if (errAny.stderr) console.error(errAny.stderr.toString());
-    console.error('[varlock] ⚠️ failed to load env — see error above');
-    /* eslint-enable no-console */
+    if (err instanceof VarlockExecError) {
+      if (err.stderr) process.stderr.write(err.stderr);
+      // eslint-disable-next-line no-console
+      console.error('[varlock] ⚠️ failed to load env — see error above');
+    }
 
     // In a build, we want to fail hard so broken env doesn't get deployed
     if (!dev) {
-      process.exit((err as any).status ?? 1);
+      process.exit((err as any).exitCode ?? 1);
     }
 
     // if we dont do this, we'll see an error that looks like `process.env.__VARLOCK_ENV is not set` which is misleading.

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -57,12 +57,11 @@ let loadCount = 0;
 function reloadConfig(cwd?: string) {
   debug('loading config - count =', ++loadCount, cwd ? `(cwd: ${cwd})` : '');
   try {
-    const { stdout, stderr } = execSyncVarlock('load --format json-full --compact --summary-stderr', {
+    const { stdout } = execSyncVarlock('load --format json-full --compact', {
       fullResult: true,
       env: originalProcessEnv,
       ...(cwd && { cwd }),
     });
-    if (stderr) process.stderr.write(stderr);
     process.env.__VARLOCK_ENV = stdout;
     varlockLoadedEnv = JSON.parse(stdout) as SerializedEnvGraph;
     configIsValid = true;

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -9,7 +9,7 @@ import { patchGlobalConsole } from 'varlock/patch-console';
 import { patchGlobalServerResponse } from 'varlock/patch-server-response';
 import { patchGlobalResponse } from 'varlock/patch-response';
 import { createDebug, type SerializedEnvGraph } from 'varlock';
-import { execSyncVarlock } from 'varlock/exec-sync-varlock';
+import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 
 import { createReplacerTransformFn, SUPPORTED_FILES } from './transform';
 
@@ -57,25 +57,26 @@ let loadCount = 0;
 function reloadConfig(cwd?: string) {
   debug('loading config - count =', ++loadCount, cwd ? `(cwd: ${cwd})` : '');
   try {
-    const execResult = execSyncVarlock('load --format json-full --compact', {
+    const { stdout, stderr } = execSyncVarlock('load --format json-full --compact --summary-stderr', {
+      fullResult: true,
       env: originalProcessEnv,
       ...(cwd && { cwd }),
     });
-    process.env.__VARLOCK_ENV = execResult;
-    varlockLoadedEnv = JSON.parse(process.env.__VARLOCK_ENV) as SerializedEnvGraph;
+    if (stderr) process.stderr.write(stderr);
+    process.env.__VARLOCK_ENV = stdout;
+    varlockLoadedEnv = JSON.parse(stdout) as SerializedEnvGraph;
     configIsValid = true;
   } catch (err) {
     // CLI exits non-zero on validation failure but still outputs JSON to stdout.
     // Try to parse it so we have sources (for file watching) and error details.
-    const errAny = err as any;
-    const stdout = errAny?.stdout?.toString();
-    if (stdout) {
-      try {
-        varlockLoadedEnv = JSON.parse(stdout) as SerializedEnvGraph;
-      } catch { /* not parseable — hard failure */ }
+    if (err instanceof VarlockExecError) {
+      if (err.stdout) {
+        try {
+          varlockLoadedEnv = JSON.parse(err.stdout) as SerializedEnvGraph;
+        } catch { /* not parseable — hard failure */ }
+      }
+      if (err.stderr) console.error(err.stderr);
     }
-    // Show the human-readable error output from the CLI
-    if (errAny?.stderr) console.error(errAny.stderr.toString());
     configIsValid = false;
     resetStaticReplacements();
     return;

--- a/packages/varlock/src/auto-load.ts
+++ b/packages/varlock/src/auto-load.ts
@@ -11,14 +11,13 @@ import { patchGlobalResponse } from './runtime/patch-response';
 // this also isolates the varlock loading process from the end user process
 
 try {
-  const { stdout, stderr } = execSyncVarlock('load --format json-full --compact --summary-stderr', {
+  const { stdout } = execSyncVarlock('load --format json-full --compact', {
     fullResult: true,
     // Pass the directory of this module so that in monorepos the binary search
     // starts from inside the varlock package (e.g. apps/web/node_modules/varlock)
     // rather than from process.cwd(), which may be an unrelated workspace root.
     callerDir: import.meta.dirname ?? new URL('.', import.meta.url).pathname,
   });
-  if (stderr) process.stderr.write(stderr);
   process.env.__VARLOCK_ENV = stdout;
 } catch (err) {
   if (err instanceof VarlockExecError && err.stderr) {

--- a/packages/varlock/src/auto-load.ts
+++ b/packages/varlock/src/auto-load.ts
@@ -1,4 +1,4 @@
-import { execSyncVarlock } from './lib/exec-sync-varlock';
+import { execSyncVarlock, VarlockExecError } from './lib/exec-sync-varlock';
 
 import { initVarlockEnv } from './runtime/env';
 import { patchGlobalConsole } from './runtime/patch-console';
@@ -10,16 +10,25 @@ import { patchGlobalResponse } from './runtime/patch-response';
 // so we call out to the CLI using execSync
 // this also isolates the varlock loading process from the end user process
 
-
-const execResult = execSyncVarlock('load --format json-full --compact', {
-  exitOnError: true,
-  showLogsOnError: true,
-  // Pass the directory of this module so that in monorepos the binary search
-  // starts from inside the varlock package (e.g. apps/web/node_modules/varlock)
-  // rather than from process.cwd(), which may be an unrelated workspace root.
-  callerDir: import.meta.dirname ?? new URL('.', import.meta.url).pathname,
-});
-process.env.__VARLOCK_ENV = execResult;
+try {
+  const { stdout, stderr } = execSyncVarlock('load --format json-full --compact --summary-stderr', {
+    fullResult: true,
+    // Pass the directory of this module so that in monorepos the binary search
+    // starts from inside the varlock package (e.g. apps/web/node_modules/varlock)
+    // rather than from process.cwd(), which may be an unrelated workspace root.
+    callerDir: import.meta.dirname ?? new URL('.', import.meta.url).pathname,
+  });
+  if (stderr) process.stderr.write(stderr);
+  process.env.__VARLOCK_ENV = stdout;
+} catch (err) {
+  if (err instanceof VarlockExecError && err.stderr) {
+    process.stderr.write(err.stderr);
+  } else {
+    // eslint-disable-next-line no-console
+    console.error(err);
+  }
+  process.exit((err as any).exitCode ?? 1);
+}
 
 // initialize varlock and patch globals as necessary
 initVarlockEnv();
@@ -27,4 +36,3 @@ initVarlockEnv();
 patchGlobalConsole();
 patchGlobalServerResponse();
 patchGlobalResponse();
-

--- a/packages/varlock/src/cli/commands/load.command.ts
+++ b/packages/varlock/src/cli/commands/load.command.ts
@@ -1,3 +1,4 @@
+import { writeFileSync } from 'node:fs';
 import { define } from 'gunshi';
 import { gracefulExit } from 'exit-hook';
 
@@ -37,6 +38,14 @@ export const commandSpec = define({
       multiple: true,
       description: 'Path to a specific .env file or directory to use as the entry point (can be specified multiple times)',
     },
+    'summary-stderr': {
+      type: 'boolean',
+      description: 'Also output the pretty (redacted) summary to stderr (useful alongside --format json-full to get both machine-readable output on stdout and a human-readable summary on stderr)',
+    },
+    'summary-file': {
+      type: 'string',
+      description: 'Also write the pretty (redacted) summary to a file path (useful for CI, e.g. $GITHUB_STEP_SUMMARY)',
+    },
   },
   examples: `
 Loads and validates environment variables according to your .env files, and prints the results.
@@ -51,6 +60,8 @@ Examples:
   varlock load -p ./envs -p ./overrides  # Load from multiple directories
   varlock load --compact          # Use compact format - skips undefined values, no indentation for json-full
   varlock load --env production   # Load for a specific environment (⚠️ ignored if using @currentEnv!)
+  varlock load --format json-full --summary-stderr   # JSON on stdout + redacted human summary on stderr
+  varlock load --format json-full --summary-file /tmp/summary.txt   # JSON on stdout + redacted human summary written to file
 `.trim(),
 });
 
@@ -65,7 +76,9 @@ export function formatShellValue(value: string): string {
 }
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
-  const { format, compact, 'show-all': showAll } = ctx.values;
+  const {
+    format, compact, 'show-all': showAll, 'summary-stderr': summaryStderr, 'summary-file': summaryFile,
+  } = ctx.values;
 
   const envGraph = await loadVarlockEnvGraph({
     currentEnvFallback: ctx.values.env,
@@ -91,6 +104,19 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     checkForConfigErrors(envGraph, { showAll, noThrow: true });
   } else {
     checkForConfigErrors(envGraph, { showAll });
+  }
+
+  if ((summaryStderr || summaryFile) && format !== 'pretty') {
+    const summaryLines = envGraph.sortedConfigKeys.map(
+      (key) => getItemSummary(envGraph.configSchema[key]),
+    );
+    const summaryStr = `${summaryLines.join('\n')}\n`;
+    if (summaryStderr) {
+      process.stderr.write(summaryStr);
+    }
+    if (summaryFile) {
+      writeFileSync(summaryFile, summaryStr);
+    }
   }
 
   if (format === 'pretty') {

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -41,26 +41,53 @@ function findVarlockBin(startDir: string): string | null {
   return null;
 }
 
+
+/** Error thrown by `execSyncVarlock` when the CLI exits with a non-zero status code and `fullResult` is enabled. */
+export class VarlockExecError extends Error {
+  constructor(
+    message: string,
+    public stdout: string,
+    public stderr: string,
+    public exitCode: number,
+  ) {
+    super(message);
+  }
+}
+
+export type ExecVarlockResult = { stdout: string, stderr: string };
+
+type ExecSyncVarlockOpts = Parameters<typeof execSyncType>[1] & {
+  exitOnError?: boolean,
+  showLogsOnError?: boolean,
+  /**
+   * Additional directory to start searching for the varlock binary from.
+   * Searched before process.cwd(). Pass `import.meta.dirname` from the
+   * call-site so that in monorepos the binary installed next to the
+   * importing package is found even when cwd is an unrelated workspace root.
+   */
+  callerDir?: string,
+  /**
+   * When true, return `{ stdout, stderr }` instead of just the stdout string,
+   * and throw `VarlockExecError` (with `.stdout`, `.stderr`, `.exitCode`) on failure
+   * instead of the raw execSync error.
+   */
+  fullResult?: boolean,
+};
+
 /**
- * small helper to call execSync and call the varlock cli
+ * Small helper to call execSync and call the varlock cli.
  *
- * when end user runs via a package manager, it will inject node_modules/.bin into PATH
- * but otherwise we may need to try to find that path ourselves
+ * When the user runs via a package manager, it will inject node_modules/.bin into PATH
+ * but otherwise we may need to try to find that path ourselves.
+ *
+ * @returns stdout as a string by default, or `{ stdout, stderr }` when `fullResult: true`
  */
+export function execSyncVarlock(command: string, opts?: ExecSyncVarlockOpts & { fullResult?: false }): string;
+export function execSyncVarlock(command: string, opts: ExecSyncVarlockOpts & { fullResult: true }): ExecVarlockResult;
 export function execSyncVarlock(
   command: string,
-  opts?: (Parameters<typeof execSyncType>[1] & {
-    exitOnError?: boolean,
-    showLogsOnError?: boolean,
-    /**
-     * Additional directory to start searching for the varlock binary from.
-     * Searched before process.cwd(). Pass `import.meta.dirname` from the
-     * call-site so that in monorepos the binary installed next to the
-     * importing package is found even when cwd is an unrelated workspace root.
-     */
-    callerDir?: string,
-  }),
-) {
+  opts?: ExecSyncVarlockOpts,
+): string | ExecVarlockResult {
   try {
     // in most cases, user will be running via their package manager
     // and a package.json script (ie `pnpm run start`)
@@ -71,7 +98,9 @@ export function execSyncVarlock(
         ...opts?.cwd && { cwd: opts.cwd },
         stdio: 'pipe',
       });
-      return result.toString();
+      return opts?.fullResult
+        ? { stdout: result.toString(), stderr: '' }
+        : result.toString();
     } catch (err) {
       // code 127 means not found (on linux only)
       // ENOENT from execSync means that a shell was not found
@@ -102,11 +131,30 @@ export function execSyncVarlock(
           stdio: 'pipe',
           ...(needsShell && { shell: true }),
         });
-        return result.toString();
+        return opts?.fullResult
+          ? { stdout: result.toString(), stderr: '' }
+          : result.toString();
       }
     }
     throw new Error('Unable to find varlock executable');
   } catch (err) {
+    // In fullResult mode, wrap the error as VarlockExecError with structured fields
+    if (opts?.fullResult) {
+      if (err instanceof VarlockExecError) throw err; // already wrapped
+      const errAny = err as any;
+      // execSync/execFileSync attach stdout/stderr Buffers on the error
+      if (errAny.status != null) {
+        throw new VarlockExecError(
+          `varlock ${command} failed (exit code ${errAny.status})`,
+          errAny.stdout?.toString() ?? '',
+          errAny.stderr?.toString() ?? '',
+          errAny.status ?? 1,
+        );
+      }
+      throw err; // not a process error (e.g. "Unable to find varlock executable")
+    }
+
+    // Legacy behavior for non-fullResult callers
     const errAny = err as any;
     if (opts?.showLogsOnError) {
       /* eslint-disable no-console */


### PR DESCRIPTION
## Summary

- Add `--summary-stderr` and `--summary-file` flags to `varlock load` so integrations can get a human-readable redacted summary alongside machine-readable JSON output
- Add backwards-compatible `fullResult` option to `execSyncVarlock` that returns `{ stdout, stderr }` and throws `VarlockExecError` on failure — the old string-return behavior is preserved by default
- Migrate all integrations to use `fullResult: true` with explicit stderr handling
- Summary flags are silently skipped when `--format pretty` (stdout already has the summary)

## Motivation

When integrations call `varlock load --format json-full`, they get JSON on stdout but have no way to surface a human-readable summary to the developer. Previously `execSyncVarlock` discarded stderr on success entirely, and used `showLogsOnError`/`exitOnError` workarounds for error display.

Now integrations pass `--summary-stderr` to get the pretty summary on stderr, and use `fullResult: true` to access both streams with proper error typing via `VarlockExecError`.

## Test plan

- [x] All 5 packages typecheck clean
- [x] Expo integration tests pass (28/28)
- [ ] Smoke tests
- [ ] Manual test with vite/next dev server