### PR TITLE
chore: remove bun dependency caching from CI

### DIFF
--- a/.github/workflows/binary-preview.yaml
+++ b/.github/workflows/binary-preview.yaml
@@ -51,13 +51,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-      - name: Cache bun dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
       - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -79,13 +79,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-      - name: Cache bun dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
       - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -49,14 +49,6 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Cache bun dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -94,14 +86,6 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-
-      - name: Cache bun dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,13 +78,6 @@ jobs:
           persist-credentials: false
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-      - name: Cache bun dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
       - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -47,14 +47,6 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Cache bun dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,15 +26,6 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      # this caching step is kind of a wash
-      # downloading the cache adds a few seconds and then installing is a bit faster
-      - name: Cache bun dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
       - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:
@@ -176,13 +167,6 @@ jobs:
           fetch-depth: 0
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-      - name: Cache bun dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
       - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/vscode-release.yaml
+++ b/.github/workflows/vscode-release.yaml
@@ -14,13 +14,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-      - name: Cache bun dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            bun-${{ runner.os }}-
       - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- Removes `~/.bun/install/cache` caching steps from all 7 CI workflow files
- The bun install cache was a wash — downloading the cache took about as long as it saved during install
- Simplifies workflows without meaningful performance impact