### PR TITLE
fix: improve CI workflow concurrency and gate release on tests

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,6 +9,10 @@ on:
     # weekly scan — Sundays at 4am UTC
     - cron: '0 4 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   security-events: write

--- a/.github/workflows/framework-tests.yaml
+++ b/.github/workflows/framework-tests.yaml
@@ -10,6 +10,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -9,6 +9,10 @@ on:
       - synchronize
       - reopened
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pr-labeler:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,12 +9,38 @@ permissions:
   contents: read
 
 concurrency:
-  group: bumpy-release
+  group: bumpy-release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  # Wait for the CI test suite to pass before releasing
+  wait-for-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for CI test suite to complete
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Waiting for CI test suite (build-and-test) to complete..."
+          for i in $(seq 1 60); do
+            STATUS=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs \
+              --jq '.check_runs[] | select(.name == "build-and-test") | .status + ":" + (.conclusion // "pending")')
+            echo "Attempt $i: $STATUS"
+            if [[ "$STATUS" == "completed:success" ]]; then
+              echo "CI test suite passed!"
+              exit 0
+            elif [[ "$STATUS" == "completed:"* ]]; then
+              echo "::error::CI test suite failed with: $STATUS"
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for CI test suite"
+          exit 1
+
   # Determine what bumpy will do — only run expensive build/notarize when publishing
   plan:
+    needs: wait-for-tests
     runs-on: ubuntu-latest
     outputs:
       mode: ${{ steps.plan.outputs.mode }}

--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -13,6 +13,10 @@ on:
       - reopened
       - ready_for_review
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   request-copilot:
     if: github.event.pull_request.head.repo.fork == true && !github.event.pull_request.draft

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -6,6 +6,10 @@ on:
   # Allow manual trigger for testing
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: write
@@ -33,7 +37,7 @@ jobs:
       - name: Install js deps (w/ bun)
         run: bun install
       - name: Audit dependencies
-        run: bun audit
+        run: bun audit --audit-level=moderate
       - name: Enable turborepo build cache
         uses: rharkor/caching-for-turbo@56219402aacc0d06b650d898c222996dbc1191ec # v2.3.14
 


### PR DESCRIPTION
## Summary

- **Gate release on test suite**: added a `wait-for-tests` job to `release.yaml` that polls the `build-and-test` check run and blocks publishing if CI fails
- **Fix audit threshold**: changed `bun audit` to `--audit-level=moderate` so low-severity advisories don't block CI
- **Add concurrency groups** to all workflows missing them (`test`, `framework-tests`, `smoke-test`, `codeql`, `pr-labeler`, `copilot-review`) — new pushes to a PR cancel stale in-flight runs
- **Scope release concurrency** per branch (`bumpy-release-${{ github.ref }}`) so cross-branch release workflows don't interfere

## Context

After merging a release PR, the CI test suite failed due to a low-severity `bun audit` finding, but the release workflow proceeded independently and published anyway. These changes fix both the audit sensitivity and the missing dependency between the two workflows.

## Test plan

- [ ] Verify CI passes on this PR (concurrency groups are set correctly)
- [ ] On next main push, confirm `wait-for-tests` job runs before `plan` in release workflow