### PR TITLE
refactor: unified error handling with severity levels

### DIFF
--- a/.bumpy/cloudflare-error-handling.md
+++ b/.bumpy/cloudflare-error-handling.md
@@ -1,0 +1,5 @@
+---
+"@varlock/cloudflare-integration": patch
+---
+
+graceful error handling for varlock load failures in dev mode

--- a/.bumpy/cloudflare-error-handling.md
+++ b/.bumpy/cloudflare-error-handling.md
@@ -1,5 +1,0 @@
----
-"@varlock/cloudflare-integration": patch
----
-
-graceful error handling for varlock load failures in dev mode

--- a/.bumpy/cloudflare-error-handling.md
+++ b/.bumpy/cloudflare-error-handling.md
@@ -1,0 +1,5 @@
+---
+"@varlock/cloudflare-integration": patch
+---
+
+graceful error handling, error page in dev, stderr piping in varlock-wrangler

--- a/.bumpy/nextjs-compat.md
+++ b/.bumpy/nextjs-compat.md
@@ -1,0 +1,5 @@
+---
+"@varlock/nextjs-integration": patch
+---
+
+next-env-compat improvements

--- a/.bumpy/parser-decorator-warnings.md
+++ b/.bumpy/parser-decorator-warnings.md
@@ -1,0 +1,5 @@
+---
+"@env-spec/parser": patch
+---
+
+decorator name validation and warnings

--- a/.bumpy/unified-error-handling.md
+++ b/.bumpy/unified-error-handling.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+unified error handling with severity levels

--- a/.bumpy/vite-env-on-failure.md
+++ b/.bumpy/vite-env-on-failure.md
@@ -1,0 +1,5 @@
+---
+"@varlock/vite-integration": patch
+---
+
+set __VARLOCK_ENV on failure so ENV proxy can initialize with partial data

--- a/.bumpy/vite-error-page.md
+++ b/.bumpy/vite-error-page.md
@@ -1,0 +1,6 @@
+---
+"@varlock/cloudflare-integration": patch
+"@varlock/vite-integration": patch
+---
+
+styled html error page for varlock load failures in dev mode

--- a/framework-tests/frameworks/astro/astro-shared.ts
+++ b/framework-tests/frameworks/astro/astro-shared.ts
@@ -167,7 +167,7 @@ export function defineAstroTests(astroVersion: number, testDir: string) {
         outputAssertions: [
           {
             description: 'build output indicates config validation failure',
-            shouldContain: ['MISSING_REQUIRED_VAR'],
+            shouldContain: ['Configuration is currently invalid', 'MISSING_REQUIRED_VAR'],
           },
         ],
       });

--- a/framework-tests/frameworks/cloudflare/wrangler.test.ts
+++ b/framework-tests/frameworks/cloudflare/wrangler.test.ts
@@ -31,7 +31,7 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
   afterAll(() => wranglerEnv.teardown());
 
   wranglerEnv.describeDevScenario('basic worker', {
-    command: 'varlock-wrangler dev --port 18787',
+    command: 'varlock-wrangler dev --port 0',
     readyPattern: /Ready on|ready in/i,
     readyTimeout: 30_000,
     templateFiles: {
@@ -71,7 +71,7 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
   });
 
   wranglerEnv.describeDevScenario('leaky worker', {
-    command: 'varlock-wrangler dev --port 18788',
+    command: 'varlock-wrangler dev --port 0',
     readyPattern: /Ready on|ready in/i,
     readyTimeout: 30_000,
     templateFiles: {
@@ -97,7 +97,7 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
   });
 
   wranglerEnv.describeDevScenario('leaky worker (Uint8Array body)', {
-    command: 'varlock-wrangler dev --port 18790',
+    command: 'varlock-wrangler dev --port 0',
     readyPattern: /Ready on|ready in/i,
     readyTimeout: 30_000,
     templateFiles: {
@@ -123,7 +123,7 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
   });
 
   wranglerEnv.describeDevScenario('large env (chunking)', {
-    command: 'varlock-wrangler dev --port 18789',
+    command: 'varlock-wrangler dev --port 0',
     readyPattern: /Ready on|ready in/i,
     readyTimeout: 30_000,
     templateFiles: {
@@ -149,7 +149,7 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
   });
 
   wranglerEnv.describeDevScenario('env reload on file change', {
-    command: 'varlock-wrangler dev --port 18790',
+    command: 'varlock-wrangler dev --port 0',
     readyPattern: /Ready on|ready in/i,
     readyTimeout: 30_000,
     templateFiles: {
@@ -193,7 +193,7 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
   });
 
   wranglerEnv.describeDevScenario('no restart on unchanged env content', {
-    command: 'varlock-wrangler dev --port 18792',
+    command: 'varlock-wrangler dev --port 0',
     readyPattern: /Ready on|ready in/i,
     readyTimeout: 30_000,
     templateFiles: {
@@ -254,7 +254,7 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
     // The worker runs but ENV proxy warns on access. Use killAfterPattern to
     // stop the long-running process once we see the error output.
     wranglerEnv.describeScenario('invalid schema shows errors in dev', {
-      command: 'varlock-wrangler dev --port 18791',
+      command: 'varlock-wrangler dev --port 0',
       killAfterPattern: /config is invalid|config has errors|Configuration is currently invalid/,
       templateFiles: {
         'src/index.ts': { path: 'workers/basic-worker.ts', prepend: "import '@varlock/cloudflare-integration/init';\n" },

--- a/framework-tests/frameworks/cloudflare/wrangler.test.ts
+++ b/framework-tests/frameworks/cloudflare/wrangler.test.ts
@@ -249,7 +249,11 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
     // file watchers for auto-reload), but the workerd runtime still fails
     // to start because the worker code can't initialize without valid env
     // bindings. The important thing is the error details are shown.
+    // varlock-wrangler dev now stays alive on invalid config (waiting for
+    // file fix + reload), so it can't be tested with describeScenario which
+    // waits for exit. The behavior is verified by manual testing.
     wranglerEnv.describeScenario('invalid schema shows errors in dev', {
+      skip: true,
       command: 'varlock-wrangler dev --port 18791',
       expectSuccess: false,
       timeout: 30_000,

--- a/framework-tests/frameworks/cloudflare/wrangler.test.ts
+++ b/framework-tests/frameworks/cloudflare/wrangler.test.ts
@@ -249,14 +249,13 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
     // file watchers for auto-reload), but the workerd runtime still fails
     // to start because the worker code can't initialize without valid env
     // bindings. The important thing is the error details are shown.
-    // varlock-wrangler dev now stays alive on invalid config (waiting for
-    // file fix + reload), so it can't be tested with describeScenario which
-    // waits for exit. The behavior is verified by manual testing.
+    // varlock-wrangler dev boots with invalid config. Kill once we see
+    // varlock-wrangler dev boots even with invalid config (for fix-and-reload).
+    // The worker runs but ENV proxy warns on access. Use killAfterPattern to
+    // stop the long-running process once we see the error output.
     wranglerEnv.describeScenario('invalid schema shows errors in dev', {
-      skip: true,
       command: 'varlock-wrangler dev --port 18791',
-      expectSuccess: false,
-      timeout: 30_000,
+      killAfterPattern: /config is invalid|config has errors|Configuration is currently invalid/,
       templateFiles: {
         'src/index.ts': { path: 'workers/basic-worker.ts', prepend: "import '@varlock/cloudflare-integration/init';\n" },
         'wrangler.jsonc': '_base-wrangler/wrangler.jsonc',
@@ -265,8 +264,8 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
       },
       outputAssertions: [
         {
-          description: 'validation error details are shown',
-          shouldContain: ['Configuration is currently invalid', 'MISSING_REQUIRED_VAR'],
+          description: 'varlock error output is shown',
+          shouldContain: ['MISSING_REQUIRED_VAR'],
         },
       ],
     });

--- a/framework-tests/frameworks/cloudflare/wrangler.test.ts
+++ b/framework-tests/frameworks/cloudflare/wrangler.test.ts
@@ -245,9 +245,14 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
   });
 
   describe('invalid config', () => {
-    wranglerEnv.describeScenario('invalid schema causes dev failure', {
+    // Note: varlock-wrangler dev now boots with invalid config (sets up
+    // file watchers for auto-reload), but the workerd runtime still fails
+    // to start because the worker code can't initialize without valid env
+    // bindings. The important thing is the error details are shown.
+    wranglerEnv.describeScenario('invalid schema shows errors in dev', {
       command: 'varlock-wrangler dev --port 18791',
       expectSuccess: false,
+      timeout: 30_000,
       templateFiles: {
         'src/index.ts': { path: 'workers/basic-worker.ts', prepend: "import '@varlock/cloudflare-integration/init';\n" },
         'wrangler.jsonc': '_base-wrangler/wrangler.jsonc',
@@ -257,7 +262,7 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
       outputAssertions: [
         {
           description: 'validation error details are shown',
-          shouldContain: ['MISSING_REQUIRED_VAR'],
+          shouldContain: ['Configuration is currently invalid', 'MISSING_REQUIRED_VAR'],
         },
       ],
     });

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -66,7 +66,29 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
         outputAssertions: [
           {
             description: 'validation error details are shown',
-            shouldContain: ['MISSING_REQUIRED_VAR'],
+            shouldContain: ['Configuration is currently invalid', 'MISSING_REQUIRED_VAR'],
+          },
+        ],
+      });
+
+      nextEnv.describeDevScenario('invalid schema shows errors in dev and boots', {
+        command: 'next dev --turbopack --port 13900',
+        readyPattern: /Ready in/,
+        readyTimeout: 30_000,
+        templateFiles: {
+          'app/page.tsx': 'pages/basic-page.tsx',
+          '.env.schema': 'schemas/.env.schema.invalid',
+        },
+        requests: [
+          {
+            path: '/',
+            // dev server should still boot even with invalid config
+          },
+        ],
+        outputAssertions: [
+          {
+            description: 'error details shown in terminal',
+            shouldContain: ['Configuration is currently invalid', 'MISSING_REQUIRED_VAR'],
           },
         ],
       });

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -71,9 +71,12 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
         ],
       });
 
+      // Next 14's turbo dev support is limited; skip this test for v14
+      const devFlag = getBuildToolFlag(nextVersion, 'turbopack');
       nextEnv.describeDevScenario('invalid schema shows errors in dev and boots', {
-        command: `next dev --turbopack --port ${13900 + nextVersion}`,
-        readyPattern: /Ready in/,
+        skip: nextVersion === 14,
+        command: `next dev ${devFlag} --port ${13900 + nextVersion}`,
+        readyPattern: /Ready in|Starting\.\.\./,
         readyTimeout: 30_000,
         templateFiles: {
           'app/page.tsx': 'pages/basic-page.tsx',

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -72,7 +72,7 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
       });
 
       nextEnv.describeDevScenario('invalid schema shows errors in dev and boots', {
-        command: 'next dev --turbopack --port 13900',
+        command: `next dev --turbopack --port ${13900 + nextVersion}`,
         readyPattern: /Ready in/,
         readyTimeout: 30_000,
         templateFiles: {

--- a/framework-tests/frameworks/vite/vite-shared.ts
+++ b/framework-tests/frameworks/vite/vite-shared.ts
@@ -507,6 +507,7 @@ export function defineViteTests(
         requests: [
           {
             path: '/',
+            expectedStatus: 500,
             bodyAssertions: {
               shouldContain: ['invalid'],
               shouldNotContain: ['public-test-value'],

--- a/framework-tests/frameworks/vite/vite-shared.ts
+++ b/framework-tests/frameworks/vite/vite-shared.ts
@@ -489,7 +489,7 @@ export function defineViteTests(
         outputAssertions: [
           {
             description: 'build output indicates config validation failure',
-            shouldContain: ['Varlock config validation failed', 'MISSING_REQUIRED_VAR'],
+            shouldContain: ['Configuration is currently invalid', 'MISSING_REQUIRED_VAR'],
           },
         ],
       });

--- a/framework-tests/harness/command-runner.ts
+++ b/framework-tests/harness/command-runner.ts
@@ -1,5 +1,19 @@
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 import type { BuildResult } from './types.js';
+
+/**
+ * Kill a detached process group. Uses SIGKILL on the negative PID to ensure
+ * all children (wrangler, workerd, etc.) are terminated and stdio pipes close.
+ */
+function killProcessGroup(child: ChildProcess) {
+  if (child.pid) {
+    try {
+      process.kill(-child.pid, 'SIGKILL');
+    } catch { /* already dead */ }
+  } else {
+    child.kill('SIGKILL');
+  }
+}
 
 export interface RunCommandOptions {
   env?: Record<string, string>;
@@ -17,6 +31,10 @@ export function runCommand(
     const child = spawn(command, {
       cwd,
       shell: true,
+      // Use detached so we can kill the entire process group (shell + children)
+      // via process.kill(-pid). Without this, child.kill() only kills the shell
+      // and grandchildren (e.g. wrangler/workerd) survive, keeping pipes open.
+      detached: true,
       // Ignore stdin so commands that prompt for input get EOF immediately
       // instead of hanging (e.g. wrangler telemetry consent).
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -40,11 +58,10 @@ export function runCommand(
       const combined = (stdoutChunks.join('') + stderrChunks.join('')).replace(ANSI_RE, '');
       if (opts.killAfterPattern.test(combined)) {
         killScheduled = true;
-        // brief delay to collect any trailing output, then force-kill
+        // brief delay to collect any trailing output, then force-kill the process group
         setTimeout(() => {
           killedByTimeout = true; // eslint-disable-line no-use-before-define
-          // Use SIGKILL to ensure process tree dies (SIGTERM may not kill child processes like workerd)
-          child.kill('SIGKILL');
+          killProcessGroup(child);
         }, 1000);
       }
     }
@@ -62,7 +79,7 @@ export function runCommand(
     let killedByTimeout = false;
     const timer = setTimeout(() => {
       killedByTimeout = true;
-      child.kill('SIGTERM');
+      killProcessGroup(child);
     }, timeout);
 
     child.on('close', (code) => {

--- a/framework-tests/harness/command-runner.ts
+++ b/framework-tests/harness/command-runner.ts
@@ -4,6 +4,8 @@ import type { BuildResult } from './types.js';
 export interface RunCommandOptions {
   env?: Record<string, string>;
   timeout?: number;
+  /** Kill the process shortly after this pattern appears in stdout/stderr */
+  killAfterPattern?: RegExp;
 }
 
 export function runCommand(
@@ -31,27 +33,46 @@ export function runCommand(
     const stdoutChunks: Array<string> = [];
     const stderrChunks: Array<string> = [];
 
+    const ANSI_RE = /\x1b\[[0-9;]*m/g; // eslint-disable-line no-control-regex
+    let killScheduled = false;
+    function checkKillPattern() {
+      if (!opts?.killAfterPattern || killScheduled) return;
+      const combined = (stdoutChunks.join('') + stderrChunks.join('')).replace(ANSI_RE, '');
+      if (opts.killAfterPattern.test(combined)) {
+        killScheduled = true;
+        // brief delay to collect any trailing output, then force-kill
+        setTimeout(() => {
+          killedByTimeout = true; // eslint-disable-line no-use-before-define
+          // Use SIGKILL to ensure process tree dies (SIGTERM may not kill child processes like workerd)
+          child.kill('SIGKILL');
+        }, 1000);
+      }
+    }
+
     child.stdout?.on('data', (data) => {
       stdoutChunks.push(data.toString());
+      checkKillPattern();
     });
     child.stderr?.on('data', (data) => {
       stderrChunks.push(data.toString());
+      checkKillPattern();
     });
 
     const timeout = opts?.timeout ?? 120_000;
+    let killedByTimeout = false;
     const timer = setTimeout(() => {
+      killedByTimeout = true;
       child.kill('SIGTERM');
-      reject(new Error(`Command timed out after ${timeout}ms: ${command}`));
     }, timeout);
 
     child.on('close', (code) => {
       clearTimeout(timer);
-      const exitCode = code ?? 1;
+      const exitCode = killedByTimeout ? 1 : (code ?? 1);
       resolve({
         exitCode,
         stdout: stdoutChunks.join(''),
         stderr: stderrChunks.join(''),
-        success: exitCode === 0,
+        success: !killedByTimeout && exitCode === 0,
       });
     });
 

--- a/framework-tests/harness/dev-server.ts
+++ b/framework-tests/harness/dev-server.ts
@@ -239,8 +239,8 @@ export async function runDevServer(
 
   try {
     log(`Waiting for ready pattern (timeout=${readyTimeout}ms)...`);
-    const serverUrl = await waitForReady(child, stdoutChunks, stderrChunks, scenario.readyPattern, readyTimeout);
-    if (!serverUrl) {
+    let currentUrl = await waitForReady(child, stdoutChunks, stderrChunks, scenario.readyPattern, readyTimeout);
+    if (!currentUrl) {
       logError(`Timeout waiting for ready pattern. Command: ${command}`);
       dumpOutput();
       return {
@@ -252,7 +252,7 @@ export async function runDevServer(
       };
     }
 
-    log(`Server ready at ${serverUrl}`);
+    log(`Server ready at ${currentUrl}`);
 
     const responses: Array<DevServerRequestResult> = [];
     for (let i = 0; i < scenario.requests.length; i++) {
@@ -297,11 +297,13 @@ export async function runDevServer(
               error: 'Server did not become ready again after file edit',
             };
           }
-          log(`Server restarted at ${newUrl}`);
+          // Update URL in case the port changed (e.g. when using --port 0)
+          currentUrl = newUrl;
+          log(`Server restarted at ${currentUrl}`);
         }
       }
 
-      const url = `${serverUrl}${req.path}`;
+      const url = `${currentUrl}${req.path}`;
       log(`Request ${i + 1}/${scenario.requests.length}: GET ${url}`);
       try {
         const result = await fetchWithRetry(url);
@@ -326,7 +328,7 @@ export async function runDevServer(
       stdout: getStdout(),
       stderr: getStderr(),
       responses,
-      serverUrl,
+      serverUrl: currentUrl,
     };
   } catch (err) {
     logError(`Error: ${(err as Error).message}`);

--- a/framework-tests/harness/test-fixture.ts
+++ b/framework-tests/harness/test-fixture.ts
@@ -273,6 +273,7 @@ export class FrameworkTestEnv {
     return runCommand(this.dir, buildCmd, {
       env: scenario.env,
       timeout: scenario.timeout ?? 120_000,
+      killAfterPattern: scenario.killAfterPattern,
     });
   }
 
@@ -308,15 +309,21 @@ export class FrameworkTestEnv {
       const ctx: { result?: BuildResult } = {};
       beforeAll(async () => {
         ctx.result = await env.runScenario(scenario);
-      }, scenario.timeout ?? 120_000);
+      // Add buffer over command timeout so the command can resolve before the hook times out
+      }, (scenario.timeout ?? 120_000) + 5_000);
 
-      const expectSuccess = scenario.expectSuccess ?? true;
-      test(expectSuccess ? 'build succeeds' : 'build fails as expected', () => {
-        assertBuildResult(ctx.result!, {
-          command: scenario.command,
-          expectSuccess: scenario.expectSuccess,
+      // When expectSuccess is explicitly set, assert on the exit code.
+      // When omitted (undefined), skip the assertion (useful for long-running
+      // commands killed by killAfterPattern where exit code is meaningless).
+      if (scenario.expectSuccess !== undefined) {
+        const expectSuccess = scenario.expectSuccess;
+        test(expectSuccess ? 'build succeeds' : 'build fails as expected', () => {
+          assertBuildResult(ctx.result!, {
+            command: scenario.command,
+            expectSuccess,
+          });
         });
-      });
+      }
 
       for (const assertion of scenario.outputAssertions ?? []) {
         const testName = assertion.description ?? 'output assertions pass';

--- a/framework-tests/harness/types.ts
+++ b/framework-tests/harness/types.ts
@@ -107,6 +107,8 @@ export interface TestScenario {
   fileAssertions?: Array<OutputAssertion>;
   /** Timeout for this scenario in ms (default: 120_000) */
   timeout?: number;
+  /** Kill the process shortly after this pattern appears in output (useful for long-running commands that don't exit) */
+  killAfterPattern?: RegExp;
   /** Also run the entire scenario with `export const runtime = 'edge'` inserted after directives in all .tsx/.ts template files */
   alsoTestEdgeRuntime?: boolean;
   /** Skip this entire scenario */

--- a/packages/env-spec-parser/grammar.peggy
+++ b/packages/env-spec-parser/grammar.peggy
@@ -24,11 +24,11 @@ EnvSpecFile =
   }
 
 ConfigItem =
-  preComments:(@(IgnoredDecoratorComment / DecoratorComment / Comment) "\n")*
+  preComments:(@(DecoratorComment / Comment) "\n")*
   (_ "export " _)? // we'll allow `export SOME_VAR=...` so we can read other env files
   _ key:ConfigItemKey _ "=" value:ConfigItemValue? // I don't like supporting the extra spaces around the key
   _
-  postComment:(@(IgnoredDecoratorComment / DecoratorComment / Comment))?
+  postComment:(@(DecoratorComment / Comment))?
   _n
   {
     return new ParsedEnvSpecConfigItem({
@@ -46,7 +46,7 @@ ConfigItemValue = FunctionCall / multiLineString / quotedString / unquotedString
 
 CommentBlock =
   // not sure if we want to treat these as decorators if within comment block?
-  comments:(@(IgnoredDecoratorComment / DecoratorComment / Comment) _n)+
+  comments:(@(DecoratorComment / Comment) _n)+
   end:(Divider / _n)
   {
     return new ParsedEnvSpecCommentBlock({
@@ -70,25 +70,27 @@ Comment =
     })
   }
 
-IgnoredDecoratorComment =
-  "#" leadingSpace:$_
-  contents:$(
-    ("@" [a-zA-Z]+ ":" [^\n]*)
-    / ("@" [a-zA-Z]+ __ !([@#]) [^\n]*)
-  )
-  {
-    return new ParsedEnvSpecComment({ contents, leadingSpace, _location: location() })
-  }
-
 DecoratorComment =
   "#" leadingSpace:$_
   first:Decorator
   rest:(__ @(Decorator))*
+  trailingText:(__ @$([^\n]+) / @$("#" [^\n]*))?
   _
-  postComment:$("#" [^\n]*)? // extra post comments after decorators are not parsed at all
   {
+    const allDecorators = [first, ...rest];
+    let postComment;
+    if (trailingText) {
+      if (trailingText.startsWith('#')) {
+        postComment = trailingText;
+      } else {
+        // attach trailing text warning to the last decorator on the line
+        const lastDec = allDecorators[allDecorators.length - 1];
+        lastDec.data.warning = `Unexpected trailing text after @${lastDec.name}`;
+        postComment = trailingText;
+      }
+    }
     return new ParsedEnvSpecDecoratorComment({
-      decorators: [first, ...rest],
+      decorators: allDecorators,
       leadingSpace,
       postComment,
       _location: location(),
@@ -111,9 +113,10 @@ Decorator =
   }
 
 
-// we allow an ending ":", because we don't want to choke on pre-existing comments
-// but we will treat the entire line as a normal comment if we do see that
-DecoratorName = $([a-zA-Z] [a-zA-Z0-9_]*)
+// Permissive decorator name: starts with a letter, then any non-whitespace
+// except characters that have syntactic meaning (=, (, ), #, @).
+// Invalid names are flagged downstream as warnings.
+DecoratorName = $([a-zA-Z] [^ \t\n=()#@]*)
 DecoratorValue = DecoratorFunctionCall / quotedString / unquotedStringWithoutSpaces
 
 // Decorator-specific function call (supports multi-line with # continuation)

--- a/packages/env-spec-parser/src/classes.ts
+++ b/packages/env-spec-parser/src/classes.ts
@@ -159,6 +159,7 @@ export class ParsedEnvSpecDecorator {
     value: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall
       | ParsedEnvSpecFunctionArgs | undefined;
     isBareFnCall?: boolean; // true if decorator is a bare fn call (eg: @import(...))
+    warning?: string;
     _location?: any;
   }) {
     // bare decorator is equivalent to `@decorator=true`
@@ -175,8 +176,16 @@ export class ParsedEnvSpecDecorator {
     }
   }
 
+  static VALID_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_]*$/;
+
   get name() {
     return this.data.name;
+  }
+  get hasInvalidName() {
+    return !ParsedEnvSpecDecorator.VALID_NAME_RE.test(this.data.name);
+  }
+  get warning() {
+    return this.data.warning;
   }
   get isBareFnCall() {
     return !!this.data.isBareFnCall;

--- a/packages/env-spec-parser/test/decorators.test.ts
+++ b/packages/env-spec-parser/test/decorators.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import outdent from 'outdent';
 import {
-  ParsedEnvSpecFunctionCall, ParsedEnvSpecFunctionArgs, ParsedEnvSpecStaticValue, parseEnvSpecDotEnvFile,
+  ParsedEnvSpecFunctionCall, ParsedEnvSpecFunctionArgs, ParsedEnvSpecStaticValue,
+  parseEnvSpecDotEnvFile,
 } from '../src';
 import { expectInstanceOf } from './test-utils';
 
@@ -194,21 +195,10 @@ describe('decorator parsing', () => {
     ['# @dec="`"', { dec: '`' }],
     ['# @dec="\\""', { dec: '"' }],
     ['# @dec=qu"ote', { dec: 'qu"ote' }],
-    ['# @dec=foo bar', new Error()],
     ['# @dec="""', new Error()],
-    ['# @dec="foo" not commented', new Error()],
     ['# @dec1@dec2', new Error()],
     ['# @', new Error()],
     ['# @0badDecorator', new Error()],
-    ['# @bad-decorator', new Error()],
-    ['# @okDec @badDecWithColon:', new Error()],
-
-    // want to gracefully handle these, since we've seen them in the wild
-    // so instead of dying, we'll just treat them as normal comments
-    ['# @see https://example.com for info', { '!see': true }],
-    ['# @see @something https://example.com for info', new Error()],
-    ['# @todo:', { '!todo': true, '!todo:': true }],
-    ['# @todo: fix me later', { '!todo': true, '!todo:': true }],
   ]));
 
   describe('comments and line breaks', basicDecoratorTests([
@@ -263,4 +253,78 @@ describe('decorator parsing', () => {
       expected: { dec: true, '!ignored': true },
     },
   ]));
+
+  describe('warnings on decorator-like comments with trailing text', () => {
+    function parseDecorators(comments: string) {
+      const result = parseEnvSpecDotEnvFile(`${comments}\nVAL=`);
+      return result.configItems[0].decoratorsArray;
+    }
+
+    // trailing text warning is attached to the last decorator on the line
+    it('should produce a warning for `# @foo blah` (decorator with trailing text)', () => {
+      const decs = parseDecorators('# @foo blah');
+      expect(decs).toHaveLength(1);
+      expect(decs[0].warning).toBeTruthy();
+    });
+
+    it('should produce a warning for `# @see https://example.com`', () => {
+      const decs = parseDecorators('# @see https://example.com');
+      expect(decs).toHaveLength(1);
+      expect(decs[0].warning).toBeTruthy();
+    });
+
+    // colon after decorator name is also a warning (via hasInvalidName)
+    it('should flag `# @todo: fix me later` as invalid name + trailing text', () => {
+      const decs = parseDecorators('# @todo: fix me later');
+      expect(decs).toHaveLength(1);
+      expect(decs[0].hasInvalidName).toBe(true);
+      expect(decs[0].warning).toBeTruthy();
+    });
+
+    it('should flag `# @todo:` as invalid name', () => {
+      const decs = parseDecorators('# @todo:');
+      expect(decs).toHaveLength(1);
+      expect(decs[0].hasInvalidName).toBe(true);
+    });
+
+    it('should attach warning to last decorator for `# @dec1 @dec2 bad comment`', () => {
+      const decs = parseDecorators('# @dec1 @dec2 bad comment');
+      expect(decs).toHaveLength(2);
+      expect(decs[0].warning).toBeUndefined();
+      expect(decs[1].warning).toBeTruthy();
+    });
+
+    it('should produce a warning for `# @dec=foo bar` (trailing text after value)', () => {
+      const decs = parseDecorators('# @dec=foo bar');
+      expect(decs).toHaveLength(1);
+      expect(decs[0].warning).toBeTruthy();
+    });
+
+    it('should produce a warning for `# @dec="foo" not commented` (trailing text after quoted value)', () => {
+      const decs = parseDecorators('# @dec="foo" not commented');
+      expect(decs).toHaveLength(1);
+      expect(decs[0].warning).toBeTruthy();
+    });
+
+    // invalid decorator names (hyphens, colons) produce hasInvalidName
+    it('should flag `# @bad-decorator` as invalid name', () => {
+      const decs = parseDecorators('# @bad-decorator');
+      expect(decs).toHaveLength(1);
+      expect(decs[0].hasInvalidName).toBe(true);
+    });
+
+    it('should flag only the bad decorator in `# @okDec @badDecWithColon:`', () => {
+      const decs = parseDecorators('# @okDec @badDecWithColon:');
+      expect(decs).toHaveLength(2);
+      expect(decs[0].hasInvalidName).toBe(false);
+      expect(decs[1].hasInvalidName).toBe(true);
+    });
+
+    // post-decorator comments prefixed with # are valid
+    it('should NOT produce a warning for `# @dec # this is ok` (post comment)', () => {
+      const decs = parseDecorators('# @dec # this is ok');
+      expect(decs).toHaveLength(1);
+      expect(decs[0].warning).toBeUndefined();
+    });
+  });
 });

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -3,7 +3,9 @@ import {
   existsSync, readdirSync, unlinkSync, writeFileSync,
 } from 'node:fs';
 import { execSync, spawn, type ChildProcess } from 'node:child_process';
-import { varlockVitePlugin, varlockLoadedEnv } from '@varlock/vite-integration';
+import {
+  varlockVitePlugin, varlockLoadedEnv, varlockLastError, buildErrorPageHtml,
+} from '@varlock/vite-integration';
 import { cloudflare, type PluginConfig, type WorkerConfig } from '@cloudflare/vite-plugin';
 import { CLOUDFLARE_SSR_ENTRY_CODE } from './shared-ssr-entry-code';
 
@@ -11,6 +13,7 @@ const isWindows = process.platform === 'win32';
 
 /** Name exposed by `@cloudflare/vite-plugin`'s main plugin object. */
 const CLOUDFLARE_PLUGIN_NAME = 'vite-plugin-cloudflare';
+
 
 
 // --- helpers for preview FIFO env injection --------------------------------
@@ -236,8 +239,10 @@ export function varlockCloudflareVitePlugin(
     // Reuse the env already loaded by the varlock vite plugin (avoids a duplicate CLI call).
     // The vite plugin's reloadConfig() runs at module load time, before this callback.
     const serializedGraph = process.env.__VARLOCK_ENV;
-    if (!varlockLoadedEnv || !serializedGraph) {
-      // vite plugin failed to load — it already showed the error
+    if (!varlockLoadedEnv || !serializedGraph || varlockLoadedEnv.errors) {
+      // vite plugin failed to load or config is invalid — it already showed the error.
+      // Return minimal vars so the cloudflare plugin doesn't crash,
+      // but don't inject real values.
       return {
         ...userResult,
         vars: {
@@ -260,6 +265,25 @@ export function varlockCloudflareVitePlugin(
         ...cfg.vars, ...userResult?.vars, ...vars, __VARLOCK_ENV: serializedGraph,
       },
     };
+  };
+
+  // Show an error page when config is invalid (cloudflare workers don't get
+  // the vite HMR error overlay since they run in a separate workerd runtime)
+  const errorPagePlugin: import('vite').Plugin = {
+    name: 'varlock-cloudflare-error-page',
+    configureServer(server) {
+      // Return middleware — returning from configureServer adds it in the
+      // "post" phase, after internal vite middlewares
+      return () => {
+        server.middlewares.use((req, res, next) => {
+          if (!varlockLoadedEnv?.errors) return next();
+
+          res.statusCode = 500;
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.end(buildErrorPageHtml(varlockLastError));
+        });
+      };
+    },
   };
 
   const varlockPlugin = varlockVitePlugin({
@@ -336,6 +360,7 @@ export function varlockCloudflareVitePlugin(
     conflictGuard,
     modeDetector,
     previewEnvInjector,
+    errorPagePlugin,
     varlockPlugin,
     // cloudflare() may return a single plugin or an array
     ...(Array.isArray(cloudflarePlugin) ? cloudflarePlugin : [cloudflarePlugin]),

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -4,7 +4,7 @@ import {
 } from 'node:fs';
 import { execSync, spawn, type ChildProcess } from 'node:child_process';
 import { varlockVitePlugin, varlockLoadedEnv } from '@varlock/vite-integration';
-import { execSyncVarlock } from 'varlock/exec-sync-varlock';
+import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 import { cloudflare, type PluginConfig, type WorkerConfig } from '@cloudflare/vite-plugin';
 import { CLOUDFLARE_SSR_ENTRY_CODE } from './shared-ssr-entry-code';
 
@@ -235,7 +235,43 @@ export function varlockCloudflareVitePlugin(
     if (!isDevMode) return userResult;
 
     // Single CLI call for the full graph, then extract individual vars.
-    const { stdout: serializedGraph } = execSyncVarlock('load --format json-full --compact', { fullResult: true });
+    let serializedGraph: string;
+    try {
+      const result = execSyncVarlock('load --format json-full --compact', { fullResult: true });
+      serializedGraph = result.stdout;
+    } catch (err) {
+      // Pipe stderr so the user sees varlock's pretty error output
+      if (err instanceof VarlockExecError) {
+        if (err.stderr) process.stderr.write(err.stderr);
+        // The CLI outputs JSON to stdout even on failure — try to use it
+        // so the vite plugin can still set up file watchers for auto-reload
+        if (err.stdout) {
+          try {
+            const parsed = JSON.parse(err.stdout);
+            // Set __VARLOCK_ENV with error details so downstream code knows what happened
+            const fallbackGraph = JSON.stringify(parsed);
+            return {
+              ...userResult,
+              vars: { ...cfg.vars, ...userResult?.vars, __VARLOCK_ENV: fallbackGraph },
+            };
+          } catch { /* stdout not parseable */ }
+        }
+      }
+      // eslint-disable-next-line no-console
+      console.error('\n[varlock] ⚠️ failed to load env — see error above\n');
+      // Return empty vars so the dev server can still start (errors will show in the browser via vite plugin)
+      return {
+        ...userResult,
+        vars: {
+          ...cfg.vars,
+          ...userResult?.vars,
+          __VARLOCK_ENV: JSON.stringify({
+            sources: [], config: {}, settings: {}, errors: { root: ['failed to load env'] },
+          }),
+        },
+      };
+    }
+
     let graph: { config: Record<string, { value: unknown }> };
     try {
       graph = JSON.parse(serializedGraph);

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -4,7 +4,6 @@ import {
 } from 'node:fs';
 import { execSync, spawn, type ChildProcess } from 'node:child_process';
 import { varlockVitePlugin, varlockLoadedEnv } from '@varlock/vite-integration';
-import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 import { cloudflare, type PluginConfig, type WorkerConfig } from '@cloudflare/vite-plugin';
 import { CLOUDFLARE_SSR_ENTRY_CODE } from './shared-ssr-entry-code';
 
@@ -234,53 +233,24 @@ export function varlockCloudflareVitePlugin(
     // Only inject vars in dev — production gets them via varlock-wrangler deploy.
     if (!isDevMode) return userResult;
 
-    // Single CLI call for the full graph, then extract individual vars.
-    let serializedGraph: string;
-    try {
-      const result = execSyncVarlock('load --format json-full --compact', { fullResult: true });
-      serializedGraph = result.stdout;
-    } catch (err) {
-      // Pipe stderr so the user sees varlock's pretty error output
-      if (err instanceof VarlockExecError) {
-        if (err.stderr) process.stderr.write(err.stderr);
-        // The CLI outputs JSON to stdout even on failure — try to use it
-        // so the vite plugin can still set up file watchers for auto-reload
-        if (err.stdout) {
-          try {
-            const parsed = JSON.parse(err.stdout);
-            // Set __VARLOCK_ENV with error details so downstream code knows what happened
-            const fallbackGraph = JSON.stringify(parsed);
-            return {
-              ...userResult,
-              vars: { ...cfg.vars, ...userResult?.vars, __VARLOCK_ENV: fallbackGraph },
-            };
-          } catch { /* stdout not parseable */ }
-        }
-      }
-      // eslint-disable-next-line no-console
-      console.error('\n[varlock] ⚠️ failed to load env — see error above\n');
-      // Return empty vars so the dev server can still start (errors will show in the browser via vite plugin)
+    // Reuse the env already loaded by the varlock vite plugin (avoids a duplicate CLI call).
+    // The vite plugin's reloadConfig() runs at module load time, before this callback.
+    const serializedGraph = process.env.__VARLOCK_ENV;
+    if (!varlockLoadedEnv || !serializedGraph) {
+      // vite plugin failed to load — it already showed the error
       return {
         ...userResult,
         vars: {
           ...cfg.vars,
           ...userResult?.vars,
-          __VARLOCK_ENV: JSON.stringify({
-            sources: [], config: {}, settings: {}, errors: { root: ['failed to load env'] },
-          }),
+          ...(serializedGraph && { __VARLOCK_ENV: serializedGraph }),
         },
       };
     }
 
-    let graph: { config: Record<string, { value: unknown }> };
-    try {
-      graph = JSON.parse(serializedGraph);
-    } catch (err) {
-      throw new Error(`[varlock] failed to parse config graph: ${(err as Error).message}`);
-    }
     const vars: Record<string, string> = {};
-    for (const key in graph.config) {
-      const { value } = graph.config[key];
+    for (const key in varlockLoadedEnv.config) {
+      const { value } = varlockLoadedEnv.config[key] as { value: unknown };
       if (value === undefined) continue;
       vars[key] = typeof value === 'string' ? value : JSON.stringify(value);
     }

--- a/packages/integrations/cloudflare/src/varlock-wrangler.ts
+++ b/packages/integrations/cloudflare/src/varlock-wrangler.ts
@@ -381,21 +381,41 @@ async function handleDev(args: Array<string>) {
   }
 
   debug('dev: resolving env');
-  let loaded;
+  let loaded: ReturnType<typeof loadSerializedGraph> | undefined;
+  let configIsValid = false;
   try {
     loaded = loadSerializedGraph();
+    configIsValid = true;
   } catch (err) {
-    if (err instanceof VarlockExecError && err.stderr) process.stderr.write(err.stderr);
-    console.error('\n[varlock-wrangler] Failed to resolve environment variables\n');
+    if (err instanceof VarlockExecError) {
+      if (err.stderr) process.stderr.write(err.stderr);
+      // Parse stdout even on failure — we need sources for file watchers
+      if (err.stdout) {
+        try {
+          const parsed = JSON.parse(err.stdout);
+          loaded = { json: err.stdout, graph: parsed };
+        } catch { /* not parseable */ }
+      }
+    }
+    console.error('\n[varlock-wrangler] ⚠️ config is invalid — fix the error(s) above and save to reload\n');
+  }
+
+  if (!loaded) {
+    console.error('[varlock-wrangler] Failed to parse env — cannot start dev server');
     process.exitCode = 1;
     return;
   }
-  debug('dev: resolved', Object.keys(loaded.graph.config).length, 'env vars');
+  debug('dev: resolved', Object.keys(loaded.graph.config).length, 'env vars, valid =', configIsValid);
 
   const tmp = createServingTempFile('varlock-dev-env');
   debug('dev: created FIFO at', tmp.filePath);
 
-  let cachedContent = formatEnvFileContent(loaded);
+  // When config is invalid, serve a minimal env file with __VARLOCK_ENV containing
+  // the error JSON — this lets the worker's initVarlockEnv() succeed (with configHasErrors=true)
+  // instead of throwing "initVarlockEnv failed"
+  let cachedContent = configIsValid
+    ? formatEnvFileContent(loaded)
+    : `${formatEnvLine('__VARLOCK_ENV', loaded.json)}\n`;
   let wranglerChild: ReturnType<typeof spawn> | undefined;
   const watchers: Array<ReturnType<typeof watch>> = [];
 
@@ -443,6 +463,7 @@ async function handleDev(args: Array<string>) {
         }
         cachedGraphJson = freshLoaded.json;
         loaded = freshLoaded;
+        configIsValid = true;
         lastRestartAt = now;
         cachedContent = formatEnvFileContent(freshLoaded);
         handle.update(cachedContent);
@@ -450,9 +471,28 @@ async function handleDev(args: Array<string>) {
         wranglerChild?.kill();
         // NOTE: restartTimeout stays truthy so the exit handler knows this was a restart-kill
       } catch (err) {
+        configIsValid = false;
+        if (err instanceof VarlockExecError) {
+          if (err.stderr) process.stderr.write(err.stderr);
+          // Update FIFO with error-state env and restart wrangler so the
+          // worker picks up configHasErrors=true and warns on ENV access
+          if (err.stdout) {
+            try {
+              const parsed = JSON.parse(err.stdout);
+              loaded = { json: err.stdout, graph: parsed };
+              cachedGraphJson = err.stdout;
+              cachedContent = `${formatEnvLine('__VARLOCK_ENV', err.stdout)}\n`;
+              handle.update(cachedContent);
+              lastRestartAt = Date.now();
+              console.error('\n[varlock-wrangler] \u26a0\ufe0f config is invalid \u2014 fix the error(s) above and save to reload\n');
+              wranglerChild?.kill();
+              // restartTimeout stays truthy so the exit handler knows this was a restart-kill
+              return;
+            } catch { /* not parseable */ }
+          }
+        }
         restartTimeout = undefined;
-        if (err instanceof VarlockExecError && err.stderr) process.stderr.write(err.stderr);
-        console.error('\n[varlock-wrangler] ⚠️ failed to re-resolve env — fix the error(s) above and save to reload\n');
+        console.error('\n[varlock-wrangler] \u26a0\ufe0f config is invalid \u2014 fix the error(s) above and save to reload\n');
       }
     }, DEBOUNCE_MS);
   }

--- a/packages/integrations/cloudflare/src/varlock-wrangler.ts
+++ b/packages/integrations/cloudflare/src/varlock-wrangler.ts
@@ -8,7 +8,7 @@ import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { spawn, execSync } from 'node:child_process';
 
-import { execSyncVarlock } from 'varlock/exec-sync-varlock';
+import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 
 const isWindows = process.platform === 'win32';
 const debugEnabled = !!process.env.VARLOCK_DEBUG;
@@ -265,8 +265,9 @@ async function handleDeploy(args: Array<string>) {
   let loaded;
   try {
     loaded = loadSerializedGraph();
-  } catch {
-    console.error('Failed to resolve environment variables');
+  } catch (err) {
+    if (err instanceof VarlockExecError && err.stderr) process.stderr.write(err.stderr);
+    console.error('\n[varlock-wrangler] Failed to resolve environment variables\n');
     process.exitCode = 1;
     return;
   }
@@ -335,8 +336,9 @@ async function handleTypes(args: Array<string>) {
   let loaded;
   try {
     loaded = loadSerializedGraph();
-  } catch {
-    console.error('Failed to resolve environment variables');
+  } catch (err) {
+    if (err instanceof VarlockExecError && err.stderr) process.stderr.write(err.stderr);
+    console.error('\n[varlock-wrangler] Failed to resolve environment variables\n');
     process.exitCode = 1;
     return;
   }
@@ -383,8 +385,8 @@ async function handleDev(args: Array<string>) {
   try {
     loaded = loadSerializedGraph();
   } catch (err) {
-    console.error('Failed to resolve environment variables');
-    console.error(err);
+    if (err instanceof VarlockExecError && err.stderr) process.stderr.write(err.stderr);
+    console.error('\n[varlock-wrangler] Failed to resolve environment variables\n');
     process.exitCode = 1;
     return;
   }
@@ -449,7 +451,8 @@ async function handleDev(args: Array<string>) {
         // NOTE: restartTimeout stays truthy so the exit handler knows this was a restart-kill
       } catch (err) {
         restartTimeout = undefined;
-        console.error('[varlock-wrangler] failed to re-resolve env:', (err as Error).message);
+        if (err instanceof VarlockExecError && err.stderr) process.stderr.write(err.stderr);
+        console.error('\n[varlock-wrangler] ⚠️ failed to re-resolve env — fix the error(s) above and save to reload\n');
       }
     }, DEBOUNCE_MS);
   }

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -205,9 +205,15 @@ function writeResolvedEnvFile() {
 // - these methods are the same as the original module -----------------
 
 export function updateInitialEnv(newEnv: Env) {
-  if (Object.keys(newEnv).length) {
-    debug('updateInitialEnv', newEnv);
-    Object.assign(initialEnv || {}, newEnv);
+  if (!Object.keys(newEnv).length) return;
+  debug('updateInitialEnv', newEnv);
+  // Only merge keys that were already in initialEnv or are Next.js internal vars.
+  // Varlock-managed keys injected into process.env by initVarlockEnv should NOT
+  // pollute initialEnv — otherwise they get treated as process.env overrides on reload.
+  for (const [key, value] of Object.entries(newEnv)) {
+    if (key in (initialEnv || {}) || key.startsWith('__NEXT')) {
+      (initialEnv || {})[key] = value;
+    }
   }
 }
 
@@ -380,9 +386,12 @@ export function loadEnvConfig(
       process.exit((err as any).exitCode ?? 1);
     }
 
-    // Set __VARLOCK_ENV so downstream code doesn't see a missing-env error.
-    // Pass through whatever the CLI returned (includes error details + sources)
-    // so file watchers can be set up for auto-reload on fix.
+    // Reset process.env to initial state so stale values from a previous
+    // successful load don't persist (Next.js reads process.env directly for SSR)
+    replaceProcessEnv(initialEnv);
+
+    // Set __VARLOCK_ENV with error details so the ENV proxy knows config is
+    // invalid (throws a clear error) and file watchers can be set up.
     process.env.__VARLOCK_ENV = JSON.stringify(varlockLoadedEnv || {
       sources: [],
       config: {},

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -359,25 +359,40 @@ export function loadEnvConfig(
       process.exit(1);
     }
 
-    // For real errors (validation failures, etc.) show the CLI output
+    // The CLI writes pretty-formatted errors to stderr and JSON to stdout (even on failure).
+    // Pipe stderr through so the user sees the nice error output, and parse stdout
+    // for structured data (sources for file watching, etc.)
     if (err instanceof VarlockExecError) {
       if (err.stderr) process.stderr.write(err.stderr);
-      // eslint-disable-next-line no-console
-      console.error('[varlock] ⚠️ failed to load env — see error above');
+
+      if (err.stdout) {
+        try {
+          varlockLoadedEnv = JSON.parse(err.stdout);
+        } catch { /* stdout not parseable — hard failure */ }
+      }
     }
+
+    // eslint-disable-next-line no-console
+    console.error('\n[varlock] ⚠️ fix the error(s) above and save to reload\n');
 
     // In a build, we want to fail hard so broken env doesn't get deployed
     if (!dev) {
       process.exit((err as any).exitCode ?? 1);
     }
 
-    // if we dont do this, we'll see an error that looks like `process.env.__VARLOCK_ENV is not set` which is misleading.
-    // Ideally we would pass through an error of some kind and trigger the webpack runtime error popup
-    process.env.__VARLOCK_ENV = JSON.stringify({
+    // Set __VARLOCK_ENV so downstream code doesn't see a missing-env error.
+    // Pass through whatever the CLI returned (includes error details + sources)
+    // so file watchers can be set up for auto-reload on fix.
+    process.env.__VARLOCK_ENV = JSON.stringify(varlockLoadedEnv || {
       sources: [],
       config: {},
       settings: {},
+      errors: { root: ['failed to load env'] },
     });
+
+    if (dev && varlockLoadedEnv) {
+      enableExtraFileWatchers(varlockLoadedEnv.sources, varlockLoadedEnv.basePath);
+    }
 
     return { combinedEnv: {}, parsedEnv: {}, loadedEnvFiles: [] };
   }

--- a/packages/integrations/vite/src/ansi-to-html.ts
+++ b/packages/integrations/vite/src/ansi-to-html.ts
@@ -1,0 +1,98 @@
+const ANSI_COLORS: Record<number, string> = {
+  30: '#45475a',
+  31: '#f38ba8',
+  32: '#a6e3a1',
+  33: '#f9e2af',
+  34: '#89b4fa',
+  35: '#f5c2e7',
+  36: '#94e2d5',
+  37: '#cdd6f4',
+  90: '#585b70',
+  91: '#f38ba8',
+  92: '#a6e3a1',
+  93: '#f9e2af',
+  94: '#89b4fa',
+  95: '#f5c2e7',
+  96: '#94e2d5',
+  97: '#cdd6f4',
+};
+
+
+const ANSI_RE = new RegExp(`${String.fromCharCode(27)}\\[([0-9;]*)m`, 'g');
+
+/**
+ * Convert a string with ANSI escape codes to HTML with inline styles.
+ * Uses a "close all, re-open with active styles" approach so that
+ * nested/overlapping ANSI sequences render correctly.
+ */
+export function ansiToHtml(str: string): string {
+  // track active style state
+  let bold = false;
+  let dim = false;
+  let italic = false;
+  let underline = false;
+  let strikethrough = false;
+  let color: string | undefined;
+  let isOpen = false;
+
+  function buildSpan(): string {
+    const styles: Array<string> = [];
+    if (bold) styles.push('font-weight:bold');
+    if (dim) styles.push('opacity:0.6');
+    if (italic) styles.push('font-style:italic');
+    if (underline) styles.push('text-decoration:underline');
+    if (strikethrough) styles.push('text-decoration:line-through');
+    if (color) styles.push(`color:${color}`);
+    if (!styles.length) return '';
+    isOpen = true;
+    return `<span style="${styles.join(';')}">`;
+  }
+
+  function closeIfOpen(): string {
+    if (!isOpen) return '';
+    isOpen = false;
+    return '</span>';
+  }
+
+  let html = str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+  html = html.replace(ANSI_RE, (_, codes: string) => {
+    const parts = codes.split(';').filter(Boolean).map(Number);
+
+    // full reset
+    if (parts.length === 0 || parts.includes(0)) {
+      bold = false;
+      dim = false;
+      italic = false;
+      underline = false;
+      strikethrough = false;
+      color = undefined;
+      return closeIfOpen();
+    }
+
+    // close current span, update state, re-open
+    const close = closeIfOpen();
+    for (const code of parts) {
+      if (code === 1) bold = true;
+      else if (code === 2) dim = true;
+      else if (code === 3) italic = true;
+      else if (code === 4) underline = true;
+      else if (code === 9) strikethrough = true;
+      else if (code === 22) {
+        bold = false;
+        dim = false;
+      } else if (code === 23) italic = false;
+      else if (code === 24) underline = false;
+      else if (code === 29) strikethrough = false;
+      else if (code === 39) color = undefined;
+      else if (ANSI_COLORS[code]) color = ANSI_COLORS[code];
+    }
+    return close + buildSpan();
+  });
+
+  html += closeIfOpen();
+  return html;
+}

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -48,6 +48,8 @@ let configIsValid = true;
 export let varlockLoadedEnv: SerializedEnvGraph;
 /** Stderr output from the last failed varlock load (ANSI-colored) */
 export let varlockLastError: string | undefined;
+let lastErrorAt = 0;
+let configHookCalled = false;
 let staticReplacements: Record<string, any> = {};
 let replacerFn: ReturnType<typeof createReplacerTransformFn>;
 
@@ -84,6 +86,7 @@ function reloadConfig(cwd?: string) {
     process.env.__VARLOCK_ENV = stdout;
     varlockLoadedEnv = JSON.parse(stdout) as SerializedEnvGraph;
     varlockLastError = undefined;
+    lastErrorAt = 0;
     configIsValid = true;
   } catch (err) {
     // CLI exits non-zero on validation failure but still outputs JSON to stdout.
@@ -97,10 +100,18 @@ function reloadConfig(cwd?: string) {
           process.env.__VARLOCK_ENV = err.stdout;
         } catch { /* not parseable — hard failure */ }
       }
-      if (err.stderr && err.stderr !== varlockLastError) {
+      if (err.stderr) {
+        // Debounce identical errors — frameworks like Astro can trigger
+        // multiple rapid reloads. But if some time has passed, show it
+        // again (the user may have re-introduced the same error).
+        const now = Date.now();
+        const isDuplicate = err.stderr === varlockLastError && (now - lastErrorAt) < 5000;
         varlockLastError = err.stderr;
-        console.error(err.stderr);
-        console.error('\n[varlock] ⚠️ config is invalid — fix the error(s) above and save to reload\n');
+        lastErrorAt = now;
+        if (!isDuplicate) {
+          console.error(err.stderr);
+          console.error('\n[varlock] ⚠️ config is invalid — fix the error(s) above to continue\n');
+        }
       }
     }
     configIsValid = false;
@@ -201,7 +212,7 @@ export function varlockVitePlugin(
 
     // hook to modify config before it is resolved
     async config(config, env) {
-      debug('vite plugin - config fn called');
+      debug('vite plugin - config fn called, loadCount =', loadCount, 'command =', env.command);
 
       // warn if the user has set envDir - varlock ignores this option
       // and instead reads env files from cwd (or the path configured in package.json)
@@ -235,11 +246,16 @@ See https://varlock.dev/integrations/vite/ for more details.
         // Vitest workspace setups where each child project has its own
         // env files — the module-level load used cwd which may be wrong.
         reloadConfig(projectRoot);
+      } else if (!configHookCalled) {
+        // First config hook call — module-level reloadConfig() already
+        // loaded from the correct directory, no need to reload.
+        configHookCalled = true;
+      } else if (isDevCommand) {
+        // Dev mode restart (triggered by configFileDependencies change).
+        // The module stays cached so the module-level reloadConfig()
+        // doesn't re-run — we need to reload here.
+        reloadConfig();
       }
-      // Otherwise, the module-level reloadConfig() already loaded from
-      // the correct directory. In dev mode, file changes trigger a full
-      // vite restart (via configFileDependencies) which re-evaluates
-      // this module and runs a fresh reloadConfig() automatically.
 
       // we do not want to inject via config.define - instead we use @rollup/plugin-replace
 
@@ -248,7 +264,7 @@ See https://varlock.dev/integrations/vite/ for more details.
           // adjust vite's setting so it doesnt bury the error messages
           config.clearScreen = false;
         } else {
-          // CLI already printed formatted errors to stderr — just exit
+          console.error('\n[varlock] config is invalid — cannot proceed with build\n');
           process.exit(1);
         }
       }
@@ -271,17 +287,17 @@ See https://varlock.dev/integrations/vite/ for more details.
     async configureServer(server) {
       debug('vite plugin - configureServer fn called');
 
-      if (!configIsValid) {
-        // serve an error page for all requests
-        server.middlewares.use((req, res, next) => {
-          // skip HMR websocket and vite internal requests
-          if (req.url?.startsWith('/@')) return next();
+      // Always register middleware — check configIsValid dynamically on each
+      // request so the error page appears/disappears as config is fixed/broken
+      server.middlewares.use((req, res, next) => {
+        if (configIsValid) return next();
+        // skip HMR websocket and vite internal requests
+        if (req.url?.startsWith('/@')) return next();
 
-          res.statusCode = 500;
-          res.setHeader('Content-Type', 'text/html; charset=utf-8');
-          res.end(buildErrorPageHtml(varlockLastError));
-        });
-      }
+        res.statusCode = 500;
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.end(buildErrorPageHtml(varlockLastError));
+      });
     },
 
     transform(code, id, options) {
@@ -359,6 +375,7 @@ See https://varlock.dev/integrations/vite/ for more details.
     // this enables replacing %ENV.xxx% constants in html entry-point files
     // see https://vite.dev/guide/env-and-mode.html#html-constant-replacement
     transformIndexHtml(html) {
+      debug('transformIndexHtml called, configIsValid =', configIsValid);
       if (!configIsValid) {
         return buildErrorPageHtml(varlockLastError);
       }

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -41,9 +41,7 @@ const originalProcessEnv = { ...process.env };
 
 const debug = createDebug('varlock:vite-integration');
 
-let isFirstLoad = !(process as any).__VARLOCK_ENV;
-
-debug('varlock vite plugin loaded. first load = ', isFirstLoad);
+debug('varlock vite plugin loaded');
 
 let isDevCommand: boolean;
 let configIsValid = true;
@@ -85,6 +83,7 @@ function reloadConfig(cwd?: string) {
     });
     process.env.__VARLOCK_ENV = stdout;
     varlockLoadedEnv = JSON.parse(stdout) as SerializedEnvGraph;
+    varlockLastError = undefined;
     configIsValid = true;
   } catch (err) {
     // CLI exits non-zero on validation failure but still outputs JSON to stdout.
@@ -98,9 +97,10 @@ function reloadConfig(cwd?: string) {
           process.env.__VARLOCK_ENV = err.stdout;
         } catch { /* not parseable — hard failure */ }
       }
-      if (err.stderr) {
+      if (err.stderr && err.stderr !== varlockLastError) {
         varlockLastError = err.stderr;
         console.error(err.stderr);
+        console.error('\n[varlock] ⚠️ config is invalid — fix the error(s) above and save to reload\n');
       }
     }
     configIsValid = false;
@@ -231,21 +231,15 @@ See https://varlock.dev/integrations/vite/ for more details.
       const rootDiffersFromCwd = !!(projectRoot && path.relative(projectRoot, process.cwd()) !== '');
 
       if (rootDiffersFromCwd) {
-        // Always reload with the correct project root when it differs from
-        // cwd. This handles monorepo Vitest workspace setups where each child
-        // project has its own env files — even if the monorepo root also has
-        // env files (which would cause the initial module-level load to
-        // succeed with the wrong project's config).
+        // Reload with the correct project root. This handles monorepo
+        // Vitest workspace setups where each child project has its own
+        // env files — the module-level load used cwd which may be wrong.
         reloadConfig(projectRoot);
-      } else if (isFirstLoad) {
-        isFirstLoad = false;
-        // Roots match — the module-level reloadConfig() already loaded from
-        // the correct directory, no need to reload.
-      } else if (isDevCommand) {
-        // Dev mode re-trigger (e.g., after .env file updates)
-        // TODO: be smarter about only reloading if the env files changed?
-        reloadConfig();
       }
+      // Otherwise, the module-level reloadConfig() already loaded from
+      // the correct directory. In dev mode, file changes trigger a full
+      // vite restart (via configFileDependencies) which re-evaluates
+      // this module and runs a fresh reloadConfig() automatically.
 
       // we do not want to inject via config.define - instead we use @rollup/plugin-replace
 
@@ -278,9 +272,6 @@ See https://varlock.dev/integrations/vite/ for more details.
       debug('vite plugin - configureServer fn called');
 
       if (!configIsValid) {
-        // remind the user after vite's startup output scrolls by
-        console.error('\n[varlock] ⚠️ config is invalid — fix the error(s) above and save to reload\n');
-
         // serve an error page for all requests
         server.middlewares.use((req, res, next) => {
           // skip HMR websocket and vite internal requests
@@ -369,20 +360,7 @@ See https://varlock.dev/integrations/vite/ for more details.
     // see https://vite.dev/guide/env-and-mode.html#html-constant-replacement
     transformIndexHtml(html) {
       if (!configIsValid) {
-        // TODO: build a nice error page somehow and just use it here
-        // we should be showing you specific errors and have links to the right files/lines where possible
-        return `
-<html>
-<head>
-  <script type="module" src="/@vite/client"></script>
-  <title>Invalid config</title>
-</head>
-<body>
-  <h2>Your varlock config is currently invalid!</h2>
-  <p>Check your terminal for more details</p>
-</body>
-</html>
-        `;
+        return buildErrorPageHtml(varlockLastError);
       }
 
       //! Note on vite's built-in html constant replacement

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -13,6 +13,25 @@ import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 
 import { createReplacerTransformFn, SUPPORTED_FILES } from './transform';
 
+import { ansiToHtml } from './ansi-to-html';
+export { ansiToHtml };
+
+export function buildErrorPageHtml(ansiError?: string): string {
+  const errorContent = ansiError
+    ? ansiToHtml(ansiError)
+    : 'Config is invalid — check your terminal for details.';
+
+  return `<!DOCTYPE html>
+<html><head><title>varlock - config error</title></head>
+<body style="font-family: monospace; background: #1e1e2e; color: #cdd6f4; margin: 0; padding: 2rem;">
+<div style="margin-bottom: 1.5rem;">
+  <h2 style="color: #f38ba8; margin: 0 0 0.5rem 0;">🔒 Varlock — env config validation failed</h2>
+  <p style="color: #6c7086; margin: 0;">Your environment variables are loaded and validated by <a href="https://varlock.dev" style="color: #89b4fa;">varlock</a>. Fix the error(s) below and save to reload.</p>
+</div>
+<pre style="white-space: pre-wrap; word-wrap: break-word; line-height: 1.5; background: #181825; padding: 1rem; border-radius: 8px;">${errorContent}</pre>
+</body></html>`;
+}
+
 
 // enables throwing when user accesses a bad key on ENV
 (globalThis as any).__varlockThrowOnMissingKeys = true;
@@ -29,6 +48,8 @@ debug('varlock vite plugin loaded. first load = ', isFirstLoad);
 let isDevCommand: boolean;
 let configIsValid = true;
 export let varlockLoadedEnv: SerializedEnvGraph;
+/** Stderr output from the last failed varlock load (ANSI-colored) */
+export let varlockLastError: string | undefined;
 let staticReplacements: Record<string, any> = {};
 let replacerFn: ReturnType<typeof createReplacerTransformFn>;
 
@@ -72,9 +93,15 @@ function reloadConfig(cwd?: string) {
       if (err.stdout) {
         try {
           varlockLoadedEnv = JSON.parse(err.stdout) as SerializedEnvGraph;
+          // Set __VARLOCK_ENV even on failure so `varlock/env` can initialize
+          // with partial data (prevents "ENV not initialized" throws)
+          process.env.__VARLOCK_ENV = err.stdout;
         } catch { /* not parseable — hard failure */ }
       }
-      if (err.stderr) console.error(err.stderr);
+      if (err.stderr) {
+        varlockLastError = err.stderr;
+        console.error(err.stderr);
+      }
     }
     configIsValid = false;
     resetStaticReplacements();
@@ -227,18 +254,7 @@ See https://varlock.dev/integrations/vite/ for more details.
           // adjust vite's setting so it doesnt bury the error messages
           config.clearScreen = false;
         } else {
-          console.log('💥 Varlock config validation failed 💥');
-          if (varlockLoadedEnv?.errors?.root) {
-            for (const msg of varlockLoadedEnv.errors.root) {
-              console.log(`  - ${msg}`);
-            }
-          }
-          if (varlockLoadedEnv?.errors?.configItems) {
-            for (const [key, msg] of Object.entries(varlockLoadedEnv.errors.configItems)) {
-              console.log(`  - ${key}: ${msg}`);
-            }
-          }
-          // throwing an error spits out a big useless stack trace... so better to just exit?
+          // CLI already printed formatted errors to stderr — just exit
           process.exit(1);
         }
       }
@@ -262,17 +278,17 @@ See https://varlock.dev/integrations/vite/ for more details.
       debug('vite plugin - configureServer fn called');
 
       if (!configIsValid) {
-        // triggers the built-in vite error overlay
+        // remind the user after vite's startup output scrolls by
+        console.error('\n[varlock] ⚠️ config is invalid — fix the error(s) above and save to reload\n');
+
+        // serve an error page for all requests
         server.middlewares.use((req, res, next) => {
-          server.hot.send({
-            type: 'error',
-            err: {
-              plugin: 'varlock',
-              message: 'Your config is currently invalid - check your terminal for more details',
-              stack: '',
-            },
-          });
-          return next();
+          // skip HMR websocket and vite internal requests
+          if (req.url?.startsWith('/@')) return next();
+
+          res.statusCode = 500;
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.end(buildErrorPageHtml(varlockLastError));
         });
       }
     },

--- a/packages/varlock/src/cli/cli-executable.ts
+++ b/packages/varlock/src/cli/cli-executable.ts
@@ -5,7 +5,7 @@ import { VARLOCK_BANNER_COLOR } from '../lib/ascii-art';
 import { CliExitError } from './helpers/exit-error';
 import { fmt } from './helpers/pretty-format';
 import { trackCommand, trackInstall } from './helpers/telemetry';
-import { InvalidEnvError } from './helpers/error-checks';
+import { FatalSchemaError, InvalidEnvError } from './helpers/error-checks';
 import { checkBunVersion } from '../lib/check-bun-version';
 import { checkLocalVersionMismatch } from '../lib/check-local-version';
 import packageJson from '../../package.json';
@@ -137,7 +137,7 @@ subCommands.set('install-plugin', buildLazyCommand(installPluginCommandSpec, asy
         suggestion: `Run \`${fmt.command('varlock --help', { jsPackageManager: true })}\` for more info.`,
       });
       console.error(badCommandErr.getFormattedOutput());
-    } else if (error instanceof CliExitError || error instanceof InvalidEnvError) {
+    } else if (error instanceof CliExitError || error instanceof InvalidEnvError || error instanceof FatalSchemaError) {
       // in watch mode, we just log but do not actually exit
       console.error(error.getFormattedOutput());
       // TODO: we'll probably want to implement watch mode, so it wont actually exit

--- a/packages/varlock/src/cli/cli-executable.ts
+++ b/packages/varlock/src/cli/cli-executable.ts
@@ -5,7 +5,7 @@ import { VARLOCK_BANNER_COLOR } from '../lib/ascii-art';
 import { CliExitError } from './helpers/exit-error';
 import { fmt } from './helpers/pretty-format';
 import { trackCommand, trackInstall } from './helpers/telemetry';
-import { FatalSchemaError, InvalidEnvError } from './helpers/error-checks';
+import { InvalidEnvError } from './helpers/error-checks';
 import { checkBunVersion } from '../lib/check-bun-version';
 import { checkLocalVersionMismatch } from '../lib/check-local-version';
 import packageJson from '../../package.json';
@@ -137,7 +137,7 @@ subCommands.set('install-plugin', buildLazyCommand(installPluginCommandSpec, asy
         suggestion: `Run \`${fmt.command('varlock --help', { jsPackageManager: true })}\` for more info.`,
       });
       console.error(badCommandErr.getFormattedOutput());
-    } else if (error instanceof CliExitError || error instanceof InvalidEnvError || error instanceof FatalSchemaError) {
+    } else if (error instanceof CliExitError || error instanceof InvalidEnvError) {
       // in watch mode, we just log but do not actually exit
       console.error(error.getFormattedOutput());
       // TODO: we'll probably want to implement watch mode, so it wont actually exit

--- a/packages/varlock/src/cli/commands/load.command.ts
+++ b/packages/varlock/src/cli/commands/load.command.ts
@@ -9,6 +9,7 @@ import {
   checkForConfigErrors, checkForNoEnvFiles, checkForSchemaErrors, showPluginWarnings,
 } from '../helpers/error-checks';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
+import ansis from 'ansis';
 
 export const commandSpec = define({
   name: 'load',
@@ -97,25 +98,37 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     entryFilePaths: ctx.values.path,
   });
 
-  // For json-full, always output the serialized graph — it includes `errors` and
-  // `configErrors` fields so consumers can handle failures gracefully.
+  // For json-full, still run the checks so their pretty output goes to stderr,
+  // but use noThrow so we can continue to output JSON to stdout.
   // For all other formats, exit on errors as before.
-  if (outputFormat !== 'json-full') {
-    checkForSchemaErrors(envGraph);
+  let hasSchemaErrors = false;
+  let hadSchemaOutput = false;
+  if (outputFormat === 'json-full') {
+    const result = checkForSchemaErrors(envGraph, { noThrow: true });
+    hasSchemaErrors = result.hasErrors;
+    hadSchemaOutput = result.hasOutput;
+    checkForNoEnvFiles(envGraph, { noThrow: true });
+  } else {
+    const result = checkForSchemaErrors(envGraph);
+    hadSchemaOutput = result.hasOutput;
     checkForNoEnvFiles(envGraph);
   }
 
   if (!envGraph.rootDataSource) throw new Error('expected root data source to be set');
 
-  // Generate types before resolving values — uses only non-env-specific schema info
-  await envGraph.generateTypesIfNeeded();
+  // Skip resolution + config checks when schema has errors — the downstream
+  // errors would just be noise caused by the parse/schema failure
+  if (!hasSchemaErrors) {
+    // Generate types before resolving values — uses only non-env-specific schema info
+    await envGraph.generateTypesIfNeeded();
 
-  await envGraph.resolveEnvValues();
+    await envGraph.resolveEnvValues();
 
-  if (outputFormat === 'json-full') {
-    checkForConfigErrors(envGraph, { showAll, noThrow: true });
-  } else {
-    checkForConfigErrors(envGraph, { showAll });
+    if (outputFormat === 'json-full') {
+      checkForConfigErrors(envGraph, { showAll, noThrow: true });
+    } else {
+      checkForConfigErrors(envGraph, { showAll });
+    }
   }
 
   if ((summaryStderr || summaryFile) && outputFormat !== 'pretty') {
@@ -151,6 +164,10 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
 
   if (outputFormat === 'pretty') {
     showPluginWarnings(envGraph);
+    if (hadSchemaOutput) {
+      console.error();
+    }
+    console.error(ansis.bold.green('-- Resolved config --'));
     for (const itemKey of envGraph.sortedConfigKeys) {
       const item = envGraph.configSchema[itemKey];
       console.log(getItemSummary(item));

--- a/packages/varlock/src/cli/helpers/error-checks.ts
+++ b/packages/varlock/src/cli/helpers/error-checks.ts
@@ -1,21 +1,13 @@
 import ansis from 'ansis';
-import _ from '@env-spec/utils/my-dash';
-import { EnvGraph, ConfigItem, FileBasedDataSource } from '../../env-graph';
+import { EnvGraph, FileBasedDataSource } from '../../env-graph';
 import { getItemSummary, joinAndCompact } from '../../lib/formatting';
-import { ParseError, VarlockError } from '../../env-graph/lib/errors';
+import {
+  LoadingError, ParseError, VarlockError,
+} from '../../env-graph/lib/errors';
+import { CliExitError } from './exit-error';
 
-
-export class FatalSchemaError extends Error {
-  constructor(message = 'Fatal schema error') {
-    super(message);
-  }
-  getFormattedOutput() {
-    return ''; // details already logged to stderr
-  }
-}
-
-function showErrorLocationDetails(err: Error) {
-  if (!(err instanceof VarlockError) || !err.location) return;
+function showErrorLocationDetails(err: VarlockError) {
+  if (!err.location) return;
   const errLoc = err.location;
   const errPreview = [
     errLoc.lineStr,
@@ -27,6 +19,13 @@ function showErrorLocationDetails(err: Error) {
   console.error(errPreview);
 }
 
+function showErrorTip(err: VarlockError) {
+  if (!err.tip) return;
+  for (const line of err.tip.split('\n')) {
+    console.error(`  ${line}`);
+  }
+}
+
 export function checkForNoEnvFiles(envGraph: EnvGraph, opts?: { noThrow?: boolean }) {
   if (Object.keys(envGraph.configSchema).length === 0) {
     // If a source has a parse error, the schema couldn't be read at all so
@@ -35,7 +34,7 @@ export function checkForNoEnvFiles(envGraph: EnvGraph, opts?: { noThrow?: boolea
     const hasParseErrors = envGraph.sortedDataSources.some((s) => s.loadingError instanceof ParseError);
     if (hasParseErrors) {
       if (opts?.noThrow) return;
-      throw new FatalSchemaError('Parse error');
+      throw new CliExitError('Parse error', { silent: true });
     }
 
     const displayPath = envGraph.basePath ?? process.cwd();
@@ -48,62 +47,58 @@ export function checkForNoEnvFiles(envGraph: EnvGraph, opts?: { noThrow?: boolea
       console.error('Add items to your .env.schema file to get started.');
     }
     if (opts?.noThrow) return;
-    throw new FatalSchemaError('No env files');
+    throw new CliExitError('No env files', { silent: true });
   }
 }
 
 export function checkForSchemaErrors(envGraph: EnvGraph, opts?: { noThrow?: boolean }) {
-  // first we check for loading/parse errors - some cases we may want to let it fail silently?
   let hasErrors = false;
+  let hasOutput = false;
   for (const source of envGraph.sortedDataSources) {
-    // do we care about loading errors from disabled sources?
-    // if (source.disabled) continue;
+    const warnings = source.errors.filter((e) => e.isWarning);
+    const errors = source.errors.filter((e) => !e.isWarning);
 
-    if (source.loadingError) {
-      hasErrors = true;
-      console.error(`🚨 Error encountered while loading ${source.label}\n`);
+    if (!warnings.length && !errors.length) continue;
+    hasOutput = true;
 
-      console.error(source.loadingError.message);
-      showErrorLocationDetails(source.loadingError);
+    // group by error type for clearer output
+    const loadingErrors = errors.filter((e) => e instanceof LoadingError || e instanceof ParseError);
+    const otherErrors = errors.filter((e) => !(e instanceof LoadingError || e instanceof ParseError));
 
-      // For plugin loading errors, show the full stack trace since it's usually
-      // a runtime error from executing the plugin code
-      if (source.loadingError.stack && !(source.loadingError instanceof VarlockError)) {
-        console.error(`\n${ansis.dim('Stack trace:')}`);
-        console.error(ansis.dim(source.loadingError.stack));
-      }
+    // single header per file
+    console.error(ansis.bold[errors.length ? 'red' : 'yellow'](`-- Problems encountered in ${source.label} --`));
 
-      if (!opts?.noThrow) throw new FatalSchemaError('Loading error');
+    if (source instanceof FileBasedDataSource) {
+      console.error('📁', ansis.dim(`${source.fullPath}`));
+      console.log('');
     }
-    // TODO: unify this with the above!
-    const schemaWarnings = source.schemaErrors.filter((e) => e.isWarning);
-    const schemaErrors = source.schemaErrors.filter((e) => !e.isWarning);
 
-    for (const warning of schemaWarnings) {
-      console.error(ansis.yellow(`⚠️  [WARNING] ${warning.message} (${source.label})`));
+    for (const warning of warnings) {
+      console.error(ansis.yellow(`- ⚠️  ${warning.message}`));
       showErrorLocationDetails(warning);
     }
 
-    if (schemaErrors.length) {
-      hasErrors = true;
-      console.error(`🚨 Error(s) encountered in ${source.label}`);
-
-      for (const schemaErr of schemaErrors) {
-        console.error(`- ${schemaErr.message}`);
-        showErrorLocationDetails(schemaErr);
+    for (const err of loadingErrors) {
+      console.error(ansis.red(`- ❌ ${err.message}`));
+      showErrorLocationDetails(err);
+      if (err.isUnexpected && err.originalError?.stack) {
+        console.error(`\n${ansis.dim('Stack trace:')}`);
+        console.error(ansis.dim(err.originalError.stack));
       }
-      if (!opts?.noThrow) throw new FatalSchemaError('Schema error');
+    }
+
+    for (const err of otherErrors) {
+      console.error(ansis.red(`- ❌ ${err.message}`));
+      showErrorTip(err);
+      showErrorLocationDetails(err);
+    }
+
+    if (errors.length) {
+      hasErrors = true;
+      if (!opts?.noThrow) throw new CliExitError('Schema error', { silent: true });
     }
   }
-
-  // now we check for any schema errors - where something about how things are wired up is invalid
-  // NOTE - we should not have run any resolution yet
-  // TODO: make sure we are calling this before attempting to resolve values
-  // const failingItems = _.filter(_.values(envGraph.configSchema), (item) => item.validationState === 'error');
-  // if (failingItems.length > 0) {
-  //   throw new CliExitError('Schema is currently invalid');
-  // }
-  return hasErrors;
+  return { hasErrors, hasOutput };
 }
 
 
@@ -135,27 +130,27 @@ export function checkForConfigErrors(envGraph: EnvGraph, opts?: {
   /** Log errors to stderr but don't throw — used when the caller will handle errors itself (e.g. json-full output) */
   noThrow?: boolean;
 }) {
-  // check for root decorator "execution"
+  // check for root decorator execution errors (fatal — stop before showing items)
   let hasRootDecoratorErrors = false;
   for (const source of envGraph.sortedDataSources) {
-    if (source.resolutionErrors.length) {
+    const resErrors = source.resolutionErrors;
+    if (resErrors.length) {
       hasRootDecoratorErrors = true;
       console.error(`🚨 Root decorator error(s) in ${source.label}`);
+      if (source instanceof FileBasedDataSource) {
+        console.error(ansis.dim(`   ${source.fullPath}`));
+      }
 
-      for (const err of source.resolutionErrors) {
-        console.error(`- ${err.message}`);
-        if (err instanceof VarlockError && err.tip) {
-          for (const line of err.tip.split('\n')) {
-            console.error(`  ${line}`);
-          }
-        }
+      for (const err of resErrors) {
+        console.error(ansis.red(`  - ❌ ${err.message}`));
+        showErrorTip(err);
         showErrorLocationDetails(err);
       }
     }
   }
 
   if (hasRootDecoratorErrors) {
-    if (!opts?.noThrow) throw new FatalSchemaError('Root decorator error');
+    if (!opts?.noThrow) throw new CliExitError('Schema error', { silent: true });
     return;
   }
 
@@ -166,36 +161,28 @@ export function checkForConfigErrors(envGraph: EnvGraph, opts?: {
     .map((k) => envGraph.configSchema[k])
     .filter((item) => item.validationState === 'warn');
 
-  // TODO: use service.isValid?
   if (failingItems.length > 0) {
-    console.error(`\n🚨 🚨 🚨  ${ansis.bold.underline('Configuration is currently invalid ')}  🚨 🚨 🚨\n`);
-    console.error('Invalid items:\n');
+    console.error(`\n🚨🚨🚨  ${ansis.bold.red.underline('Configuration is currently invalid')}  🚨🚨🚨\n`);
 
-    _.each(failingItems, (item: ConfigItem) => {
+    for (const item of failingItems) {
       console.error(getItemSummary(item));
-      console.error();
-    });
-
-    if (warningItems.length) {
-      console.error('Items with warnings:\n');
-      _.each(warningItems, (item: ConfigItem) => {
-        console.error(getItemSummary(item));
-        console.error();
-      });
     }
+    for (const item of warningItems) {
+      console.error(getItemSummary(item));
+    }
+
     if (opts?.showAll) {
       console.error();
       console.error(joinAndCompact([
         'Valid items:',
         ansis.italic.gray('(remove `--show-all` flag to hide)'),
       ]));
-      console.error();
       const validItems = envGraph.sortedConfigKeys
         .map((k) => envGraph.configSchema[k])
         .filter((i) => !!i.isValid);
-      _.each(validItems, (item: ConfigItem) => {
+      for (const item of validItems) {
         console.error(getItemSummary(item));
-      });
+      }
     }
 
     showPluginWarnings(envGraph);

--- a/packages/varlock/src/cli/helpers/error-checks.ts
+++ b/packages/varlock/src/cli/helpers/error-checks.ts
@@ -1,10 +1,18 @@
 import ansis from 'ansis';
-import { gracefulExit } from 'exit-hook';
 import _ from '@env-spec/utils/my-dash';
 import { EnvGraph, ConfigItem, FileBasedDataSource } from '../../env-graph';
 import { getItemSummary, joinAndCompact } from '../../lib/formatting';
-import { VarlockError } from '../../env-graph/lib/errors';
+import { ParseError, VarlockError } from '../../env-graph/lib/errors';
 
+
+export class FatalSchemaError extends Error {
+  constructor(message = 'Fatal schema error') {
+    super(message);
+  }
+  getFormattedOutput() {
+    return ''; // details already logged to stderr
+  }
+}
 
 function showErrorLocationDetails(err: Error) {
   if (!(err instanceof VarlockError) || !err.location) return;
@@ -19,8 +27,17 @@ function showErrorLocationDetails(err: Error) {
   console.error(errPreview);
 }
 
-export function checkForNoEnvFiles(envGraph: EnvGraph) {
+export function checkForNoEnvFiles(envGraph: EnvGraph, opts?: { noThrow?: boolean }) {
   if (Object.keys(envGraph.configSchema).length === 0) {
+    // If a source has a parse error, the schema couldn't be read at all so
+    // "no config items defined" is misleading — the parse error (already
+    // reported by checkForSchemaErrors) is the real problem.
+    const hasParseErrors = envGraph.sortedDataSources.some((s) => s.loadingError instanceof ParseError);
+    if (hasParseErrors) {
+      if (opts?.noThrow) return;
+      throw new FatalSchemaError('Parse error');
+    }
+
     const displayPath = envGraph.basePath ?? process.cwd();
     const hasLoadedFiles = envGraph.sortedDataSources.some((s) => s instanceof FileBasedDataSource);
     if (!hasLoadedFiles) {
@@ -30,17 +47,20 @@ export function checkForNoEnvFiles(envGraph: EnvGraph) {
       console.error(`🚨 No config items defined in ${displayPath}\n`);
       console.error('Add items to your .env.schema file to get started.');
     }
-    return gracefulExit(1);
+    if (opts?.noThrow) return;
+    throw new FatalSchemaError('No env files');
   }
 }
 
-export function checkForSchemaErrors(envGraph: EnvGraph) {
+export function checkForSchemaErrors(envGraph: EnvGraph, opts?: { noThrow?: boolean }) {
   // first we check for loading/parse errors - some cases we may want to let it fail silently?
+  let hasErrors = false;
   for (const source of envGraph.sortedDataSources) {
     // do we care about loading errors from disabled sources?
     // if (source.disabled) continue;
 
     if (source.loadingError) {
+      hasErrors = true;
       console.error(`🚨 Error encountered while loading ${source.label}\n`);
 
       console.error(source.loadingError.message);
@@ -53,17 +73,26 @@ export function checkForSchemaErrors(envGraph: EnvGraph) {
         console.error(ansis.dim(source.loadingError.stack));
       }
 
-      return gracefulExit(1);
+      if (!opts?.noThrow) throw new FatalSchemaError('Loading error');
     }
     // TODO: unify this with the above!
-    if (source.schemaErrors.length) {
+    const schemaWarnings = source.schemaErrors.filter((e) => e.isWarning);
+    const schemaErrors = source.schemaErrors.filter((e) => !e.isWarning);
+
+    for (const warning of schemaWarnings) {
+      console.error(ansis.yellow(`⚠️  [WARNING] ${warning.message} (${source.label})`));
+      showErrorLocationDetails(warning);
+    }
+
+    if (schemaErrors.length) {
+      hasErrors = true;
       console.error(`🚨 Error(s) encountered in ${source.label}`);
 
-      for (const schemaErr of source.schemaErrors) {
+      for (const schemaErr of schemaErrors) {
         console.error(`- ${schemaErr.message}`);
         showErrorLocationDetails(schemaErr);
       }
-      return gracefulExit(1);
+      if (!opts?.noThrow) throw new FatalSchemaError('Schema error');
     }
   }
 
@@ -74,6 +103,7 @@ export function checkForSchemaErrors(envGraph: EnvGraph) {
   // if (failingItems.length > 0) {
   //   throw new CliExitError('Schema is currently invalid');
   // }
+  return hasErrors;
 }
 
 
@@ -106,8 +136,10 @@ export function checkForConfigErrors(envGraph: EnvGraph, opts?: {
   noThrow?: boolean;
 }) {
   // check for root decorator "execution"
+  let hasRootDecoratorErrors = false;
   for (const source of envGraph.sortedDataSources) {
     if (source.resolutionErrors.length) {
+      hasRootDecoratorErrors = true;
       console.error(`🚨 Root decorator error(s) in ${source.label}`);
 
       for (const err of source.resolutionErrors) {
@@ -122,11 +154,17 @@ export function checkForConfigErrors(envGraph: EnvGraph, opts?: {
     }
   }
 
-
+  if (hasRootDecoratorErrors) {
+    if (!opts?.noThrow) throw new FatalSchemaError('Root decorator error');
+    return;
+  }
 
   const failingItems = envGraph.sortedConfigKeys
     .map((k) => envGraph.configSchema[k])
     .filter((item) => item.validationState === 'error');
+  const warningItems = envGraph.sortedConfigKeys
+    .map((k) => envGraph.configSchema[k])
+    .filter((item) => item.validationState === 'warn');
 
   // TODO: use service.isValid?
   if (failingItems.length > 0) {
@@ -137,6 +175,14 @@ export function checkForConfigErrors(envGraph: EnvGraph, opts?: {
       console.error(getItemSummary(item));
       console.error();
     });
+
+    if (warningItems.length) {
+      console.error('Items with warnings:\n');
+      _.each(warningItems, (item: ConfigItem) => {
+        console.error(getItemSummary(item));
+        console.error();
+      });
+    }
     if (opts?.showAll) {
       console.error();
       console.error(joinAndCompact([

--- a/packages/varlock/src/cli/helpers/exit-error.ts
+++ b/packages/varlock/src/cli/helpers/exit-error.ts
@@ -10,6 +10,8 @@ export class CliExitError extends Error {
       suggestion?: string | Array<string>,
       /** always triggers a full exit, even in watch mode - useful if problem is irrecoverable */
       forceExit?: boolean,
+      /** suppress formatted output (details already logged to stderr) */
+      silent?: boolean,
     },
   ) {
     super(message);
@@ -18,6 +20,8 @@ export class CliExitError extends Error {
   get forceExit() { return !!this.more?.forceExit; }
 
   getFormattedOutput() {
+    if (this.more?.silent) return '';
+
     let msg = `\n💥 ${ansis.red(this.message)} 💥\n`;
 
     if (this.more?.details) {

--- a/packages/varlock/src/env-graph/index.ts
+++ b/packages/varlock/src/env-graph/index.ts
@@ -8,7 +8,8 @@ export { Resolver, StaticValueResolver } from './lib/resolver';
 export { ConfigItem, type TypeGenItemInfo } from './lib/config-item';
 export {
   VarlockError,
-  ConfigLoadError, SchemaError, ValidationError, CoercionError, ResolutionError,
+  ConfigLoadError, LoadingError, ParseError, SchemaError, ValidationError, CoercionError, ResolutionError,
+  type ErrorSeverity,
 } from './lib/errors';
 export {
   BUILTIN_VARS, isBuiltinVar,

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -244,13 +244,13 @@ export class ConfigItem {
           this.effectiveDecoratorFns[dec.name].push(dec);
         } else {
           if (decKeysInThisDef.has(dec.name)) {
-            dec._schemaErrors.push(new SchemaError(`decorator @${dec.name} cannot be used twice in same definition`));
+            dec._errors.push(new SchemaError(`decorator @${dec.name} cannot be used twice in same definition`));
             continue;
           }
           if (dec.incompatibleWith) {
             for (const otherDecName of dec.incompatibleWith) {
               if (allDecsInThisDef?.includes(otherDecName)) {
-                dec._schemaErrors.push(new SchemaError(`decorator @${dec.name} is incompatible with @${otherDecName} in the same definition`));
+                dec._errors.push(new SchemaError(`decorator @${dec.name} is incompatible with @${otherDecName} in the same definition`));
                 continue;
               }
             }
@@ -348,7 +348,7 @@ export class ConfigItem {
 
         const requiredDecoratorVal = await requiredDec.resolve();
         // if we got an error, we'll bail and the error will be checked later
-        if (requiredDec.schemaErrors.length) {
+        if (requiredDec.schemaErrors.some((e) => !e.isWarning)) {
           // but we mark as not required so we don't _also_ get required error
           this._isRequired = false;
           return;
@@ -414,7 +414,7 @@ export class ConfigItem {
 
       const usingPublic = sensitiveDec.name === 'public';
       const sensitiveDecValue = await sensitiveDec.resolve();
-      if (sensitiveDec.schemaErrors.length) return;
+      if (sensitiveDec.schemaErrors.some((e) => !e.isWarning)) return;
       if (![true, false, undefined].includes(sensitiveDecValue)) {
         throw new SchemaError('@sensitive/@public must resolve to a boolean or undefined');
       }
@@ -657,7 +657,7 @@ export class ConfigItem {
           }
 
           const requiredDecoratorVal = await requiredDec.resolve();
-          if (requiredDec.schemaErrors.length) {
+          if (requiredDec.schemaErrors.some((e) => !e.isWarning)) {
             isRequired = false;
             break;
           }
@@ -706,7 +706,7 @@ export class ConfigItem {
           // Skip dynamic decorators to avoid caching a stale result (same as @required fix above)
           if (sensitiveDec.decValueResolver?.fnName !== '\0static') break;
           const sensitiveDecValue = await sensitiveDec.resolve();
-          if (sensitiveDec.schemaErrors.length) break;
+          if (sensitiveDec.schemaErrors.some((e) => !e.isWarning)) break;
           if (![true, false, undefined].includes(sensitiveDecValue)) break;
           if (sensitiveDecValue !== undefined) {
             isSensitive = usingPublic ? !sensitiveDecValue : sensitiveDecValue;

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -243,7 +243,7 @@ export class ConfigItem {
           this.effectiveDecoratorFns[dec.name] ||= [];
           this.effectiveDecoratorFns[dec.name].push(dec);
         } else {
-          if (decKeysInThisDef.has(dec.name)) {
+          if (decKeysInThisDef.has(dec.name) && !dec._errors.length) {
             dec._errors.push(new SchemaError(`decorator @${dec.name} cannot be used twice in same definition`));
             continue;
           }

--- a/packages/varlock/src/env-graph/lib/data-source.ts
+++ b/packages/varlock/src/env-graph/lib/data-source.ts
@@ -751,7 +751,7 @@ export class DotEnvFileDataSource extends FileBasedDataSource {
           `Item decorator @${dec.name} cannot be used in the file header - it must be attached to a config item`,
           { location: this._locationFromParsed(dec) },
         ));
-      } else if (!dec.isBareFnCall) {
+      } else if (!dec.isBareFnCall && !dec.hasInvalidName && dec.name in this.graph!.rootDecoratorsRegistry) {
         if (seenRootDecs.has(dec.name)) {
           this._errors.push(new SchemaError(
             `Root decorator @${dec.name} cannot be used more than once in the same file`,

--- a/packages/varlock/src/env-graph/lib/data-source.ts
+++ b/packages/varlock/src/env-graph/lib/data-source.ts
@@ -11,7 +11,9 @@ import {
 import { ConfigItem, type ConfigItemDef } from './config-item';
 import { EnvGraph } from './env-graph';
 
-import { ParseError, SchemaError } from './errors';
+import {
+  LoadingError, ParseError, SchemaError, VarlockError,
+} from './errors';
 import { pathExists } from '@env-spec/utils/fs-utils';
 import { processPluginInstallDecorators } from './plugins';
 import { RootDecoratorInstance } from './decorators';
@@ -206,7 +208,7 @@ export abstract class EnvGraphDataSource {
 
       const disabledVal = await disabledDec.resolve();
       if (!_.isBoolean(disabledVal)) {
-        this._loadingError = new Error('expected @disable to be boolean value');
+        this._errors.push(new LoadingError('expected @disable to be boolean value'));
         return;
       }
       this._disabled = disabledVal;
@@ -233,7 +235,7 @@ export abstract class EnvGraphDataSource {
         const isMatchingStatic = itemDef.parsedValue instanceof ParsedEnvSpecStaticValue
           && itemDef.parsedValue.unescapedValue === existingItem.resolvedValue;
         if (!isMatchingStatic) {
-          this._schemaErrors.push(new SchemaError(
+          this._errors.push(new SchemaError(
             `"${itemKey}" was already resolved during early initialization (used by @currentEnv, @import, or @disable) `
             + `and cannot be redefined by ${this.label}`,
           ));
@@ -252,7 +254,7 @@ export abstract class EnvGraphDataSource {
     const envFlagDec = this.getRootDec('envFlag');
     if (currentEnvDec && envFlagDec) {
       // TODO can we set this in the decorator definition?
-      this._loadingError = new Error('Cannot use both @currentEnv and @envFlag decorators');
+      this._errors.push(new LoadingError('Cannot use both @currentEnv and @envFlag decorators'));
     }
     let envFlagItemKey: string | undefined;
     let skipCurrentEnvProcessing = false;
@@ -296,7 +298,7 @@ export abstract class EnvGraphDataSource {
 
     if (envFlagItemKey) {
       if (!this.configItemDefs[envFlagItemKey] && !isBuiltinVar(envFlagItemKey)) {
-        this._loadingError = new Error(`environment flag "${envFlagItemKey}" must be defined within this schema`);
+        this._errors.push(new LoadingError(`environment flag "${envFlagItemKey}" must be defined within this schema`));
         return;
       }
 
@@ -415,7 +417,7 @@ export abstract class EnvGraphDataSource {
                 const dirExists = Object.keys(this.graph.virtualImports).some((p) => p.startsWith(fullImportPath));
                 if (!dirExists && allowMissing) continue;
                 if (!dirExists) {
-                  this._loadingError = new Error(`Virtual directory import ${fullImportPath} not found`);
+                  this._errors.push(new LoadingError(`Virtual directory import ${fullImportPath} not found`));
                   return;
                 }
                 // eslint-disable-next-line no-use-before-define
@@ -428,7 +430,7 @@ export abstract class EnvGraphDataSource {
                 const fileExists = this.graph.virtualImports[fullImportPath];
                 if (!fileExists && allowMissing) continue;
                 if (!fileExists) {
-                  this._loadingError = new Error(`Virtual import ${fullImportPath} not found`);
+                  this._errors.push(new LoadingError(`Virtual import ${fullImportPath} not found`));
                   return;
                 }
                 // eslint-disable-next-line no-use-before-define
@@ -445,7 +447,7 @@ export abstract class EnvGraphDataSource {
 
               if (!fsStat && allowMissing) continue;
               if (!fsStat) {
-                this._loadingError = new Error(`Import path does not exist: ${fullImportPath}`);
+                this._errors.push(new LoadingError(`Import path does not exist: ${fullImportPath}`));
                 return;
               }
 
@@ -459,16 +461,16 @@ export abstract class EnvGraphDataSource {
                   });
                   this.graph.recordLoadedImportPath(fullImportPath, dirChild);
                 } else {
-                  this._loadingError = new Error(`Imported path ending with "/" is not a directory: ${fullImportPath}`);
+                  this._errors.push(new LoadingError(`Imported path ending with "/" is not a directory: ${fullImportPath}`));
                   return;
                 }
               // File import
               } else {
                 if (fsStat.isDirectory()) {
-                  this._loadingError = new Error('Imported path is a directory, add trailing "/" to import');
+                  this._errors.push(new LoadingError('Imported path is a directory, add trailing "/" to import'));
                   return;
                 } else if (!fileName.startsWith('.env.')) {
-                  this._loadingError = new Error('imported file must be a .env.* file');
+                  this._errors.push(new LoadingError('imported file must be a .env.* file'));
                   return;
                 }
                 // TODO: once we have more file types, here we would detect the type and import it correctly
@@ -481,17 +483,17 @@ export abstract class EnvGraphDataSource {
               }
             }
           } else if (importPath.startsWith('http://') || importPath.startsWith('https://')) {
-            this._loadingError = new Error('http imports not supported yet');
+            this._errors.push(new LoadingError('http imports not supported yet'));
             return;
           } else if (importPath.startsWith('npm:')) {
-            this._loadingError = new Error('npm imports not supported yet');
+            this._errors.push(new LoadingError('npm imports not supported yet'));
             return;
           } else {
-            this._loadingError = new Error('unsupported import type');
+            this._errors.push(new LoadingError('unsupported import type'));
             return;
           }
         } catch (err) {
-          this._loadingError = err as Error;
+          this._errors.push(err instanceof LoadingError ? err : new LoadingError(err as Error));
           return;
         }
       }
@@ -518,16 +520,17 @@ export abstract class EnvGraphDataSource {
     return this._disabled || this.parent?._disabled;
   }
 
-  /** an error encountered while loading/parsing the data source */
-  _loadingError?: Error;
-  get loadingError() {
-    if (this._loadingError) return this._loadingError;
+  _errors: Array<VarlockError> = [];
+
+  /** first loading/parse error on this data source (including plugin loading errors) */
+  get loadingError(): VarlockError | undefined {
+    const ownError = this._errors.find((e) => e instanceof LoadingError || e instanceof ParseError);
+    if (ownError) return ownError;
 
     // Check if any plugins loaded by this data source have errors
     if (this.graph) {
       for (const plugin of this.graph.plugins) {
         if (plugin.loadingError) {
-          // Check if this plugin was installed by this data source
           for (const installDecorator of plugin.installDecoratorInstances) {
             if (installDecorator.dataSource === this) {
               return plugin.loadingError;
@@ -539,20 +542,29 @@ export abstract class EnvGraphDataSource {
 
     return undefined;
   }
-  _schemaErrors: Array<SchemaError> = [];
+
   get schemaErrors() {
-    return _.compact([
-      ...this._schemaErrors,
+    return [
+      ...this._errors.filter((e) => e instanceof SchemaError),
       ...this.rootDecorators.flatMap((d) => d.schemaErrors),
-    ]);
+    ];
   }
 
   get resolutionErrors() {
     return _.compact([...this.rootDecorators.flatMap((d) => d._executionError)]);
   }
 
+  /** all errors from this data source (own + decorator schema + decorator execution) */
+  get errors(): Array<VarlockError> {
+    return [
+      ...this._errors,
+      ...this.rootDecorators.flatMap((d) => d.schemaErrors),
+      ...this.resolutionErrors,
+    ];
+  }
+
   get isValid() {
-    return !this.loadingError && !this.schemaErrors.some((e) => !e.isWarning) && !this.resolutionErrors.length;
+    return this.errors.every((e) => e.isWarning);
   }
 
   configItemDefs: Record<string, ConfigItemDef> = {};
@@ -675,7 +687,7 @@ export abstract class FileBasedDataSource extends EnvGraphDataSource {
   async _finishInit() {
     if (!this.rawContents) {
       if (!await pathExists(this.fullPath)) {
-        this._loadingError = new Error(`File does not exist: ${this.fullPath}`);
+        this._errors.push(new LoadingError(`File does not exist: ${this.fullPath}`));
         return;
       }
       this.rawContents = await fs.readFile(this.fullPath, 'utf8');
@@ -697,7 +709,7 @@ export class DotEnvFileDataSource extends FileBasedDataSource {
     this.parsedFile = await tryCatch(
       () => parseEnvSpecDotEnvFile(rawContents),
       (error) => {
-        this._loadingError = new ParseError(`Parse error: ${error.message}`, {
+        const parseError = new ParseError(`Parse error: ${error.message}`, {
           location: {
             id: this.fullPath,
             lineNumber: error.location.start.line,
@@ -706,7 +718,8 @@ export class DotEnvFileDataSource extends FileBasedDataSource {
           },
         });
         // TODO: figure out cause vs passing in as `err` param
-        this._loadingError.cause = error;
+        parseError.cause = error;
+        this._errors.push(parseError);
       },
     );
 
@@ -734,13 +747,13 @@ export class DotEnvFileDataSource extends FileBasedDataSource {
     const seenRootDecs = new Set<string>();
     for (const dec of parsedFile.decoratorsArray) {
       if (dec.name in this.graph!.itemDecoratorsRegistry) {
-        this._schemaErrors.push(new SchemaError(
+        this._errors.push(new SchemaError(
           `Item decorator @${dec.name} cannot be used in the file header - it must be attached to a config item`,
           { location: this._locationFromParsed(dec) },
         ));
       } else if (!dec.isBareFnCall) {
         if (seenRootDecs.has(dec.name)) {
-          this._schemaErrors.push(new SchemaError(
+          this._errors.push(new SchemaError(
             `Root decorator @${dec.name} cannot be used more than once in the same file`,
             { location: this._locationFromParsed(dec) },
           ));
@@ -757,7 +770,7 @@ export class DotEnvFileDataSource extends FileBasedDataSource {
       for (const comment of block.comments) {
         if (comment instanceof ParsedEnvSpecDecoratorComment) {
           for (const dec of comment.decorators) {
-            this._schemaErrors.push(new SchemaError(
+            this._errors.push(new SchemaError(
               `Decorator @${dec.name} is in a detached comment block - decorators must be in the file header or attached directly to a config item (no blank lines between the decorator and the item)`,
               { location: this._locationFromParsed(dec) },
             ));
@@ -841,11 +854,11 @@ export class DirectoryDataSource extends EnvGraphDataSource {
       // Check if this is a partial import that forgot to include the env flag key
       // (only for directories - files can fall back to parent's env setting for forEnv)
       if (this.isPartialImport && !this.importKeys?.includes(envFlagKey)) {
-        this._loadingError = new Error(
+        this._errors.push(new LoadingError(
           `Imported directory has @currentEnv set to $${envFlagKey}, `
           + `but "${envFlagKey}" is not included in the import list. `
           + `Add "${envFlagKey}" to the @import() arguments.`,
-        );
+        ));
         return undefined;
       }
       const envFlagItem = this.graph.configSchema[envFlagKey];
@@ -886,7 +899,7 @@ export class DirectoryDataSource extends EnvGraphDataSource {
 
     // Resolve currentEnv from schema's own @currentEnv (set during finishInit, not during imports)
     let currentEnv = await this._resolveCurrentEnv();
-    if (this._loadingError) return;
+    if (this.loadingError) return;
 
     if (currentEnv) {
       await this._loadEnvSpecificFiles(currentEnv);
@@ -902,7 +915,7 @@ export class DirectoryDataSource extends EnvGraphDataSource {
     // If we didn't load env-specific files above, check again now and process their imports too.
     if (!currentEnv) {
       currentEnv = await this._resolveCurrentEnv();
-      if (this._loadingError) return;
+      if (this.loadingError) return;
       if (currentEnv) {
         const envSources = await this._loadEnvSpecificFiles(currentEnv);
         for (const source of envSources) {

--- a/packages/varlock/src/env-graph/lib/decorators.ts
+++ b/packages/varlock/src/env-graph/lib/decorators.ts
@@ -8,7 +8,7 @@ import {
 import { EnvGraphDataSource } from './data-source';
 import type { ConfigItem } from './config-item';
 import { StaticValueResolver, type Resolver, convertParsedValueToResolvers } from './resolver';
-import { SchemaError } from './errors';
+import { ResolutionError, SchemaError, type VarlockError } from './errors';
 import type { EnvGraph } from './env-graph';
 
 
@@ -28,16 +28,26 @@ export abstract class DecoratorInstance {
 
   abstract graph: EnvGraph;
 
-  _schemaErrors: Array<SchemaError> = [];
-  get schemaErrors() {
+  _errors: Array<VarlockError> = [];
+
+  get schemaErrors(): Array<VarlockError> {
     return [
-      ...this._schemaErrors,
+      ...this._errors.filter((e) => e instanceof SchemaError),
       ...this._decValueResolver?.schemaErrors || [],
     ];
   }
 
   // error encountered during `execute` function
-  _executionError?: Error;
+  get _executionError(): VarlockError | undefined {
+    return this._errors.find((e) => e instanceof ResolutionError);
+  }
+
+  get errors(): Array<VarlockError> {
+    return [
+      ...this._errors,
+      ...this._decValueResolver?.schemaErrors || [],
+    ];
+  }
 
   private decoratorDef?: ItemDecoratorDef | RootDecoratorDef;
   get incompatibleWith() {
@@ -58,6 +68,20 @@ export abstract class DecoratorInstance {
         : this.graph.itemDecoratorsRegistry;
       this.decoratorDef = decRegistry[this.name];
       if (!this.decoratorDef) {
+        // decorators like @todo and @see are common in comments and should only warn
+        const commentLikeDecorators = ['todo', 'see', 'note'];
+        const nameLower = this.name.toLowerCase().replace(/:$/, '');
+        if (commentLikeDecorators.includes(nameLower)) {
+          const hint = nameLower === 'see'
+            ? ' - use @docs() to link documentation'
+            : ' - did you mean to write a comment?';
+          throw new SchemaError(`@${this.name} is not a valid decorator${hint}`, { isWarning: true });
+        }
+
+        if (this.parsedDecorator.hasInvalidName) {
+          throw new SchemaError(`"@${this.name}" is not a valid decorator name - only letters, numbers, and underscores are allowed`);
+        }
+
         // check if the decorator exists in the other registry (misplaced)
         const otherRegistry = this.isRootDecorator
           ? this.graph.itemDecoratorsRegistry
@@ -69,7 +93,13 @@ export abstract class DecoratorInstance {
             throw new SchemaError(`@${this.name} is a root decorator and cannot be attached to a config item - it must be in the file header (before the first config item)`);
           }
         }
-        throw new Error(`Unknown decorator: @${this.name}`);
+        throw new SchemaError(`Unknown decorator: @${this.name}`);
+      }
+
+      // surface parser-level warnings (e.g. trailing text after decorator)
+      // placed after unknown-decorator checks so comment-like names (which throw above) skip this
+      if (this.parsedDecorator.warning) {
+        this._errors.push(new SchemaError(this.parsedDecorator.warning, { isWarning: true }));
       }
 
       // validate function-call vs value syntax
@@ -112,7 +142,7 @@ export abstract class DecoratorInstance {
         this.processedData = await this.decoratorDef.process?.(this.decValueResolver);
       }
     } catch (e) {
-      this._schemaErrors.push(e instanceof SchemaError ? e : new SchemaError(e as Error));
+      this._errors.push(e instanceof SchemaError ? e : new SchemaError(e as Error));
     }
   }
   async execute() {
@@ -127,14 +157,14 @@ export abstract class DecoratorInstance {
 
     await this.process();
     if (!this.decValueResolver) {
-      // process() already recorded schema errors, don't throw again (warnings don't block)
-      if (this._schemaErrors.some((e) => !e.isWarning)) return;
+      // process() already recorded schema errors, don't throw again
+      if (this._errors.length) return;
       throw new Error('expected decorator to have a value resolver');
     }
     try {
       this.resolvedValue = await this.decValueResolver.resolve();
     } catch (err) {
-      this._schemaErrors.push(err as any);
+      this._errors.push(err as any);
       return;
     }
 
@@ -357,8 +387,7 @@ export const builtInRootDecorators: Array<RootDecoratorDef<any>> = [
       if (enabledResolver !== undefined) {
         const enabledValue = await enabledResolver.resolve();
         if (!_.isBoolean(enabledValue)) {
-          dataSource._loadingError = new SchemaError('@setValuesBulk: enabled must be a boolean');
-          return;
+          throw new SchemaError('@setValuesBulk: enabled must be a boolean');
         }
         if (!enabledValue) return; // disabled - skip data resolution entirely
       }
@@ -374,8 +403,7 @@ export const builtInRootDecorators: Array<RootDecoratorDef<any>> = [
       }
 
       if (typeof dataString !== 'string') {
-        dataSource._loadingError = new SchemaError('@setValuesBulk: data resolver must return a string');
-        return;
+        throw new SchemaError('@setValuesBulk: data resolver must return a string');
       }
 
       // detect or use explicit format
@@ -383,16 +411,10 @@ export const builtInRootDecorators: Array<RootDecoratorDef<any>> = [
 
       // parse the data
       let entries: Record<string, { value: string | number | boolean, description?: string }>;
-      try {
-        if (effectiveFormat === 'json') {
-          entries = parseJsonBulkValues(dataString);
-        } else {
-          entries = parseEnvBulkValues(dataString);
-        }
-      } catch (err) {
-        // surface parse errors as loading errors on the data source
-        dataSource._loadingError = err instanceof SchemaError ? err : new SchemaError(err as Error);
-        return;
+      if (effectiveFormat === 'json') {
+        entries = parseJsonBulkValues(dataString);
+      } else {
+        entries = parseEnvBulkValues(dataString);
       }
 
       // dynamic import to avoid circular dependency

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -186,7 +186,7 @@ export class EnvGraph {
     // because its a class, we can't use `name`
     const fnName = resolverClass.fnName;
     if (fnName in this.registeredResolverFunctions) {
-      throw new Error(`Resolver ${fnName} already registered`);
+      throw new SchemaError(`Resolver ${fnName} already registered`);
     }
     this.registeredResolverFunctions[fnName] = resolverClass;
   }
@@ -195,7 +195,7 @@ export class EnvGraph {
   registerDataType(factory: EnvGraphDataTypeFactory) {
     const name = factory.dataTypeName;
     if (name in this.dataTypesRegistry) {
-      throw new Error(`Data type "${name}" already registered`);
+      throw new SchemaError(`Data type "${name}" already registered`);
     }
     this.dataTypesRegistry[factory.dataTypeName] = factory;
   }
@@ -204,7 +204,7 @@ export class EnvGraph {
   registerItemDecorator(decoratorDef: ItemDecoratorDef) {
     const name = decoratorDef.name;
     if (name in this.itemDecoratorsRegistry) {
-      throw new Error(`Item decorator "${name}" already registered`);
+      throw new SchemaError(`Item decorator "${name}" already registered`);
     }
     this.itemDecoratorsRegistry[decoratorDef.name] = decoratorDef;
   }
@@ -213,7 +213,7 @@ export class EnvGraph {
   registerRootDecorator(decoratorDef: RootDecoratorDef) {
     const name = decoratorDef.name;
     if (name in this.itemDecoratorsRegistry) {
-      throw new Error(`Root decorator "${name}" already registered`);
+      throw new SchemaError(`Root decorator "${name}" already registered`);
     }
     this.rootDecoratorsRegistry[decoratorDef.name] = decoratorDef;
   }
@@ -344,12 +344,12 @@ export class EnvGraph {
     }
 
     // process root decorators
-    let processingError = false;
+    let hasErrors = false;
     for (const source of this.sortedDataSources) {
       if (source.disabled) continue;
       for (const decInstance of source.rootDecorators) {
         await decInstance.process();
-        if (decInstance.schemaErrors.some((e) => !e.isWarning)) processingError = true;
+        if (decInstance.schemaErrors.some((e) => !e.isWarning)) hasErrors = true;
       }
     }
 
@@ -364,10 +364,10 @@ export class EnvGraph {
     for (const itemKey in this.configSchema) {
       const item = this.configSchema[itemKey];
       await item.process();
-      if (item.errors.some((e) => !e.isWarning)) processingError = true;
+      if (item.errors.some((e) => !e.isWarning)) hasErrors = true;
     }
 
-    if (processingError) return;
+    if (hasErrors) return;
 
     // check for cycles in resolver dependencies
     const cycles = findGraphCycles(this.graphAdjacencyList);
@@ -388,7 +388,7 @@ export class EnvGraph {
     for (const source of this.sortedDataSources) {
       if (source.disabled) continue;
       for (const decInstance of source.rootDecorators) {
-        if (!decInstance.decValueResolver) throw new Error('expected decorator value resolver');
+        if (!decInstance.decValueResolver) continue; // no resolver = errored during process()
         await this.resolveEnvValues(decInstance.decValueResolver.deps);
         try {
           await decInstance.execute();
@@ -396,13 +396,14 @@ export class EnvGraph {
           // prefer the error's own location (e.g. from a nested resolver) over the decorator's
           const errLocation = (err as any).more?.location
             || getErrorLocation(source, decInstance.parsedDecorator);
-          decInstance._executionError = new SchemaError(
+          decInstance._errors.push(new ResolutionError(
             err as Error,
             {
+              severity: 'fatal',
               location: errLocation,
               ...((err as any).tip && { tip: (err as any).tip }),
             },
-          );
+          ));
         }
       }
     }
@@ -561,13 +562,7 @@ export class EnvGraph {
     // root-level errors (loading, schema, resolution errors from data sources)
     const rootErrors: Array<string> = [];
     for (const source of this.sortedDataSources) {
-      if (source.loadingError) {
-        rootErrors.push(`${source.label}: ${source.loadingError.message}`);
-      }
-      for (const err of source.schemaErrors) {
-        rootErrors.push(`${source.label}: ${err.message}`);
-      }
-      for (const err of source.resolutionErrors) {
+      for (const err of source.errors.filter((e) => !e.isWarning)) {
         rootErrors.push(`${source.label}: ${err.message}`);
       }
     }

--- a/packages/varlock/src/env-graph/lib/errors.ts
+++ b/packages/varlock/src/env-graph/lib/errors.ts
@@ -42,6 +42,8 @@ export type VarlockErrorLocationDetails = {
 };
 
 
+export type ErrorSeverity = 'warning' | 'error' | 'fatal';
+
 export class VarlockError extends Error {
   originalError?: Error;
   get isUnexpected() { return !!this.originalError; }
@@ -52,11 +54,13 @@ export class VarlockError extends Error {
   static defaultIcon = '❌';
   icon: string;
 
-  _isWarning = false;
+  private _severity: ErrorSeverity = 'error';
 
   constructor(errOrMessage: string | Error, readonly more?: {
     tip?: string | Array<string>,
     err?: Error,
+    severity?: ErrorSeverity,
+    /** @deprecated use severity: 'warning' instead */
     isWarning?: boolean,
     /** machine-friendly error code if needed for anything else */
     code?: string,
@@ -74,7 +78,11 @@ export class VarlockError extends Error {
     }
     if (_.isArray(more?.tip)) more.tip = more.tip.join('\n');
     this.name = this.constructor.name;
-    if (more?.isWarning) this.isWarning = true;
+    if (more?.severity) {
+      this.severity = more.severity;
+    } else if (more?.isWarning) {
+      this.severity = 'warning';
+    }
 
     this.icon ||= (this.constructor as any).defaultIcon;
   }
@@ -96,13 +104,16 @@ export class VarlockError extends Error {
     return this.more?.extraMetadata;
   }
 
-  set isWarning(w: boolean) {
-    this._isWarning = w;
-    if (this._isWarning) {
-      this.icon = '🧐';
-    }
+  get severity() { return this._severity; }
+  set severity(s: ErrorSeverity) {
+    this._severity = s;
+    if (s === 'warning') this.icon = '🧐';
   }
-  get isWarning() { return this._isWarning; }
+
+  get isWarning() { return this._severity === 'warning'; }
+  set isWarning(w: boolean) { this.severity = w ? 'warning' : 'error'; }
+
+  get isFatal() { return this._severity === 'fatal'; }
 
   toJSON() {
     return {
@@ -110,9 +121,10 @@ export class VarlockError extends Error {
       type: this.type,
       name: this.name,
       message: this.message,
+      severity: this.severity,
       isUnexpected: this.isUnexpected,
       ...this.tip && { tip: this.tip },
-      ...this.isWarning && { isWarning: this.isWarning },
+      ...this.isWarning && { isWarning: true },
     };
   }
 }
@@ -148,6 +160,9 @@ export class ConfigLoadError extends VarlockError {
   }
 }
 
+export class LoadingError extends VarlockError {
+  static defaultIcon = '📂';
+}
 export class ParseError extends VarlockError {
   static defaultIcon = '😵‍💫';
 }

--- a/packages/varlock/src/env-graph/lib/plugins.ts
+++ b/packages/varlock/src/env-graph/lib/plugins.ts
@@ -19,7 +19,7 @@ import { confirm } from '../../cli/helpers/prompts';
 
 import { FileBasedDataSource, type EnvGraphDataSource } from './data-source';
 import {
-  CoercionError, ResolutionError, SchemaError, ValidationError,
+  CoercionError, LoadingError, ResolutionError, SchemaError, ValidationError, VarlockError,
 } from './errors';
 import { getErrorLocation } from './error-location';
 import { createResolver, type ResolverDef } from './resolver';
@@ -143,10 +143,10 @@ async function loadPluginModuleESM(filePath: string): Promise<void> {
       source = new Bun.Transpiler({ loader: 'ts' }).transformSync(source);
     }
 
-    await import(`data:text/javascript,${encodeURIComponent(source)}`);
+    await import(/* webpackIgnore: true */ `data:text/javascript,${encodeURIComponent(source)}`);
   } else {
     const fileUrl = pathToFileURL(filePath).href;
-    await import(`${fileUrl}?t=${Date.now()}`);
+    await import(/* webpackIgnore: true */ `${fileUrl}?t=${Date.now()}`);
   }
 }
 
@@ -174,7 +174,7 @@ export class VarlockPlugin {
   get icon() { return this._icon || 'mdi:puzzle'; }
   set icon(val: string) { this._icon = val; }
 
-  loadingError?: Error;
+  loadingError?: VarlockError;
   warnings: Array<SchemaError> = [];
 
   readonly localPath?: string;
@@ -187,7 +187,7 @@ export class VarlockPlugin {
   constructor(opts: {
     type: 'single-file' | 'package',
     localPath: string,
-    loadingError?: Error,
+    loadingError?: VarlockError,
     packageJson?: { name: string; version?: string; description?: string };
   }) {
     this.type = opts.type;
@@ -354,7 +354,7 @@ export class VarlockPlugin {
         loadPluginModuleCJS(this.pluginFilePath);
       }
     } catch (err) {
-      this.loadingError = err as Error;
+      this.loadingError = err instanceof VarlockError ? err : new LoadingError(err as Error);
     } finally {
       // Restore globalThis.plugin to its previous state
       if (hadGlobalPlugin) {
@@ -427,13 +427,13 @@ async function registerPluginInGraph(graph: EnvGraph, plugin: VarlockPlugin, plu
         if (possibleMatchingPlugin.version === plugin.version) {
           const installedInSources = possibleMatchingPlugin.installDecoratorInstances.map((dec) => dec.dataSource);
           if (installedInSources.includes(pluginDecorator.dataSource)) {
-            pluginDecorator._schemaErrors.push(new SchemaError(`Plugin ${plugin.name} already installed in this data source`));
+            pluginDecorator._errors.push(new SchemaError(`Plugin ${plugin.name} already installed in this data source`));
             return;
           }
 
           existingPlugin = possibleMatchingPlugin;
         } else {
-          pluginDecorator._schemaErrors.push(new SchemaError(`Plugin ${plugin.name} version conflict: tried to install version ${plugin.version} but version ${possibleMatchingPlugin.version} is already installed`));
+          pluginDecorator._errors.push(new SchemaError(`Plugin ${plugin.name} version conflict: tried to install version ${plugin.version} but version ${possibleMatchingPlugin.version} is already installed`));
           return;
         }
       }
@@ -596,7 +596,7 @@ export async function processPluginInstallDecorators(dataSource: EnvGraphDataSou
   const installPluginDecorators = dataSource.getRootDecFns('plugin');
   if (installPluginDecorators.length) {
     if (!(dataSource instanceof FileBasedDataSource)) {
-      dataSource._loadingError = new Error('@plugin can only be used from a file-based data source');
+      dataSource._errors.push(new SchemaError('@plugin can only be used from a file-based data source'));
       return;
     }
     const dataSourceDir = path.dirname(dataSource.fullPath);
@@ -751,7 +751,7 @@ export async function processPluginInstallDecorators(dataSource: EnvGraphDataSou
         // might return an existing plugin if matches one in the graph
         await registerPluginInGraph(graph, plugin, pluginDecorator);
       } catch (err) {
-        pluginDecorator._schemaErrors.push(err as any);
+        pluginDecorator._errors.push(err instanceof SchemaError ? err : new SchemaError(err as Error));
         continue;
       }
     }

--- a/packages/varlock/src/env-graph/lib/resolver.ts
+++ b/packages/varlock/src/env-graph/lib/resolver.ts
@@ -63,7 +63,7 @@ export class Resolver {
   /** reference to the parsed node that created this resolver, used for error location tracking */
   _parsedNode?: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall
     | ParsedEnvSpecFunctionArgs;
-  _schemaErrors: Array<SchemaError> = [];
+  _errors: Array<SchemaError> = [];
   private _depsObj: Record<string, boolean> = {};
 
   get childResolvers(): Array<Resolver> {
@@ -75,11 +75,10 @@ export class Resolver {
 
   get schemaErrors(): Array<SchemaError> {
     return [
-      ...this._schemaErrors,
+      ...this._errors,
       ...this.childResolvers.flatMap((r) => r.schemaErrors),
     ];
   }
-  set schemaErrors(v: Array<SchemaError>) { throw new Error('set _schemaErrors instead'); }
 
   get depsObj(): Record<string, boolean> {
     const mergedDepsObj = { ...this._depsObj };
@@ -98,14 +97,14 @@ export class Resolver {
 
     const { argsSchema } = this.def;
     if (argsSchema?.type === 'array' && this.objArgs !== undefined) {
-      this._schemaErrors.push(new SchemaError('Resolver does not support key-value args'));
+      this._errors.push(new SchemaError('Resolver does not support key-value args'));
     } else if (argsSchema?.type === 'object' && this.arrArgs !== undefined) {
-      this._schemaErrors.push(new SchemaError('Resolver expects only key-value args'));
+      this._errors.push(new SchemaError('Resolver expects only key-value args'));
     }
 
     if (argsSchema?.arrayExactLength !== undefined) {
       if (this.arrArgs?.length !== argsSchema.arrayExactLength) {
-        this._schemaErrors.push(
+        this._errors.push(
           new SchemaError(
             `expects exactly ${argsSchema.arrayExactLength} argument${argsSchema.arrayExactLength > 1 ? 's' : ''}`,
           ),
@@ -114,7 +113,7 @@ export class Resolver {
     }
     if (argsSchema?.arrayMinLength !== undefined) {
       if ((this.arrArgs?.length ?? 0) < argsSchema.arrayMinLength) {
-        this._schemaErrors.push(
+        this._errors.push(
           new SchemaError(
             `expects at least ${argsSchema.arrayMinLength} argument${argsSchema.arrayMinLength > 1 ? 's' : ''}`,
           ),
@@ -123,7 +122,7 @@ export class Resolver {
     }
     if (argsSchema?.arrayMaxLength !== undefined) {
       if ((this.arrArgs?.length ?? 0) > argsSchema.arrayMaxLength) {
-        this._schemaErrors.push(
+        this._errors.push(
           new SchemaError(`expects at most ${argsSchema.arrayMaxLength} argument${argsSchema.arrayMaxLength > 1 ? 's' : ''}`),
         );
       }
@@ -132,7 +131,7 @@ export class Resolver {
     if (argsSchema?.objKeyMinLength !== undefined) {
       const objKeyLengths = Object.keys(this.objArgs || {}).length;
       if (objKeyLengths < argsSchema.objKeyMinLength) {
-        this._schemaErrors.push(
+        this._errors.push(
           new SchemaError(
             `expects at least ${argsSchema.objKeyMinLength} key value arg${argsSchema.objKeyMinLength > 1 ? 's' : ''}`,
           ),
@@ -141,14 +140,14 @@ export class Resolver {
     }
 
     // call specific resolve fn for the resolver
-    if (this._schemaErrors.length === 0) {
+    if (this._errors.length === 0) {
       try {
         this.meta = this.def.process?.call(this);
       } catch (error) {
         if (error instanceof SchemaError) {
-          this._schemaErrors.push(error);
+          this._errors.push(error);
         } else if (error instanceof Error) {
-          this._schemaErrors.push(new SchemaError(error));
+          this._errors.push(new SchemaError(error));
         } else {
           throw new Error(`Non-error thrown while processing resolver - ${error}`);
         }
@@ -157,7 +156,7 @@ export class Resolver {
 
     // adding fn name to resolver schema errors
     if (!this.def.name.startsWith('\0')) {
-      for (const e of this._schemaErrors) {
+      for (const e of this._errors) {
         e.message = `${this.def.name}(): ${e.message}`;
       }
     }
@@ -307,7 +306,7 @@ export class ErrorResolver extends Resolver {
   };
   constructor(readonly err: SchemaError) {
     super([]);
-    this._schemaErrors.push(err);
+    this._errors.push(err);
   }
 }
 
@@ -464,7 +463,7 @@ export const RemapResolver: typeof Resolver = createResolver({
         throw new SchemaError('expects at least 1 key=value remapping pair');
       }
       // add a deprecation warning - will show in `varlock load` pretty output below the item
-      this._schemaErrors.push(new SchemaError('key=value syntax is deprecated', {
+      this._errors.push(new SchemaError('key=value syntax is deprecated', {
         isWarning: true,
         tip: 'Use positional pairs instead: remap($VAR, match1, result1, match2, result2, ...)',
       }));

--- a/packages/varlock/src/env-graph/test/decorator-placement.test.ts
+++ b/packages/varlock/src/env-graph/test/decorator-placement.test.ts
@@ -62,7 +62,7 @@ describe('decorator placement validation', () => {
           ITEM=foo
         `,
       },
-      earlyError: true,
+      expectError: true,
     }));
 
     test('item decorator in header without divider causes schema error', envFilesTest({
@@ -73,7 +73,7 @@ describe('decorator placement validation', () => {
           ITEM=foo
         `,
       },
-      earlyError: true,
+      expectError: true,
     }));
   });
 
@@ -112,7 +112,7 @@ describe('decorator placement validation', () => {
           ITEM2=bar
         `,
       },
-      earlyError: true,
+      expectError: true,
     }));
   });
 
@@ -125,7 +125,7 @@ describe('decorator placement validation', () => {
           ITEM=foo
         `,
       },
-      earlyError: true,
+      expectError: true,
     }));
 
     test('duplicate root decorator across header comment blocks', envFilesTest({
@@ -138,7 +138,7 @@ describe('decorator placement validation', () => {
           ITEM=foo
         `,
       },
-      earlyError: true,
+      expectError: true,
     }));
 
     test('function-call root decorators can be used multiple times', envFilesTest({
@@ -163,7 +163,7 @@ describe('decorator placement validation', () => {
           ITEM=foo
         `,
       },
-      earlyError: true,
+      expectError: true,
     }));
 
     test('value-only decorator used as function call causes schema error', envFilesTest({
@@ -174,7 +174,7 @@ describe('decorator placement validation', () => {
           ITEM=foo
         `,
       },
-      earlyError: true,
+      expectError: true,
     }));
 
     test('item function-only decorator used as value causes schema error', envFilesTest({
@@ -217,7 +217,7 @@ describe('decorator placement validation', () => {
           ITEM=foo
         `,
       },
-      earlyError: true,
+      expectError: true,
     }));
   });
 });

--- a/packages/varlock/src/env-graph/test/decorator-placement.test.ts
+++ b/packages/varlock/src/env-graph/test/decorator-placement.test.ts
@@ -198,6 +198,51 @@ describe('decorator placement validation', () => {
     }));
   });
 
+  describe('duplicate unknown/invalid decorators do not trigger dupe errors', () => {
+    test('duplicate unknown item decorators only get unknown-decorator errors', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @see @see
+          ITEM=foo
+        `,
+      },
+      // should still resolve — @see is just a warning, not a fatal error
+      expectValues: { ITEM: 'foo' },
+    }));
+
+    test('duplicate unknown item decorators with valid names only get unknown-decorator errors', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @badDec @badDec
+          ITEM=foo
+        `,
+      },
+      expectValues: { ITEM: SchemaError },
+    }));
+
+    test('duplicate invalid-name item decorators only get invalid-name errors', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @todo: @todo:
+          ITEM=foo
+        `,
+      },
+      expectValues: { ITEM: 'foo' },
+    }));
+
+    test('duplicate unknown root decorators do not trigger dupe errors', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @see @see
+          # ---
+          ITEM=foo
+        `,
+      },
+      // @see in header is a warning, not a fatal error
+      expectValues: { ITEM: 'foo' },
+    }));
+  });
+
   describe('unknown decorators trigger errors', () => {
     test('unknown item decorator causes schema error', envFilesTest({
       files: {

--- a/packages/varlock/src/env-graph/test/disabled-decorator.test.ts
+++ b/packages/varlock/src/env-graph/test/disabled-decorator.test.ts
@@ -36,6 +36,6 @@ describe('@disable root decorator', () => {
       # ---
       FOO=bar
     `,
-    loadingError: true,
+    expectError: true,
   }));
 });

--- a/packages/varlock/src/env-graph/test/early-resolve-order.test.ts
+++ b/packages/varlock/src/env-graph/test/early-resolve-order.test.ts
@@ -153,7 +153,7 @@ describe('early resolve order - error when later file redefines early-resolved i
       `,
       '.env.dev': 'APP_ENV=staging',
     },
-    earlyError: true,
+    expectError: true,
   }));
 
   test('error when imported file redefines item used in @import enabled condition', envFilesTest({
@@ -171,7 +171,7 @@ describe('early resolve order - error when later file redefines early-resolved i
         AZURE_CLIENT_ID=some-client-id
       `,
     },
-    earlyError: true,
+    expectError: true,
   }));
 
   test('error when imported file redefines item used in @disable condition', envFilesTest({
@@ -191,7 +191,7 @@ describe('early resolve order - error when later file redefines early-resolved i
         AZURE_CLIENT_ID=some-client-id
       `,
     },
-    earlyError: true,
+    expectError: true,
   }));
 
   test('no error when imported file defines a different item (not the early-resolved one)', envFilesTest({

--- a/packages/varlock/src/env-graph/test/environments.test.ts
+++ b/packages/varlock/src/env-graph/test/environments.test.ts
@@ -13,7 +13,7 @@ describe('@currentEnv and .env.* file loading logic', () => {
       `,
       '.env': 'APP_ENV=dev',
     },
-    loadingError: true,
+    expectError: true,
   }));
 
   test('all .env.* files are loaded in correct precedence order', envFilesTest({
@@ -106,7 +106,7 @@ describe('@currentEnv and .env.* file loading logic', () => {
         APP_ENV=dev
       `,
     },
-    loadingError: true,
+    expectError: true,
   }));
 
   // some other tools (e.g. dotenv-expand, Next.js) automatically skip .env.local for test mode
@@ -268,7 +268,7 @@ describe('@currentEnv and .env.* file loading logic', () => {
       'dir/.env.dev': 'IMPORTED_ITEM=dev-val',
       'dir/.env.prod': 'IMPORTED_ITEM=prod-val',
     },
-    loadingError: true,
+    expectError: true,
   }));
   test('currentEnv can be set from an imported file', envFilesTest({
     files: {

--- a/packages/varlock/src/env-graph/test/helpers/generic-test.ts
+++ b/packages/varlock/src/env-graph/test/helpers/generic-test.ts
@@ -2,6 +2,7 @@ import { expect, vi } from 'vitest';
 import path from 'node:path';
 import {
   EnvGraph, SchemaError, DirectoryDataSource, DotEnvFileDataSource, MultiplePathsContainerDataSource,
+  type VarlockError,
 } from '../../index';
 import type { Constructor } from '@env-spec/utils/type-utils';
 
@@ -26,8 +27,16 @@ export function envFilesTest(spec: {
   /** Override process.env for builtin var detection (avoids modifying real process.env) */
   processEnv?: Record<string, string | undefined>;
   debug?: boolean;
-  earlyError?: boolean;
-  loadingError?: boolean;
+  /**
+   * Expect an error before resolution.
+   * - `true` — any non-warning error on a data source or plugin
+   * - A VarlockError subclass — additionally asserts the error is an instance of that class
+   */
+  expectError?: boolean | Constructor<VarlockError>;
+  /**
+   * Expect a root decorator execution error (happens during resolution).
+   */
+  resolutionError?: boolean;
   expectValues?: Record<string, string | number | boolean | undefined | Constructor<Error>>;
   expectNotInSchema?: Array<string>,
   expectRequired?: Record<string, boolean | Constructor<Error>>;
@@ -96,26 +105,36 @@ export function envFilesTest(spec: {
       }
     }
 
-    // TODO - improve terminology around errors
-    // and how we distinguish between errors in different phases
-    if (spec.earlyError) {
-      expect(
-        g.plugins.some((p) => p.loadingError)
-        || g.sortedDataSources.some((s) => s.schemaErrors.length > 0 || s.loadingError),
-        'Expected an early error, but didnt find one',
-      ).toBeTruthy();
+    if (spec.expectError) {
+      const allErrors = [
+        ...g.sortedDataSources.flatMap((s) => s.errors.filter((e) => !e.isWarning)),
+        ...g.plugins.filter((p) => p.loadingError).map((p) => p.loadingError!),
+      ];
+      expect(allErrors.length, 'Expected an error, but didnt find one').toBeGreaterThan(0);
+      if (typeof spec.expectError === 'function') {
+        const ErrorClass = spec.expectError;
+        expect(
+          allErrors.some((e) => e instanceof ErrorClass),
+          `Expected a ${ErrorClass.name}, but got: ${allErrors.map((e) => e.constructor.name).join(', ')}`,
+        ).toBe(true);
+      }
     }
 
-    if (spec.loadingError) {
+    if (spec.expectError) {
+      // don't proceed to resolution checks
+    } else if (spec.resolutionError) {
+      await g.resolveEnvValues();
       expect(
-        g.sortedDataSources.some((s) => s.loadingError),
-        'Expected a loading error, but didnt find one',
+        g.sortedDataSources.some((s) => s.resolutionErrors.length > 0),
+        'Expected a resolution error, but didnt find one',
       ).toBeTruthy();
     } else {
-      const firstLoadingError = g.sortedDataSources.find((s) => s.loadingError)?.loadingError;
+      // check for source-level errors (loading, schema on the source itself)
+      // item-level schema errors are fine — they don't prevent resolution
+      const firstSourceError = g.sortedDataSources.flatMap((s) => s._errors).find((e) => !e.isWarning);
       expect(
-        firstLoadingError,
-        `Expected no loading errors, but got - ${firstLoadingError?.message}`,
+        firstSourceError,
+        `Expected no errors, but got - ${firstSourceError?.message}`,
       ).toBeFalsy();
 
       // Simulate calling getTypeGenInfo() before resolveEnvValues(), as the CLI does

--- a/packages/varlock/src/env-graph/test/import.test.ts
+++ b/packages/varlock/src/env-graph/test/import.test.ts
@@ -86,7 +86,7 @@ describe('@import', () => {
         APP_ENV=dev
       `,
     },
-    loadingError: true,
+    expectError: true,
   }));
 
   describe('partial imports', () => {
@@ -154,7 +154,7 @@ describe('@import', () => {
       `,
         'env.json': '',
       },
-      loadingError: true,
+      expectError: true,
     }));
 
     test('importing non-existant file triggers an error', envFilesTest({
@@ -164,7 +164,7 @@ describe('@import', () => {
         # ---
       `,
       },
-      loadingError: true,
+      expectError: true,
     }));
   });
 
@@ -309,7 +309,7 @@ describe('@import', () => {
           ITEM2=value-from-.env.import
         `,
       },
-      loadingError: true,
+      expectError: true,
     }));
     test('error - bad reference', envFilesTest({
       files: {
@@ -322,7 +322,7 @@ describe('@import', () => {
           ITEM2=value-from-.env.import
         `,
       },
-      loadingError: true,
+      expectError: true,
     }));
 
     // forEnv has special handling, so good to test
@@ -369,7 +369,7 @@ describe('@import', () => {
           ITEM1=value-from-.env.schema
         `,
       },
-      loadingError: true,
+      expectError: true,
     }));
 
     test('allowMissing=true with existing file imports normally', envFilesTest({
@@ -443,7 +443,7 @@ describe('@import', () => {
           ITEM2=value-from-.env.import
         `,
       },
-      loadingError: true,
+      expectError: true,
     }));
   });
 

--- a/packages/varlock/src/env-graph/test/plugins.test.ts
+++ b/packages/varlock/src/env-graph/test/plugins.test.ts
@@ -21,7 +21,7 @@ describe('plugins ', () => {
       # @plugin(@varlock/test-plugin@xxx)
       # ---
     `,
-    earlyError: true,
+    expectError: true,
   }));
   test('adding plugin twice in same file creates error', envFilesTest({
     envFile: outdent`
@@ -29,7 +29,7 @@ describe('plugins ', () => {
       # @plugin(./plugins/test-plugin)
       # ---
     `,
-    earlyError: true,
+    expectError: true,
   }));
   test('adding plugin in multiple files is allowed', envFilesTest({
     files: {
@@ -52,7 +52,7 @@ describe('plugins ', () => {
       # @plugin(not-varlock-plugin)
       # ---
     `,
-    earlyError: true,
+    expectError: true,
   }));
   test('plugins cannot have naming conflicts for registered decorators/etc', envFilesTest({
     envFile: outdent`
@@ -60,7 +60,7 @@ describe('plugins ', () => {
       # @plugin(./plugins/test-plugin-conflict-2)
       # ---
     `,
-    earlyError: true,
+    expectError: true,
   }));
   test('plugins cannot have version conflicts', envFilesTest({
     envFile: outdent`
@@ -68,14 +68,14 @@ describe('plugins ', () => {
       # @plugin(./plugins/test-plugin-version-conflict)
       # ---
     `,
-    earlyError: true,
+    expectError: true,
   }));
   test('plugin folder must have package.json', envFilesTest({
     envFile: outdent`
       # @plugin(./plugins/test-plugin-no-package-json)
       # ---
     `,
-    earlyError: true,
+    expectError: true,
   }));
 
   test('warning on item does not block plugin resolver on same item', envFilesTest({

--- a/packages/varlock/src/env-graph/test/set-values-bulk.test.ts
+++ b/packages/varlock/src/env-graph/test/set-values-bulk.test.ts
@@ -31,7 +31,7 @@ describe('@setValuesBulk() root decorator', () => {
         # @setValuesBulk('{bad-json}', format=json)
         # ---
       `,
-      loadingError: true,
+      resolutionError: true,
     }));
 
     test('numeric and boolean values remain typed', envFilesTest({
@@ -76,7 +76,7 @@ describe('@setValuesBulk() root decorator', () => {
         # @setValuesBulk('NOT_VALID_ENV', format=env)
         # ---
       `,
-      loadingError: true,
+      resolutionError: true,
     }));
 
     test('quoted values handled correctly', envFilesTest({
@@ -173,7 +173,7 @@ describe('@setValuesBulk() root decorator', () => {
         # ---
         API_KEY=
       `,
-      earlyError: true,
+      expectError: true,
     }));
 
     test('invalid format option', envFilesTest({
@@ -182,7 +182,7 @@ describe('@setValuesBulk() root decorator', () => {
         # ---
         API_KEY=
       `,
-      earlyError: true,
+      expectError: true,
     }));
 
     test('invalid auto-detect format', envFilesTest({
@@ -190,7 +190,7 @@ describe('@setValuesBulk() root decorator', () => {
         # @setValuesBulk('FOO: "bar"')
         # ---
       `,
-      loadingError: true,
+      resolutionError: true,
     }));
 
     test('unknown option name', envFilesTest({
@@ -199,7 +199,7 @@ describe('@setValuesBulk() root decorator', () => {
         # ---
         API_KEY=
       `,
-      earlyError: true,
+      expectError: true,
     }));
   });
 

--- a/packages/varlock/src/lib/formatting.ts
+++ b/packages/varlock/src/lib/formatting.ts
@@ -91,7 +91,9 @@ const VALIDATION_STATE_COLORS = {
 export function getItemSummary(item: ConfigItem) {
   const summary: Array<string> = [];
   const itemErrors = item.errors;
-  const icon = itemErrors.length ? itemErrors[0].icon : '✅';
+  const icon = itemErrors.length
+    ? (itemErrors.find((e) => !e.isWarning) ?? itemErrors[0]).icon
+    : '✅';
   const isSensitive = item.isSensitive;
   const isRequired = item.isRequired;
   summary.push(joinAndCompact([

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -330,7 +330,25 @@ const EnvProxy = new Proxy<TypedEnvSchema>({}, {
     if (IGNORED_PROXY_KEYS.includes(prop)) return;
 
     if (!initializedEnv) {
-      throw new Error('varlock ENV not initialized');
+      // Check if __VARLOCK_ENV was set but contained errors (config invalid)
+      const rawEnv = globalThis.process?.env?.__VARLOCK_ENV;
+      if (rawEnv) {
+        try {
+          const parsed = JSON.parse(rawEnv);
+          if (parsed.errors) {
+            throw new Error(
+              'varlock ENV failed to load — your config has errors.\n'
+              + 'Fix the errors above and save to reload.',
+            );
+          }
+        } catch (e) {
+          if (e instanceof Error && e.message.includes('varlock ENV failed')) throw e;
+        }
+      }
+      throw new Error(
+        'varlock ENV not initialized — make sure varlock is set up correctly.\n'
+        + 'See https://varlock.dev/docs/get-started for setup instructions.',
+      );
     }
 
     if (prop in envValues) return envValues[prop];

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -339,10 +339,9 @@ const EnvProxy = new Proxy<TypedEnvSchema>({}, {
     }
 
     if (configHasErrors) {
-      throw new Error(
-        'varlock ENV failed to load — your config has errors.\n'
-        + 'Fix the error(s) and try again.',
-      );
+      // eslint-disable-next-line no-console
+      console.error(`[varlock] ⚠️ ENV.${prop} accessed but config has errors — values may be missing or incorrect`);
+      return undefined;
     }
 
     if (prop in envValues) return envValues[prop];

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -223,6 +223,7 @@ export function scanForLeaks(
 // --------------
 
 let initializedEnv = false;
+let configHasErrors = false;
 const envValues = {} as Record<string, any>;
 export const varlockSettings = {} as Record<string, any>;
 
@@ -264,6 +265,7 @@ export function initVarlockEnv(opts?: {
     throw new Error('initVarlockEnv failed');
   }
   Object.assign(varlockSettings, serializedEnvData.settings);
+  configHasErrors = !!(serializedEnvData as any).errors;
   resetRedactionMap(serializedEnvData);
 
   const setProcessEnv = processExists;
@@ -330,24 +332,16 @@ const EnvProxy = new Proxy<TypedEnvSchema>({}, {
     if (IGNORED_PROXY_KEYS.includes(prop)) return;
 
     if (!initializedEnv) {
-      // Check if __VARLOCK_ENV was set but contained errors (config invalid)
-      const rawEnv = globalThis.process?.env?.__VARLOCK_ENV;
-      if (rawEnv) {
-        try {
-          const parsed = JSON.parse(rawEnv);
-          if (parsed.errors) {
-            throw new Error(
-              'varlock ENV failed to load — your config has errors.\n'
-              + 'Fix the errors above and save to reload.',
-            );
-          }
-        } catch (e) {
-          if (e instanceof Error && e.message.includes('varlock ENV failed')) throw e;
-        }
-      }
       throw new Error(
         'varlock ENV not initialized — make sure varlock is set up correctly.\n'
         + 'See https://varlock.dev/docs/get-started for setup instructions.',
+      );
+    }
+
+    if (configHasErrors) {
+      throw new Error(
+        'varlock ENV failed to load — your config has errors.\n'
+        + 'Fix the error(s) and try again.',
       );
     }
 

--- a/packages/varlock/src/test-helpers/plugin-test.ts
+++ b/packages/varlock/src/test-helpers/plugin-test.ts
@@ -85,20 +85,20 @@ export function pluginTest(spec: PluginTestSpec) {
     }
 
     if (spec.expectSchemaError) {
-      const hasError = g.plugins.some((p) => p.loadingError)
-        || g.sortedDataSources.some((s) => s.schemaErrors.length > 0 || s.loadingError);
-      expect(hasError, 'Expected a schema error, but none found').toBeTruthy();
-      return; // don't resolve if we expected schema errors
+      const allErrors = [
+        ...g.sortedDataSources.flatMap((s) => s.errors.filter((e) => !e.isWarning)),
+        ...g.plugins.filter((p) => p.loadingError).map((p) => p.loadingError!),
+      ];
+      expect(allErrors.length, 'Expected an error, but none found').toBeGreaterThan(0);
+      return; // don't resolve if we expected errors
     }
 
-    // verify no unexpected loading errors
-    for (const p of g.plugins) {
-      expect(p.loadingError, `Plugin loading error: ${p.loadingError?.message}`).toBeFalsy();
-    }
-    for (const ds of g.sortedDataSources) {
-      expect(ds.loadingError, `Data source loading error: ${ds.loadingError?.message}`).toBeFalsy();
-      expect(ds.schemaErrors.length, `Schema errors: ${ds.schemaErrors.map((e) => e.message).join(', ')}`).toBe(0);
-    }
+    // verify no unexpected errors
+    const firstError = [
+      ...g.sortedDataSources.flatMap((s) => s.errors),
+      ...g.plugins.filter((p) => p.loadingError).map((p) => p.loadingError!),
+    ].find((e) => !e.isWarning);
+    expect(firstError, `Unexpected error: ${firstError?.message}`).toBeFalsy();
 
     await g.resolveEnvValues();
 

--- a/scripts/check-release-packages.ts
+++ b/scripts/check-release-packages.ts
@@ -39,7 +39,7 @@ if (bumpyStatusRaw) {
     const bumpyStatus = JSON.parse(jsonMatch[0]);
     const isPR = !!process.env.GITHUB_HEAD_REF || !!process.env.GITHUB_BASE_REF;
 
-    let bumpyReleases = bumpyStatus.releases
+    const bumpyReleases = bumpyStatus.releases
       .filter((r: any) => r.publishTargets?.some((t: any) => t.type === 'npm'));
 
     if (isPR) {

--- a/smoke-tests/smoke-test-invalid-items/.env.schema
+++ b/smoke-tests/smoke-test-invalid-items/.env.schema
@@ -1,0 +1,10 @@
+# @defaultSensitive=false
+# ---
+
+PUBLIC_VAR=public-value
+
+# @sensitive,
+SENSITIVE_VAR=secret
+
+# @required
+REQUIRED_MISSING=

--- a/smoke-tests/smoke-test-invalid/.env.schema
+++ b/smoke-tests/smoke-test-invalid/.env.schema
@@ -1,0 +1,6 @@
+# @defaultSensitive=false
+# @badRootDecorator
+# ---
+
+PUBLIC_VAR=public-value
+SENSITIVE_VAR=secret

--- a/smoke-tests/tests/cli.test.ts
+++ b/smoke-tests/tests/cli.test.ts
@@ -189,4 +189,53 @@ describe('CLI Commands', () => {
       expect(existsSync(typeFilePathAutoFalse)).toBe(false);
     });
   });
+
+  describe('error output - schema errors', () => {
+    test('exits non-zero on unknown root decorator', () => {
+      const result = varlockLoad({ cwd: 'smoke-test-invalid' });
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    test('shows the unknown decorator error in output', () => {
+      const result = varlockLoad({ cwd: 'smoke-test-invalid' });
+      expect(result.output).toContain('Unknown decorator');
+      expect(result.output).toContain('@badRootDecorator');
+    });
+
+    test('shows file path in error output', () => {
+      const result = varlockLoad({ cwd: 'smoke-test-invalid' });
+      expect(result.output).toContain('.env.schema');
+    });
+
+    test('--format json-full outputs JSON even on schema errors', () => {
+      const result = varlockLoad({ cwd: 'smoke-test-invalid', format: 'json-full' });
+      expect(() => JSON.parse(result.stdout)).not.toThrow();
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.errors).toBeDefined();
+    });
+  });
+
+  describe('error output - validation errors', () => {
+    test('exits non-zero on invalid config', () => {
+      const result = varlockLoad({ cwd: 'smoke-test-invalid-items' });
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    test('shows invalid decorator name error', () => {
+      const result = varlockLoad({ cwd: 'smoke-test-invalid-items' });
+      expect(result.output).toContain('not a valid decorator name');
+      expect(result.output).toContain('@sensitive,');
+    });
+
+    test('shows required value error', () => {
+      const result = varlockLoad({ cwd: 'smoke-test-invalid-items' });
+      expect(result.output).toContain('REQUIRED_MISSING');
+      expect(result.output).toContain('required but is currently empty');
+    });
+
+    test('shows "Configuration is currently invalid" banner', () => {
+      const result = varlockLoad({ cwd: 'smoke-test-invalid-items' });
+      expect(result.output).toContain('Configuration is currently invalid');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add `ErrorSeverity` type (`'warning' | 'error' | 'fatal'`) to `VarlockError`, replacing the binary `isWarning` boolean
- Add `LoadingError` class for data source loading failures (replaces plain `Error`)
- Unify error storage: single `_errors: VarlockError[]` array on `DataSource`, `DecoratorInstance`, and `Resolver` (replaces separate `_loadingError`, `_schemaErrors`, `_executionError` fields)
- Root decorator execution errors now use `ResolutionError` with `severity: 'fatal'` instead of being wrapped as `SchemaError`
- Replace `FatalSchemaError` with `CliExitError({ silent: true })` — reuses existing CLI error class
- Simplify test helpers: merge `earlyError`/`loadingError` into single `expectError` flag with optional error type assertion

### CLI output improvements
- Group warnings and errors per file under a single header
- Show full clickable file path below the header
- Add "Resolved config:" header to separate schema output from item list
- Fix item icon preferring first non-warning error
- Fix warning-only decorators (`@todo`, `@see`) crashing during execution phase
- Errors shown in red with ❌ emoji, warnings with ⚠️
- Remove separate "Invalid items" / "Items with warnings" sections — show all problem items together (errors first)

### Non-breaking
- `isWarning` constructor option still works (deprecated, maps to `severity: 'warning'`)
- `toJSON()` now includes `severity` field (additive)
- No changes needed for plugin authors or integrations