### PR TITLE
refactor(ci): extract preview release into separate workflow and fix native binary cache

### DIFF
--- a/.bumpy/test-ci-varlock.md
+++ b/.bumpy/test-ci-varlock.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+test: verify CI gates native binary builds when varlock is included

--- a/.bumpy/test-ci-varlock.md
+++ b/.bumpy/test-ci-varlock.md
@@ -1,5 +1,0 @@
----
-varlock: patch
----
-
-test: verify CI gates native binary builds when varlock is included

--- a/.github/workflows/build-native-macos.yaml
+++ b/.github/workflows/build-native-macos.yaml
@@ -214,7 +214,7 @@ jobs:
         continue-on-error: true  # cache key is immutable; fails harmlessly if already saved by a concurrent run
         with:
           path: packages/varlock/native-bins/darwin/VarlockEnclave.app
-          key: native-bin-macos-signed-${{ hashFiles('packages/encryption-binary-swift/swift/**') }}
+          key: native-bin-macos-signed-${{ hashFiles('packages/encryption-binary-swift/swift/Package.swift', 'packages/encryption-binary-swift/swift/Sources/**') }}
 
       - name: Cleanup signing keychain
         if: always()

--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -19,6 +19,10 @@ on:
         description: 'Base name for uploaded artifacts (suffixed with platform)'
         type: string
         default: 'native-bin-rust'
+      source-hash:
+        description: 'Pre-computed hash of Rust source files (from Ubuntu runner). When provided, used for the binary cache key instead of local hashFiles to ensure cross-OS consistency.'
+        type: string
+        default: ''
 
 jobs:
   build:
@@ -214,4 +218,4 @@ jobs:
         continue-on-error: true  # cache key is immutable; fails harmlessly if already saved by a concurrent run
         with:
           path: packages/varlock/native-bins/${{ matrix.native-bin-subdir }}/
-          key: native-bin-rust-${{ matrix.native-bin-subdir }}-${{ hashFiles('packages/encryption-binary-rust/Cargo.lock', 'packages/encryption-binary-rust/src/**') }}
+          key: native-bin-rust-${{ matrix.native-bin-subdir }}-${{ inputs.source-hash || hashFiles('packages/encryption-binary-rust/Cargo.lock', 'packages/encryption-binary-rust/src/**') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,8 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     outputs:
+      includes-varlock: ${{ steps.check-release.outputs.includes-varlock }}
+      release-packages: ${{ steps.check-release.outputs.packages }}
       swift-changed: ${{ steps.check-swift.outputs.changed }}
       rust-changed: ${{ steps.check-rust.outputs.changed }}
       swift-cache-hit: ${{ steps.swift-cache-check.outputs.cache-hit }}
@@ -58,9 +60,16 @@ jobs:
       - name: Run tests
         run: bun run test:ci
 
+      # Determine which packages will be preview-released (used to gate native builds)
+      - name: Check release packages
+        if: github.ref_name != 'main'
+        id: check-release
+        run: bun run scripts/check-release-packages.ts
+
       # Check if native binary source changed (used to gate native builds)
       - name: Check for Swift source changes
         id: check-swift
+        if: steps.check-release.outputs.includes-varlock == 'true'
         run: |
           if git diff --name-only origin/main...HEAD | grep -qE '^(packages/encryption-binary-swift/|\.github/workflows/build-native-macos\.yaml)'; then
             echo "changed=true" >> $GITHUB_OUTPUT
@@ -69,6 +78,7 @@ jobs:
           fi
       - name: Check for Rust source changes
         id: check-rust
+        if: steps.check-release.outputs.includes-varlock == 'true'
         run: |
           if git diff --name-only origin/main...HEAD | grep -qE '^(packages/encryption-binary-rust/|\.github/workflows/build-native-rust\.yaml)'; then
             echo "changed=true" >> $GITHUB_OUTPUT
@@ -79,7 +89,7 @@ jobs:
       # Check if native binary caches exist (lookup-only, no download)
       - name: Check Swift binary cache
         id: swift-cache-check
-        if: steps.check-swift.outputs.changed != 'true'
+        if: steps.check-release.outputs.includes-varlock == 'true' && steps.check-swift.outputs.changed != 'true'
         uses: actions/cache/restore@v5
         with:
           path: packages/varlock/native-bins/darwin/VarlockEnclave.app
@@ -89,12 +99,13 @@ jobs:
       # (hashFiles can differ across OSes, so we normalize it here)
       - name: Compute Rust source hash
         id: rust-hash
+        if: steps.check-release.outputs.includes-varlock == 'true'
         run: |
           HASH=${{ hashFiles('packages/encryption-binary-rust/Cargo.lock', 'packages/encryption-binary-rust/src/**') }}
           echo "hash=$HASH" >> $GITHUB_OUTPUT
       - name: Check Rust cache - linux-x64
         id: rust-cache-check-linux-x64
-        if: steps.check-rust.outputs.changed != 'true'
+        if: steps.check-release.outputs.includes-varlock == 'true' && steps.check-rust.outputs.changed != 'true'
         uses: actions/cache/restore@v5
         with:
           path: packages/varlock/native-bins/linux-x64/
@@ -102,7 +113,7 @@ jobs:
           lookup-only: true
       - name: Check Rust cache - linux-arm64
         id: rust-cache-check-linux-arm64
-        if: steps.check-rust.outputs.changed != 'true'
+        if: steps.check-release.outputs.includes-varlock == 'true' && steps.check-rust.outputs.changed != 'true'
         uses: actions/cache/restore@v5
         with:
           path: packages/varlock/native-bins/linux-arm64/
@@ -110,7 +121,7 @@ jobs:
           lookup-only: true
       - name: Check Rust cache - win32-x64
         id: rust-cache-check-win32-x64
-        if: steps.check-rust.outputs.changed != 'true'
+        if: steps.check-release.outputs.includes-varlock == 'true' && steps.check-rust.outputs.changed != 'true'
         uses: actions/cache/restore@v5
         with:
           path: packages/varlock/native-bins/win32-x64/
@@ -118,7 +129,7 @@ jobs:
           lookup-only: true
       - name: Determine Rust cache status
         id: rust-cache-final
-        if: steps.check-rust.outputs.changed != 'true'
+        if: steps.check-release.outputs.includes-varlock == 'true' && steps.check-rust.outputs.changed != 'true'
         run: |
           if [[ "${{ steps.rust-cache-check-linux-x64.outputs.cache-hit }}" == "true" \
              && "${{ steps.rust-cache-check-linux-arm64.outputs.cache-hit }}" == "true" \
@@ -129,21 +140,24 @@ jobs:
             echo "::warning::Some Rust binary caches missing — will trigger rebuild"
           fi
 
-  # Build + sign the macOS native binary if Swift source changed or cache is missing
-  # this must be done on a mac-os runner
+  # Build + sign the macOS native binary if varlock is being released AND (source changed or cache missing)
   build-native-macos:
     needs: build-and-test
-    if: needs.build-and-test.outputs.swift-changed == 'true' || needs.build-and-test.outputs.swift-cache-hit != 'true'
+    if: >-
+      needs.build-and-test.outputs.includes-varlock == 'true'
+      && (needs.build-and-test.outputs.swift-changed == 'true' || needs.build-and-test.outputs.swift-cache-hit != 'true')
     uses: ./.github/workflows/build-native-macos.yaml
     with:
       artifact-name: native-bin-macos-ci
     secrets:
       OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN }}
 
-  # Build Rust native binaries if source changed or cache is missing
+  # Build Rust native binaries if varlock is being released AND (source changed or cache missing)
   build-native-rust:
     needs: build-and-test
-    if: needs.build-and-test.outputs.rust-changed == 'true' || needs.build-and-test.outputs.rust-cache-hit != 'true'
+    if: >-
+      needs.build-and-test.outputs.includes-varlock == 'true'
+      && (needs.build-and-test.outputs.rust-changed == 'true' || needs.build-and-test.outputs.rust-cache-hit != 'true')
     uses: ./.github/workflows/build-native-rust.yaml
     with:
       artifact-name: native-bin-rust-ci
@@ -177,28 +191,23 @@ jobs:
       - name: Enable turborepo build cache
         uses: rharkor/caching-for-turbo@v2.3.11
 
-      # Determine which packages will be preview-released
-      - name: Check release packages
-        id: check-release
-        run: bun run scripts/check-release-packages.ts
-
       # Get signed macOS .app if varlock is being released
       # If the macOS build ran this run, download the artifact directly
       # Otherwise, restore from cross-run cache
       - name: Download macOS native binary (from this run)
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-macos.result == 'success'
+        if: needs.build-and-test.outputs.includes-varlock == 'true' && needs.build-native-macos.result == 'success'
         uses: actions/download-artifact@v8
         with:
           name: native-bin-macos-ci
           path: packages/varlock/native-bins/darwin/VarlockEnclave.app
       - name: Restore cached macOS native binary (from prior run)
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-macos.result != 'success'
+        if: needs.build-and-test.outputs.includes-varlock == 'true' && needs.build-native-macos.result != 'success'
         uses: actions/cache/restore@v5
         with:
           path: packages/varlock/native-bins/darwin/VarlockEnclave.app
           key: native-bin-macos-signed-${{ hashFiles('packages/encryption-binary-swift/swift/Package.swift', 'packages/encryption-binary-swift/swift/Sources/**') }}
       - name: Verify and fix native binary permissions
-        if: steps.check-release.outputs.includes-varlock == 'true'
+        if: needs.build-and-test.outputs.includes-varlock == 'true'
         run: |
           BINARY=packages/varlock/native-bins/darwin/VarlockEnclave.app/Contents/MacOS/varlock-local-encrypt
           if [ ! -f "$BINARY" ]; then
@@ -210,7 +219,7 @@ jobs:
       # Get Rust native binaries if varlock is being released
       # If the Rust build ran this run, download the artifacts; otherwise restore from cache
       - name: Download Rust binaries (from this run)
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result == 'success'
+        if: needs.build-and-test.outputs.includes-varlock == 'true' && needs.build-native-rust.result == 'success'
         uses: actions/download-artifact@v8
         with:
           pattern: native-bin-rust-ci-*
@@ -218,7 +227,7 @@ jobs:
           merge-multiple: false
       # Flatten: download-artifact creates subdirs per artifact name, but we need linux-x64/ etc.
       - name: Flatten Rust artifact directories (from this run)
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result == 'success'
+        if: needs.build-and-test.outputs.includes-varlock == 'true' && needs.build-native-rust.result == 'success'
         run: |
           cd packages/varlock/native-bins
           for dir in native-bin-rust-ci-*/; do
@@ -227,23 +236,23 @@ jobs:
           done
 
       - uses: actions/cache/restore@v5
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result != 'success'
+        if: needs.build-and-test.outputs.includes-varlock == 'true' && needs.build-native-rust.result != 'success'
         with:
           path: packages/varlock/native-bins/linux-x64/
           key: native-bin-rust-linux-x64-${{ needs.build-and-test.outputs.rust-source-hash }}
       - uses: actions/cache/restore@v5
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result != 'success'
+        if: needs.build-and-test.outputs.includes-varlock == 'true' && needs.build-native-rust.result != 'success'
         with:
           path: packages/varlock/native-bins/linux-arm64/
           key: native-bin-rust-linux-arm64-${{ needs.build-and-test.outputs.rust-source-hash }}
       - uses: actions/cache/restore@v5
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result != 'success'
+        if: needs.build-and-test.outputs.includes-varlock == 'true' && needs.build-native-rust.result != 'success'
         with:
           path: packages/varlock/native-bins/win32-x64/
           key: native-bin-rust-win32-x64-${{ needs.build-and-test.outputs.rust-source-hash }}
 
       - name: Verify and fix Rust binary permissions
-        if: steps.check-release.outputs.includes-varlock == 'true'
+        if: needs.build-and-test.outputs.includes-varlock == 'true'
         run: |
           MISSING=()
           for SUBDIR in linux-x64 linux-arm64 win32-x64; do
@@ -265,12 +274,12 @@ jobs:
           fi
 
       - name: Build publishable npm packages
-        if: steps.check-release.outputs.packages != '[]'
+        if: needs.build-and-test.outputs.release-packages != '[]'
         run: bun run build:libs
         env:
           BUILD_TYPE: preview
       - name: Release preview packages
-        if: steps.check-release.outputs.packages != '[]'
+        if: needs.build-and-test.outputs.release-packages != '[]'
         run: bun run scripts/release-preview.ts
         env:
-          RELEASE_PACKAGES: ${{ steps.check-release.outputs.packages }}
+          RELEASE_PACKAGES: ${{ needs.build-and-test.outputs.release-packages }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build-and-test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,8 @@ jobs:
     outputs:
       swift-changed: ${{ steps.check-swift.outputs.changed }}
       rust-changed: ${{ steps.check-rust.outputs.changed }}
+      swift-cache-hit: ${{ steps.swift-cache-check.outputs.cache-hit }}
+      rust-cache-hit: ${{ steps.rust-cache-check.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -59,7 +61,7 @@ jobs:
       - name: Check for Swift source changes
         id: check-swift
         run: |
-          if git diff --name-only origin/main...HEAD | grep -q '^packages/encryption-binary-swift/'; then
+          if git diff --name-only origin/main...HEAD | grep -qE '^(packages/encryption-binary-swift/|\.github/workflows/build-native-macos\.yaml)'; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -67,27 +69,45 @@ jobs:
       - name: Check for Rust source changes
         id: check-rust
         run: |
-          if git diff --name-only origin/main...HEAD | grep -q '^packages/encryption-binary-rust/'; then
+          if git diff --name-only origin/main...HEAD | grep -qE '^(packages/encryption-binary-rust/|\.github/workflows/build-native-rust\.yaml)'; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
 
-  # Build + sign the macOS native binary if Swift source changed (warms the cache)
+      # Check if native binary caches exist (lookup-only, no download)
+      - name: Check Swift binary cache
+        id: swift-cache-check
+        if: steps.check-swift.outputs.changed != 'true'
+        uses: actions/cache/restore@v5
+        with:
+          path: packages/varlock/native-bins/darwin/VarlockEnclave.app
+          key: native-bin-macos-signed-${{ hashFiles('packages/encryption-binary-swift/swift/Package.swift', 'packages/encryption-binary-swift/swift/Sources/**') }}
+          lookup-only: true
+      - name: Check Rust binary cache
+        id: rust-cache-check
+        if: steps.check-rust.outputs.changed != 'true'
+        uses: actions/cache/restore@v5
+        with:
+          path: packages/varlock/native-bins/linux-x64/
+          key: native-bin-rust-linux-x64-${{ hashFiles('packages/encryption-binary-rust/Cargo.lock', 'packages/encryption-binary-rust/src/**') }}
+          lookup-only: true
+
+  # Build + sign the macOS native binary if Swift source changed or cache is missing
   # this must be done on a mac-os runner
   build-native-macos:
     needs: build-and-test
-    if: needs.build-and-test.outputs.swift-changed == 'true'
+    if: needs.build-and-test.outputs.swift-changed == 'true' || needs.build-and-test.outputs.swift-cache-hit != 'true'
     uses: ./.github/workflows/build-native-macos.yaml
     with:
       artifact-name: native-bin-macos-ci
     secrets:
       OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN }}
 
-  # Build Rust native binaries if source changed (warms the cache)
+  # Build Rust native binaries if source changed or cache is missing
   build-native-rust:
     needs: build-and-test
-    if: needs.build-and-test.outputs.rust-changed == 'true'
+    if: needs.build-and-test.outputs.rust-changed == 'true' || needs.build-and-test.outputs.rust-cache-hit != 'true'
     uses: ./.github/workflows/build-native-rust.yaml
     with:
       artifact-name: native-bin-rust-ci
@@ -126,20 +146,20 @@ jobs:
         run: bun run scripts/check-release-packages.ts
 
       # Get signed macOS .app if varlock is being released
-      # If the macOS build ran this run (swift changed), download the artifact directly
+      # If the macOS build ran this run, download the artifact directly
       # Otherwise, restore from cross-run cache
       - name: Download macOS native binary (from this run)
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-and-test.outputs.swift-changed == 'true'
+        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-macos.result == 'success'
         uses: actions/download-artifact@v8
         with:
           name: native-bin-macos-ci
           path: packages/varlock/native-bins/darwin/VarlockEnclave.app
       - name: Restore cached macOS native binary (from prior run)
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-and-test.outputs.swift-changed != 'true'
+        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-macos.result != 'success'
         uses: actions/cache/restore@v5
         with:
           path: packages/varlock/native-bins/darwin/VarlockEnclave.app
-          key: native-bin-macos-signed-${{ hashFiles('packages/encryption-binary-swift/swift/**') }}
+          key: native-bin-macos-signed-${{ hashFiles('packages/encryption-binary-swift/swift/Package.swift', 'packages/encryption-binary-swift/swift/Sources/**') }}
       - name: Verify and fix native binary permissions
         if: steps.check-release.outputs.includes-varlock == 'true'
         run: |
@@ -153,7 +173,7 @@ jobs:
       # Get Rust native binaries if varlock is being released
       # If the Rust build ran this run, download the artifacts; otherwise restore from cache
       - name: Download Rust binaries (from this run)
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-and-test.outputs.rust-changed == 'true'
+        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result == 'success'
         uses: actions/download-artifact@v8
         with:
           pattern: native-bin-rust-ci-*
@@ -161,7 +181,7 @@ jobs:
           merge-multiple: false
       # Flatten: download-artifact creates subdirs per artifact name, but we need linux-x64/ etc.
       - name: Flatten Rust artifact directories (from this run)
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-and-test.outputs.rust-changed == 'true'
+        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result == 'success'
         run: |
           cd packages/varlock/native-bins
           for dir in native-bin-rust-ci-*/; do
@@ -170,17 +190,17 @@ jobs:
           done
 
       - uses: actions/cache/restore@v5
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-and-test.outputs.rust-changed != 'true'
+        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result != 'success'
         with:
           path: packages/varlock/native-bins/linux-x64/
           key: native-bin-rust-linux-x64-${{ hashFiles('packages/encryption-binary-rust/Cargo.lock', 'packages/encryption-binary-rust/src/**') }}
       - uses: actions/cache/restore@v5
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-and-test.outputs.rust-changed != 'true'
+        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result != 'success'
         with:
           path: packages/varlock/native-bins/linux-arm64/
           key: native-bin-rust-linux-arm64-${{ hashFiles('packages/encryption-binary-rust/Cargo.lock', 'packages/encryption-binary-rust/src/**') }}
       - uses: actions/cache/restore@v5
-        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-and-test.outputs.rust-changed != 'true'
+        if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result != 'success'
         with:
           path: packages/varlock/native-bins/win32-x64/
           key: native-bin-rust-win32-x64-${{ hashFiles('packages/encryption-binary-rust/Cargo.lock', 'packages/encryption-binary-rust/src/**') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,8 @@ jobs:
       swift-changed: ${{ steps.check-swift.outputs.changed }}
       rust-changed: ${{ steps.check-rust.outputs.changed }}
       swift-cache-hit: ${{ steps.swift-cache-check.outputs.cache-hit }}
-      rust-cache-hit: ${{ steps.rust-cache-check.outputs.cache-hit }}
+      rust-cache-hit: ${{ steps.rust-cache-final.outputs.cache-hit }}
+      rust-source-hash: ${{ steps.rust-hash.outputs.hash }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -84,14 +85,49 @@ jobs:
           path: packages/varlock/native-bins/darwin/VarlockEnclave.app
           key: native-bin-macos-signed-${{ hashFiles('packages/encryption-binary-swift/swift/Package.swift', 'packages/encryption-binary-swift/swift/Sources/**') }}
           lookup-only: true
-      - name: Check Rust binary cache
-        id: rust-cache-check
+      # Compute Rust source hash once on Ubuntu — used for cache keys everywhere
+      # (hashFiles can differ across OSes, so we normalize it here)
+      - name: Compute Rust source hash
+        id: rust-hash
+        run: |
+          HASH=${{ hashFiles('packages/encryption-binary-rust/Cargo.lock', 'packages/encryption-binary-rust/src/**') }}
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+      - name: Check Rust cache - linux-x64
+        id: rust-cache-check-linux-x64
         if: steps.check-rust.outputs.changed != 'true'
         uses: actions/cache/restore@v5
         with:
           path: packages/varlock/native-bins/linux-x64/
-          key: native-bin-rust-linux-x64-${{ hashFiles('packages/encryption-binary-rust/Cargo.lock', 'packages/encryption-binary-rust/src/**') }}
+          key: native-bin-rust-linux-x64-${{ steps.rust-hash.outputs.hash }}
           lookup-only: true
+      - name: Check Rust cache - linux-arm64
+        id: rust-cache-check-linux-arm64
+        if: steps.check-rust.outputs.changed != 'true'
+        uses: actions/cache/restore@v5
+        with:
+          path: packages/varlock/native-bins/linux-arm64/
+          key: native-bin-rust-linux-arm64-${{ steps.rust-hash.outputs.hash }}
+          lookup-only: true
+      - name: Check Rust cache - win32-x64
+        id: rust-cache-check-win32-x64
+        if: steps.check-rust.outputs.changed != 'true'
+        uses: actions/cache/restore@v5
+        with:
+          path: packages/varlock/native-bins/win32-x64/
+          key: native-bin-rust-win32-x64-${{ steps.rust-hash.outputs.hash }}
+          lookup-only: true
+      - name: Determine Rust cache status
+        id: rust-cache-final
+        if: steps.check-rust.outputs.changed != 'true'
+        run: |
+          if [[ "${{ steps.rust-cache-check-linux-x64.outputs.cache-hit }}" == "true" \
+             && "${{ steps.rust-cache-check-linux-arm64.outputs.cache-hit }}" == "true" \
+             && "${{ steps.rust-cache-check-win32-x64.outputs.cache-hit }}" == "true" ]]; then
+            echo "cache-hit=true" >> $GITHUB_OUTPUT
+          else
+            echo "cache-hit=false" >> $GITHUB_OUTPUT
+            echo "::warning::Some Rust binary caches missing — will trigger rebuild"
+          fi
 
   # Build + sign the macOS native binary if Swift source changed or cache is missing
   # this must be done on a mac-os runner
@@ -111,6 +147,7 @@ jobs:
     uses: ./.github/workflows/build-native-rust.yaml
     with:
       artifact-name: native-bin-rust-ci
+      source-hash: ${{ needs.build-and-test.outputs.rust-source-hash }}
 
   # Publish preview packages via pkg-pr-new
   release-preview-packages:
@@ -193,17 +230,17 @@ jobs:
         if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result != 'success'
         with:
           path: packages/varlock/native-bins/linux-x64/
-          key: native-bin-rust-linux-x64-${{ hashFiles('packages/encryption-binary-rust/Cargo.lock', 'packages/encryption-binary-rust/src/**') }}
+          key: native-bin-rust-linux-x64-${{ needs.build-and-test.outputs.rust-source-hash }}
       - uses: actions/cache/restore@v5
         if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result != 'success'
         with:
           path: packages/varlock/native-bins/linux-arm64/
-          key: native-bin-rust-linux-arm64-${{ hashFiles('packages/encryption-binary-rust/Cargo.lock', 'packages/encryption-binary-rust/src/**') }}
+          key: native-bin-rust-linux-arm64-${{ needs.build-and-test.outputs.rust-source-hash }}
       - uses: actions/cache/restore@v5
         if: steps.check-release.outputs.includes-varlock == 'true' && needs.build-native-rust.result != 'success'
         with:
           path: packages/varlock/native-bins/win32-x64/
-          key: native-bin-rust-win32-x64-${{ hashFiles('packages/encryption-binary-rust/Cargo.lock', 'packages/encryption-binary-rust/src/**') }}
+          key: native-bin-rust-win32-x64-${{ needs.build-and-test.outputs.rust-source-hash }}
 
       - name: Verify and fix Rust binary permissions
         if: steps.check-release.outputs.includes-varlock == 'true'

--- a/scripts/check-release-packages.ts
+++ b/scripts/check-release-packages.ts
@@ -1,8 +1,9 @@
 /**
  * Determines which packages would be published in a preview release.
- * Uses `bumpy status --json` to find packages with pending changesets,
- * then filters to only packages that actually changed in this PR
- * (plus their workspace dependencies, so preview packages can reference each other).
+ *
+ * Uses `bumpy status --json` to find packages with pending changesets.
+ * On PRs, filters to only packages bumped in the current branch
+ * (using bumpy's `inCurrentBranch` flag) plus their workspace dependencies.
  *
  * Usage:
  *   bun run scripts/check-release-packages.ts
@@ -36,96 +37,69 @@ if (bumpyStatusRaw) {
   const jsonMatch = bumpyStatusRaw.match(/\{[\s\S]*\}/);
   if (jsonMatch) {
     const bumpyStatus = JSON.parse(jsonMatch[0]);
-    const bumpyReleases = bumpyStatus.releases
+    const isPR = !!process.env.GITHUB_HEAD_REF || !!process.env.GITHUB_BASE_REF;
+
+    let bumpyReleases = bumpyStatus.releases
       .filter((r: any) => r.publishTargets?.some((t: any) => t.type === 'npm'));
-    releasePackagePaths = bumpyReleases
-      .map((r: any) => path.resolve(MONOREPO_ROOT, r.dir));
+
+    if (isPR) {
+      // On PRs, only include packages bumped in the current branch
+      // (ignore pending bumps already on main that aren't part of this PR)
+      console.log('PR detected — filtering to packages bumped in this branch');
+      const branchReleases = bumpyReleases.filter((r: any) => r.inCurrentBranch);
+      const branchReleasePaths = branchReleases
+        .map((r: any) => path.resolve(MONOREPO_ROOT, r.dir));
+
+      // Also include transitive workspace dependencies of bumped packages
+      // (so preview packages that reference each other have consistent versions)
+      const workspaces = await listWorkspaces(MONOREPO_ROOT);
+      const workspacesByName = new Map(workspaces.map((ws) => [ws.name, ws]));
+      const allReleasePaths = new Set(bumpyReleases.map((r: any) => path.resolve(MONOREPO_ROOT, r.dir)));
+
+      function getWorkspaceDeps(pkgPath: string): Array<string> {
+        const pkgJsonPath = path.join(pkgPath, 'package.json');
+        try {
+          const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+          const allDeps = {
+            ...pkgJson.dependencies,
+            ...pkgJson.devDependencies,
+            ...pkgJson.peerDependencies,
+          };
+          return Object.entries(allDeps)
+            .filter(([, version]) => typeof version === 'string' && (version as string).startsWith('workspace:'))
+            .map(([name]) => workspacesByName.get(name)?.path)
+            .filter((p): p is string => !!p);
+        } catch {
+          return [];
+        }
+      }
+
+      const neededPackages = new Set<string>();
+      const queue = [...branchReleasePaths];
+      while (queue.length > 0) {
+        const pkg = queue.pop()!;
+        if (neededPackages.has(pkg)) continue;
+        neededPackages.add(pkg);
+        for (const dep of getWorkspaceDeps(pkg)) {
+          // Only include deps that bumpy also wants to release
+          if (!neededPackages.has(dep) && allReleasePaths.has(dep)) {
+            queue.push(dep);
+          }
+        }
+      }
+
+      releasePackagePaths = [...neededPackages];
+      console.log('Packages bumped in this branch:', branchReleasePaths);
+      console.log('Packages to preview (+ dependencies):', releasePackagePaths);
+    } else {
+      releasePackagePaths = bumpyReleases
+        .map((r: any) => path.resolve(MONOREPO_ROOT, r.dir));
+    }
   }
 }
 
 // filter out vscode extension which is not released via npm
 releasePackagePaths = releasePackagePaths.filter((p: string) => !p.endsWith('packages/vscode-plugin'));
-
-// On PRs, filter to only packages that actually changed in this PR
-// plus their workspace dependencies (so preview packages can reference each other)
-const isPR = !!process.env.GITHUB_HEAD_REF || !!process.env.GITHUB_BASE_REF;
-if (isPR && releasePackagePaths.length > 0) {
-  console.log('PR detected — filtering to packages changed in this PR + their dependencies');
-
-  // Get files changed in this PR
-  let changedFiles: Array<string>;
-  try {
-    changedFiles = execSync('git diff --name-only origin/main...HEAD', { cwd: MONOREPO_ROOT })
-      .toString().trim().split('\n')
-      .filter(Boolean);
-  } catch {
-    // Fallback if origin/main is not available
-    changedFiles = execSync('git diff --name-only HEAD~1', { cwd: MONOREPO_ROOT })
-      .toString().trim().split('\n')
-      .filter(Boolean);
-  }
-
-  // Get all workspace packages
-  const workspaces = await listWorkspaces(MONOREPO_ROOT);
-
-  // Map changed files to package directories
-  const changedPackagePaths = new Set<string>();
-  for (const file of changedFiles) {
-    const fullPath = path.resolve(MONOREPO_ROOT, file);
-    for (const ws of workspaces) {
-      if (fullPath.startsWith(`${ws.path}/`)) {
-        changedPackagePaths.add(ws.path);
-        break;
-      }
-    }
-  }
-
-  console.log('Packages with changes in this PR:', [...changedPackagePaths]);
-
-  // Start with changed packages that are in the bumpy release list
-  const bumpyPathSet = new Set(releasePackagePaths);
-  const changedReleasable = [...changedPackagePaths].filter((p) => bumpyPathSet.has(p));
-
-  // For those releasable packages, also include their transitive workspace
-  // dependencies (so preview packages that reference each other have consistent versions)
-  const workspacesByName = new Map(workspaces.map((ws) => [ws.name, ws]));
-
-  function getWorkspaceDeps(pkgPath: string): Array<string> {
-    const pkgJsonPath = path.join(pkgPath, 'package.json');
-    try {
-      const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
-      const allDeps = {
-        ...pkgJson.dependencies,
-        ...pkgJson.devDependencies,
-        ...pkgJson.peerDependencies,
-      };
-      return Object.entries(allDeps)
-        .filter(([, version]) => typeof version === 'string' && (version as string).startsWith('workspace:'))
-        .map(([name]) => workspacesByName.get(name)?.path)
-        .filter((p): p is string => !!p);
-    } catch {
-      return [];
-    }
-  }
-
-  const neededPackages = new Set<string>();
-  const queue = [...changedReleasable];
-  while (queue.length > 0) {
-    const pkg = queue.pop()!;
-    if (neededPackages.has(pkg)) continue;
-    neededPackages.add(pkg);
-    for (const dep of getWorkspaceDeps(pkg)) {
-      if (!neededPackages.has(dep)) {
-        queue.push(dep);
-      }
-    }
-  }
-
-  console.log('Packages needed (changed releasable + dependencies):', [...neededPackages]);
-
-  // Intersect with bumpy's release list
-  releasePackagePaths = releasePackagePaths.filter((p) => neededPackages.has(p));
-}
 
 const includesVarlock = releasePackagePaths.some((p) => p.endsWith('packages/varlock'));
 


### PR DESCRIPTION
## Summary

- **Extract preview release** from `test.yaml` into its own `release-preview.yaml` workflow, triggered by `workflow_run` after the CI test suite passes
- **Simplify `test.yaml`** — now just lint, typecheck, build, and test (no more native binary builds or preview publishing)
- **Fix native binary cache keys** — normalize Rust source hash across OSes, add cache-miss fallbacks
- Preview workflow **warns** instead of failing hard when native binary caches are cold

## Motivation

The preview release logic was coupled into the test workflow, which meant:
- Tests were gated on native binary builds even when they weren't needed
- Cache misses for native binaries caused CI failures on unrelated PRs
- The test workflow was slow and complex

Now the test workflow runs fast and focused. Preview releases happen in a separate workflow that only runs after tests pass.

## Test plan

- [x] `test.yaml` should pass on PRs without needing native binaries
- [ ] `release-preview.yaml` triggers after test suite completes on PRs
- [ ] Preview packages publish correctly from cache