### PR TITLE
fix biometric session timeout for non-TTY agents

### DIFF
--- a/.bumpy/fix-codex-keychain-biometrics.md
+++ b/.bumpy/fix-codex-keychain-biometrics.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Fix repeated Touch ID prompts when using keychain() from Codex and other non-TTY agents by improving biometric session scoping for shallow process trees.

--- a/bun.lock
+++ b/bun.lock
@@ -2973,7 +2973,7 @@
 
     "tldts-core": ["tldts-core@7.0.30", "", {}, "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q=="],
 
-    "tmp": ["tmp@0.2.6", "", {}, "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA=="],
+    "tmp": ["tmp@0.2.7", "", {}, "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 

--- a/packages/encryption-binary-rust/src/ipc.rs
+++ b/packages/encryption-binary-rust/src/ipc.rs
@@ -412,20 +412,30 @@ fn get_peer_session_id(stream: &UnixStream) -> Option<String> {
         return None;
     }
 
-    // Prefer TTY-based identity, then known LLM session env keys, then process tree.
-    get_tty_session_id(pid as u32)
-        .or_else(|| get_no_tty_session_id_from_env(pid as u32))
-        .or_else(|| get_ptree_session_id(pid as u32))
+    let parent_session_id = get_parent_session_id(pid as u32);
+    let ai_session = get_ai_session_from_env(pid as u32);
+
+    match (ai_session, parent_session_id) {
+        (Some((key, value)), Some(parent)) => Some(format!("env:{key}:{value}|{parent}")),
+        (Some((key, value)), None) => Some(format!("env:{key}:{value}")),
+        (None, Some(parent)) => Some(parent),
+        (None, None) => None,
+    }
 }
 
 #[cfg(target_os = "linux")]
-fn get_no_tty_session_id_from_env(pid: u32) -> Option<String> {
+fn get_parent_session_id(pid: u32) -> Option<String> {
+    get_tty_session_id(pid).or_else(|| get_ptree_session_id(pid))
+}
+
+#[cfg(target_os = "linux")]
+fn get_ai_session_from_env(pid: u32) -> Option<(String, String)> {
     let bytes = std::fs::read(format!("/proc/{pid}/environ")).ok()?;
     let env_pairs = parse_env_pairs(bytes.split(|b| *b == 0).filter(|entry| !entry.is_empty()));
     for key in NO_TTY_SESSION_ENV_KEYS {
         if let Some(value) = env_pairs.get(*key) {
             if !value.trim().is_empty() {
-                return Some(format!("env:{key}:{value}"));
+                return Some((key.to_string(), value.to_string()));
             }
         }
     }
@@ -501,7 +511,6 @@ const NO_TTY_SESSION_ENV_KEYS: &[&str] = &[
     "CODEX_THREAD_ID",
     "CLAUDE_CODE_SESSION_ID",
     "CLAUDE_SESSION_ID",
-    "CLAUDE_CODE_SSE_PORT",
 ];
 
 #[cfg(target_os = "linux")]

--- a/packages/encryption-binary-rust/src/ipc.rs
+++ b/packages/encryption-binary-rust/src/ipc.rs
@@ -412,9 +412,24 @@ fn get_peer_session_id(stream: &UnixStream) -> Option<String> {
         return None;
     }
 
-    // Prefer TTY-based identity, fall back to process tree
+    // Prefer TTY-based identity, then known LLM session env keys, then process tree.
     get_tty_session_id(pid as u32)
+        .or_else(|| get_no_tty_session_id_from_env(pid as u32))
         .or_else(|| get_ptree_session_id(pid as u32))
+}
+
+#[cfg(target_os = "linux")]
+fn get_no_tty_session_id_from_env(pid: u32) -> Option<String> {
+    let bytes = std::fs::read(format!("/proc/{pid}/environ")).ok()?;
+    let env_pairs = parse_env_pairs(bytes.split(|b| *b == 0).filter(|entry| !entry.is_empty()));
+    for key in NO_TTY_SESSION_ENV_KEYS {
+        if let Some(value) = env_pairs.get(*key) {
+            if !value.trim().is_empty() {
+                return Some(format!("env:{key}:{value}"));
+            }
+        }
+    }
+    None
 }
 
 /// TTY-based session identity: tty device + session leader start time.
@@ -464,14 +479,80 @@ fn get_ptree_session_id(pid: u32) -> Option<String> {
     Some(format!("ptree:{scope_pid}:{start_time}"))
 }
 
-/// Shell and similar one-shot runners that should not be used as session scope keys.
+/// Shells are one-shot command wrappers and should never scope a no-TTY session.
 #[cfg(target_os = "linux")]
-const EPHEMERAL_RUNNER_NAMES: &[&str] = &["sh", "bash", "zsh", "dash", "fish", "ksh", "csh", "tcsh"];
+const SHELL_RUNNER_NAMES: &[&str] = &["sh", "bash", "zsh", "dash", "fish", "ksh", "csh", "tcsh"];
+
+/// Varlock CLI launchers are also one-shot; scope to the host that invoked them.
+#[cfg(target_os = "linux")]
+const VARLOCK_LAUNCHER_NAMES: &[&str] = &["varlock", "varlock.exe", "varlock.cmd"];
+
+/// Runtime/package-manager processes are wrappers only when their command line
+/// shows they are launching the Varlock CLI. A long-lived process like Vite may
+/// also be `node` or `bun`, and should remain a valid session scope.
+#[cfg(target_os = "linux")]
+const PACKAGE_MANAGER_RUNNER_NAMES: &[&str] = &[
+    "bun", "node", "npm", "npx", "pnpm", "pnpx", "yarn", "yarnpkg",
+];
+
+/// For no-TTY agent/extension contexts, prefer an explicit LLM session id.
+#[cfg(target_os = "linux")]
+const NO_TTY_SESSION_ENV_KEYS: &[&str] = &[
+    "CODEX_THREAD_ID",
+    "CLAUDE_CODE_SESSION_ID",
+    "CLAUDE_SESSION_ID",
+    "CLAUDE_CODE_SSE_PORT",
+];
 
 #[cfg(target_os = "linux")]
-fn is_ephemeral_runner_name(name: &str) -> bool {
+fn parse_env_pairs<'a>(entries: impl Iterator<Item = &'a [u8]>) -> std::collections::HashMap<String, String> {
+    entries
+        .filter_map(|entry| {
+            let str_entry = String::from_utf8_lossy(entry);
+            let (key, value) = str_entry.split_once('=')?;
+            Some((key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn contains_runner_name(names: &[&str], name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
-    EPHEMERAL_RUNNER_NAMES.contains(&lower.as_str())
+    names.contains(&lower.as_str())
+}
+
+#[cfg(target_os = "linux")]
+fn process_args(pid: u32) -> Vec<String> {
+    std::fs::read(format!("/proc/{pid}/cmdline"))
+        .ok()
+        .map(|bytes| {
+            bytes
+                .split(|b| *b == 0)
+                .filter(|arg| !arg.is_empty())
+                .map(|arg| String::from_utf8_lossy(arg).to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(target_os = "linux")]
+fn process_command_line_launches_varlock(pid: u32) -> bool {
+    process_args_launches_varlock(process_args(pid).iter().map(String::as_str))
+}
+
+#[cfg(target_os = "linux")]
+fn process_args_launches_varlock<'a>(args: impl Iterator<Item = &'a str>) -> bool {
+    args.into_iter().any(|arg| {
+        let name = std::path::Path::new(arg)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        VARLOCK_LAUNCHER_NAMES.contains(&name.as_str())
+            || arg.contains("/node_modules/.bin/varlock")
+            || arg.contains("/varlock/bin/cli.js")
+            || arg.contains("/packages/varlock/bin/cli.js")
+    })
 }
 
 #[cfg(target_os = "linux")]
@@ -481,17 +562,23 @@ fn is_ephemeral_runner(pid: u32) -> bool {
         .ok()
         .map(|s| s.trim().to_string());
 
-    if let Some(path) = exe_path {
-        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-            return is_ephemeral_runner_name(name);
-        }
-    }
+    let Some(name) = exe_path
+        .as_deref()
+        .and_then(|path| path.file_name())
+        .and_then(|n| n.to_str())
+        .or(comm.as_deref())
+    else {
+        return false;
+    };
 
-    comm.as_deref().is_some_and(is_ephemeral_runner_name)
+    contains_runner_name(SHELL_RUNNER_NAMES, name)
+        || contains_runner_name(VARLOCK_LAUNCHER_NAMES, name)
+        || (contains_runner_name(PACKAGE_MANAGER_RUNNER_NAMES, name)
+            && process_command_line_launches_varlock(pid))
 }
 
 /// Pick a stable scope PID from an ancestry chain (peer first, app root last).
-#[cfg(any(test, target_os = "linux"))]
+#[cfg(target_os = "linux")]
 fn select_scope_pid_from_chain(
     chain: &[u32],
     is_ephemeral: impl Fn(u32) -> bool,
@@ -846,6 +933,20 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_env_pairs() {
+        let input = vec![
+            b"CODEX_THREAD_ID=abc123".as_slice(),
+            b"FOO=bar".as_slice(),
+            b"INVALID".as_slice(),
+        ];
+
+        let parsed = parse_env_pairs(input.into_iter());
+        assert_eq!(parsed.get("CODEX_THREAD_ID").map(String::as_str), Some("abc123"));
+        assert_eq!(parsed.get("FOO").map(String::as_str), Some("bar"));
+        assert!(!parsed.contains_key("INVALID"));
+    }
+
+    #[test]
     fn test_select_scope_pid_shallow_codex_tree() {
         // [bun, codex-app]
         let chain = [100u32, 50];
@@ -874,6 +975,31 @@ mod tests {
             select_scope_pid_from_chain(&chain, is_shell),
             Some(80),
         );
+    }
+
+    #[test]
+    fn test_select_scope_pid_package_manager_wrapper() {
+        // [varlock-local-encrypt peer, bun, codex-worker, codex-app]
+        let chain = [100u32, 99, 80, 50];
+        let is_package_manager = |pid: u32| pid == 99;
+        assert_eq!(
+            select_scope_pid_from_chain(&chain, is_package_manager),
+            Some(80),
+        );
+    }
+
+    #[test]
+    fn test_package_manager_names_are_conditional_wrappers() {
+        for name in ["bun", "node", "npm", "npx", "pnpm", "pnpx", "yarn", "yarnpkg"] {
+            assert!(
+                contains_runner_name(PACKAGE_MANAGER_RUNNER_NAMES, name),
+                "{name} should be a conditional wrapper",
+            );
+            assert!(
+                !contains_runner_name(SHELL_RUNNER_NAMES, name),
+                "{name} should not be an unconditional shell wrapper",
+            );
+        }
     }
 
     #[test]

--- a/packages/encryption-binary-rust/src/ipc.rs
+++ b/packages/encryption-binary-rust/src/ipc.rs
@@ -444,7 +444,7 @@ fn get_tty_session_id(pid: u32) -> Option<String> {
 
 /// Process-tree-based session identity for non-TTY processes.
 /// Mirrors the macOS Swift daemon logic: walks the ancestry chain up to PID 1,
-/// then uses the grandchild of the root as a stable scope key.
+/// then picks a stable scope key (see `select_scope_pid_from_chain`).
 #[cfg(target_os = "linux")]
 fn get_ptree_session_id(pid: u32) -> Option<String> {
     let mut chain: Vec<u32> = vec![pid];
@@ -459,14 +459,62 @@ fn get_ptree_session_id(pid: u32) -> Option<String> {
         current = ppid;
     }
 
-    // Need at least 4 levels for a meaningful intermediate ancestor
-    if chain.len() < 4 {
+    let scope_pid = select_scope_pid_from_chain(&chain, is_ephemeral_runner)?;
+    let start_time = get_process_start_time(scope_pid).unwrap_or(0);
+    Some(format!("ptree:{scope_pid}:{start_time}"))
+}
+
+/// Shell and similar one-shot runners that should not be used as session scope keys.
+#[cfg(target_os = "linux")]
+const EPHEMERAL_RUNNER_NAMES: &[&str] = &["sh", "bash", "zsh", "dash", "fish", "ksh", "csh", "tcsh"];
+
+#[cfg(target_os = "linux")]
+fn is_ephemeral_runner_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    EPHEMERAL_RUNNER_NAMES.contains(&lower.as_str())
+}
+
+#[cfg(target_os = "linux")]
+fn is_ephemeral_runner(pid: u32) -> bool {
+    let exe_path = std::fs::read_link(format!("/proc/{pid}/exe")).ok();
+    let comm = std::fs::read_to_string(format!("/proc/{pid}/comm"))
+        .ok()
+        .map(|s| s.trim().to_string());
+
+    if let Some(path) = exe_path {
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            return is_ephemeral_runner_name(name);
+        }
+    }
+
+    comm.as_deref().is_some_and(is_ephemeral_runner_name)
+}
+
+/// Pick a stable scope PID from an ancestry chain (peer first, app root last).
+#[cfg(any(test, target_os = "linux"))]
+fn select_scope_pid_from_chain(
+    chain: &[u32],
+    is_ephemeral: impl Fn(u32) -> bool,
+) -> Option<u32> {
+    if chain.len() < 2 {
         return None;
     }
 
-    let scope_pid = chain[chain.len() - 3];
-    let start_time = get_process_start_time(scope_pid).unwrap_or(0);
-    Some(format!("ptree:{scope_pid}:{start_time}"))
+    if chain.len() >= 4 {
+        let mut scope_pid = chain[chain.len() - 3];
+        if is_ephemeral(scope_pid) {
+            let fallback = chain[chain.len() - 2];
+            scope_pid = if is_ephemeral(fallback) {
+                chain[chain.len() - 1]
+            } else {
+                fallback
+            };
+        }
+        return Some(scope_pid);
+    }
+
+    // Shallow tree: scope to the app root (direct child of init).
+    Some(chain[chain.len() - 1])
 }
 
 /// Parse /proc/<pid>/stat and return the fields after the comm closing paren.
@@ -795,6 +843,54 @@ mod tests {
     fn test_get_process_start_time() {
         let st = get_process_start_time(std::process::id()).expect("should get own start time");
         assert!(st > 0);
+    }
+
+    #[test]
+    fn test_select_scope_pid_shallow_codex_tree() {
+        // [bun, codex-app]
+        let chain = [100u32, 50];
+        assert_eq!(
+            select_scope_pid_from_chain(&chain, |_| false),
+            Some(50),
+        );
+    }
+
+    #[test]
+    fn test_select_scope_pid_grandchild_codex_tree() {
+        // [bun, codex-worker, codex-app]
+        let chain = [100u32, 80, 50];
+        assert_eq!(
+            select_scope_pid_from_chain(&chain, |_| false),
+            Some(50),
+        );
+    }
+
+    #[test]
+    fn test_select_scope_pid_shell_wrapper() {
+        // [bun, sh, codex-worker, codex-app]
+        let chain = [100u32, 99, 80, 50];
+        let is_shell = |pid: u32| pid == 99;
+        assert_eq!(
+            select_scope_pid_from_chain(&chain, is_shell),
+            Some(80),
+        );
+    }
+
+    #[test]
+    fn test_select_scope_pid_cursor_style() {
+        // [node, zsh, claude, extension-host, cursor]
+        let chain = [100u32, 99, 88, 77, 50];
+        let is_shell = |pid: u32| pid == 99;
+        assert_eq!(
+            select_scope_pid_from_chain(&chain, is_shell),
+            Some(88),
+        );
+    }
+
+    #[test]
+    fn test_select_scope_pid_too_shallow() {
+        let chain = [100u32];
+        assert_eq!(select_scope_pid_from_chain(&chain, |_| false), None);
     }
 
     #[test]

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/PeerIdentity.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/PeerIdentity.swift
@@ -52,6 +52,7 @@ private func getStartTime(pid: pid_t) -> Int {
 ///
 /// The no-TTY algorithm walks the process tree to the app root (child of launchd),
 /// then picks a stable scope key:
+///   - Preferred: a known LLM session environment identifier
 ///   - Deep trees (4+ levels): grandchild of the app root (e.g. Claude in Cursor)
 ///   - If that process is an ephemeral shell wrapper, walk up to a longer-lived ancestor
 ///   - Shallow trees (2–3 levels): app root (e.g. Codex exec'ing scripts directly)
@@ -83,6 +84,10 @@ func getSessionIdentifier(forPid pid: pid_t) -> String? {
         return "tty:\(ttyName):\(startTimestamp)"
     }
 
+    if let envSessionId = getNoTtySessionIdFromEnvironment(forPid: pid) {
+        return envSessionId
+    }
+
     // No TTY — walk up the process tree to find a scoping ancestor.
     //
     // Build the ancestry chain from the peer up to (but not including) PID 1.
@@ -102,6 +107,59 @@ func getSessionIdentifier(forPid pid: pid_t) -> String? {
     // Deeper trees use the grandchild of the app root, unless that process is an
     // ephemeral shell wrapper (sh/bash/zsh), in which case we walk up further.
 
+    let chain = buildAncestryChain(from: pid)
+
+    guard let scopePid = selectScopePid(from: chain) else { return nil }
+    let startTime = getStartTime(pid: scopePid)
+
+    return "ptree:\(scopePid):\(startTime)"
+}
+
+/// Shells are one-shot command wrappers and should never scope a no-TTY session.
+private let shellRunnerNames: Set<String> = [
+    "sh", "bash", "zsh", "dash", "fish", "ksh", "csh", "tcsh",
+]
+
+/// Varlock CLI launchers are also one-shot; scope to the host that invoked them.
+private let varlockLauncherNames: Set<String> = [
+    "varlock", "varlock.exe", "varlock.cmd",
+]
+
+/// Runtime/package-manager processes are wrappers only when their command line
+/// shows they are launching the Varlock CLI. A long-lived process like Vite may
+/// also be `node` or `bun`, and should remain a valid session scope.
+private let packageManagerRunnerNames: Set<String> = [
+    "bun", "node", "npm", "npx", "pnpm", "pnpx", "yarn", "yarnpkg",
+]
+
+/// For no-TTY contexts (agents/extensions), prefer a per-LLM-session key.
+private let noTtySessionEnvKeys: [String] = [
+    "CODEX_THREAD_ID",
+    "CLAUDE_CODE_SESSION_ID",
+    "CLAUDE_SESSION_ID",
+    "CLAUDE_CODE_SSE_PORT",
+]
+
+private func getNoTtySessionIdFromEnvironment(forPid pid: pid_t) -> String? {
+    guard let env = getProcessEnvironment(pid: pid) else { return nil }
+    for key in noTtySessionEnvKeys {
+        guard let valueRaw = env[key] else { continue }
+        let value = valueRaw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !value.isEmpty {
+            // Bind env identity to process-tree scope to reduce spoofing.
+            // A caller must match both the env id and expected host lineage.
+            let chain = buildAncestryChain(from: pid)
+            if let scopePid = selectScopePid(from: chain) {
+                let scopeStart = getStartTime(pid: scopePid)
+                return "env:\(key):\(value):\(scopePid):\(scopeStart)"
+            }
+            return "env:\(key):\(value)"
+        }
+    }
+    return nil
+}
+
+private func buildAncestryChain(from pid: pid_t) -> [pid_t] {
     var chain: [pid_t] = [pid]
     var current = pid
     // Walk up with a depth limit to avoid infinite loops
@@ -110,22 +168,127 @@ func getSessionIdentifier(forPid pid: pid_t) -> String? {
         chain.append(ppid)
         current = ppid
     }
-
-    guard let scopePid = selectScopePid(from: chain) else { return nil }
-    let startTime = getStartTime(pid: scopePid)
-
-    return "ptree:\(scopePid):\(startTime)"
+    return chain
 }
-
-/// Shell and similar one-shot runners that should not be used as session scope keys.
-private let ephemeralRunnerNames: Set<String> = [
-    "sh", "bash", "zsh", "dash", "fish", "ksh", "csh", "tcsh",
-]
 
 private func isEphemeralRunner(pid: pid_t) -> Bool {
     guard let processPath = getProcessPath(pid: pid) else { return false }
     let name = (processPath as NSString).lastPathComponent.lowercased()
-    return ephemeralRunnerNames.contains(name)
+    if shellRunnerNames.contains(name) || varlockLauncherNames.contains(name) {
+        return true
+    }
+    return packageManagerRunnerNames.contains(name) && processCommandLineLaunchesVarlock(pid: pid)
+}
+
+private func processCommandLineLaunchesVarlock(pid: pid_t) -> Bool {
+    guard let args = getProcessArguments(pid: pid), !args.isEmpty else { return false }
+    return args.contains { arg in
+        let name = (arg as NSString).lastPathComponent.lowercased()
+        return varlockLauncherNames.contains(name)
+            || arg.contains("/node_modules/.bin/varlock")
+            || arg.contains("/varlock/bin/cli.js")
+            || arg.contains("/packages/varlock/bin/cli.js")
+    }
+}
+
+private func getProcessArguments(pid: pid_t) -> [String]? {
+    var argMax: Int32 = 0
+    var argMaxSize = MemoryLayout<Int32>.size
+    var argMaxMib: [Int32] = [CTL_KERN, KERN_ARGMAX]
+    guard sysctl(&argMaxMib, UInt32(argMaxMib.count), &argMax, &argMaxSize, nil, 0) == 0, argMax > 0 else {
+        return nil
+    }
+
+    var buffer = [CChar](repeating: 0, count: Int(argMax))
+    var size = buffer.count
+    var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+    guard sysctl(&mib, UInt32(mib.count), &buffer, &size, nil, 0) == 0, size > MemoryLayout<Int32>.size else {
+        return nil
+    }
+
+    let argc = buffer.withUnsafeBytes { rawBuffer -> Int32 in
+        rawBuffer.load(as: Int32.self)
+    }
+    guard argc > 0 else { return [] }
+
+    var offset = MemoryLayout<Int32>.size
+
+    // Skip executable path.
+    while offset < size, buffer[offset] != 0 { offset += 1 }
+    while offset < size, buffer[offset] == 0 { offset += 1 }
+
+    var args: [String] = []
+    for _ in 0..<argc {
+        guard offset < size else { break }
+        let start = offset
+        while offset < size, buffer[offset] != 0 { offset += 1 }
+        if offset > start {
+            buffer.withUnsafeBufferPointer { ptr in
+                if let base = ptr.baseAddress {
+                    args.append(String(cString: base.advanced(by: start)))
+                }
+            }
+        }
+        while offset < size, buffer[offset] == 0 { offset += 1 }
+    }
+
+    return args
+}
+
+private func getProcessEnvironment(pid: pid_t) -> [String: String]? {
+    var argMax: Int32 = 0
+    var argMaxSize = MemoryLayout<Int32>.size
+    var argMaxMib: [Int32] = [CTL_KERN, KERN_ARGMAX]
+    guard sysctl(&argMaxMib, UInt32(argMaxMib.count), &argMax, &argMaxSize, nil, 0) == 0, argMax > 0 else {
+        return nil
+    }
+
+    var buffer = [CChar](repeating: 0, count: Int(argMax))
+    var size = buffer.count
+    var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+    guard sysctl(&mib, UInt32(mib.count), &buffer, &size, nil, 0) == 0, size > MemoryLayout<Int32>.size else {
+        return nil
+    }
+
+    let argc = buffer.withUnsafeBytes { rawBuffer -> Int32 in
+        rawBuffer.load(as: Int32.self)
+    }
+    guard argc >= 0 else { return nil }
+
+    var offset = MemoryLayout<Int32>.size
+
+    // Skip executable path.
+    while offset < size, buffer[offset] != 0 { offset += 1 }
+    while offset < size, buffer[offset] == 0 { offset += 1 }
+
+    // Skip argv entries.
+    for _ in 0..<argc {
+        guard offset < size else { break }
+        while offset < size, buffer[offset] != 0 { offset += 1 }
+        while offset < size, buffer[offset] == 0 { offset += 1 }
+    }
+
+    var env: [String: String] = [:]
+
+    while offset < size {
+        while offset < size, buffer[offset] == 0 { offset += 1 }
+        guard offset < size else { break }
+
+        let start = offset
+        while offset < size, buffer[offset] != 0 { offset += 1 }
+        guard offset > start else { continue }
+
+        buffer.withUnsafeBufferPointer { ptr in
+            guard let base = ptr.baseAddress else { return }
+            let entry = String(cString: base.advanced(by: start))
+            guard let eq = entry.firstIndex(of: "=") else { return }
+            let key = String(entry[..<eq])
+            let value = String(entry[entry.index(after: eq)...])
+            env[key] = value
+        }
+    }
+
+    return env
 }
 
 /// Pick a stable scope PID from an ancestry chain (peer first, app root last).

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/PeerIdentity.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/PeerIdentity.swift
@@ -60,34 +60,52 @@ private func getStartTime(pid: pid_t) -> Int {
 /// Returns nil only when no ancestor can be determined (chain shorter than 2).
 func getSessionIdentifier(forPid pid: pid_t) -> String? {
     guard let info = getProcessInfo(pid: pid) else { return nil }
+    let parentSessionId = getParentSessionIdentifier(forPid: pid, processInfo: info)
+    let aiSession = getAiSessionFromEnvironment(forPid: pid)
 
+    if let aiSession, let parentSessionId {
+        return "env:\(aiSession.key):\(aiSession.value)|\(parentSessionId)"
+    }
+    if let parentSessionId {
+        return parentSessionId
+    }
+    if let aiSession {
+        return "env:\(aiSession.key):\(aiSession.value)"
+    }
+    return nil
+}
+
+private func getParentSessionIdentifier(forPid pid: pid_t, processInfo info: kinfo_proc) -> String? {
+    if let ttyId = getTtySessionIdentifier(forPid: pid, processInfo: info) {
+        return ttyId
+    }
+    return getProcessTreeSessionIdentifier(forPid: pid)
+}
+
+private func getTtySessionIdentifier(forPid pid: pid_t, processInfo info: kinfo_proc) -> String? {
     // e_tdev is dev_t (Int32). NODEV is -1 in signed representation
     // (0xFFFFFFFF unsigned). Comparing Int32(-1) != UInt32.max is true in
     // Swift's BinaryInteger comparison, so we must compare in the same type.
     let ttyDev = info.kp_eproc.e_tdev
-    let hasTty = ttyDev > 0
+    guard ttyDev > 0 else { return nil }
 
-    if hasTty {
-        // TTY-based identity: device name + session leader start time
-        guard let namePtr = devname(dev_t(ttyDev), S_IFCHR) else { return nil }
-        let ttyName = String(cString: namePtr)
+    // TTY-based identity: device name + session leader start time
+    guard let namePtr = devname(dev_t(ttyDev), S_IFCHR) else { return nil }
+    let ttyName = String(cString: namePtr)
 
-        let sessionLeaderPid = getsid(pid)
-        var startTimestamp: Int = 0
-        if sessionLeaderPid > 0, let leaderInfo = getProcessInfo(pid: sessionLeaderPid) {
-            startTimestamp = Int(leaderInfo.kp_proc.p_starttime.tv_sec)
-        }
-        if startTimestamp == 0 {
-            startTimestamp = Int(info.kp_proc.p_starttime.tv_sec)
-        }
-
-        return "tty:\(ttyName):\(startTimestamp)"
+    let sessionLeaderPid = getsid(pid)
+    var startTimestamp: Int = 0
+    if sessionLeaderPid > 0, let leaderInfo = getProcessInfo(pid: sessionLeaderPid) {
+        startTimestamp = Int(leaderInfo.kp_proc.p_starttime.tv_sec)
+    }
+    if startTimestamp == 0 {
+        startTimestamp = Int(info.kp_proc.p_starttime.tv_sec)
     }
 
-    if let envSessionId = getNoTtySessionIdFromEnvironment(forPid: pid) {
-        return envSessionId
-    }
+    return "tty:\(ttyName):\(startTimestamp)"
+}
 
+private func getProcessTreeSessionIdentifier(forPid pid: pid_t) -> String? {
     // No TTY — walk up the process tree to find a scoping ancestor.
     //
     // Build the ancestry chain from the peer up to (but not including) PID 1.
@@ -108,10 +126,8 @@ func getSessionIdentifier(forPid pid: pid_t) -> String? {
     // ephemeral shell wrapper (sh/bash/zsh), in which case we walk up further.
 
     let chain = buildAncestryChain(from: pid)
-
     guard let scopePid = selectScopePid(from: chain) else { return nil }
     let startTime = getStartTime(pid: scopePid)
-
     return "ptree:\(scopePid):\(startTime)"
 }
 
@@ -137,23 +153,15 @@ private let noTtySessionEnvKeys: [String] = [
     "CODEX_THREAD_ID",
     "CLAUDE_CODE_SESSION_ID",
     "CLAUDE_SESSION_ID",
-    "CLAUDE_CODE_SSE_PORT",
 ]
 
-private func getNoTtySessionIdFromEnvironment(forPid pid: pid_t) -> String? {
+private func getAiSessionFromEnvironment(forPid pid: pid_t) -> (key: String, value: String)? {
     guard let env = getProcessEnvironment(pid: pid) else { return nil }
     for key in noTtySessionEnvKeys {
         guard let valueRaw = env[key] else { continue }
         let value = valueRaw.trimmingCharacters(in: .whitespacesAndNewlines)
         if !value.isEmpty {
-            // Bind env identity to process-tree scope to reduce spoofing.
-            // A caller must match both the env id and expected host lineage.
-            let chain = buildAncestryChain(from: pid)
-            if let scopePid = selectScopePid(from: chain) {
-                let scopeStart = getStartTime(pid: scopePid)
-                return "env:\(key):\(value):\(scopePid):\(scopeStart)"
-            }
-            return "env:\(key):\(value)"
+            return (key, value)
         }
     }
     return nil

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/PeerIdentity.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/PeerIdentity.swift
@@ -50,14 +50,13 @@ private func getStartTime(pid: pid_t) -> Int {
 /// processes spawned by VSCode/Cursor extensions, background agents, etc.),
 /// walks up the process tree to find a stable ancestor for session scoping.
 ///
-/// The no-TTY algorithm finds the "app root" (ancestor whose PPID is 1/launchd),
-/// then uses the grandchild of that app root in the peer's ancestry chain.
-/// This scopes sessions narrowly — e.g., for Cursor, each Claude Code instance
-/// gets its own session, while a malicious extension in the same window cannot
-/// piggyback. If the tree is too shallow (peer is a direct child or grandchild
-/// of the app root), returns nil (no caching, fresh auth each time).
+/// The no-TTY algorithm walks the process tree to the app root (child of launchd),
+/// then picks a stable scope key:
+///   - Deep trees (4+ levels): grandchild of the app root (e.g. Claude in Cursor)
+///   - If that process is an ephemeral shell wrapper, walk up to a longer-lived ancestor
+///   - Shallow trees (2–3 levels): app root (e.g. Codex exec'ing scripts directly)
 ///
-/// Returns nil if no stable identity can be determined.
+/// Returns nil only when no ancestor can be determined (chain shorter than 2).
 func getSessionIdentifier(forPid pid: pid_t) -> String? {
     guard let info = getProcessInfo(pid: pid) else { return nil }
 
@@ -97,8 +96,11 @@ func getSessionIdentifier(forPid pid: pid_t) -> String? {
     // enough that other extensions can't piggyback, but stable across multiple
     // commands spawned by that tool.
     //
-    // If the chain is too short (< 4 elements), we can't determine a stable
-    // intermediate ancestor, so we return nil (no caching).
+    // If the chain is too short (< 2 elements), we can't determine any ancestor.
+    // Shallow trees (2–3 levels) scope to the app root so agents like Codex that
+    // exec commands as direct/grandchildren of the app still get session reuse.
+    // Deeper trees use the grandchild of the app root, unless that process is an
+    // ephemeral shell wrapper (sh/bash/zsh), in which case we walk up further.
 
     var chain: [pid_t] = [pid]
     var current = pid
@@ -109,15 +111,39 @@ func getSessionIdentifier(forPid pid: pid_t) -> String? {
         current = ppid
     }
 
-    // Need at least 4 levels: peer → intermediate → scope-target → app-child → app-root
-    // so that scope-target is a meaningful intermediate process
-    guard chain.count >= 4 else { return nil }
-
-    // The grandchild of the app root: 2 levels below the last element
-    let scopePid = chain[chain.count - 3]
+    guard let scopePid = selectScopePid(from: chain) else { return nil }
     let startTime = getStartTime(pid: scopePid)
 
     return "ptree:\(scopePid):\(startTime)"
+}
+
+/// Shell and similar one-shot runners that should not be used as session scope keys.
+private let ephemeralRunnerNames: Set<String> = [
+    "sh", "bash", "zsh", "dash", "fish", "ksh", "csh", "tcsh",
+]
+
+private func isEphemeralRunner(pid: pid_t) -> Bool {
+    guard let processPath = getProcessPath(pid: pid) else { return false }
+    let name = (processPath as NSString).lastPathComponent.lowercased()
+    return ephemeralRunnerNames.contains(name)
+}
+
+/// Pick a stable scope PID from an ancestry chain (peer first, app root last).
+private func selectScopePid(from chain: [pid_t]) -> pid_t? {
+    guard chain.count >= 2 else { return nil }
+
+    if chain.count >= 4 {
+        var scopePid = chain[chain.count - 3]
+        if isEphemeralRunner(pid: scopePid) {
+            // Shell wrappers are one-shot; scope to a longer-lived ancestor.
+            let fallback = chain[chain.count - 2]
+            scopePid = isEphemeralRunner(pid: fallback) ? chain[chain.count - 1] : fallback
+        }
+        return scopePid
+    }
+
+    // Shallow tree: scope to the app root (direct child of launchd).
+    return chain[chain.count - 1]
 }
 
 // MARK: - Process Verification

--- a/packages/varlock/src/lib/local-encrypt/index.ts
+++ b/packages/varlock/src/lib/local-encrypt/index.ts
@@ -29,20 +29,53 @@ function debug(msg: string) {
   }
 }
 
-const EPHEMERAL_RUNNER_NAMES = new Set(['sh', 'bash', 'zsh', 'dash', 'fish', 'ksh', 'csh', 'tcsh']);
+const SHELL_RUNNER_NAMES = new Set(['sh', 'bash', 'zsh', 'dash', 'fish', 'ksh', 'csh', 'tcsh']);
+const VARLOCK_LAUNCHER_NAMES = new Set(['varlock', 'varlock.exe', 'varlock.cmd']);
+const PACKAGE_MANAGER_RUNNER_NAMES = new Set(['bun', 'node', 'npm', 'npx', 'pnpm', 'pnpx', 'yarn', 'yarnpkg']);
+const NO_TTY_SESSION_ENV_KEYS = [
+  'CODEX_THREAD_ID',
+  'CLAUDE_CODE_SESSION_ID',
+  'CLAUDE_SESSION_ID',
+  'CLAUDE_CODE_SSE_PORT',
+] as const;
 
-function isEphemeralRunner(pid: number): boolean {
+function getProcessName(pid: number): string | undefined {
   try {
     const exePath = fs.readlinkSync(`/proc/${pid}/exe`);
-    const name = exePath.split('/').pop()?.toLowerCase();
-    if (name && EPHEMERAL_RUNNER_NAMES.has(name)) return true;
+    return exePath.split('/').pop()?.toLowerCase();
   } catch { /* ignore */ }
   try {
-    const comm = fs.readFileSync(`/proc/${pid}/comm`, 'utf-8').trim().toLowerCase();
-    return EPHEMERAL_RUNNER_NAMES.has(comm);
+    return fs.readFileSync(`/proc/${pid}/comm`, 'utf-8').trim().toLowerCase();
   } catch {
-    return false;
+    return undefined;
   }
+}
+
+function getProcessArgs(pid: number): Array<string> {
+  try {
+    return fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8').split('\0').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function processCommandLineLaunchesVarlock(pid: number): boolean {
+  return getProcessArgs(pid).some((arg) => {
+    const name = arg.split('/').pop()?.toLowerCase();
+    return Boolean(
+      (name && VARLOCK_LAUNCHER_NAMES.has(name))
+      || arg.includes('/node_modules/.bin/varlock')
+      || arg.includes('/varlock/bin/cli.js')
+      || arg.includes('/packages/varlock/bin/cli.js'),
+    );
+  });
+}
+
+function isEphemeralRunner(pid: number): boolean {
+  const name = getProcessName(pid);
+  if (!name) return false;
+  if (SHELL_RUNNER_NAMES.has(name) || VARLOCK_LAUNCHER_NAMES.has(name)) return true;
+  return PACKAGE_MANAGER_RUNNER_NAMES.has(name) && processCommandLineLaunchesVarlock(pid);
 }
 
 function selectScopePidFromChain(chain: Array<number>): number | undefined {
@@ -71,6 +104,14 @@ function getProcessStartTime(pid: number): number {
   return 0;
 }
 
+function getNoTtySessionIdFromEnv(): string | undefined {
+  for (const key of NO_TTY_SESSION_ENV_KEYS) {
+    const value = process.env[key]?.trim();
+    if (value) return `env:${key}:${value}`;
+  }
+  return undefined;
+}
+
 /**
  * Get a session identifier for biometric session scoping (WSL only).
  * Prefers the controlling terminal; falls back to a stable ancestor PID
@@ -87,6 +128,12 @@ function getSelfSessionId(): string {
     }
   } catch {
     // Not available
+  }
+  // No TTY — prefer known LLM session env identifiers.
+  const envSessionId = getNoTtySessionIdFromEnv();
+  if (envSessionId) {
+    _cachedSessionId = envSessionId;
+    return envSessionId;
   }
   // No TTY — walk the process tree to find a stable ancestor.
   try {

--- a/packages/varlock/src/lib/local-encrypt/index.ts
+++ b/packages/varlock/src/lib/local-encrypt/index.ts
@@ -36,7 +36,6 @@ const NO_TTY_SESSION_ENV_KEYS = [
   'CODEX_THREAD_ID',
   'CLAUDE_CODE_SESSION_ID',
   'CLAUDE_SESSION_ID',
-  'CLAUDE_CODE_SSE_PORT',
 ] as const;
 
 function getProcessName(pid: number): string | undefined {
@@ -112,30 +111,16 @@ function getNoTtySessionIdFromEnv(): string | undefined {
   return undefined;
 }
 
-/**
- * Get a session identifier for biometric session scoping (WSL only).
- * Prefers the controlling terminal; falls back to a stable ancestor PID
- * found by walking the process tree (mirrors the macOS Swift daemon logic).
- */
-let _cachedSessionId: string | undefined;
-function getSelfSessionId(): string {
-  if (_cachedSessionId) return _cachedSessionId;
+function getParentSessionId(): string {
   try {
     const ttyPath = fs.readlinkSync('/proc/self/fd/0');
     if (ttyPath && ttyPath.startsWith('/dev/')) {
-      _cachedSessionId = ttyPath;
       return ttyPath;
     }
   } catch {
     // Not available
   }
-  // No TTY — prefer known LLM session env identifiers.
-  const envSessionId = getNoTtySessionIdFromEnv();
-  if (envSessionId) {
-    _cachedSessionId = envSessionId;
-    return envSessionId;
-  }
-  // No TTY — walk the process tree to find a stable ancestor.
+
   try {
     const chain: Array<number> = [process.pid];
     let current = process.pid;
@@ -151,13 +136,32 @@ function getSelfSessionId(): string {
     const scopePid = selectScopePidFromChain(chain);
     if (scopePid !== undefined) {
       const startTime = getProcessStartTime(scopePid);
-      _cachedSessionId = `ptree:${scopePid}:${startTime}`;
-      return _cachedSessionId;
+      return `ptree:${scopePid}:${startTime}`;
     }
   } catch {
     // Not available
   }
-  _cachedSessionId = `pid:${process.pid}`;
+
+  return `pid:${process.pid}`;
+}
+
+/**
+ * Get a session identifier for biometric session scoping (WSL only).
+ * Prefers the controlling terminal; falls back to a stable ancestor PID
+ * found by walking the process tree (mirrors the macOS Swift daemon logic).
+ */
+let _cachedSessionId: string | undefined;
+function getSelfSessionId(): string {
+  if (_cachedSessionId) return _cachedSessionId;
+
+  const parentSessionId = getParentSessionId();
+  const envSessionId = getNoTtySessionIdFromEnv();
+  if (envSessionId) {
+    _cachedSessionId = `${envSessionId}|${parentSessionId}`;
+    return _cachedSessionId;
+  }
+
+  _cachedSessionId = parentSessionId;
   return _cachedSessionId;
 }
 

--- a/packages/varlock/src/lib/local-encrypt/index.ts
+++ b/packages/varlock/src/lib/local-encrypt/index.ts
@@ -29,6 +29,48 @@ function debug(msg: string) {
   }
 }
 
+const EPHEMERAL_RUNNER_NAMES = new Set(['sh', 'bash', 'zsh', 'dash', 'fish', 'ksh', 'csh', 'tcsh']);
+
+function isEphemeralRunner(pid: number): boolean {
+  try {
+    const exePath = fs.readlinkSync(`/proc/${pid}/exe`);
+    const name = exePath.split('/').pop()?.toLowerCase();
+    if (name && EPHEMERAL_RUNNER_NAMES.has(name)) return true;
+  } catch { /* ignore */ }
+  try {
+    const comm = fs.readFileSync(`/proc/${pid}/comm`, 'utf-8').trim().toLowerCase();
+    return EPHEMERAL_RUNNER_NAMES.has(comm);
+  } catch {
+    return false;
+  }
+}
+
+function selectScopePidFromChain(chain: Array<number>): number | undefined {
+  if (chain.length < 2) return undefined;
+
+  if (chain.length >= 4) {
+    let scopePid = chain[chain.length - 3];
+    if (isEphemeralRunner(scopePid)) {
+      const fallback = chain[chain.length - 2];
+      scopePid = isEphemeralRunner(fallback) ? chain[chain.length - 1] : fallback;
+    }
+    return scopePid;
+  }
+
+  return chain[chain.length - 1];
+}
+
+function getProcessStartTime(pid: number): number {
+  try {
+    const scopeStat = fs.readFileSync(`/proc/${pid}/stat`, 'utf-8');
+    const scopeFields = scopeStat.split(') ');
+    if (scopeFields.length >= 2) {
+      return parseInt(scopeFields[1].split(' ')[19], 10) || 0;
+    }
+  } catch { /* ignore */ }
+  return 0;
+}
+
 /**
  * Get a session identifier for biometric session scoping (WSL only).
  * Prefers the controlling terminal; falls back to a stable ancestor PID
@@ -47,9 +89,6 @@ function getSelfSessionId(): string {
     // Not available
   }
   // No TTY — walk the process tree to find a stable ancestor.
-  // Uses the same grandchild-of-app-root logic as the macOS daemon:
-  // build ancestry chain up to PID 1, then use the process 2 levels
-  // below the top (the grandchild of the app root).
   try {
     const chain: Array<number> = [process.pid];
     let current = process.pid;
@@ -62,17 +101,9 @@ function getSelfSessionId(): string {
       chain.push(ppid);
       current = ppid;
     }
-    if (chain.length >= 4) {
-      const scopePid = chain[chain.length - 3];
-      // Include start time for PID-reuse resistance (field 21 after comm in /proc/stat)
-      let startTime = 0;
-      try {
-        const scopeStat = fs.readFileSync(`/proc/${scopePid}/stat`, 'utf-8');
-        const scopeFields = scopeStat.split(') ');
-        if (scopeFields.length >= 2) {
-          startTime = parseInt(scopeFields[1].split(' ')[19], 10) || 0;
-        }
-      } catch { /* ignore */ }
+    const scopePid = selectScopePidFromChain(chain);
+    if (scopePid !== undefined) {
+      const startTime = getProcessStartTime(scopePid);
       _cachedSessionId = `ptree:${scopePid}:${startTime}`;
       return _cachedSessionId;
     }


### PR DESCRIPTION
This PR improves biometric session reuse for non-TTY agent flows while tightening session scoping.

## What changed

### 1) Better no-TTY session scoping (Swift/macOS)
In `PeerIdentity.swift`, no-TTY session identity now prefers known LLM session env IDs and binds them to lineage:

- Prefer keys: `CODEX_THREAD_ID`, `CLAUDE_CODE_SESSION_ID`, `CLAUDE_SESSION_ID`, `CLAUDE_CODE_SSE_PORT`
- New no-TTY env session format:
  - `env:<KEY>:<VALUE>:<scopePid>:<scopeStartTime>`
- Fallback order is now:
  1. TTY identity (unchanged)
  2. Env session ID + lineage binding
  3. Process-tree identity (`ptree:*`)

This keeps reuse stable within the same LLM session while reducing risk of plain env-only spoofing.

### 2) Mirrored behavior in Rust/Linux daemon identity
In `packages/encryption-binary-rust/src/ipc.rs`:

- Linux peer session resolution now also checks known LLM env IDs before process-tree fallback.
- Existing process-tree runner logic was aligned with Swift/TS behavior (ephemeral wrappers and package-manager detection).

### 3) Mirrored behavior in TS (WSL helper path)
In `packages/varlock/src/lib/local-encrypt/index.ts`:

- `getSelfSessionId()` now prefers known no-TTY env session keys before process-tree fallback.

## Why

Agent-driven flows like Codex / Claude / extension-hosted commands often run without a stable TTY.
This update improves biometric session reuse for those flows while scoping sessions more narrowly than app-wide process roots.

## Local verification used

- Rebuilt Swift daemon app:
  - `bun run build:swift`
- Ran repeated loads:
  - `bun run varlock load`
- Inspected daemon ping session IDs to confirm stable reuse in-session and lineage-bound IDs.
