### PR TITLE
chore: update bumpy to 1.10.1 with provenance

### DIFF
--- a/.bumpy/_config.json
+++ b/.bumpy/_config.json
@@ -1,6 +1,9 @@
 {
   "$schema": "../node_modules/@varlock/bumpy/config-schema.json",
   "baseBranch": "main",
+  "publish": {
+    "provenance": true
+  },
   "changelog": [
     "github", {
       "internalAuthors": ["theoephraim", "philmillman", "@app/copilot-swe-agent", "claude"]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,10 +87,6 @@ jobs:
       - name: Enable turborepo build cache
         uses: rharkor/caching-for-turbo@56219402aacc0d06b650d898c222996dbc1191ec # v2.3.14
 
-      # Ensure npm 11.5.1 or later is installed (for trusted publishing)
-      - name: Update npm
-        run: npm install -g npm@latest
-
       # Download signed macOS native binary so it's included in the npm package
       - name: Download macOS native binary
         if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,10 @@ jobs:
       - name: Enable turborepo build cache
         uses: rharkor/caching-for-turbo@56219402aacc0d06b650d898c222996dbc1191ec # v2.3.14
 
+      # Ensure npm >= 11.15.0 for OIDC/provenance
+      - name: Update npm
+        run: npm install -g npm@latest
+
       # Download signed macOS native binary so it's included in the npm package
       - name: Download macOS native binary
         if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@types/node": "catalog:",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.56.1",
-        "@varlock/bumpy": "^1.8.1",
+        "@varlock/bumpy": "^1.10.1",
         "@varlock/tsconfig": "workspace:*",
         "eslint": "^10.0.2",
         "eslint-plugin-es-x": "^9.5.0",
@@ -1346,7 +1346,7 @@
 
     "@varlock/bitwarden-plugin": ["@varlock/bitwarden-plugin@workspace:packages/plugins/bitwarden"],
 
-    "@varlock/bumpy": ["@varlock/bumpy@1.8.1", "", { "bin": { "bumpy": "dist/cli.mjs" } }, "sha512-HhJ4UYeCPAMtSWYKO9lc5RABjpHjLZdu1lEzCJbgEWo+QOz2JCRcxpDLeH6XQJ1oQddrxUQeSiqcuuElJoCVEw=="],
+    "@varlock/bumpy": ["@varlock/bumpy@1.10.1", "", { "bin": { "bumpy": "dist/cli.mjs" } }, "sha512-kSZa++cc7zyyJl5mJW9venc4M83nsjAuVfzss11xR/3uI+whWBmLECREFq4y5M0eWRnn1IO7//kC9VWTAjfNuw=="],
 
     "@varlock/ci-env-info": ["@varlock/ci-env-info@workspace:packages/ci-env-info"],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/node": "catalog:",
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.56.1",
-    "@varlock/bumpy": "^1.8.1",
+    "@varlock/bumpy": "^1.10.1",
     "@varlock/tsconfig": "workspace:*",
     "eslint": "^10.0.2",
     "eslint-plugin-es-x": "^9.5.0",


### PR DESCRIPTION
## Summary
- Bump `@varlock/bumpy` from `^1.8.1` to `^1.10.1`
- Enable npm provenance attestation via `publish.provenance` config
- Remove unnecessary `npm install -g npm@latest` step from release workflow (no longer needed as of bumpy 1.10.1)