### PR TITLE
fix: include plugin loading errors in DataSource.errors getter

### DIFF
--- a/.bumpy/fix-nextjs-dev-error-env.md
+++ b/.bumpy/fix-nextjs-dev-error-env.md
@@ -1,0 +1,5 @@
+---
+"@varlock/nextjs-integration": patch
+---
+
+fix: preserve initial env vars in nextjs dev error path to prevent v15 turbopack from exiting

--- a/.bumpy/fix-plugin-errors-getter.md
+++ b/.bumpy/fix-plugin-errors-getter.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+include plugin loading errors in DataSource.errors getter

--- a/framework-tests/harness/dev-server.ts
+++ b/framework-tests/harness/dev-server.ts
@@ -185,6 +185,16 @@ export async function runDevServer(
   const stdoutChunks: Array<string> = [];
   const stderrChunks: Array<string> = [];
 
+  const spawnEnv = {
+    ...process.env,
+    // Dev servers should run in development mode, not vitest's test mode
+    NODE_ENV: 'development',
+    COREPACK_ENABLE_STRICT: '0',
+    COREPACK_ENABLE_PROJECT_SPEC: '0',
+    WRANGLER_SEND_METRICS: 'false',
+    VARLOCK_DEBUG: '1',
+    ...scenario.env,
+  };
   log(`Spawning: ${command}`);
   let child: ChildProcess;
   try {
@@ -192,14 +202,7 @@ export async function runDevServer(
       cwd,
       shell: true,
       detached: true,
-      env: {
-        ...process.env,
-        COREPACK_ENABLE_STRICT: '0',
-        COREPACK_ENABLE_PROJECT_SPEC: '0',
-        WRANGLER_SEND_METRICS: 'false',
-        VARLOCK_DEBUG: '1',
-        ...scenario.env,
-      },
+      env: spawnEnv,
     });
   } catch (err) {
     logError(`Failed to spawn: ${(err as Error).message}`);

--- a/framework-tests/harness/test-fixture.ts
+++ b/framework-tests/harness/test-fixture.ts
@@ -100,6 +100,15 @@ export class FrameworkTestEnv {
 
     // Isolate from parent workspaces so the test project
     // is treated as its own independent root
+
+    // Prevent bun from inheriting the repo root's bunfig.toml which has
+    // minimumReleaseAge and a security scanner that can block/hang installs
+    writeFileSync(join(this.dir, 'bunfig.toml'), [
+      '[install]',
+      'minimumReleaseAge = 0',
+      '',
+    ].join('\n'));
+
     // pnpm v11 defaults: block all build scripts, and error on packages missing time metadata.
     // Allow known native packages that need postinstall scripts, and skip age check for packages
     // without registry time metadata (common for some npm packages).

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -403,7 +403,7 @@ export function loadEnvConfig(
       enableExtraFileWatchers(varlockLoadedEnv.sources, varlockLoadedEnv.basePath);
     }
 
-    return { combinedEnv: {}, parsedEnv: {}, loadedEnvFiles: [] };
+    return { combinedEnv: { ...initialEnv }, parsedEnv: {}, loadedEnvFiles: [] };
   }
 
   parsedEnv = {};

--- a/packages/varlock/src/env-graph/lib/data-source.ts
+++ b/packages/varlock/src/env-graph/lib/data-source.ts
@@ -554,13 +554,19 @@ export abstract class EnvGraphDataSource {
     return _.compact([...this.rootDecorators.flatMap((d) => d._executionError)]);
   }
 
-  /** all errors from this data source (own + decorator schema + decorator execution) */
+  /** all errors from this data source (own + decorator schema + decorator execution + plugin loading) */
   get errors(): Array<VarlockError> {
-    return [
+    const errs = [
       ...this._errors,
       ...this.rootDecorators.flatMap((d) => d.schemaErrors),
       ...this.resolutionErrors,
     ];
+    // include plugin loading errors (checked via loadingError getter which looks at plugins)
+    const pluginErr = this.loadingError;
+    if (pluginErr && !errs.includes(pluginErr)) {
+      errs.push(pluginErr);
+    }
+    return errs;
   }
 
   get isValid() {

--- a/scripts/detect-changed-integrations.ts
+++ b/scripts/detect-changed-integrations.ts
@@ -179,6 +179,7 @@ if (changedPackages.has('varlock')) {
 
 // Detect integrations whose test files themselves changed (git diff against base)
 const changedTestIntegrations = new Set<string>();
+let harnessChanged = false;
 try {
   execSync('git fetch origin main --depth=1', { stdio: 'pipe' });
   const diffOutput = execSync('git diff origin/main --name-only -- framework-tests/', {
@@ -191,10 +192,9 @@ try {
     if (match && ALL_INTEGRATIONS.includes(match[1])) {
       changedTestIntegrations.add(match[1]);
     } else if (filePath.startsWith('framework-tests/harness/') || filePath === 'framework-tests/vitest.config.ts') {
-      // Shared test infrastructure changed — trigger all
-      console.log(`Shared framework test file changed (${filePath}) — running all integration tests`);
-      writeResults(ALL_INTEGRATIONS.map((name) => toEntry(name, 'quick')));
-      process.exit(0);
+      // Shared test infrastructure changed — flag for all integrations
+      console.log(`Shared framework test file changed (${filePath}) — will run all integration tests`);
+      harnessChanged = true;
     }
   }
   if (changedTestIntegrations.size > 0) {
@@ -210,6 +210,12 @@ for (const [name, packages] of Object.entries(INTEGRATION_PACKAGES)) {
   // Test files changed or integration package changed → full suite
   if (changedTestIntegrations.has(name) || packages.some((pkg) => changedPackages.has(pkg))) {
     entries.push(toEntry(name, 'full'));
+    continue;
+  }
+  // Harness changed → run all integrations, but only full if the integration's
+  // own package also changed (already handled above), otherwise quick
+  if (harnessChanged) {
+    entries.push(toEntry(name, 'quick'));
     continue;
   }
   // Suites with no integration packages are triggered by core varlock changes (quick)

--- a/smoke-tests/tests/cli.test.ts
+++ b/smoke-tests/tests/cli.test.ts
@@ -143,7 +143,7 @@ describe('CLI Commands', () => {
 
     test('varlock run should forward child stderr', () => {
       const result = varlockRun(
-        ['node', '-e', 'process.stderr.write("error-output\\n")'],
+        ['node', '-e', "process.stderr.write('error-output\\n')"],
         { cwd: 'smoke-test-basic' },
       );
       expect(result.exitCode).toBe(0);


### PR DESCRIPTION
## Summary
- The unified error handling refactor (#708) moved error storage to `_errors` arrays but the `DataSource.errors` getter didn't include plugin loading errors (stored on `Plugin` objects, not in `_errors`)
- This caused `checkForSchemaErrors` to miss plugin load failures, so legacy plugins showed a generic "Configuration is currently invalid" validation error instead of the helpful migration message
- Fix: include `loadingError` (which already checks plugins) in the `errors` getter when not already present

Fixes the smoke test failure in #712.

## Test plan
- [x] Smoke test `binary-plugin.test.ts > legacy plugin using implicit global shows migration error` passes locally
- [ ] CI smoke tests pass with `smoke-tests` label