### PR TITLE
fix: better trailing decorator text handling + bun exec docs fix

### DIFF
--- a/.bumpy/parser-trailing-text-warning.md
+++ b/.bumpy/parser-trailing-text-warning.md
@@ -1,5 +1,6 @@
 ---
 "@env-spec/parser": patch
+"varlock": patch
 ---
 
-improve warning message for trailing text after decorators
+improve stray text handling on decorator lines - decorators after stray text are no longer silently ignored

--- a/.bumpy/parser-trailing-text-warning.md
+++ b/.bumpy/parser-trailing-text-warning.md
@@ -1,0 +1,5 @@
+---
+"@env-spec/parser": patch
+---
+
+improve warning message for trailing text after decorators

--- a/bun.lock
+++ b/bun.lock
@@ -497,6 +497,7 @@
     "@xmldom/xmldom": ">=0.9.10",
     "postcss": ">=8.5.10",
     "qs": "^6.15.2",
+    "tmp": ">=0.2.6",
     "ws": ">=8.20.1",
   },
   "catalog": {
@@ -2963,7 +2964,7 @@
 
     "tldts-core": ["tldts-core@7.0.30", "", {}, "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q=="],
 
-    "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
+    "tmp": ["tmp@0.2.6", "", {}, "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "@modelcontextprotocol/sdk": ">=1.29.0",
     "postcss": ">=8.5.10",
     "qs": "^6.15.2",
-    "ws": ">=8.20.1"
+    "ws": ">=8.20.1",
+    "tmp": ">=0.2.6"
   },
   "catalog": {
     "@sindresorhus/is": "^7.2.0",

--- a/packages/env-spec-parser/grammar.peggy
+++ b/packages/env-spec-parser/grammar.peggy
@@ -85,7 +85,7 @@ DecoratorComment =
       } else {
         // attach trailing text warning to the last decorator on the line
         const lastDec = allDecorators[allDecorators.length - 1];
-        lastDec.data.warning = `Unexpected trailing text after @${lastDec.name}`;
+        lastDec.data.warning = `Unexpected trailing text after @${lastDec.name} - use another # for trailing comment`;
         postComment = trailingText;
       }
     }

--- a/packages/env-spec-parser/grammar.peggy
+++ b/packages/env-spec-parser/grammar.peggy
@@ -73,20 +73,19 @@ Comment =
 DecoratorComment =
   "#" leadingSpace:$_
   first:Decorator
-  rest:(__ @(Decorator))*
-  trailingText:(__ @$([^\n]+) / @$("#" [^\n]*))?
+  rest:(__ @DecoratorOrText)*
+  postComment:(_  @$("#" [^\n]*))?
   _
   {
-    const allDecorators = [first, ...rest];
-    let postComment;
-    if (trailingText) {
-      if (trailingText.startsWith('#')) {
-        postComment = trailingText;
+    const allDecorators = [first];
+    let lastDecorator = first;
+    for (const item of rest) {
+      if (item instanceof ParsedEnvSpecDecorator) {
+        allDecorators.push(item);
+        lastDecorator = item;
       } else {
-        // attach trailing text warning to the last decorator on the line
-        const lastDec = allDecorators[allDecorators.length - 1];
-        lastDec.data.warning = `Unexpected trailing text after @${lastDec.name} - use another # for trailing comment`;
-        postComment = trailingText;
+        // attach stray text to the preceding decorator
+        lastDecorator.data.strayText = item;
       }
     }
     return new ParsedEnvSpecDecoratorComment({
@@ -96,6 +95,14 @@ DecoratorComment =
       _location: location(),
     })
   }
+
+// either a decorator (@name...) or a non-decorator text chunk
+// words must start with a non-#, non-@, non-whitespace char but may contain # mid-word
+// this ensures `# comment` is still captured by postComment
+DecoratorOrText =
+  Decorator
+  / first:$([^ \t@#\n] [^ \t@\n]*) rest:(__ @$([^ \t@#\n] [^ \t@\n]*))*
+    { return [first, ...rest].join(' '); }
 
 Decorator =
   "@" name:DecoratorName

--- a/packages/env-spec-parser/src/classes.ts
+++ b/packages/env-spec-parser/src/classes.ts
@@ -159,7 +159,7 @@ export class ParsedEnvSpecDecorator {
     value: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall
       | ParsedEnvSpecFunctionArgs | undefined;
     isBareFnCall?: boolean; // true if decorator is a bare fn call (eg: @import(...))
-    warning?: string;
+    strayText?: string; // unexpected text found after this decorator
     _location?: any;
   }) {
     // bare decorator is equivalent to `@decorator=true`
@@ -184,8 +184,8 @@ export class ParsedEnvSpecDecorator {
   get hasInvalidName() {
     return !ParsedEnvSpecDecorator.VALID_NAME_RE.test(this.data.name);
   }
-  get warning() {
-    return this.data.warning;
+  get strayText() {
+    return this.data.strayText;
   }
   get isBareFnCall() {
     return !!this.data.isBareFnCall;

--- a/packages/env-spec-parser/test/decorators.test.ts
+++ b/packages/env-spec-parser/test/decorators.test.ts
@@ -54,7 +54,7 @@ function basicDecoratorTests(tests: Array<[string, any] | { label: string, comme
               }
             } else {
               expectInstanceOf(decoratorObject[key].value, ParsedEnvSpecStaticValue);
-              expect(decoratorObject[key].value.value).toEqual(expectedValue);
+              expect((decoratorObject[key].value as any).value).toEqual(expectedValue);
             }
           }
         }
@@ -260,25 +260,25 @@ describe('decorator parsing', () => {
       return result.configItems[0].decoratorsArray;
     }
 
-    // trailing text warning is attached to the last decorator on the line
-    it('should produce a warning for `# @foo blah` (decorator with trailing text)', () => {
+    // stray text is attached to the preceding decorator
+    it('should attach stray text to decorator for `# @foo blah`', () => {
       const decs = parseDecorators('# @foo blah');
       expect(decs).toHaveLength(1);
-      expect(decs[0].warning).toBeTruthy();
+      expect(decs[0].strayText).toBe('blah');
     });
 
-    it('should produce a warning for `# @see https://example.com`', () => {
+    it('should attach stray text for `# @see https://example.com`', () => {
       const decs = parseDecorators('# @see https://example.com');
       expect(decs).toHaveLength(1);
-      expect(decs[0].warning).toBeTruthy();
+      expect(decs[0].strayText).toBe('https://example.com');
     });
 
     // colon after decorator name is also a warning (via hasInvalidName)
-    it('should flag `# @todo: fix me later` as invalid name + trailing text', () => {
+    it('should flag `# @todo: fix me later` as invalid name + stray text', () => {
       const decs = parseDecorators('# @todo: fix me later');
       expect(decs).toHaveLength(1);
       expect(decs[0].hasInvalidName).toBe(true);
-      expect(decs[0].warning).toBeTruthy();
+      expect(decs[0].strayText).toBe('fix me later');
     });
 
     it('should flag `# @todo:` as invalid name', () => {
@@ -287,23 +287,25 @@ describe('decorator parsing', () => {
       expect(decs[0].hasInvalidName).toBe(true);
     });
 
-    it('should attach warning to last decorator for `# @dec1 @dec2 bad comment`', () => {
+    it('should attach stray text to last decorator for `# @dec1 @dec2 bad comment`', () => {
       const decs = parseDecorators('# @dec1 @dec2 bad comment');
       expect(decs).toHaveLength(2);
-      expect(decs[0].warning).toBeUndefined();
-      expect(decs[1].warning).toBeTruthy();
+      expect(decs[0].name).toBe('dec1');
+      expect(decs[0].strayText).toBeUndefined();
+      expect(decs[1].name).toBe('dec2');
+      expect(decs[1].strayText).toBe('bad comment');
     });
 
-    it('should produce a warning for `# @dec=foo bar` (trailing text after value)', () => {
+    it('should attach stray text for `# @dec=foo bar`', () => {
       const decs = parseDecorators('# @dec=foo bar');
       expect(decs).toHaveLength(1);
-      expect(decs[0].warning).toBeTruthy();
+      expect(decs[0].strayText).toBe('bar');
     });
 
-    it('should produce a warning for `# @dec="foo" not commented` (trailing text after quoted value)', () => {
+    it('should attach stray text for `# @dec="foo" not commented`', () => {
       const decs = parseDecorators('# @dec="foo" not commented');
       expect(decs).toHaveLength(1);
-      expect(decs[0].warning).toBeTruthy();
+      expect(decs[0].strayText).toBe('not commented');
     });
 
     // invalid decorator names (hyphens, colons) produce hasInvalidName
@@ -321,10 +323,26 @@ describe('decorator parsing', () => {
     });
 
     // post-decorator comments prefixed with # are valid
-    it('should NOT produce a warning for `# @dec # this is ok` (post comment)', () => {
+    it('should NOT have stray text for `# @dec # this is ok` (post comment)', () => {
       const decs = parseDecorators('# @dec # this is ok');
       expect(decs).toHaveLength(1);
-      expect(decs[0].warning).toBeUndefined();
+      expect(decs[0].strayText).toBeUndefined();
+    });
+
+    // decorators after stray text are still parsed as real decorators
+    it('should parse both decorators in `# @dec1 extra @dec2 extra` with stray text on each', () => {
+      const decs = parseDecorators('# @dec1 extra @dec2 extra');
+      expect(decs).toHaveLength(2);
+      expect(decs[0].name).toBe('dec1');
+      expect(decs[0].strayText).toBe('extra');
+      expect(decs[1].name).toBe('dec2');
+      expect(decs[1].strayText).toBe('extra');
+    });
+
+    it('should attach stray text to decorator', () => {
+      const decs = parseDecorators('# @dec1 extra');
+      expect(decs).toHaveLength(1);
+      expect(decs[0].strayText).toBe('extra');
     });
   });
 });

--- a/packages/varlock-website/src/components/ExecCommandWidget.astro
+++ b/packages/varlock-website/src/components/ExecCommandWidget.astro
@@ -18,7 +18,7 @@ const { command, showBinary = true, dlx = false } = Astro.props;
     <Code code={`pnpm ${dlx ? "dlx" : "exec --"} ${command}`} lang="bash" />
   </TabItem>
   <TabItem label="bun">
-    <Code code={`${dlx ? "bunx" : "bun exec"} ${command}`} lang="bash" />
+    <Code code={`bunx ${command}`} lang="bash" />
   </TabItem>
   <TabItem label="vlt">
     <Code code={`${dlx ? "vlx" : "vlx --"} ${command}`} lang="bash" />

--- a/packages/varlock-website/src/content/docs/guides/schema.mdx
+++ b/packages/varlock-website/src/content/docs/guides/schema.mdx
@@ -65,7 +65,7 @@ lines
 ### Item comments
 Comments are used to attach additional documentation and metadata to config items using [item decorators](/reference/item-decorators). This additional metadata is used by varlock to perform validation, coercion, and generate types / documentation.
 
-Multiple comment lines _directly_ preceding an item will be attached to that item. A blank line or a divider breaks a comment block and detaches it from the following config item.
+Multiple comment lines _directly_ preceding an item will be attached to that item. A blank line or a divider (e.g., `# ---`) breaks a comment block and detaches it from the following config item.
 Any comment block before the first item is still part of the document header until it is ended by a blank line, a divider, or the end of the file.
 Comment lines can either contain regular comments or [item decorators](/reference/item-decorators). Standalone comments only count as decorator comments when the comment content starts with `@`.
 

--- a/packages/varlock/src/env-graph/lib/decorators.ts
+++ b/packages/varlock/src/env-graph/lib/decorators.ts
@@ -96,10 +96,13 @@ export abstract class DecoratorInstance {
         throw new SchemaError(`Unknown decorator: @${this.name}`);
       }
 
-      // surface parser-level warnings (e.g. trailing text after decorator)
-      // placed after unknown-decorator checks so comment-like names (which throw above) skip this
-      if (this.parsedDecorator.warning) {
-        this._errors.push(new SchemaError(this.parsedDecorator.warning, { isWarning: true }));
+
+      // stray text found after this decorator (e.g. `# @dec some text`)
+      if (this.parsedDecorator.strayText) {
+        this._errors.push(new SchemaError(
+          `Unexpected text "${this.parsedDecorator.strayText}" after @${this.name} - use another # for trailing comments`,
+          { isWarning: true },
+        ));
       }
 
       // validate function-call vs value syntax


### PR DESCRIPTION
## Summary
- Improve handling of trailing text after decorators in env-spec parser — attach stray text to the preceding decorator instead of emitting a warning string
- Improve warning message for trailing text after decorators
- Clarify divider syntax in schema docs

Also:
- Fix `bun exec` → `bunx` in docs (`ExecCommandWidget.astro`), since `bun exec` doesn't resolve binaries from `node_modules/.bin` (fixes #658)
- Add `tmp>=0.2.6` override to fix high-severity path traversal vulnerability (GHSA-ph9p-34f9-6g65)