### PR TITLE
fix: use unique ports per version in framework tests

### DIFF
--- a/framework-tests/frameworks/astro/astro-shared.ts
+++ b/framework-tests/frameworks/astro/astro-shared.ts
@@ -3,8 +3,10 @@ import {
 } from 'vitest';
 import { FrameworkTestEnv } from '../../harness/index';
 
-export function defineAstroTests(astroVersion: number, testDir: string) {
+export function defineAstroTests(astroVersion: number, testDir: string, opts: { portBase: number }) {
   const nodeAdapterVersion = astroVersion >= 6 ? '^10' : '^9';
+  let nextPort = opts.portBase;
+  const port = () => nextPort++;
 
   describe(`Astro v${astroVersion}`, () => {
     const astroEnv = new FrameworkTestEnv({
@@ -177,7 +179,7 @@ export function defineAstroTests(astroVersion: number, testDir: string) {
 
     describe('server output', () => {
       astroEnv.describeDevScenario('basic SSR page', {
-        command: 'astro dev --port 14321',
+        command: `astro dev --port ${port()}`,
         readyPattern: /http:\/\/localhost/,
         readyTimeout: 30_000,
         templateFiles: {
@@ -208,7 +210,7 @@ export function defineAstroTests(astroVersion: number, testDir: string) {
       });
 
       astroEnv.describeDevScenario('leaky SSR page', {
-        command: 'astro dev --port 14322',
+        command: `astro dev --port ${port()}`,
         readyPattern: /http:\/\/localhost/,
         readyTimeout: 30_000,
         templateFiles: {
@@ -235,7 +237,7 @@ export function defineAstroTests(astroVersion: number, testDir: string) {
       });
 
       astroEnv.describeDevScenario('API endpoint', {
-        command: 'astro dev --port 14323',
+        command: `astro dev --port ${port()}`,
         readyPattern: /http:\/\/localhost/,
         readyTimeout: 30_000,
         templateFiles: {
@@ -259,7 +261,7 @@ export function defineAstroTests(astroVersion: number, testDir: string) {
       });
 
       astroEnv.describeDevScenario('leaky API endpoint', {
-        command: 'astro dev --port 14324',
+        command: `astro dev --port ${port()}`,
         readyPattern: /http:\/\/localhost/,
         readyTimeout: 30_000,
         templateFiles: {
@@ -285,7 +287,7 @@ export function defineAstroTests(astroVersion: number, testDir: string) {
       });
 
       astroEnv.describeDevScenario('non-existent var access in API endpoint', {
-        command: 'astro dev --port 14325',
+        command: `astro dev --port ${port()}`,
         readyPattern: /http:\/\/localhost/,
         readyTimeout: 30_000,
         templateFiles: {
@@ -319,7 +321,7 @@ export function defineAstroTests(astroVersion: number, testDir: string) {
       // This appears to be a vitest + Astro-specific interaction issue.
       astroEnv.describeDevScenario('env reload on .env file change', {
         skip: true,
-        command: 'astro dev --port 14326',
+        command: `astro dev --port ${port()}`,
         readyPattern: /http:\/\/localhost/,
         readyTimeout: 30_000,
         templateFiles: {

--- a/framework-tests/frameworks/astro/astro-v5.test.ts
+++ b/framework-tests/frameworks/astro/astro-v5.test.ts
@@ -1,3 +1,3 @@
 import { defineAstroTests } from './astro-shared';
 
-defineAstroTests(5, import.meta.dirname);
+defineAstroTests(5, import.meta.dirname, { portBase: 14200 });

--- a/framework-tests/frameworks/astro/astro-v6.test.ts
+++ b/framework-tests/frameworks/astro/astro-v6.test.ts
@@ -1,3 +1,3 @@
 import { defineAstroTests } from './astro-shared';
 
-defineAstroTests(6, import.meta.dirname);
+defineAstroTests(6, import.meta.dirname, { portBase: 14300 });

--- a/framework-tests/frameworks/tanstack-start/tanstack-shared.ts
+++ b/framework-tests/frameworks/tanstack-start/tanstack-shared.ts
@@ -20,9 +20,12 @@ export function defineTanstackTests(
   opts: {
     viteVersion: string;
     reactPluginVersion?: string;
+    portBase: number;
   },
 ) {
-  const { viteVersion, reactPluginVersion = '^5' } = opts;
+  const { viteVersion, reactPluginVersion = '^5', portBase } = opts;
+  let nextPort = portBase;
+  const port = () => nextPort++;
 
   // ---- Node target (plain vite plugin) ------------------------------------
   describe(`TanStack Start (${label}) — node target`, () => {
@@ -50,7 +53,7 @@ export function defineTanstackTests(
     afterAll(() => nodeEnv.teardown());
 
     nodeEnv.describeDevScenario('dev server', {
-      command: 'vite dev --port 15190',
+      command: `vite dev --port ${port()}`,
       readyPattern: /Local:.*http/,
       readyTimeout: 45_000,
       templateFiles: {
@@ -93,7 +96,7 @@ export function defineTanstackTests(
     });
 
     nodeEnv.describeDevScenario('build + preview', {
-      command: 'vite build && vite preview --port 15193',
+      command: `vite build && vite preview --port ${port()}`,
       readyPattern: /Local:.*http/,
       readyTimeout: 60_000,
       timeout: 120_000,
@@ -118,7 +121,7 @@ export function defineTanstackTests(
     // Top-level ENV access — verifies initVarlockEnv runs before
     // application modules so ENV.x works outside handlers/async fns.
     nodeEnv.describeDevScenario('top-level ENV access (build + preview)', {
-      command: 'vite build && vite preview --port 15194',
+      command: `vite build && vite preview --port ${port()}`,
       readyPattern: /Local:.*http/,
       readyTimeout: 60_000,
       timeout: 120_000,
@@ -174,7 +177,7 @@ export function defineTanstackTests(
     afterAll(() => cfEnv.teardown());
 
     cfEnv.describeDevScenario('dev server', {
-      command: 'vite dev --port 15191',
+      command: `vite dev --port ${port()}`,
       readyPattern: /Local:.*http/,
       readyTimeout: 45_000,
       templateFiles: {
@@ -227,7 +230,7 @@ export function defineTanstackTests(
     });
 
     cfEnv.describeDevScenario('build + preview', {
-      command: 'vite build && vite preview --port 15192',
+      command: `vite build && vite preview --port ${port()}`,
       readyPattern: /Local:.*http/,
       readyTimeout: 60_000,
       timeout: 120_000,
@@ -253,7 +256,7 @@ export function defineTanstackTests(
     // Top-level ENV access — verifies initVarlockEnv runs before
     // application modules so ENV.x works outside handlers/async fns.
     cfEnv.describeDevScenario('top-level ENV access (build + preview)', {
-      command: 'vite build && vite preview --port 15195',
+      command: `vite build && vite preview --port ${port()}`,
       readyPattern: /Local:.*http/,
       readyTimeout: 60_000,
       timeout: 120_000,

--- a/framework-tests/frameworks/tanstack-start/tanstack-shared.ts
+++ b/framework-tests/frameworks/tanstack-start/tanstack-shared.ts
@@ -7,9 +7,9 @@ import {
 import { FrameworkTestEnv } from '../../harness/index';
 
 const TANSTACK_DEPS = {
-  '@tanstack/react-router': '^1.169.1',
-  '@tanstack/react-start': '^1.167.62',
-  '@tanstack/router-plugin': '^1.167.32',
+  '@tanstack/react-router': '^1.170.8',
+  '@tanstack/react-start': '^1.168.13',
+  '@tanstack/router-plugin': '^1.168.11',
   react: '19.2.4',
   'react-dom': '19.2.4',
 };

--- a/framework-tests/frameworks/tanstack-start/tanstack-vite6.test.ts
+++ b/framework-tests/frameworks/tanstack-start/tanstack-vite6.test.ts
@@ -2,4 +2,5 @@ import { defineTanstackTests } from './tanstack-shared';
 
 defineTanstackTests('vite6', import.meta.dirname, {
   viteVersion: '^6',
+  portBase: 15200,
 });

--- a/framework-tests/frameworks/tanstack-start/tanstack-vite7.test.ts
+++ b/framework-tests/frameworks/tanstack-start/tanstack-vite7.test.ts
@@ -2,4 +2,5 @@ import { defineTanstackTests } from './tanstack-shared';
 
 defineTanstackTests('vite7', import.meta.dirname, {
   viteVersion: '^7',
+  portBase: 15300,
 });

--- a/framework-tests/frameworks/tanstack-start/tanstack-vite8.test.ts
+++ b/framework-tests/frameworks/tanstack-start/tanstack-vite8.test.ts
@@ -3,4 +3,5 @@ import { defineTanstackTests } from './tanstack-shared';
 defineTanstackTests('vite8', import.meta.dirname, {
   viteVersion: '^8',
   reactPluginVersion: '^6',
+  portBase: 15400,
 });


### PR DESCRIPTION
## Summary
- Tanstack Start and Astro shared test definitions hardcoded the same dev server ports across all version variants (e.g. vite6/7/8). When tests run in parallel, this causes port collisions and spurious failures.
- Each variant now receives a `portBase` and auto-increments via a `port()` helper, with well-separated ranges per version.

## Test plan
- [ ] Tanstack Start CI tests pass without port collision errors
- [ ] Astro CI tests continue to pass