### PR TITLE
fix(cloudflare): skip wrangler restart when env is unchanged

### DIFF
--- a/.bumpy/cf-skip-restart-when-env-unchanged.md
+++ b/.bumpy/cf-skip-restart-when-env-unchanged.md
@@ -1,0 +1,5 @@
+---
+'@varlock/cloudflare-integration': patch
+---
+
+cloudflare: skip wrangler restart when env file is saved with unchanged contents (drops the 5s idle threshold that re-triggered restarts on every save after a short pause)

--- a/packages/integrations/cloudflare/src/varlock-wrangler.ts
+++ b/packages/integrations/cloudflare/src/varlock-wrangler.ts
@@ -441,12 +441,8 @@ async function handleDev(args: Array<string>) {
 
   // watch env source files for changes and restart wrangler with fresh data
   const DEBOUNCE_MS = 300;
-  // force a restart if the last save event was more than this long after the previous restart,
-  // even when the resolved env is identical — handles repeated saves of an unchanged file
-  const FORCE_RESTART_IDLE_MS = 5000;
   let restartTimeout: ReturnType<typeof setTimeout> | undefined;
   let cachedGraphJson = loaded.json;
-  let lastRestartAt = Date.now();
   function scheduleRestart() {
     // debounce — multiple files may change at once (e.g. editor saves multiple files,
     // or macOS fs.watch() emits extra events for unchanged files)
@@ -454,17 +450,15 @@ async function handleDev(args: Array<string>) {
     restartTimeout = setTimeout(() => {
       try {
         const freshLoaded = loadSerializedGraph();
-        const now = Date.now();
-        const idleSinceLastRestart = now - lastRestartAt > FORCE_RESTART_IDLE_MS;
-        // skip restart only when env is unchanged AND a restart happened recently
-        if (freshLoaded.json === cachedGraphJson && !idleSinceLastRestart) {
+        // skip restart when env is unchanged — fs.watch fires on every save,
+        // even when the file contents are identical
+        if (freshLoaded.json === cachedGraphJson) {
           restartTimeout = undefined;
           return;
         }
         cachedGraphJson = freshLoaded.json;
         loaded = freshLoaded;
         configIsValid = true;
-        lastRestartAt = now;
         cachedContent = formatEnvFileContent(freshLoaded);
         handle.update(cachedContent);
         console.log('[varlock-wrangler] env changed, restarting wrangler...');
@@ -483,7 +477,6 @@ async function handleDev(args: Array<string>) {
               cachedGraphJson = err.stdout;
               cachedContent = `${formatEnvLine('__VARLOCK_ENV', err.stdout)}\n`;
               handle.update(cachedContent);
-              lastRestartAt = Date.now();
               console.error('\n[varlock-wrangler] \u26a0\ufe0f config is invalid \u2014 fix the error(s) above and save to reload\n');
               wranglerChild?.kill();
               // restartTimeout stays truthy so the exit handler knows this was a restart-kill


### PR DESCRIPTION
## Problem

`@varlock/cloudflare-integration` restarts wrangler whenever a watched env file emits an fs event, even if the file contents haven't changed, provided more than 5s has passed since the previous restart. In practice this wipes worker state on every save during dev (open `.env`, hit save twice, second save kills the worker).

## Root cause

PR #631 added a debounce + cache-equality check so unchanged-env saves were no-ops. PR #635 then layered a `FORCE_RESTART_IDLE_MS = 5000` override that re-triggers a restart after the idle window even when `freshLoaded.json === cachedGraphJson`, reintroducing the very behaviour #631 was meant to suppress.

`fs.watch` already fires on every save regardless of content, so the cache-equality check alone is sufficient. The idle threshold has no remaining job, if the env didn't change, wrangler has nothing to reload.

## Fix

Restart only when the resolved env JSON actually changes. Drop `FORCE_RESTART_IDLE_MS`, `lastRestartAt`, and `idleSinceLastRestart`.