### PR TITLE
fix: run framework test files sequentially

### DIFF
--- a/framework-tests/vitest.config.ts
+++ b/framework-tests/vitest.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
     globals: true,
     include: ['frameworks/**/*.test.ts'],
     pool: 'forks',
+    poolOptions: {
+      forks: {
+        // Run test files sequentially — these tests spawn heavy dev servers
+        // (wrangler/workerd, next dev, vite dev) that exhaust CI runner resources
+        // when running concurrently
+        singleFork: true,
+      },
+    },
     teardownTimeout: 30_000,
   },
 });


### PR DESCRIPTION
 to avoid CI resource exhaustion

Framework tests spawn heavy dev servers (wrangler/workerd, next dev, vite dev) that compete for resources when Vitest's fork pool runs them concurrently on 2-core CI runners. This was causing flaky timeouts where wrangler would hang during startup (printed banner but never reached ready state).

Uses singleFork: true so test files within each integration job run sequentially, while cross-integration parallelism via the CI matrix is preserved.