### PR TITLE
Add Kubernetes plugin

### DIFF
--- a/.bumpy/kubernetes-plugin.md
+++ b/.bumpy/kubernetes-plugin.md
@@ -1,0 +1,5 @@
+---
+"@varlock/kubernetes-plugin": minor
+---
+
+Add a Kubernetes plugin for reading Secrets and ConfigMaps.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Varlock is built on top of @env-spec, a new DSL for attaching a schema and addit
 | [@varlock/hashicorp-vault-plugin](packages/plugins/hashicorp-vault) | [![npm version](https://img.shields.io/npm/v/@varlock/hashicorp-vault-plugin.svg)](https://npmjs.com/package/@varlock/hashicorp-vault-plugin) |
 | [@varlock/infisical-plugin](packages/plugins/infisical) | [![npm version](https://img.shields.io/npm/v/@varlock/infisical-plugin.svg)](https://npmjs.com/package/@varlock/infisical-plugin) |
 | [@varlock/keepass-plugin](packages/plugins/keepass) | [![npm version](https://img.shields.io/npm/v/@varlock/keepass-plugin.svg)](https://npmjs.com/package/@varlock/keepass-plugin) |
+| [@varlock/kubernetes-plugin](packages/plugins/kubernetes) | [![npm version](https://img.shields.io/npm/v/@varlock/kubernetes-plugin.svg)](https://npmjs.com/package/@varlock/kubernetes-plugin) |
 | [@varlock/pass-plugin](packages/plugins/pass) | [![npm version](https://img.shields.io/npm/v/@varlock/pass-plugin.svg)](https://npmjs.com/package/@varlock/pass-plugin) |
 | [@varlock/passbolt-plugin](packages/plugins/passbolt) | [![npm version](https://img.shields.io/npm/v/@varlock/passbolt-plugin.svg)](https://npmjs.com/package/@varlock/passbolt-plugin) |
 | [@varlock/proton-pass-plugin](packages/plugins/proton-pass) | [![npm version](https://img.shields.io/npm/v/@varlock/proton-pass-plugin.svg)](https://npmjs.com/package/@varlock/proton-pass-plugin) |

--- a/bun.lock
+++ b/bun.lock
@@ -344,6 +344,21 @@
         "varlock": "workspace:^",
       },
     },
+    "packages/plugins/kubernetes": {
+      "name": "@varlock/kubernetes-plugin",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@kubernetes/client-node": "^1.4.0",
+        "@types/node": "catalog:",
+        "outdent": "catalog:",
+        "tsup": "catalog:",
+        "varlock": "workspace:^",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "varlock": "workspace:^",
+      },
+    },
     "packages/plugins/pass": {
       "name": "@varlock/pass-plugin",
       "version": "1.0.0",
@@ -948,7 +963,13 @@
 
     "@jsdevtools/ono": ["@jsdevtools/ono@7.1.3", "", {}, "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="],
 
+    "@jsep-plugin/assignment": ["@jsep-plugin/assignment@1.3.0", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ=="],
+
+    "@jsep-plugin/regex": ["@jsep-plugin/regex@1.0.4", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg=="],
+
     "@keeper-security/secrets-manager-core": ["@keeper-security/secrets-manager-core@17.4.0", "", {}, "sha512-KjJKPlQiHK00ft2lhirLSyZHv1qLui4oD0AkMTFXXC4BpNlQFwR/CLTtJc4dLTJ3tKoA5aGs8A8l4sNqcNPUxQ=="],
+
+    "@kubernetes/client-node": ["@kubernetes/client-node@1.4.0", "", { "dependencies": { "@types/js-yaml": "^4.0.1", "@types/node": "^24.0.0", "@types/node-fetch": "^2.6.13", "@types/stream-buffers": "^3.0.3", "form-data": "^4.0.0", "hpagent": "^1.2.0", "isomorphic-ws": "^5.0.0", "js-yaml": "^4.1.0", "jsonpath-plus": "^10.3.0", "node-fetch": "^2.7.0", "openid-client": "^6.1.3", "rfc4648": "^1.3.0", "socks-proxy-agent": "^8.0.4", "stream-buffers": "^3.0.2", "tar-fs": "^3.0.9", "ws": "^8.18.2" } }, "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -1340,6 +1361,8 @@
 
     "@types/node": ["@types/node@25.3.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q=="],
 
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
+
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
     "@types/sarif": ["@types/sarif@2.1.7", "", {}, "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ=="],
@@ -1351,6 +1374,8 @@
     "@types/set-cookie-parser": ["@types/set-cookie-parser@2.4.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
+
+    "@types/stream-buffers": ["@types/stream-buffers@3.0.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1417,6 +1442,8 @@
     "@varlock/keepass-plugin": ["@varlock/keepass-plugin@workspace:packages/plugins/keepass"],
 
     "@varlock/keeper-plugin": ["@varlock/keeper-plugin@workspace:packages/plugins/keeper"],
+
+    "@varlock/kubernetes-plugin": ["@varlock/kubernetes-plugin@workspace:packages/plugins/kubernetes"],
 
     "@varlock/nextjs-integration": ["@varlock/nextjs-integration@workspace:packages/integrations/nextjs"],
 
@@ -1578,9 +1605,23 @@
 
     "azure-devops-node-api": ["azure-devops-node-api@12.5.0", "", { "dependencies": { "tunnel": "0.0.6", "typed-rest-client": "^1.8.4" } }, "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og=="],
 
+    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
+
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "bare-events": ["bare-events@2.9.1", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg=="],
+
+    "bare-fs": ["bare-fs@4.7.2", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg=="],
+
+    "bare-os": ["bare-os@3.9.1", "", {}, "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ=="],
+
+    "bare-path": ["bare-path@3.0.1", "", { "dependencies": { "bare-os": "^3.0.1" } }, "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ=="],
+
+    "bare-stream": ["bare-stream@2.13.1", "", { "dependencies": { "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow=="],
+
+    "bare-url": ["bare-url@2.4.3", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ=="],
 
     "base-64": ["base-64@1.0.0", "", {}, "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="],
 
@@ -1914,6 +1955,8 @@
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
@@ -1933,6 +1976,8 @@
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -2126,6 +2171,8 @@
 
     "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
+    "hpagent": ["hpagent@1.2.0", "", {}, "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA=="],
+
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
@@ -2258,6 +2305,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
+
     "istextorbinary": ["istextorbinary@9.5.0", "", { "dependencies": { "binaryextensions": "^6.11.0", "editions": "^6.21.0", "textextensions": "^6.11.0" } }, "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw=="],
 
     "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
@@ -2271,6 +2320,8 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "jsep": ["jsep@1.4.0", "", {}, "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -2297,6 +2348,8 @@
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
+    "jsonpath-plus": ["jsonpath-plus@10.4.0", "", { "dependencies": { "@jsep-plugin/assignment": "^1.3.0", "@jsep-plugin/regex": "^1.0.4", "jsep": "^1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA=="],
 
     "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
 
@@ -2568,7 +2621,7 @@
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
-    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
@@ -2585,6 +2638,8 @@
     "npm-run-all": ["npm-run-all@4.1.5", "", { "dependencies": { "ansi-styles": "^3.2.1", "chalk": "^2.4.1", "cross-spawn": "^6.0.5", "memorystream": "^0.3.1", "minimatch": "^3.0.4", "pidtree": "^0.3.0", "read-pkg": "^3.0.0", "shell-quote": "^1.6.1", "string.prototype.padend": "^3.0.0" }, "bin": { "run-p": "bin/run-p/index.js", "run-s": "bin/run-s/index.js", "npm-run-all": "bin/npm-run-all/index.js" } }, "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "oauth4webapi": ["oauth4webapi@3.8.6", "", {}, "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -2609,6 +2664,8 @@
     "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
+
+    "openid-client": ["openid-client@6.8.4", "", { "dependencies": { "jose": "^6.2.2", "oauth4webapi": "^3.8.5" } }, "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw=="],
 
     "openpgp": ["openpgp@6.3.0", "", {}, "sha512-pLzCU8IgyKXPSO11eeharQkQ4GzOKNWhXq79pQarIRZEMt1/ssyr+MIuWBv1mNoenJLg04gvPx+fi4gcKZ4bag=="],
 
@@ -2832,6 +2889,8 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "rfc4648": ["rfc4648@1.5.4", "", {}, "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg=="],
+
     "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.25.2", "", { "dependencies": { "@babel/generator": "8.0.0-rc.6", "@babel/helper-validator-identifier": "8.0.0-rc.6", "@babel/parser": "8.0.0-rc.6", "ast-kit": "^3.0.0-beta.1", "birpc": "^4.0.0", "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.1" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20260325.1", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-nMhN/R+vmR8GM45ZW1FWMSjRTSDDn/6w4GTf8RNrEFCBdl8B1kySWrU1ixPtbwzXoRlcO+R/S88VgXuJQwfdDg=="],
@@ -2914,7 +2973,13 @@
 
     "slice-ansi": ["slice-ansi@4.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ=="],
 
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
@@ -2942,7 +3007,11 @@
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
+    "stream-buffers": ["stream-buffers@3.0.3", "", {}, "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw=="],
+
     "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
+
+    "streamx": ["streamx@2.26.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A=="],
 
     "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
 
@@ -2994,11 +3063,15 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
-    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+    "tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
 
-    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
+
+    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
 
     "terminal-link": ["terminal-link@4.0.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "supports-hyperlinks": "^3.2.0" } }, "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
     "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
 
@@ -3033,6 +3106,8 @@
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
@@ -3192,9 +3267,13 @@
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -3290,6 +3369,8 @@
 
     "@inquirer/core/mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
+    "@kubernetes/client-node/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
@@ -3348,6 +3429,8 @@
 
     "astro/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "astro-iconify/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
     "astro-iconify/svgo": ["svgo@3.3.3", "", { "dependencies": { "commander": "^7.2.0", "css-select": "^5.1.0", "css-tree": "^2.3.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.0.0", "sax": "^1.5.0" }, "bin": "./bin/svgo" }, "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng=="],
 
     "astro-og-canvas/canvaskit-wasm": ["canvaskit-wasm@0.41.1", "", { "dependencies": { "@webgpu/types": "0.1.21" } }, "sha512-gO2rNMIE0lOQ8MaarM4qNeq2zZAEknAObKP2XAKidMSAY8P5sURGdFkrx1TSdHuBFqTf5w35JqjuUzjibqkD5g=="],
@@ -3385,6 +3468,8 @@
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "globby/path-type": ["path-type@6.0.0", "", {}, "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="],
 
@@ -3431,6 +3516,8 @@
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
     "rolldown-plugin-dts/@babel/generator": ["@babel/generator@8.0.0-rc.6", "", { "dependencies": { "@babel/parser": "^8.0.0-rc.6", "@babel/types": "^8.0.0-rc.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ=="],
 
@@ -3494,6 +3581,8 @@
 
     "@infisical/sdk/@aws-sdk/credential-providers/@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.993.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.973.11", "@aws-sdk/middleware-host-header": "^3.972.3", "@aws-sdk/middleware-logger": "^3.972.3", "@aws-sdk/middleware-recursion-detection": "^3.972.3", "@aws-sdk/middleware-user-agent": "^3.972.11", "@aws-sdk/region-config-resolver": "^3.972.3", "@aws-sdk/types": "^3.973.1", "@aws-sdk/util-endpoints": "3.993.0", "@aws-sdk/util-user-agent-browser": "^3.972.3", "@aws-sdk/util-user-agent-node": "^3.972.9", "@smithy/config-resolver": "^4.4.6", "@smithy/core": "^3.23.2", "@smithy/fetch-http-handler": "^5.3.9", "@smithy/hash-node": "^4.2.8", "@smithy/invalid-dependency": "^4.2.8", "@smithy/middleware-content-length": "^4.2.8", "@smithy/middleware-endpoint": "^4.4.16", "@smithy/middleware-retry": "^4.4.33", "@smithy/middleware-serde": "^4.2.9", "@smithy/middleware-stack": "^4.2.8", "@smithy/node-config-provider": "^4.3.8", "@smithy/node-http-handler": "^4.4.10", "@smithy/protocol-http": "^5.3.8", "@smithy/smithy-client": "^4.11.5", "@smithy/types": "^4.12.0", "@smithy/url-parser": "^4.2.8", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-body-length-node": "^4.2.1", "@smithy/util-defaults-mode-browser": "^4.3.32", "@smithy/util-defaults-mode-node": "^4.2.35", "@smithy/util-endpoints": "^3.2.8", "@smithy/util-middleware": "^4.2.8", "@smithy/util-retry": "^4.2.8", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-iOq86f2H67924kQUIPOAvlmMaOAvOLoDOIb66I2YqSUpMYB6ufiuJW3RlREgskxv86S5qKzMnfy/X6CqMjK6XQ=="],
 
+    "@kubernetes/client-node/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@secretlint/config-loader/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
@@ -3541,6 +3630,8 @@
     "npm-run-all/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "rolldown-plugin-dts/@babel/generator/@babel/types": ["@babel/types@8.0.0-rc.6", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.6", "@babel/helper-validator-identifier": "^8.0.0-rc.6" } }, "sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -346,7 +346,7 @@
     },
     "packages/plugins/kubernetes": {
       "name": "@varlock/kubernetes-plugin",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "devDependencies": {
         "@kubernetes/client-node": "^1.4.0",
         "@types/node": "catalog:",

--- a/packages/plugins/kubernetes/CHANGELOG.md
+++ b/packages/plugins/kubernetes/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @varlock/kubernetes-plugin
+
+## 0.1.0
+
+- Initial Kubernetes plugin for reading values from Secrets and ConfigMaps.

--- a/packages/plugins/kubernetes/README.md
+++ b/packages/plugins/kubernetes/README.md
@@ -1,0 +1,119 @@
+# @varlock/kubernetes-plugin
+
+Load values from Kubernetes [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) and [ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/) into your Varlock configuration.
+
+## Features
+
+- Fetch individual keys from Kubernetes Secrets and ConfigMaps
+- Bulk-load whole Secrets or ConfigMaps with `@setValuesBulk`
+- Local kubeconfig, in-cluster service account, or explicit API server/token auth
+- Multiple plugin instances for different namespaces or clusters
+- Auto-infer Secret/ConfigMap keys from Varlock item names
+- Read-only behavior; the plugin does not write to the cluster
+
+## Installation
+
+```bash
+npm install @varlock/kubernetes-plugin
+```
+
+Then load it from your `.env.schema`:
+
+```env-spec
+# @plugin(@varlock/kubernetes-plugin)
+```
+
+## Setup
+
+For local development, the plugin uses your default kubeconfig unless configured otherwise:
+
+```env-spec
+# @plugin(@varlock/kubernetes-plugin)
+# @initKubernetes(namespace=default)
+# ---
+```
+
+Inside a pod, omit kubeconfig settings and the plugin will use the in-cluster service account.
+
+For explicit API server authentication:
+
+```env-spec
+# @plugin(@varlock/kubernetes-plugin)
+# @initKubernetes(
+#   namespace=default,
+#   clusterServer="https://kubernetes.default.svc",
+#   token=$KUBERNETES_TOKEN
+# )
+# ---
+# @type=kubernetesBearerToken @sensitive
+KUBERNETES_TOKEN=
+```
+
+## Usage
+
+### Secret keys
+
+```env-spec
+# The key defaults to the Varlock config item name
+DATABASE_URL=k8sSecret(app-secrets)
+
+# Or provide the key explicitly
+DB_URL=k8sSecret(app-secrets, DATABASE_URL)
+```
+
+Kubernetes Secret values are base64-decoded before being returned.
+
+### ConfigMap keys
+
+```env-spec
+PUBLIC_API_HOST=k8sConfigMap(app-config)
+API_HOST=k8sConfigMap(app-config, PUBLIC_API_HOST)
+```
+
+### Multiple instances
+
+```env-spec
+# @initKubernetes(id=dev, namespace=dev)
+# @initKubernetes(id=prod, namespace=prod, context=prod)
+# ---
+
+DEV_DATABASE_URL=k8sSecret(dev, app-secrets, DATABASE_URL)
+PROD_DATABASE_URL=k8sSecret(prod, app-secrets, DATABASE_URL)
+```
+
+### Bulk loading
+
+```env-spec
+# @plugin(@varlock/kubernetes-plugin)
+# @initKubernetes(namespace=default)
+# @setValuesBulk(k8sSecretBulk(app-secrets), format=json)
+# @setValuesBulk(k8sConfigMapBulk(app-config), format=json)
+# ---
+
+DATABASE_URL=
+PUBLIC_API_HOST=
+```
+
+## `@initKubernetes()` options
+
+- `id` optional static instance id, defaults to `_default`
+- `namespace` optional namespace, defaults to kubeconfig context namespace or `default`
+- `context` optional kubeconfig context name
+- `kubeconfig` optional path to kubeconfig file, or raw kubeconfig YAML/JSON
+- `clusterServer` optional Kubernetes API server URL for explicit auth
+- `token` optional bearer token for explicit auth
+- `skipTlsVerify` optional boolean for explicit auth only
+- `allowMissing` optional boolean; missing resources or keys return `undefined` instead of throwing
+
+## Resolver functions
+
+- `k8sSecret(secretName)`
+- `k8sSecret(secretName, key)`
+- `k8sSecret(instanceId, secretName, key)`
+- `k8sConfigMap(configMapName)`
+- `k8sConfigMap(configMapName, key)`
+- `k8sConfigMap(instanceId, configMapName, key)`
+- `k8sSecretBulk(secretName)`
+- `k8sSecretBulk(instanceId, secretName)`
+- `k8sConfigMapBulk(configMapName)`
+- `k8sConfigMapBulk(instanceId, configMapName)`

--- a/packages/plugins/kubernetes/README.md
+++ b/packages/plugins/kubernetes/README.md
@@ -2,14 +2,27 @@
 
 Load values from Kubernetes [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) and [ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/) into your Varlock configuration.
 
+## Scope
+
+This plugin is **read-only**. It performs `get` requests on Secrets and ConfigMaps in a configured namespace and surfaces the values to your `.env` schema — nothing more. It does **not** create, update, or delete cluster resources, generate or template manifests, watch for changes, or manage deployments.
+
+**Typical use cases:**
+- **Local development** — pull dev/staging Secrets and ConfigMaps from a cluster into your local app without copying values by hand
+- **In-cluster runtime** — read additional Secrets/ConfigMaps at runtime that aren't already mounted into the pod via `envFrom`/`valueFrom`
+- **CI/CD** — read Secrets/ConfigMaps from a cluster using an explicit service account token
+
+Deeper Kubernetes integration is on our radar. If you have ideas, a use case this plugin doesn't cover, or feedback from running it in production, come chat on [Discord](https://chat.dmno.dev) — we'd love to hear from you.
+
 ## Features
 
-- Fetch individual keys from Kubernetes Secrets and ConfigMaps
+- Zero-config local development using your default kubeconfig
+- In-cluster authentication using the pod's mounted service account
+- Explicit auth via cluster API URL + bearer token (CI/CD, deployed apps)
+- Fetch individual keys from Secrets and ConfigMaps
 - Bulk-load whole Secrets or ConfigMaps with `@setValuesBulk`
-- Local kubeconfig, in-cluster service account, or explicit API server/token auth
+- Configurable default Secret / ConfigMap so common cases don't repeat themselves
 - Multiple plugin instances for different namespaces or clusters
-- Auto-infer Secret/ConfigMap keys from Varlock item names
-- Read-only behavior; the plugin does not write to the cluster
+- Auto-decode base64 Secret values and ConfigMap `binaryData`
 
 ## Installation
 
@@ -23,65 +36,144 @@ Then load it from your `.env.schema`:
 # @plugin(@varlock/kubernetes-plugin)
 ```
 
-## Setup
+## Setup + Auth
 
-For local development, the plugin uses your default kubeconfig unless configured otherwise:
+### Automatic auth (Recommended for local dev)
+
+For local development, just initialize the plugin and it will use your default kubeconfig (`$KUBECONFIG` or `~/.kube/config`):
 
 ```env-spec
 # @plugin(@varlock/kubernetes-plugin)
 # @initKubernetes(namespace=default)
-# ---
 ```
 
-Inside a pod, omit kubeconfig settings and the plugin will use the in-cluster service account.
+Inside a pod, omit kubeconfig-related settings and the plugin will use the mounted service account credentials at `/var/run/secrets/kubernetes.io/serviceaccount/`.
 
-For explicit API server authentication:
+### Explicit cluster server + token (For CI/CD)
+
+For deployments without a kubeconfig, provide the API server URL and a bearer token directly:
 
 ```env-spec
 # @plugin(@varlock/kubernetes-plugin)
 # @initKubernetes(
 #   namespace=default,
-#   clusterServer="https://kubernetes.default.svc",
+#   clusterServer="https://kubernetes.example.com:6443",
 #   token=$KUBERNETES_TOKEN
 # )
 # ---
+
 # @type=kubernetesBearerToken @sensitive
 KUBERNETES_TOKEN=
 ```
 
-## Usage
+See [Kubernetes Setup](#kubernetes-setup) below for how to mint a long-lived service account token.
 
-### Secret keys
+### Raw kubeconfig
 
-```env-spec
-# The key defaults to the Varlock config item name
-DATABASE_URL=k8sSecret(app-secrets)
-
-# Or provide the key explicitly
-DB_URL=k8sSecret(app-secrets, DATABASE_URL)
-```
-
-Kubernetes Secret values are base64-decoded before being returned.
-
-### ConfigMap keys
+You can also pass a full kubeconfig as a string (YAML or JSON) — useful when injecting credentials from a secret manager:
 
 ```env-spec
-PUBLIC_API_HOST=k8sConfigMap(app-config)
-API_HOST=k8sConfigMap(app-config, PUBLIC_API_HOST)
+# @initKubernetes(kubeconfig=$KUBECONFIG_DATA)
+# ---
+# @sensitive
+KUBECONFIG_DATA=
 ```
+
+### Authentication priority
+
+The plugin tries authentication methods in this order:
+1. **Explicit cluster server + token** — if `clusterServer` is provided
+2. **Explicit kubeconfig** — if `kubeconfig` is provided (file path or raw YAML/JSON)
+3. **In-cluster service account** — auto-detected via `KUBERNETES_SERVICE_HOST` / `KUBERNETES_SERVICE_PORT`
+4. **Default kubeconfig** — `$KUBECONFIG` or `~/.kube/config`
+
+You can override the active kubeconfig context with `context=...`.
 
 ### Multiple instances
 
+To read from multiple namespaces or clusters, register named instances:
+
 ```env-spec
 # @initKubernetes(id=dev, namespace=dev)
-# @initKubernetes(id=prod, namespace=prod, context=prod)
+# @initKubernetes(id=prod, namespace=prod, context=prod-cluster)
 # ---
 
 DEV_DATABASE_URL=k8sSecret(dev, app-secrets, DATABASE_URL)
 PROD_DATABASE_URL=k8sSecret(prod, app-secrets, DATABASE_URL)
 ```
 
+## Reading values
+
+### How Secrets and ConfigMaps are structured
+
+A Kubernetes Secret/ConfigMap is a **named resource that holds a map of key/value pairs**:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets       # ← the resource name
+data:
+  DATABASE_URL: cG9zdGdyZXM6...    # ← keys inside the resource
+  API_KEY: c2VjcmV0LWtleQ==
+```
+
+So fetching a value is always a two-level lookup: which resource (`name`), and which key inside it (`key`).
+
+### Secret keys
+
+Secret `data` values are base64-decoded automatically.
+
+```env-spec
+# Auto-infer key from item name (fetches app-secrets.data.DATABASE_URL)
+DATABASE_URL=k8sSecret(app-secrets)
+
+# Explicit key name
+DB_URL=k8sSecret(app-secrets, DATABASE_URL)
+
+# Named args also work
+DB_URL=k8sSecret(name=app-secrets, key=DATABASE_URL)
+```
+
+### ConfigMap keys
+
+Both `data` (strings) and `binaryData` (base64-decoded) fields are supported.
+
+```env-spec
+PUBLIC_API_HOST=k8sConfigMap(app-config)
+API_HOST=k8sConfigMap(app-config, PUBLIC_API_HOST)
+```
+
+### Default Secret / ConfigMap
+
+The idiomatic k8s pattern is one Secret + one ConfigMap per app. Set defaults on the init decorator and skip the name argument:
+
+```env-spec
+# @plugin(@varlock/kubernetes-plugin)
+# @initKubernetes(
+#   namespace=default,
+#   defaultSecret=app-secrets,
+#   defaultConfigMap=app-config,
+# )
+# ---
+
+# Both default to app-secrets / app-config and infer the key from the item name
+DATABASE_URL=k8sSecret()
+API_KEY=k8sSecret()
+PUBLIC_API_HOST=k8sConfigMap()
+
+# Override just the key while still using the default Secret
+STRIPE_KEY=k8sSecret(key=stripe_api_key)
+
+# Override the resource name to read from a different Secret
+SHARED_TOKEN=k8sSecret(shared-secrets, AUTH_TOKEN)
+```
+
+You can mix positional and named arguments, but providing the same field both ways (e.g. `k8sSecret(app-secrets, name=other)`) is a schema error.
+
 ### Bulk loading
+
+Use bulk loading when one Secret or ConfigMap contains several env vars. The bulk resolvers return a JSON object, which pairs with `@setValuesBulk`:
 
 ```env-spec
 # @plugin(@varlock/kubernetes-plugin)
@@ -91,29 +183,201 @@ PROD_DATABASE_URL=k8sSecret(prod, app-secrets, DATABASE_URL)
 # ---
 
 DATABASE_URL=
+API_KEY=
 PUBLIC_API_HOST=
 ```
 
-## `@initKubernetes()` options
+Only items declared in your schema will be populated — extra keys in the resource are ignored. Bulk resolvers also pick up `defaultSecret` / `defaultConfigMap`, so the names can be omitted.
 
-- `id` optional static instance id, defaults to `_default`
-- `namespace` optional namespace, defaults to kubeconfig context namespace or `default`
-- `context` optional kubeconfig context name
-- `kubeconfig` optional path to kubeconfig file, or raw kubeconfig YAML/JSON
-- `clusterServer` optional Kubernetes API server URL for explicit auth
-- `token` optional bearer token for explicit auth
-- `skipTlsVerify` optional boolean for explicit auth only
-- `allowMissing` optional boolean; missing resources or keys return `undefined` instead of throwing
+### Optional values
 
-## Resolver functions
+By default, fetching from a missing Secret/ConfigMap throws. To resolve missing resources or keys to `undefined`, set `allowMissing=true`:
 
-- `k8sSecret(secretName)`
-- `k8sSecret(secretName, key)`
-- `k8sSecret(instanceId, secretName, key)`
-- `k8sConfigMap(configMapName)`
-- `k8sConfigMap(configMapName, key)`
-- `k8sConfigMap(instanceId, configMapName, key)`
-- `k8sSecretBulk(secretName)`
-- `k8sSecretBulk(instanceId, secretName)`
-- `k8sConfigMapBulk(configMapName)`
-- `k8sConfigMapBulk(instanceId, configMapName)`
+```env-spec
+# @initKubernetes(namespace=default, allowMissing=true)
+# ---
+
+# @required=false
+OPTIONAL_FLAG=k8sConfigMap(feature-flags, NEW_UI)
+```
+
+Mark optional items with `@required=false` (or wrap with `fallback()`) so validation doesn't fail.
+
+## Reference
+
+### Root decorators
+
+#### `@initKubernetes()`
+
+Initialize a Kubernetes plugin instance for the resolvers below.
+
+**Parameters:**
+
+- `id?: string` (static) - Instance identifier for multiple instances (defaults to `_default`)
+- `namespace?: string` - Kubernetes namespace. Defaults to the kubeconfig context namespace, the in-cluster service account namespace, or `default`
+- `context?: string` - Kubeconfig context name (overrides the current context)
+- `kubeconfig?: string` - Path to a kubeconfig file, or raw kubeconfig YAML/JSON content
+- `clusterServer?: string` - Kubernetes API server URL for explicit auth (e.g., `https://kubernetes.example.com:6443`)
+- `token?: string` - Bearer token for explicit auth
+- `skipTlsVerify?: boolean` - Skip TLS verification (only applies to explicit `clusterServer` + `token` auth)
+- `allowMissing?: boolean` - Missing resources or keys resolve to `undefined` instead of throwing
+- `defaultSecret?: string` - Default Secret name for `k8sSecret()` / `k8sSecretBulk()`
+- `defaultConfigMap?: string` - Default ConfigMap name for `k8sConfigMap()` / `k8sConfigMapBulk()`
+
+### Functions
+
+All resolvers accept positional and named arguments. The same field cannot be provided both ways.
+
+#### `k8sSecret()`
+
+Fetch a single key from a Secret. Values are base64-decoded automatically.
+
+**Signatures:**
+
+- `k8sSecret()` - Uses `defaultSecret`, infers key from item name
+- `k8sSecret(name)` - Uses given Secret, infers key from item name
+- `k8sSecret(name, key)` - Explicit name and key
+- `k8sSecret(instanceId, name, key)` - With explicit instance
+- `k8sSecret(name=..., key=..., id=...)` - Same with named args
+
+#### `k8sConfigMap()`
+
+Fetch a single key from a ConfigMap. Both `data` and `binaryData` are supported.
+
+**Signatures:** same shape as `k8sSecret()` — substitute `k8sConfigMap` and `defaultConfigMap`.
+
+#### `k8sSecretBulk()`
+
+Fetch all keys from a Secret as a JSON object. Designed for `@setValuesBulk(..., format=json)`.
+
+**Signatures:**
+
+- `k8sSecretBulk()` - Uses `defaultSecret`
+- `k8sSecretBulk(name)` - Explicit Secret name
+- `k8sSecretBulk(instanceId, name)` - With explicit instance
+- `k8sSecretBulk(name=..., id=...)` - Same with named args
+
+#### `k8sConfigMapBulk()`
+
+Same shape as `k8sSecretBulk()` — substitute `k8sConfigMapBulk` and `defaultConfigMap`.
+
+### Data Types
+
+- `kubernetesBearerToken` - Kubernetes service account / API server bearer token (sensitive)
+
+---
+
+## Kubernetes Setup
+
+### Required RBAC permissions
+
+The identity used by the plugin (your kubeconfig user, an in-cluster service account, or an explicit token) needs read access to Secrets and/or ConfigMaps in the target namespace.
+
+The minimum permissions are `get` on `secrets` and `configmaps`:
+
+```yaml
+# varlock-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: varlock-reader
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
+    verbs: ["get"]
+```
+
+```bash
+kubectl apply -f varlock-rbac.yaml
+```
+
+For least privilege, omit `"secrets"` if you only need ConfigMaps. Prefer namespaced `Role`s over `ClusterRole`s whenever possible.
+
+### Service account for in-cluster use
+
+```bash
+kubectl create serviceaccount varlock-reader -n default
+```
+
+Bind the role to the service account:
+
+```yaml
+# varlock-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: varlock-reader-binding
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: varlock-reader
+    namespace: default
+roleRef:
+  kind: Role
+  name: varlock-reader
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Then use it in your pod spec:
+
+```yaml
+spec:
+  serviceAccountName: varlock-reader
+  containers:
+    - name: app
+      image: my-app:latest
+```
+
+### Generate a bearer token for explicit auth
+
+For CI/CD or other external use cases, create a long-lived service account token:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: varlock-reader-token
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: varlock-reader
+type: kubernetes.io/service-account-token
+EOF
+
+kubectl get secret varlock-reader-token -n default -o jsonpath='{.data.token}' | base64 -d
+```
+
+### Verify access
+
+```bash
+kubectl auth can-i get secrets -n default
+kubectl auth can-i get configmaps -n default --as=system:serviceaccount:default:varlock-reader
+```
+
+## Troubleshooting
+
+### Secret or ConfigMap not found (404)
+- Verify the resource exists: `kubectl get secret <name> -n <namespace>`
+- Double-check the namespace — the plugin only reads from the configured namespace
+- Resource names are case-sensitive and namespace-scoped
+- If the resource is genuinely optional, set `allowMissing=true` on `@initKubernetes()` and `@required=false` on the item
+
+### Permission denied (403)
+- Check that the active identity has the required RBAC: `kubectl auth can-i get secrets -n <namespace>`
+- For in-cluster use, verify the pod's `serviceAccountName` is set and bound to a `Role`/`ClusterRole` that grants `get` on `secrets`/`configmaps`
+- The error message includes the exact `Role` snippet you need to grant
+
+### Authentication failed (401)
+- **Local dev:** Run `kubectl config current-context` and `kubectl get secrets` to confirm your kubeconfig works
+- **Explicit token:** Verify the token isn't expired or revoked
+- **In-cluster:** Check the pod's mounted service account token at `/var/run/secrets/kubernetes.io/serviceaccount/token`
+
+### Connection refused or TLS errors
+- Verify the cluster API URL is reachable from your machine/pod
+- For clusters with self-signed certificates and explicit auth, set `skipTlsVerify=true` (development only)
+- If `kubectl` works but the plugin doesn't, your kubeconfig may rely on an exec credential plugin (`aws eks get-token`, `gke-gcloud-auth-plugin`, `kubelogin`) — ensure the helper binary is on your `$PATH`
+
+### Wrong namespace
+- The plugin uses (in order): explicit `namespace` argument, kubeconfig context namespace, pod's mounted SA namespace, or `default`
+- Force a specific namespace with `@initKubernetes(namespace=my-ns)`

--- a/packages/plugins/kubernetes/package.json
+++ b/packages/plugins/kubernetes/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@varlock/kubernetes-plugin",
+  "description": "Varlock plugin to load values from Kubernetes Secrets and ConfigMaps",
+  "version": "0.1.0",
+  "type": "module",
+  "homepage": "https://varlock.dev/plugins/kubernetes/",
+  "bugs": "https://github.com/dmno-dev/varlock/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dmno-dev/varlock.git",
+    "directory": "packages/plugins/kubernetes"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "./plugin": "./dist/plugin.cjs"
+  },
+  "files": ["dist"],
+  "scripts": {
+    "dev": "tsup --watch",
+    "build": "tsup",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "varlock",
+    "plugin",
+    "varlock-plugin",
+    "kubernetes",
+    "k8s",
+    "secrets",
+    "configmap",
+    "env",
+    ".env",
+    "dotenv",
+    "environment variables",
+    "env vars",
+    "config"
+  ],
+  "author": "dmno-dev",
+  "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
+  "peerDependencies": {
+    "varlock": "workspace:^"
+  },
+  "devDependencies": {
+    "@kubernetes/client-node": "^1.4.0",
+    "@types/node": "catalog:",
+    "outdent": "catalog:",
+    "tsup": "catalog:",
+    "varlock": "workspace:^",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugins/kubernetes/package.json
+++ b/packages/plugins/kubernetes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@varlock/kubernetes-plugin",
   "description": "Varlock plugin to load values from Kubernetes Secrets and ConfigMaps",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "type": "module",
   "homepage": "https://varlock.dev/plugins/kubernetes/",
   "bugs": "https://github.com/dmno-dev/varlock/issues",

--- a/packages/plugins/kubernetes/src/plugin.ts
+++ b/packages/plugins/kubernetes/src/plugin.ts
@@ -4,7 +4,7 @@ import * as k8s from '@kubernetes/client-node';
 
 const { SchemaError, ResolutionError, ValidationError } = plugin.ERRORS;
 
-const KUBERNETES_ICON = 'logos:kubernetes';
+const KUBERNETES_ICON = 'mdi:kubernetes';
 const SERVICE_ACCOUNT_NAMESPACE_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
 
 plugin.name = 'kubernetes';
@@ -20,7 +20,7 @@ plugin.standardVars = {
   },
 };
 
-type KubernetesAuthConfig = {
+type KubernetesInstanceConfig = {
   namespace?: string;
   context?: string;
   kubeconfig?: string;
@@ -28,6 +28,8 @@ type KubernetesAuthConfig = {
   token?: string;
   skipTlsVerify?: boolean;
   allowMissing?: boolean;
+  defaultSecret?: string;
+  defaultConfigMap?: string;
 };
 
 type KubernetesObjectKind = 'Secret' | 'ConfigMap';
@@ -111,7 +113,7 @@ function decodeConfigMapData(configMap: {
 }
 
 class KubernetesPluginInstance {
-  private authConfig: KubernetesAuthConfig = {};
+  private config: KubernetesInstanceConfig = {};
   private namespace = 'default';
   private clientPromise?: Promise<k8s.CoreV1Api>;
 
@@ -119,12 +121,12 @@ class KubernetesPluginInstance {
     readonly id: string,
   ) {}
 
-  setAuth(config: KubernetesAuthConfig) {
-    this.authConfig = config;
+  setConfig(config: KubernetesInstanceConfig) {
+    this.config = config;
     debug(
       'kubernetes instance',
       this.id,
-      'set auth - namespace:',
+      'set config - namespace:',
       config.namespace,
       'context:',
       config.context,
@@ -136,7 +138,15 @@ class KubernetesPluginInstance {
       !!config.token,
       'allowMissing:',
       !!config.allowMissing,
+      'defaultSecret:',
+      config.defaultSecret,
+      'defaultConfigMap:',
+      config.defaultConfigMap,
     );
+  }
+
+  getDefaultName(kind: KubernetesObjectKind): string | undefined {
+    return kind === 'Secret' ? this.config.defaultSecret : this.config.defaultConfigMap;
   }
 
   private async initKubeConfig(): Promise<k8s.KubeConfig> {
@@ -147,7 +157,7 @@ class KubernetesPluginInstance {
       clusterServer,
       token,
       skipTlsVerify,
-    } = this.authConfig;
+    } = this.config;
 
     const kc = new k8s.KubeConfig();
 
@@ -229,17 +239,12 @@ class KubernetesPluginInstance {
     return this.clientPromise;
   }
 
-  private missingValue(): undefined {
-    if (this.authConfig.allowMissing) return undefined;
-    throw new Error('unreachable');
-  }
-
-  private handleReadError(err: unknown, kind: KubernetesObjectKind, resourceName: string): never | undefined {
+  private handleReadError(err: unknown, kind: KubernetesObjectKind, resourceName: string): undefined {
     const status = getApiExceptionStatus(err);
     const location = `${kind} "${resourceName}" in namespace "${this.namespace}"`;
 
     if (status === 404) {
-      if (this.authConfig.allowMissing) return this.missingValue();
+      if (this.config.allowMissing) return undefined;
       throw new ResolutionError(`${location} not found`, {
         tip: `Check the ${kind} name and namespace, or set allowMissing=true on @initKubernetes()`,
       });
@@ -271,7 +276,7 @@ class KubernetesPluginInstance {
     key: string,
     availableKeys: Array<string>,
   ): string | undefined {
-    if (this.authConfig.allowMissing) return undefined;
+    if (this.config.allowMissing) return undefined;
     throw new ResolutionError(`Key "${key}" not found in Kubernetes ${kind} "${resourceName}"`, {
       tip: availableKeys.length
         ? `Available keys: ${availableKeys.join(', ')}`
@@ -324,9 +329,8 @@ class KubernetesPluginInstance {
       return JSON.stringify(decodeSecretData(secretName, secret.data));
     } catch (err) {
       if (err instanceof ResolutionError) throw err;
-      const maybeMissing = this.handleReadError(err, 'Secret', secretName);
-      if (maybeMissing === undefined) return '{}';
-      throw new Error('unreachable');
+      this.handleReadError(err, 'Secret', secretName);
+      return '{}';
     }
   }
 
@@ -341,9 +345,8 @@ class KubernetesPluginInstance {
       return JSON.stringify(decodeConfigMapData(configMap));
     } catch (err) {
       if (err instanceof ResolutionError) throw err;
-      const maybeMissing = this.handleReadError(err, 'ConfigMap', configMapName);
-      if (maybeMissing === undefined) return '{}';
-      throw new Error('unreachable');
+      this.handleReadError(err, 'ConfigMap', configMapName);
+      return '{}';
     }
   }
 }
@@ -394,63 +397,120 @@ function inferItemKey(resolverCtx: any, resolverName: string): string {
   });
 }
 
-function parseKeyResolverArgs(resolverCtx: any, resolverName: string) {
-  let instanceId = '_default';
-  let resourceNameResolver: Resolver;
-  let keyResolver: Resolver | undefined;
-  let inferredKey: string | undefined;
-
-  const argCount = resolverCtx.arrArgs?.length ?? 0;
-  if (argCount === 1) {
-    resourceNameResolver = resolverCtx.arrArgs[0];
-    inferredKey = inferItemKey(resolverCtx, resolverName);
-  } else if (argCount === 2) {
-    resourceNameResolver = resolverCtx.arrArgs[0];
-    keyResolver = resolverCtx.arrArgs[1];
-  } else if (argCount === 3) {
-    if (!resolverCtx.arrArgs[0].isStatic) {
-      throw new SchemaError('Expected instance id to be a static value');
-    }
-    instanceId = String(resolverCtx.arrArgs[0].staticValue);
-    resourceNameResolver = resolverCtx.arrArgs[1];
-    keyResolver = resolverCtx.arrArgs[2];
-  } else {
-    throw new SchemaError(`Expected ${resolverName}() to receive 1-3 arguments`);
+function parseStaticInstanceId(resolver: Resolver, paramLabel: string): string {
+  if (!resolver.isStatic) {
+    throw new SchemaError(`Expected ${paramLabel} to be a static value`);
   }
+  return String(resolver.staticValue);
+}
+
+function parseKeyResolverArgs(resolverCtx: any, resolverName: string, kind: KubernetesObjectKind) {
+  const arrArgs: Array<Resolver> = resolverCtx.arrArgs || [];
+  const objArgs: Record<string, Resolver> = resolverCtx.objArgs || {};
+
+  let instanceId = '_default';
+  let resourceNameResolver: Resolver | undefined;
+  let keyResolver: Resolver | undefined;
+
+  if (arrArgs.length === 3) {
+    instanceId = parseStaticInstanceId(arrArgs[0], 'instance id');
+    resourceNameResolver = arrArgs[1];
+    keyResolver = arrArgs[2];
+  } else if (arrArgs.length === 2) {
+    resourceNameResolver = arrArgs[0];
+    keyResolver = arrArgs[1];
+  } else if (arrArgs.length === 1) {
+    resourceNameResolver = arrArgs[0];
+  } else if (arrArgs.length > 3) {
+    throw new SchemaError(`Expected ${resolverName}() to receive 0-3 positional arguments`);
+  }
+
+  if (objArgs.id) {
+    if (arrArgs.length === 3) {
+      throw new SchemaError('Cannot use both positional and named id');
+    }
+    instanceId = parseStaticInstanceId(objArgs.id, 'id');
+  }
+  if (objArgs.name) {
+    if (resourceNameResolver) {
+      throw new SchemaError(`Cannot use both positional and named name for ${resolverName}()`);
+    }
+    resourceNameResolver = objArgs.name;
+  }
+  if (objArgs.key) {
+    if (keyResolver) {
+      throw new SchemaError(`Cannot use both positional and named key for ${resolverName}()`);
+    }
+    keyResolver = objArgs.key;
+  }
+
+  const inferredKey = keyResolver ? undefined : inferItemKey(resolverCtx, resolverName);
 
   getPluginInstance(instanceId, resolverName);
 
   return {
     instanceId,
-    resourceNameResolver: resourceNameResolver!,
+    resourceNameResolver,
     keyResolver,
     inferredKey,
+    kind,
   };
 }
 
-function parseBulkResolverArgs(resolverCtx: any, resolverName: string) {
-  let instanceId = '_default';
-  let resourceNameResolver: Resolver;
+function parseBulkResolverArgs(resolverCtx: any, resolverName: string, kind: KubernetesObjectKind) {
+  const arrArgs: Array<Resolver> = resolverCtx.arrArgs || [];
+  const objArgs: Record<string, Resolver> = resolverCtx.objArgs || {};
 
-  const argCount = resolverCtx.arrArgs?.length ?? 0;
-  if (argCount === 1) {
-    resourceNameResolver = resolverCtx.arrArgs[0];
-  } else if (argCount === 2) {
-    if (!resolverCtx.arrArgs[0].isStatic) {
-      throw new SchemaError('Expected instance id to be a static value');
+  let instanceId = '_default';
+  let resourceNameResolver: Resolver | undefined;
+
+  if (arrArgs.length === 2) {
+    instanceId = parseStaticInstanceId(arrArgs[0], 'instance id');
+    resourceNameResolver = arrArgs[1];
+  } else if (arrArgs.length === 1) {
+    resourceNameResolver = arrArgs[0];
+  } else if (arrArgs.length > 2) {
+    throw new SchemaError(`Expected ${resolverName}() to receive 0-2 positional arguments`);
+  }
+
+  if (objArgs.id) {
+    if (arrArgs.length === 2) {
+      throw new SchemaError('Cannot use both positional and named id');
     }
-    instanceId = String(resolverCtx.arrArgs[0].staticValue);
-    resourceNameResolver = resolverCtx.arrArgs[1];
-  } else {
-    throw new SchemaError(`Expected ${resolverName}() to receive 1-2 arguments`);
+    instanceId = parseStaticInstanceId(objArgs.id, 'id');
+  }
+  if (objArgs.name) {
+    if (resourceNameResolver) {
+      throw new SchemaError(`Cannot use both positional and named name for ${resolverName}()`);
+    }
+    resourceNameResolver = objArgs.name;
   }
 
   getPluginInstance(instanceId, resolverName);
 
   return {
     instanceId,
-    resourceNameResolver: resourceNameResolver!,
+    resourceNameResolver,
+    kind,
   };
+}
+
+async function resolveResourceName(
+  instanceId: string,
+  resourceNameResolver: Resolver | undefined,
+  kind: KubernetesObjectKind,
+): Promise<string> {
+  if (resourceNameResolver) {
+    return resolveString(resourceNameResolver, `${kind} name`);
+  }
+  const defaultName = pluginInstances[instanceId].getDefaultName(kind);
+  if (!defaultName) {
+    const defaultParam = kind === 'Secret' ? 'defaultSecret' : 'defaultConfigMap';
+    throw new SchemaError(`No ${kind} name provided`, {
+      tip: `Pass a name argument, or set ${defaultParam} on @initKubernetes()`,
+    });
+  }
+  return defaultName;
 }
 
 plugin.registerRootDecorator({
@@ -480,6 +540,8 @@ plugin.registerRootDecorator({
       tokenResolver: objArgs.token,
       skipTlsVerifyResolver: objArgs.skipTlsVerify,
       allowMissingResolver: objArgs.allowMissing,
+      defaultSecretResolver: objArgs.defaultSecret,
+      defaultConfigMapResolver: objArgs.defaultConfigMap,
     };
   },
   async execute({
@@ -491,6 +553,8 @@ plugin.registerRootDecorator({
     tokenResolver,
     skipTlsVerifyResolver,
     allowMissingResolver,
+    defaultSecretResolver,
+    defaultConfigMapResolver,
   }) {
     const namespace = asOptionalString(await namespaceResolver?.resolve());
     const context = asOptionalString(await contextResolver?.resolve());
@@ -499,8 +563,10 @@ plugin.registerRootDecorator({
     const token = asOptionalString(await tokenResolver?.resolve());
     const skipTlsVerify = asOptionalBoolean(await skipTlsVerifyResolver?.resolve(), 'skipTlsVerify');
     const allowMissing = asOptionalBoolean(await allowMissingResolver?.resolve(), 'allowMissing');
+    const defaultSecret = asOptionalString(await defaultSecretResolver?.resolve());
+    const defaultConfigMap = asOptionalString(await defaultConfigMapResolver?.resolve());
 
-    pluginInstances[id].setAuth({
+    pluginInstances[id].setConfig({
       namespace,
       context,
       kubeconfig,
@@ -508,6 +574,8 @@ plugin.registerRootDecorator({
       token,
       skipTlsVerify,
       allowMissing,
+      defaultSecret,
+      defaultConfigMap,
     });
   },
 });
@@ -536,17 +604,17 @@ plugin.registerResolverFunction({
   label: 'Fetch key from Kubernetes Secret',
   icon: KUBERNETES_ICON,
   argsSchema: {
-    type: 'array',
-    arrayMinLength: 1,
+    type: 'mixed',
+    arrayMinLength: 0,
     arrayMaxLength: 3,
   },
   process() {
-    return parseKeyResolverArgs(this, 'k8sSecret');
+    return parseKeyResolverArgs(this, 'k8sSecret', 'Secret');
   },
   async resolve({
-    instanceId, resourceNameResolver, keyResolver, inferredKey,
+    instanceId, resourceNameResolver, keyResolver, inferredKey, kind,
   }) {
-    const resourceName = await resolveString(resourceNameResolver, 'Secret name');
+    const resourceName = await resolveResourceName(instanceId, resourceNameResolver, kind);
     const key = keyResolver ? await resolveString(keyResolver, 'Secret key') : inferredKey;
     if (!key) throw new SchemaError('No Secret key provided');
     return pluginInstances[instanceId].getSecretKey(resourceName, key);
@@ -558,17 +626,17 @@ plugin.registerResolverFunction({
   label: 'Fetch key from Kubernetes ConfigMap',
   icon: KUBERNETES_ICON,
   argsSchema: {
-    type: 'array',
-    arrayMinLength: 1,
+    type: 'mixed',
+    arrayMinLength: 0,
     arrayMaxLength: 3,
   },
   process() {
-    return parseKeyResolverArgs(this, 'k8sConfigMap');
+    return parseKeyResolverArgs(this, 'k8sConfigMap', 'ConfigMap');
   },
   async resolve({
-    instanceId, resourceNameResolver, keyResolver, inferredKey,
+    instanceId, resourceNameResolver, keyResolver, inferredKey, kind,
   }) {
-    const resourceName = await resolveString(resourceNameResolver, 'ConfigMap name');
+    const resourceName = await resolveResourceName(instanceId, resourceNameResolver, kind);
     const key = keyResolver ? await resolveString(keyResolver, 'ConfigMap key') : inferredKey;
     if (!key) throw new SchemaError('No ConfigMap key provided');
     return pluginInstances[instanceId].getConfigMapKey(resourceName, key);
@@ -580,15 +648,15 @@ plugin.registerResolverFunction({
   label: 'Load all keys from Kubernetes Secret',
   icon: KUBERNETES_ICON,
   argsSchema: {
-    type: 'array',
-    arrayMinLength: 1,
+    type: 'mixed',
+    arrayMinLength: 0,
     arrayMaxLength: 2,
   },
   process() {
-    return parseBulkResolverArgs(this, 'k8sSecretBulk');
+    return parseBulkResolverArgs(this, 'k8sSecretBulk', 'Secret');
   },
-  async resolve({ instanceId, resourceNameResolver }) {
-    const resourceName = await resolveString(resourceNameResolver, 'Secret name');
+  async resolve({ instanceId, resourceNameResolver, kind }) {
+    const resourceName = await resolveResourceName(instanceId, resourceNameResolver, kind);
     return pluginInstances[instanceId].getSecretBulk(resourceName);
   },
 });
@@ -598,15 +666,15 @@ plugin.registerResolverFunction({
   label: 'Load all keys from Kubernetes ConfigMap',
   icon: KUBERNETES_ICON,
   argsSchema: {
-    type: 'array',
-    arrayMinLength: 1,
+    type: 'mixed',
+    arrayMinLength: 0,
     arrayMaxLength: 2,
   },
   process() {
-    return parseBulkResolverArgs(this, 'k8sConfigMapBulk');
+    return parseBulkResolverArgs(this, 'k8sConfigMapBulk', 'ConfigMap');
   },
-  async resolve({ instanceId, resourceNameResolver }) {
-    const resourceName = await resolveString(resourceNameResolver, 'ConfigMap name');
+  async resolve({ instanceId, resourceNameResolver, kind }) {
+    const resourceName = await resolveResourceName(instanceId, resourceNameResolver, kind);
     return pluginInstances[instanceId].getConfigMapBulk(resourceName);
   },
 });

--- a/packages/plugins/kubernetes/src/plugin.ts
+++ b/packages/plugins/kubernetes/src/plugin.ts
@@ -1,0 +1,612 @@
+import fs from 'node:fs/promises';
+import { type Resolver, plugin } from 'varlock/plugin-lib';
+import * as k8s from '@kubernetes/client-node';
+
+const { SchemaError, ResolutionError, ValidationError } = plugin.ERRORS;
+
+const KUBERNETES_ICON = 'logos:kubernetes';
+const SERVICE_ACCOUNT_NAMESPACE_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
+
+plugin.name = 'kubernetes';
+const { debug } = plugin;
+debug('init - version =', plugin.version);
+plugin.icon = KUBERNETES_ICON;
+plugin.standardVars = {
+  initDecorator: '@initKubernetes',
+  params: {
+    namespace: { key: ['KUBERNETES_NAMESPACE', 'POD_NAMESPACE'] },
+    kubeconfig: { key: 'KUBECONFIG' },
+    token: { key: 'KUBERNETES_TOKEN', dataType: 'kubernetesBearerToken' },
+  },
+};
+
+type KubernetesAuthConfig = {
+  namespace?: string;
+  context?: string;
+  kubeconfig?: string;
+  clusterServer?: string;
+  token?: string;
+  skipTlsVerify?: boolean;
+  allowMissing?: boolean;
+};
+
+type KubernetesObjectKind = 'Secret' | 'ConfigMap';
+
+function asOptionalString(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  return String(value);
+}
+
+function asOptionalBoolean(value: unknown, name: string): boolean | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+  }
+  throw new SchemaError(`${name} must be true or false`);
+}
+
+function isRawKubeconfig(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.startsWith('{') || trimmed.includes('apiVersion:') || trimmed.includes('clusters:');
+}
+
+async function readServiceAccountNamespace(): Promise<string | undefined> {
+  try {
+    const ns = await fs.readFile(SERVICE_ACCOUNT_NAMESPACE_PATH, 'utf-8');
+    return ns.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getApiExceptionStatus(err: unknown): number | undefined {
+  if (err && typeof err === 'object') {
+    const maybe = err as {
+      code?: unknown,
+      statusCode?: unknown,
+      response?: { statusCode?: unknown, status?: unknown },
+    };
+    if (typeof maybe.code === 'number') return maybe.code;
+    if (typeof maybe.statusCode === 'number') return maybe.statusCode;
+    if (typeof maybe.response?.statusCode === 'number') return maybe.response.statusCode;
+    if (typeof maybe.response?.status === 'number') return maybe.response.status;
+  }
+  return undefined;
+}
+
+function getApiExceptionMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function decodeBase64Value(value: string, resourceName: string, key: string): string {
+  try {
+    return Buffer.from(value, 'base64').toString('utf-8');
+  } catch (err) {
+    throw new ResolutionError(`Failed to decode key "${key}" from Kubernetes Secret "${resourceName}"`, {
+      tip: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function decodeSecretData(resourceName: string, data?: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(data || {})) {
+    result[key] = decodeBase64Value(value, resourceName, key);
+  }
+  return result;
+}
+
+function decodeConfigMapData(configMap: {
+  data?: Record<string, string>,
+  binaryData?: Record<string, string>,
+}): Record<string, string> {
+  const result: Record<string, string> = { ...(configMap.data || {}) };
+  for (const [key, value] of Object.entries(configMap.binaryData || {})) {
+    result[key] = Buffer.from(value, 'base64').toString('utf-8');
+  }
+  return result;
+}
+
+class KubernetesPluginInstance {
+  private authConfig: KubernetesAuthConfig = {};
+  private namespace = 'default';
+  private clientPromise?: Promise<k8s.CoreV1Api>;
+
+  constructor(
+    readonly id: string,
+  ) {}
+
+  setAuth(config: KubernetesAuthConfig) {
+    this.authConfig = config;
+    debug(
+      'kubernetes instance',
+      this.id,
+      'set auth - namespace:',
+      config.namespace,
+      'context:',
+      config.context,
+      'hasKubeconfig:',
+      !!config.kubeconfig,
+      'clusterServer:',
+      config.clusterServer,
+      'hasToken:',
+      !!config.token,
+      'allowMissing:',
+      !!config.allowMissing,
+    );
+  }
+
+  private async initKubeConfig(): Promise<k8s.KubeConfig> {
+    const {
+      namespace,
+      context,
+      kubeconfig,
+      clusterServer,
+      token,
+      skipTlsVerify,
+    } = this.authConfig;
+
+    const kc = new k8s.KubeConfig();
+
+    try {
+      if (clusterServer) {
+        kc.loadFromOptions({
+          clusters: [
+            {
+              name: 'varlock-cluster',
+              server: clusterServer,
+              skipTLSVerify: skipTlsVerify ?? false,
+            },
+          ],
+          users: [
+            {
+              name: 'varlock-user',
+              ...(token ? { token } : {}),
+            },
+          ],
+          contexts: [
+            {
+              name: 'varlock-context',
+              cluster: 'varlock-cluster',
+              user: 'varlock-user',
+              namespace: namespace || 'default',
+            },
+          ],
+          currentContext: 'varlock-context',
+        });
+      } else if (kubeconfig) {
+        if (isRawKubeconfig(kubeconfig)) {
+          kc.loadFromString(kubeconfig);
+        } else {
+          kc.loadFromFile(kubeconfig);
+        }
+      } else if (process.env.KUBERNETES_SERVICE_HOST && process.env.KUBERNETES_SERVICE_PORT) {
+        kc.loadFromCluster();
+      } else {
+        kc.loadFromDefault();
+      }
+
+      if (context) {
+        if (!kc.getContextObject(context)) {
+          throw new SchemaError(`Kubernetes context "${context}" was not found`, {
+            tip: 'Check `kubectl config get-contexts` or remove the context parameter to use the current context',
+          });
+        }
+        kc.setCurrentContext(context);
+      }
+
+      const currentContext = kc.getContextObject(kc.getCurrentContext());
+      this.namespace = namespace
+        || currentContext?.namespace
+        || await readServiceAccountNamespace()
+        || 'default';
+
+      return kc;
+    } catch (err) {
+      if (err instanceof SchemaError) throw err;
+      throw new SchemaError(`Failed to initialize Kubernetes client: ${getApiExceptionMessage(err)}`, {
+        tip: [
+          'Verify your kubeconfig/current context is valid',
+          'For local use, check `kubectl config current-context`',
+          'For in-cluster use, check the pod service account token and RBAC permissions',
+          'For explicit auth, provide clusterServer and token via @initKubernetes()',
+        ].join('\n'),
+      });
+    }
+  }
+
+  private async initClient(): Promise<k8s.CoreV1Api> {
+    if (this.clientPromise) return this.clientPromise;
+
+    this.clientPromise = (async () => {
+      const kc = await this.initKubeConfig();
+      return kc.makeApiClient(k8s.CoreV1Api);
+    })();
+
+    return this.clientPromise;
+  }
+
+  private missingValue(): undefined {
+    if (this.authConfig.allowMissing) return undefined;
+    throw new Error('unreachable');
+  }
+
+  private handleReadError(err: unknown, kind: KubernetesObjectKind, resourceName: string): never | undefined {
+    const status = getApiExceptionStatus(err);
+    const location = `${kind} "${resourceName}" in namespace "${this.namespace}"`;
+
+    if (status === 404) {
+      if (this.authConfig.allowMissing) return this.missingValue();
+      throw new ResolutionError(`${location} not found`, {
+        tip: `Check the ${kind} name and namespace, or set allowMissing=true on @initKubernetes()`,
+      });
+    }
+
+    if (status === 401) {
+      throw new ResolutionError(`Authentication failed while reading Kubernetes ${location}`, {
+        tip: 'Check your kubeconfig credentials, service account token, or explicit token',
+      });
+    }
+
+    if (status === 403) {
+      throw new ResolutionError(`Permission denied reading Kubernetes ${location}`, {
+        tip: [
+          'Grant the active user/service account read access:',
+          '  apiGroups: [""]',
+          `  resources: ["${kind === 'Secret' ? 'secrets' : 'configmaps'}"]`,
+          '  verbs: ["get"]',
+        ].join('\n'),
+      });
+    }
+
+    throw new ResolutionError(`Failed to read Kubernetes ${location}: ${getApiExceptionMessage(err)}`);
+  }
+
+  private getMissingKey(
+    kind: KubernetesObjectKind,
+    resourceName: string,
+    key: string,
+    availableKeys: Array<string>,
+  ): string | undefined {
+    if (this.authConfig.allowMissing) return undefined;
+    throw new ResolutionError(`Key "${key}" not found in Kubernetes ${kind} "${resourceName}"`, {
+      tip: availableKeys.length
+        ? `Available keys: ${availableKeys.join(', ')}`
+        : `The ${kind} has no data keys`,
+    });
+  }
+
+  async getSecretKey(secretName: string, key: string): Promise<string | undefined> {
+    const client = await this.initClient();
+
+    try {
+      const secret = await client.readNamespacedSecret({
+        name: secretName,
+        namespace: this.namespace,
+      });
+      const data = decodeSecretData(secretName, secret.data);
+      if (!(key in data)) return this.getMissingKey('Secret', secretName, key, Object.keys(data));
+      return data[key];
+    } catch (err) {
+      if (err instanceof ResolutionError) throw err;
+      return this.handleReadError(err, 'Secret', secretName);
+    }
+  }
+
+  async getConfigMapKey(configMapName: string, key: string): Promise<string | undefined> {
+    const client = await this.initClient();
+
+    try {
+      const configMap = await client.readNamespacedConfigMap({
+        name: configMapName,
+        namespace: this.namespace,
+      });
+      const data = decodeConfigMapData(configMap);
+      if (!(key in data)) return this.getMissingKey('ConfigMap', configMapName, key, Object.keys(data));
+      return data[key];
+    } catch (err) {
+      if (err instanceof ResolutionError) throw err;
+      return this.handleReadError(err, 'ConfigMap', configMapName);
+    }
+  }
+
+  async getSecretBulk(secretName: string): Promise<string> {
+    const client = await this.initClient();
+
+    try {
+      const secret = await client.readNamespacedSecret({
+        name: secretName,
+        namespace: this.namespace,
+      });
+      return JSON.stringify(decodeSecretData(secretName, secret.data));
+    } catch (err) {
+      if (err instanceof ResolutionError) throw err;
+      const maybeMissing = this.handleReadError(err, 'Secret', secretName);
+      if (maybeMissing === undefined) return '{}';
+      throw new Error('unreachable');
+    }
+  }
+
+  async getConfigMapBulk(configMapName: string): Promise<string> {
+    const client = await this.initClient();
+
+    try {
+      const configMap = await client.readNamespacedConfigMap({
+        name: configMapName,
+        namespace: this.namespace,
+      });
+      return JSON.stringify(decodeConfigMapData(configMap));
+    } catch (err) {
+      if (err instanceof ResolutionError) throw err;
+      const maybeMissing = this.handleReadError(err, 'ConfigMap', configMapName);
+      if (maybeMissing === undefined) return '{}';
+      throw new Error('unreachable');
+    }
+  }
+}
+
+const pluginInstances: Record<string, KubernetesPluginInstance> = {};
+
+function requirePluginInstances(resolverName: string) {
+  if (Object.values(pluginInstances).length) return;
+  throw new SchemaError('No Kubernetes plugin instances found', {
+    tip: `Initialize at least one Kubernetes plugin instance using @initKubernetes() before using ${resolverName}()`,
+  });
+}
+
+function getPluginInstance(instanceId: string, resolverName: string): KubernetesPluginInstance {
+  requirePluginInstances(resolverName);
+
+  const selectedInstance = pluginInstances[instanceId];
+  if (selectedInstance) return selectedInstance;
+
+  if (instanceId === '_default') {
+    throw new SchemaError('Kubernetes plugin instance (without id) not found', {
+      tip: [
+        'Either remove the `id` param from your @initKubernetes call',
+        `or use \`${resolverName}(id, ...)\` to select an instance by id`,
+        `Available ids: ${Object.keys(pluginInstances).join(', ')}`,
+      ].join('\n'),
+    });
+  }
+
+  throw new SchemaError(`Kubernetes plugin instance id "${instanceId}" not found`, {
+    tip: `Available ids: ${Object.keys(pluginInstances).join(', ')}`,
+  });
+}
+
+async function resolveString(resolver: Resolver, label: string): Promise<string> {
+  const resolved = await resolver.resolve();
+  if (typeof resolved !== 'string') {
+    throw new SchemaError(`Expected ${label} to resolve to a string`);
+  }
+  return resolved;
+}
+
+function inferItemKey(resolverCtx: any, resolverName: string): string {
+  const parent = resolverCtx.parent;
+  if (parent && typeof parent.key === 'string') return parent.key;
+  throw new SchemaError(`When called without a key argument, ${resolverName}() must be used on a config item`, {
+    tip: `Either provide a key argument or use ${resolverName}() on a config item`,
+  });
+}
+
+function parseKeyResolverArgs(resolverCtx: any, resolverName: string) {
+  let instanceId = '_default';
+  let resourceNameResolver: Resolver;
+  let keyResolver: Resolver | undefined;
+  let inferredKey: string | undefined;
+
+  const argCount = resolverCtx.arrArgs?.length ?? 0;
+  if (argCount === 1) {
+    resourceNameResolver = resolverCtx.arrArgs[0];
+    inferredKey = inferItemKey(resolverCtx, resolverName);
+  } else if (argCount === 2) {
+    resourceNameResolver = resolverCtx.arrArgs[0];
+    keyResolver = resolverCtx.arrArgs[1];
+  } else if (argCount === 3) {
+    if (!resolverCtx.arrArgs[0].isStatic) {
+      throw new SchemaError('Expected instance id to be a static value');
+    }
+    instanceId = String(resolverCtx.arrArgs[0].staticValue);
+    resourceNameResolver = resolverCtx.arrArgs[1];
+    keyResolver = resolverCtx.arrArgs[2];
+  } else {
+    throw new SchemaError(`Expected ${resolverName}() to receive 1-3 arguments`);
+  }
+
+  getPluginInstance(instanceId, resolverName);
+
+  return {
+    instanceId,
+    resourceNameResolver: resourceNameResolver!,
+    keyResolver,
+    inferredKey,
+  };
+}
+
+function parseBulkResolverArgs(resolverCtx: any, resolverName: string) {
+  let instanceId = '_default';
+  let resourceNameResolver: Resolver;
+
+  const argCount = resolverCtx.arrArgs?.length ?? 0;
+  if (argCount === 1) {
+    resourceNameResolver = resolverCtx.arrArgs[0];
+  } else if (argCount === 2) {
+    if (!resolverCtx.arrArgs[0].isStatic) {
+      throw new SchemaError('Expected instance id to be a static value');
+    }
+    instanceId = String(resolverCtx.arrArgs[0].staticValue);
+    resourceNameResolver = resolverCtx.arrArgs[1];
+  } else {
+    throw new SchemaError(`Expected ${resolverName}() to receive 1-2 arguments`);
+  }
+
+  getPluginInstance(instanceId, resolverName);
+
+  return {
+    instanceId,
+    resourceNameResolver: resourceNameResolver!,
+  };
+}
+
+plugin.registerRootDecorator({
+  name: 'initKubernetes',
+  description: 'Initialize a Kubernetes plugin instance for k8sSecret() and k8sConfigMap() resolvers',
+  isFunction: true,
+  async process(argsVal) {
+    const objArgs = argsVal.objArgs;
+    if (!objArgs) throw new SchemaError('Expected configuration arguments');
+
+    if (objArgs.id && !objArgs.id.isStatic) {
+      throw new SchemaError('Expected id to be static');
+    }
+    const id = String(objArgs?.id?.staticValue || '_default');
+    if (pluginInstances[id]) {
+      throw new SchemaError(`Instance with id "${id}" already initialized`);
+    }
+
+    pluginInstances[id] = new KubernetesPluginInstance(id);
+
+    return {
+      id,
+      namespaceResolver: objArgs.namespace,
+      contextResolver: objArgs.context,
+      kubeconfigResolver: objArgs.kubeconfig,
+      clusterServerResolver: objArgs.clusterServer,
+      tokenResolver: objArgs.token,
+      skipTlsVerifyResolver: objArgs.skipTlsVerify,
+      allowMissingResolver: objArgs.allowMissing,
+    };
+  },
+  async execute({
+    id,
+    namespaceResolver,
+    contextResolver,
+    kubeconfigResolver,
+    clusterServerResolver,
+    tokenResolver,
+    skipTlsVerifyResolver,
+    allowMissingResolver,
+  }) {
+    const namespace = asOptionalString(await namespaceResolver?.resolve());
+    const context = asOptionalString(await contextResolver?.resolve());
+    const kubeconfig = asOptionalString(await kubeconfigResolver?.resolve());
+    const clusterServer = asOptionalString(await clusterServerResolver?.resolve());
+    const token = asOptionalString(await tokenResolver?.resolve());
+    const skipTlsVerify = asOptionalBoolean(await skipTlsVerifyResolver?.resolve(), 'skipTlsVerify');
+    const allowMissing = asOptionalBoolean(await allowMissingResolver?.resolve(), 'allowMissing');
+
+    pluginInstances[id].setAuth({
+      namespace,
+      context,
+      kubeconfig,
+      clusterServer,
+      token,
+      skipTlsVerify,
+      allowMissing,
+    });
+  },
+});
+
+plugin.registerDataType({
+  name: 'kubernetesBearerToken',
+  sensitive: true,
+  typeDescription: 'Kubernetes bearer token for API authentication',
+  icon: KUBERNETES_ICON,
+  docs: [
+    {
+      description: 'Kubernetes service account tokens',
+      url: 'https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/',
+    },
+  ],
+  async validate(val): Promise<true> {
+    if (typeof val !== 'string' || val.trim().length === 0) {
+      throw new ValidationError('Must be a non-empty bearer token');
+    }
+    return true;
+  },
+});
+
+plugin.registerResolverFunction({
+  name: 'k8sSecret',
+  label: 'Fetch key from Kubernetes Secret',
+  icon: KUBERNETES_ICON,
+  argsSchema: {
+    type: 'array',
+    arrayMinLength: 1,
+    arrayMaxLength: 3,
+  },
+  process() {
+    return parseKeyResolverArgs(this, 'k8sSecret');
+  },
+  async resolve({
+    instanceId, resourceNameResolver, keyResolver, inferredKey,
+  }) {
+    const resourceName = await resolveString(resourceNameResolver, 'Secret name');
+    const key = keyResolver ? await resolveString(keyResolver, 'Secret key') : inferredKey;
+    if (!key) throw new SchemaError('No Secret key provided');
+    return pluginInstances[instanceId].getSecretKey(resourceName, key);
+  },
+});
+
+plugin.registerResolverFunction({
+  name: 'k8sConfigMap',
+  label: 'Fetch key from Kubernetes ConfigMap',
+  icon: KUBERNETES_ICON,
+  argsSchema: {
+    type: 'array',
+    arrayMinLength: 1,
+    arrayMaxLength: 3,
+  },
+  process() {
+    return parseKeyResolverArgs(this, 'k8sConfigMap');
+  },
+  async resolve({
+    instanceId, resourceNameResolver, keyResolver, inferredKey,
+  }) {
+    const resourceName = await resolveString(resourceNameResolver, 'ConfigMap name');
+    const key = keyResolver ? await resolveString(keyResolver, 'ConfigMap key') : inferredKey;
+    if (!key) throw new SchemaError('No ConfigMap key provided');
+    return pluginInstances[instanceId].getConfigMapKey(resourceName, key);
+  },
+});
+
+plugin.registerResolverFunction({
+  name: 'k8sSecretBulk',
+  label: 'Load all keys from Kubernetes Secret',
+  icon: KUBERNETES_ICON,
+  argsSchema: {
+    type: 'array',
+    arrayMinLength: 1,
+    arrayMaxLength: 2,
+  },
+  process() {
+    return parseBulkResolverArgs(this, 'k8sSecretBulk');
+  },
+  async resolve({ instanceId, resourceNameResolver }) {
+    const resourceName = await resolveString(resourceNameResolver, 'Secret name');
+    return pluginInstances[instanceId].getSecretBulk(resourceName);
+  },
+});
+
+plugin.registerResolverFunction({
+  name: 'k8sConfigMapBulk',
+  label: 'Load all keys from Kubernetes ConfigMap',
+  icon: KUBERNETES_ICON,
+  argsSchema: {
+    type: 'array',
+    arrayMinLength: 1,
+    arrayMaxLength: 2,
+  },
+  process() {
+    return parseBulkResolverArgs(this, 'k8sConfigMapBulk');
+  },
+  async resolve({ instanceId, resourceNameResolver }) {
+    const resourceName = await resolveString(resourceNameResolver, 'ConfigMap name');
+    return pluginInstances[instanceId].getConfigMapBulk(resourceName);
+  },
+});

--- a/packages/plugins/kubernetes/test/kubernetes.test.ts
+++ b/packages/plugins/kubernetes/test/kubernetes.test.ts
@@ -1,0 +1,285 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  describe, expect, test,
+} from 'vitest';
+import outdent from 'outdent';
+import { pluginTest } from 'varlock/test-helpers';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PLUGIN_PATH = path.join(__dirname, '..');
+
+type FakeKubeApi = {
+  url: string;
+  requests: Array<{ method?: string; url?: string; authorization?: string }>;
+  close: () => Promise<void>;
+};
+
+function b64(value: string): string {
+  return Buffer.from(value).toString('base64');
+}
+
+async function startFakeKubeApi(): Promise<FakeKubeApi> {
+  const requests: FakeKubeApi['requests'] = [];
+
+  const server = http.createServer((req, res) => {
+    const requestUrl = new URL(req.url || '/', 'http://127.0.0.1');
+    requests.push({
+      method: req.method,
+      url: requestUrl.pathname,
+      authorization: req.headers.authorization,
+    });
+
+    const sendJson = (statusCode: number, body: Record<string, unknown>) => {
+      res.writeHead(statusCode, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(body));
+    };
+
+    if (req.headers.authorization !== 'Bearer test-token') {
+      sendJson(401, {
+        kind: 'Status',
+        status: 'Failure',
+        reason: 'Unauthorized',
+        message: 'missing test token',
+      });
+      return;
+    }
+
+    if (requestUrl.pathname === '/api/v1/namespaces/test/secrets/app-secrets') {
+      sendJson(200, {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: { name: 'app-secrets', namespace: 'test' },
+        data: {
+          DATABASE_URL: b64('postgres://example'),
+          API_KEY: b64('secret-api-key'),
+        },
+      });
+      return;
+    }
+
+    if (requestUrl.pathname === '/api/v1/namespaces/test/configmaps/app-config') {
+      sendJson(200, {
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: { name: 'app-config', namespace: 'test' },
+        data: {
+          PUBLIC_API_HOST: 'api.example.com',
+        },
+        binaryData: {
+          CERT: b64('cert-data'),
+        },
+      });
+      return;
+    }
+
+    if (requestUrl.pathname === '/api/v1/namespaces/prod/secrets/app-secrets') {
+      sendJson(200, {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: { name: 'app-secrets', namespace: 'prod' },
+        data: {
+          DATABASE_URL: b64('postgres://prod'),
+        },
+      });
+      return;
+    }
+
+    sendJson(404, {
+      kind: 'Status',
+      status: 'Failure',
+      reason: 'NotFound',
+      message: `${requestUrl.pathname} not found`,
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const address = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () => new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    }),
+  };
+}
+
+type KubernetesTestOpts = {
+  schema: string;
+  header?: string;
+  initParams?: string;
+} & Omit<Parameters<typeof pluginTest>[0], 'schema'>;
+
+async function runKubernetesTest(api: FakeKubeApi, opts: KubernetesTestOpts) {
+  const {
+    schema,
+    header = '',
+    initParams = '',
+    injectValues,
+    ...rest
+  } = opts;
+
+  const extraParams = initParams ? `, ${initParams}` : '';
+  await pluginTest({
+    ...rest,
+    injectValues: {
+      K8S_SERVER: api.url,
+      K8S_TOKEN: 'test-token',
+      ...injectValues,
+    },
+    schema: outdent`
+      # @plugin(${PLUGIN_PATH})
+      # @initKubernetes(namespace=test, clusterServer=$K8S_SERVER, token=$K8S_TOKEN, skipTlsVerify=true${extraParams})
+      ${header}
+      # ---
+      K8S_SERVER=
+      # @type=kubernetesBearerToken
+      K8S_TOKEN=
+      ${schema}
+    `,
+  })();
+}
+
+describe('kubernetes plugin', () => {
+  test('reads a Secret key using the config item name', async () => {
+    const api = await startFakeKubeApi();
+    try {
+      await runKubernetesTest(api, {
+        schema: 'DATABASE_URL=k8sSecret(app-secrets)',
+        expectValues: { DATABASE_URL: 'postgres://example' },
+      });
+
+      expect(api.requests).toContainEqual(expect.objectContaining({
+        url: '/api/v1/namespaces/test/secrets/app-secrets',
+        authorization: 'Bearer test-token',
+      }));
+    } finally {
+      await api.close();
+    }
+  });
+
+  test('reads explicit Secret and ConfigMap keys', async () => {
+    const api = await startFakeKubeApi();
+    try {
+      await runKubernetesTest(api, {
+        schema: outdent`
+          SECRET_KEY=k8sSecret(app-secrets, API_KEY)
+          API_HOST=k8sConfigMap(app-config, PUBLIC_API_HOST)
+          CERT=k8sConfigMap(app-config, CERT)
+        `,
+        expectValues: {
+          SECRET_KEY: 'secret-api-key',
+          API_HOST: 'api.example.com',
+          CERT: 'cert-data',
+        },
+      });
+    } finally {
+      await api.close();
+    }
+  });
+
+  test('bulk loads Secret and ConfigMap data', async () => {
+    const api = await startFakeKubeApi();
+    try {
+      await runKubernetesTest(api, {
+        header: outdent`
+          # @setValuesBulk(k8sSecretBulk(app-secrets), format=json)
+          # @setValuesBulk(k8sConfigMapBulk(app-config), format=json)
+        `,
+        schema: outdent`
+          DATABASE_URL=
+          API_KEY=
+          PUBLIC_API_HOST=
+          CERT=
+        `,
+        expectValues: {
+          DATABASE_URL: 'postgres://example',
+          API_KEY: 'secret-api-key',
+          PUBLIC_API_HOST: 'api.example.com',
+          CERT: 'cert-data',
+        },
+      });
+    } finally {
+      await api.close();
+    }
+  });
+
+  test('supports named instances', async () => {
+    const api = await startFakeKubeApi();
+    try {
+      await pluginTest({
+        injectValues: {
+          K8S_SERVER: api.url,
+          K8S_TOKEN: 'test-token',
+        },
+        schema: outdent`
+          # @plugin(${PLUGIN_PATH})
+          # @initKubernetes(id=dev, namespace=test, clusterServer=$K8S_SERVER, token=$K8S_TOKEN, skipTlsVerify=true)
+          # @initKubernetes(id=prod, namespace=prod, clusterServer=$K8S_SERVER, token=$K8S_TOKEN, skipTlsVerify=true)
+          # ---
+          K8S_SERVER=
+          # @type=kubernetesBearerToken
+          K8S_TOKEN=
+          DEV_DATABASE_URL=k8sSecret(dev, app-secrets, DATABASE_URL)
+          PROD_DATABASE_URL=k8sSecret(prod, app-secrets, DATABASE_URL)
+        `,
+        expectValues: {
+          DEV_DATABASE_URL: 'postgres://example',
+          PROD_DATABASE_URL: 'postgres://prod',
+        },
+      })();
+    } finally {
+      await api.close();
+    }
+  });
+
+  test('reports missing keys unless allowMissing is enabled', async () => {
+    const api = await startFakeKubeApi();
+    try {
+      await runKubernetesTest(api, {
+        schema: 'MISSING=k8sSecret(app-secrets, NOT_THERE)',
+        expectValues: { MISSING: Error },
+      });
+
+      await runKubernetesTest(api, {
+        initParams: 'allowMissing=true',
+        schema: outdent`
+          # @required=false
+          MISSING=k8sSecret(app-secrets, NOT_THERE)
+        `,
+        expectValues: { MISSING: undefined },
+      });
+    } finally {
+      await api.close();
+    }
+  });
+
+  test('validates init and token schema', async () => {
+    await pluginTest({
+      schema: outdent`
+        # @plugin(${PLUGIN_PATH})
+        # @initKubernetes(id=$DYNAMIC_ID)
+        # ---
+        DYNAMIC_ID=prod
+      `,
+      expectSchemaError: true,
+    })();
+
+    await pluginTest({
+      schema: outdent`
+        # @plugin(${PLUGIN_PATH})
+        # @initKubernetes(clusterServer="https://127.0.0.1", token="valid-token")
+        # ---
+        # @type=kubernetesBearerToken
+        K8S_TOKEN=
+      `,
+      expectValues: { K8S_TOKEN: Error },
+      expectSensitive: { K8S_TOKEN: true },
+    })();
+  });
+});

--- a/packages/plugins/kubernetes/test/kubernetes.test.ts
+++ b/packages/plugins/kubernetes/test/kubernetes.test.ts
@@ -259,6 +259,92 @@ describe('kubernetes plugin', () => {
     }
   });
 
+  test('uses defaultSecret when no name argument is provided', async () => {
+    const api = await startFakeKubeApi();
+    try {
+      await runKubernetesTest(api, {
+        initParams: 'defaultSecret=app-secrets',
+        schema: outdent`
+          DATABASE_URL=k8sSecret()
+          SECRET_KEY=k8sSecret(key=API_KEY)
+        `,
+        expectValues: {
+          DATABASE_URL: 'postgres://example',
+          SECRET_KEY: 'secret-api-key',
+        },
+      });
+    } finally {
+      await api.close();
+    }
+  });
+
+  test('uses defaultConfigMap when no name argument is provided', async () => {
+    const api = await startFakeKubeApi();
+    try {
+      await runKubernetesTest(api, {
+        initParams: 'defaultConfigMap=app-config',
+        header: outdent`
+          # @setValuesBulk(k8sConfigMapBulk(), format=json)
+        `,
+        schema: outdent`
+          PUBLIC_API_HOST=
+          CERT=
+          API_HOST=k8sConfigMap(name=app-config, key=PUBLIC_API_HOST)
+        `,
+        expectValues: {
+          PUBLIC_API_HOST: 'api.example.com',
+          CERT: 'cert-data',
+          API_HOST: 'api.example.com',
+        },
+      });
+    } finally {
+      await api.close();
+    }
+  });
+
+  test('positional name overrides defaultSecret', async () => {
+    const api = await startFakeKubeApi();
+    try {
+      await runKubernetesTest(api, {
+        initParams: 'defaultSecret=app-secrets',
+        schema: outdent`
+          DATABASE_URL=k8sSecret()
+          STRIPE_KEY=k8sSecret(other-secrets, API_KEY)
+        `,
+        expectValues: {
+          DATABASE_URL: 'postgres://example',
+          STRIPE_KEY: Error,
+        },
+      });
+    } finally {
+      await api.close();
+    }
+  });
+
+  test('errors when no name is provided and no default is configured', async () => {
+    const api = await startFakeKubeApi();
+    try {
+      await runKubernetesTest(api, {
+        schema: 'DATABASE_URL=k8sSecret()',
+        expectValues: { DATABASE_URL: Error },
+      });
+    } finally {
+      await api.close();
+    }
+  });
+
+  test('rejects mixing positional and named args for the same field', async () => {
+    const api = await startFakeKubeApi();
+    try {
+      await runKubernetesTest(api, {
+        schema: 'MIXED=k8sSecret(app-secrets, name=other-secrets)',
+        expectValues: { MIXED: Error },
+      });
+    } finally {
+      await api.close();
+    }
+  });
+
   test('validates init and token schema', async () => {
     await pluginTest({
       schema: outdent`

--- a/packages/plugins/kubernetes/tsconfig.json
+++ b/packages/plugins/kubernetes/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@varlock/tsconfig/plugin.tsconfig.json",
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/plugins/kubernetes/tsup.config.ts
+++ b/packages/plugins/kubernetes/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/plugin.ts'],
+  dts: true,
+  sourcemap: true,
+  treeshake: true,
+  clean: false,
+  outDir: 'dist',
+  format: ['cjs'],
+  splitting: false,
+  target: 'esnext',
+  external: ['varlock'],
+});

--- a/packages/plugins/kubernetes/vitest.config.ts
+++ b/packages/plugins/kubernetes/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    conditions: ['ts-src'],
+  },
+  define: {
+    __VARLOCK_BUILD_TYPE__: JSON.stringify('test'),
+    __VARLOCK_SEA_BUILD__: 'false',
+  },
+});

--- a/packages/varlock-website/src/content/docs/plugins/kubernetes.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/kubernetes.mdx
@@ -1,0 +1,104 @@
+---
+title: Kubernetes Plugin
+description: Using Kubernetes Secrets and ConfigMaps with Varlock
+---
+
+import Badge from '@/components/Badge.astro';
+
+<div class="page-badges">
+  <Badge npmPackage="@varlock/kubernetes-plugin" />
+</div>
+
+The Kubernetes plugin reads values from Kubernetes Secrets and ConfigMaps using declarative instructions in your `.env` files.
+
+It is read-only: it does not create, update, or delete Kubernetes resources.
+
+## Features
+
+- **Fetch Secret keys** with `k8sSecret()`
+- **Fetch ConfigMap keys** with `k8sConfigMap()`
+- **Bulk-load resources** with `k8sSecretBulk()` and `k8sConfigMapBulk()`
+- **Use local kubeconfig** for development
+- **Use in-cluster service account auth** when running inside Kubernetes
+- **Multiple plugin instances** for different namespaces or clusters
+
+## Installation and setup
+
+```env-spec title=".env.schema"
+# @plugin(@varlock/kubernetes-plugin)
+# @initKubernetes(namespace=default)
+# ---
+```
+
+For local development, the plugin uses your default kubeconfig. Inside a pod, it uses the mounted service account credentials.
+
+You can also provide explicit API server auth:
+
+```env-spec title=".env.schema"
+# @plugin(@varlock/kubernetes-plugin)
+# @initKubernetes(
+#   namespace=default,
+#   clusterServer="https://kubernetes.default.svc",
+#   token=$KUBERNETES_TOKEN
+# )
+# ---
+
+# @type=kubernetesBearerToken @sensitive
+KUBERNETES_TOKEN=
+```
+
+## Loading values
+
+```env-spec title=".env.schema"
+# The key defaults to the config item key
+DATABASE_URL=k8sSecret(app-secrets)
+
+# Or provide the key explicitly
+DB_URL=k8sSecret(app-secrets, DATABASE_URL)
+
+PUBLIC_API_HOST=k8sConfigMap(app-config, PUBLIC_API_HOST)
+```
+
+Kubernetes Secret values are base64-decoded before being returned.
+
+## Bulk loading
+
+Use bulk loading when a Secret or ConfigMap contains several environment variables:
+
+```env-spec title=".env.schema"
+# @plugin(@varlock/kubernetes-plugin)
+# @initKubernetes(namespace=default)
+# @setValuesBulk(k8sSecretBulk(app-secrets), format=json)
+# @setValuesBulk(k8sConfigMapBulk(app-config), format=json)
+# ---
+
+DATABASE_URL=
+API_KEY=
+PUBLIC_API_HOST=
+```
+
+## Multiple instances
+
+```env-spec title=".env.schema"
+# @initKubernetes(id=dev, namespace=dev)
+# @initKubernetes(id=prod, namespace=prod, context=prod)
+# ---
+
+DEV_DATABASE_URL=k8sSecret(dev, app-secrets, DATABASE_URL)
+PROD_DATABASE_URL=k8sSecret(prod, app-secrets, DATABASE_URL)
+```
+
+## Options
+
+`@initKubernetes()` supports:
+
+- `id` optional static instance id, defaults to `_default`
+- `namespace` optional namespace, defaults to kubeconfig context namespace or `default`
+- `context` optional kubeconfig context name
+- `kubeconfig` optional path to a kubeconfig file, or raw kubeconfig YAML/JSON
+- `clusterServer` optional Kubernetes API server URL for explicit auth
+- `token` optional bearer token for explicit auth
+- `skipTlsVerify` optional boolean for explicit auth
+- `allowMissing` optional boolean; missing resources or keys return `undefined`
+
+If `allowMissing=true` is used, mark optional config items with `@required=false` or wrap the resolver with `fallback()`.

--- a/packages/varlock-website/src/content/docs/plugins/kubernetes.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/kubernetes.mdx
@@ -3,67 +3,224 @@ title: Kubernetes Plugin
 description: Using Kubernetes Secrets and ConfigMaps with Varlock
 ---
 
+import { Steps, Icon } from '@astrojs/starlight/components';
 import Badge from '@/components/Badge.astro';
 
 <div class="page-badges">
   <Badge npmPackage="@varlock/kubernetes-plugin" />
 </div>
 
-The Kubernetes plugin reads values from Kubernetes Secrets and ConfigMaps using declarative instructions in your `.env` files.
+Our Kubernetes plugin enables loading values from Kubernetes [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) and [ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/) using declarative instructions within your `.env` files.
 
-It is read-only: it does not create, update, or delete Kubernetes resources.
+## Scope
+
+This plugin is **read-only**. It performs `get` requests on Secrets and ConfigMaps in a configured namespace and surfaces the values to your `.env` schema — nothing more. It does **not** create, update, or delete cluster resources, generate or template manifests, watch for changes, or manage deployments.
+
+**Typical use cases:**
+- **Local development** — pull dev/staging Secrets and ConfigMaps from a cluster into your local app without copying values by hand
+- **In-cluster runtime** — read additional Secrets/ConfigMaps at runtime that aren't already mounted into the pod via `envFrom` / `valueFrom`
+- **CI/CD** — read Secrets/ConfigMaps from a cluster using an explicit service account token
+
+It supports local kubeconfig, in-cluster service account credentials, and explicit API server + token authentication.
+
+:::note[Want deeper Kubernetes integration?]
+We're considering broader Kubernetes support (manifest generation, schema-to-deployment validation, change watching, etc.). If you have a use case this plugin doesn't cover, or feedback from running it in production, come chat on [Discord](https://chat.dmno.dev) — we'd love to hear from you.
+:::
 
 ## Features
 
-- **Fetch Secret keys** with `k8sSecret()`
-- **Fetch ConfigMap keys** with `k8sConfigMap()`
-- **Bulk-load resources** with `k8sSecretBulk()` and `k8sConfigMapBulk()`
-- **Use local kubeconfig** for development
-- **Use in-cluster service account auth** when running inside Kubernetes
-- **Multiple plugin instances** for different namespaces or clusters
+- **Zero-config local development** - Automatically uses your default kubeconfig (`~/.kube/config`)
+- **In-cluster authentication** - Auto-detects the mounted service account when running inside a pod
+- **Explicit auth** - Provide a cluster API URL and bearer token directly
+- **Fetch Secret keys** with `k8sSecret()` (values are automatically base64-decoded)
+- **Fetch ConfigMap keys** with `k8sConfigMap()` (including `binaryData`)
+- **Bulk-load** whole Secrets or ConfigMaps with `k8sSecretBulk()` / `k8sConfigMapBulk()`
+- **Auto-infer keys** from environment variable names
+- **Multiple instances** for different namespaces or clusters
+- **Read-only** — the plugin never mutates cluster state
 
 ## Installation and setup
+
+In a JS/TS project, you may install the `@varlock/kubernetes-plugin` package as a normal dependency.
+Otherwise you can just load it directly from your `.env.schema` file, as long as you add a version specifier.
+See the [plugins guide](/guides/plugins/#installation) for more instructions on installing plugins.
+
+```env-spec title=".env.schema"
+# 1. Load the plugin
+# @plugin(@varlock/kubernetes-plugin)
+#
+# 2. Initialize the plugin - see below for more details on options
+# @initKubernetes(namespace=default)
+```
+
+### Authentication options
+
+The plugin tries authentication methods in this priority order:
+1. **Explicit cluster server + token** - If `clusterServer` is provided in `@initKubernetes()`
+2. **Explicit kubeconfig** - If `kubeconfig` is provided (file path or raw YAML/JSON string)
+3. **In-cluster service account** - Auto-detected via `KUBERNETES_SERVICE_HOST`/`KUBERNETES_SERVICE_PORT` env vars (set automatically inside pods)
+4. **Default kubeconfig** - Loads from `$KUBECONFIG` or `~/.kube/config`
+
+### Automatic authentication (Recommended for local dev)
+
+For local development, just initialize the plugin and the plugin will pick up your default kubeconfig automatically:
 
 ```env-spec title=".env.schema"
 # @plugin(@varlock/kubernetes-plugin)
 # @initKubernetes(namespace=default)
-# ---
 ```
 
-For local development, the plugin uses your default kubeconfig. Inside a pod, it uses the mounted service account credentials.
+**How this works:**
 
-You can also provide explicit API server auth:
+- **Local development:** Uses your active `kubectl` context from `~/.kube/config` (or `$KUBECONFIG`)
+- **Inside a pod:** Uses the pod's mounted service account credentials at `/var/run/secrets/kubernetes.io/serviceaccount/`
+
+If your kubeconfig has multiple contexts, you can select one explicitly:
+
+```env-spec title=".env.schema"
+# @initKubernetes(namespace=default, context=my-dev-cluster)
+```
+
+### Explicit cluster server and token
+
+If you don't want to rely on a kubeconfig file — for example, in CI/CD or other deployed environments — provide the API server URL and a bearer token directly:
+
+<Steps>
+1. **Create a service account and RBAC** in your cluster (see Kubernetes Setup section below)
+
+2. **Wire up the credentials in your config**. Add a config item for the token and reference it when initializing the plugin.
+
+    ```env-spec title=".env.schema"
+    # @plugin(@varlock/kubernetes-plugin)
+    # @initKubernetes(
+    #   namespace=default,
+    #   clusterServer="https://kubernetes.example.com:6443",
+    #   token=$KUBERNETES_TOKEN
+    # )
+    # ---
+
+    # @type=kubernetesBearerToken @sensitive
+    KUBERNETES_TOKEN=
+    ```
+
+3. **Set your credentials in deployed environments**. Use your platform's env var management UI to securely inject the bearer token.
+</Steps>
+
+For clusters that present self-signed or custom-CA certificates, you can disable TLS verification by adding `skipTlsVerify=true` to `@initKubernetes()`. This should generally be avoided outside of development.
+
+### Raw kubeconfig
+
+You can also pass an entire kubeconfig as a string (YAML or JSON) — useful when injecting credentials from a secret manager or platform env var:
+
+```env-spec title=".env.schema"
+# @initKubernetes(kubeconfig=$KUBECONFIG_DATA)
+# ---
+
+# @sensitive
+KUBECONFIG_DATA=
+```
+
+The plugin auto-detects whether `kubeconfig` is a file path or raw content by looking for YAML/JSON markers.
+
+### Multiple instances
+
+If you need to read from multiple namespaces or clusters, register multiple named instances:
+
+```env-spec title=".env.schema"
+# @initKubernetes(id=dev, namespace=dev)
+# @initKubernetes(id=prod, namespace=prod, context=prod-cluster)
+# ---
+
+DEV_DATABASE_URL=k8sSecret(dev, app-secrets, DATABASE_URL)
+PROD_DATABASE_URL=k8sSecret(prod, app-secrets, DATABASE_URL)
+```
+
+## Loading values
+
+Once the plugin is installed and initialized, you can start adding config items that load values using the `k8sSecret()` and `k8sConfigMap()` resolver functions.
+
+### How Secrets and ConfigMaps are structured
+
+A Kubernetes Secret or ConfigMap is a **named resource that holds a map of key/value pairs**:
+
+```yaml title="Example Secret"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets       # ← the resource name
+data:
+  DATABASE_URL: cG9zdGdyZXM6...    # ← keys inside the resource
+  API_KEY: c2VjcmV0LWtleQ==
+```
+
+So fetching a value is always a two-level lookup: which Secret/ConfigMap (`name`), and which key inside it (`key`). The resolvers reflect this directly:
+
+- `k8sSecret(name, key)` — read `name.data.key`
+- `k8sConfigMap(name, key)` — read `name.data.key` (or `name.binaryData.key`)
+
+When `key` is omitted, the plugin uses the config item's name as the key — this works well when your Secret keys already match your env var names.
+
+### Secret keys
+
+The `k8sSecret()` function fetches a key from a Kubernetes Secret. Values stored in Secret `data` are base64-encoded; the plugin decodes them automatically before returning.
+
+```env-spec title=".env.schema"
+# Auto-infer key from item name (fetches "DATABASE_URL" from "app-secrets")
+DATABASE_URL=k8sSecret(app-secrets)
+
+# Explicit key name
+DB_URL=k8sSecret(app-secrets, DATABASE_URL)
+
+# Named args also work
+DB_URL=k8sSecret(name=app-secrets, key=DATABASE_URL)
+
+# With named instance
+PROD_DB_URL=k8sSecret(prod, app-secrets, DATABASE_URL)
+```
+
+### ConfigMap keys
+
+The `k8sConfigMap()` function fetches a key from a Kubernetes ConfigMap. Both `data` (string) and `binaryData` (base64-encoded) fields are supported.
+
+```env-spec title=".env.schema"
+# Auto-infer key from item name
+PUBLIC_API_HOST=k8sConfigMap(app-config)
+
+# Explicit key name
+API_HOST=k8sConfigMap(app-config, PUBLIC_API_HOST)
+```
+
+### Default Secret/ConfigMap (Recommended for the common case)
+
+The idiomatic Kubernetes deployment pattern is one Secret + one ConfigMap per app, mounted into the pod via `envFrom`. If your app follows this pattern, set `defaultSecret` and `defaultConfigMap` once on the init decorator and skip the name argument on every call:
 
 ```env-spec title=".env.schema"
 # @plugin(@varlock/kubernetes-plugin)
 # @initKubernetes(
 #   namespace=default,
-#   clusterServer="https://kubernetes.default.svc",
-#   token=$KUBERNETES_TOKEN
+#   defaultSecret=app-secrets,
+#   defaultConfigMap=app-config,
 # )
 # ---
 
-# @type=kubernetesBearerToken @sensitive
-KUBERNETES_TOKEN=
+# Both default to app-secrets / app-config and infer the key from the item name
+DATABASE_URL=k8sSecret()
+API_KEY=k8sSecret()
+JWT_SECRET=k8sSecret()
+PUBLIC_API_HOST=k8sConfigMap()
+
+# Override just the key while still using the default Secret
+STRIPE_KEY=k8sSecret(key=stripe_api_key)
+
+# Override the resource name to read from a different Secret
+SHARED_TOKEN=k8sSecret(shared-secrets, AUTH_TOKEN)
 ```
 
-## Loading values
+You can mix positional and named arguments, but you can't provide the same field twice — e.g., `k8sSecret(app-secrets, name=other-secrets)` is a schema error.
 
-```env-spec title=".env.schema"
-# The key defaults to the config item key
-DATABASE_URL=k8sSecret(app-secrets)
+### Bulk loading
 
-# Or provide the key explicitly
-DB_URL=k8sSecret(app-secrets, DATABASE_URL)
-
-PUBLIC_API_HOST=k8sConfigMap(app-config, PUBLIC_API_HOST)
-```
-
-Kubernetes Secret values are base64-decoded before being returned.
-
-## Bulk loading
-
-Use bulk loading when a Secret or ConfigMap contains several environment variables:
+Use bulk loading when a single Secret or ConfigMap contains several environment variables you want to map into your config. The bulk resolvers return all keys as a JSON object, which pairs naturally with `@setValuesBulk`:
 
 ```env-spec title=".env.schema"
 # @plugin(@varlock/kubernetes-plugin)
@@ -77,28 +234,330 @@ API_KEY=
 PUBLIC_API_HOST=
 ```
 
-## Multiple instances
+Only items declared in your schema will be populated — any extra keys in the Secret or ConfigMap are ignored.
+
+Bulk resolvers also pick up `defaultSecret`/`defaultConfigMap`, so the names can be omitted entirely:
 
 ```env-spec title=".env.schema"
-# @initKubernetes(id=dev, namespace=dev)
-# @initKubernetes(id=prod, namespace=prod, context=prod)
-# ---
-
-DEV_DATABASE_URL=k8sSecret(dev, app-secrets, DATABASE_URL)
-PROD_DATABASE_URL=k8sSecret(prod, app-secrets, DATABASE_URL)
+# @initKubernetes(defaultSecret=app-secrets, defaultConfigMap=app-config)
+# @setValuesBulk(k8sSecretBulk(), format=json)
+# @setValuesBulk(k8sConfigMapBulk(), format=json)
 ```
 
-## Options
+### Optional values
 
-`@initKubernetes()` supports:
+By default, fetching a key from a missing Secret/ConfigMap throws an error. If you want missing resources or keys to resolve to `undefined` instead, set `allowMissing=true`:
 
-- `id` optional static instance id, defaults to `_default`
-- `namespace` optional namespace, defaults to kubeconfig context namespace or `default`
-- `context` optional kubeconfig context name
-- `kubeconfig` optional path to a kubeconfig file, or raw kubeconfig YAML/JSON
-- `clusterServer` optional Kubernetes API server URL for explicit auth
-- `token` optional bearer token for explicit auth
-- `skipTlsVerify` optional boolean for explicit auth
-- `allowMissing` optional boolean; missing resources or keys return `undefined`
+```env-spec title=".env.schema"
+# @initKubernetes(namespace=default, allowMissing=true)
+# ---
 
-If `allowMissing=true` is used, mark optional config items with `@required=false` or wrap the resolver with `fallback()`.
+# @required=false
+OPTIONAL_FLAG=k8sConfigMap(feature-flags, NEW_UI)
+```
+
+When `allowMissing=true`, also mark the corresponding items with `@required=false` (or wrap the resolver with `fallback()`) so validation does not fail.
+
+---
+
+## Kubernetes Setup
+
+### Required RBAC permissions
+
+The identity used by the plugin (your kubeconfig user, an in-cluster service account, or an explicit token) needs read access to Secrets and/or ConfigMaps in the target namespace.
+
+The minimum permissions are `get` on `secrets` and `configmaps`:
+
+```yaml title="varlock-rbac.yaml"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: varlock-reader
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
+    verbs: ["get"]
+```
+
+Apply it with:
+
+```bash
+kubectl apply -f varlock-rbac.yaml
+```
+
+:::tip[Least privilege principle]
+Scope down `resources` to only what you need. If you're only reading ConfigMaps, omit `"secrets"` entirely. For multi-namespace access, use a `ClusterRole` + `ClusterRoleBinding` instead, but prefer namespaced `Role`s whenever possible.
+:::
+
+### Service account for in-cluster use
+
+When running inside a pod, the plugin uses the pod's mounted service account. Create a dedicated service account and bind it to the role above:
+
+<Steps>
+1. **Create a service account**
+    ```bash
+    kubectl create serviceaccount varlock-reader -n default
+    ```
+
+2. **Bind the role to the service account**
+    ```yaml title="varlock-rolebinding.yaml"
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: varlock-reader-binding
+      namespace: default
+    subjects:
+      - kind: ServiceAccount
+        name: varlock-reader
+        namespace: default
+    roleRef:
+      kind: Role
+      name: varlock-reader
+      apiGroup: rbac.authorization.k8s.io
+    ```
+
+    ```bash
+    kubectl apply -f varlock-rolebinding.yaml
+    ```
+
+3. **Use the service account in your pod spec**
+    ```yaml title="deployment.yaml"
+    spec:
+      serviceAccountName: varlock-reader
+      containers:
+        - name: app
+          image: my-app:latest
+    ```
+</Steps>
+
+### Generate a bearer token for explicit auth
+
+For CI/CD or other external use cases that need an explicit token, create a long-lived service account token:
+
+```bash
+# Create a token secret bound to the service account
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: varlock-reader-token
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: varlock-reader
+type: kubernetes.io/service-account-token
+EOF
+
+# Read the token
+kubectl get secret varlock-reader-token -n default -o jsonpath='{.data.token}' | base64 -d
+```
+
+Inject the resulting token into your deployment environment as `KUBERNETES_TOKEN` (or whatever name you wire up in `@initKubernetes()`).
+
+### Verify access
+
+You can test that the configured identity can read the resources you expect:
+
+```bash
+# As your current kubeconfig user
+kubectl auth can-i get secrets -n default
+kubectl auth can-i get configmaps -n default
+
+# As a specific service account
+kubectl auth can-i get secrets -n default --as=system:serviceaccount:default:varlock-reader
+```
+
+---
+
+## Reference
+
+### Root decorators
+<div class="reference-docs">
+<div>
+#### `@initKubernetes()`
+
+Initialize a Kubernetes plugin instance for `k8sSecret()`, `k8sConfigMap()`, `k8sSecretBulk()`, and `k8sConfigMapBulk()` resolvers.
+
+**Key/value args:**
+- `id` (optional, static): Instance identifier for multiple instances, defaults to `_default`
+- `namespace` (optional): Kubernetes namespace to read from. Defaults to the kubeconfig context namespace, the pod's mounted service account namespace (when in-cluster), or `default`
+- `context` (optional): Kubeconfig context name to use (overrides the current context)
+- `kubeconfig` (optional): Path to a kubeconfig file, or raw kubeconfig YAML/JSON content
+- `clusterServer` (optional): Kubernetes API server URL for explicit auth (e.g., `https://kubernetes.example.com:6443`)
+- `token` (optional): Bearer token for explicit auth
+- `skipTlsVerify` (optional): Set to `true` to skip TLS verification on the cluster certificate. Only applies when using `clusterServer` + `token`
+- `allowMissing` (optional): If `true`, missing resources or keys return `undefined` instead of throwing
+- `defaultSecret` (optional): Default Secret name used by `k8sSecret()` / `k8sSecretBulk()` when no name argument is provided
+- `defaultConfigMap` (optional): Default ConfigMap name used by `k8sConfigMap()` / `k8sConfigMapBulk()` when no name argument is provided
+
+```env-spec "@initKubernetes"
+# @initKubernetes(namespace=default, defaultSecret=app-secrets, defaultConfigMap=app-config)
+```
+</div>
+</div>
+
+### Data types
+<div class="reference-docs">
+<div>
+#### `kubernetesBearerToken`
+
+Represents a Kubernetes bearer token used for API server authentication (typically a service account token). This type is marked as `@sensitive`.
+
+```env-spec "kubernetesBearerToken"
+# @type=kubernetesBearerToken
+KUBERNETES_TOKEN=
+```
+</div>
+</div>
+
+### Resolver functions
+<div class="reference-docs">
+<div>
+#### `k8sSecret()`
+
+Fetch a single key from a Kubernetes Secret. Secret `data` values are base64-decoded automatically.
+
+Arguments can be provided positionally or as named arguments, but the same field cannot be provided both ways.
+
+**Array args (positional):**
+- `instanceId` (optional, static): Instance identifier to use when multiple plugin instances are initialized
+- `name` (optional): Name of the Secret resource. Required unless `defaultSecret` is set on `@initKubernetes()`
+- `key` (optional): Key inside the Secret's `data` to fetch. If omitted, uses the item key (variable name)
+
+**Named args:**
+- `id` (optional, static): same as positional `instanceId`
+- `name` (optional): same as positional `name`
+- `key` (optional): same as positional `key`
+
+```env-spec /k8sSecret\(.*\)/
+# Auto-infer key from item name
+DATABASE_URL=k8sSecret(app-secrets)
+
+# Explicit key name (positional)
+DB_URL=k8sSecret(app-secrets, DATABASE_URL)
+
+# Override just the key (uses defaultSecret from @initKubernetes)
+STRIPE_KEY=k8sSecret(key=stripe_api_key)
+
+# Both positional and named
+DB_URL=k8sSecret(name=app-secrets, key=DATABASE_URL)
+
+# With instance ID
+PROD_DB=k8sSecret(prod, app-secrets, DATABASE_URL)
+```
+</div>
+
+<div>
+#### `k8sConfigMap()`
+
+Fetch a single key from a Kubernetes ConfigMap. Both `data` and `binaryData` fields are supported.
+
+Arguments can be provided positionally or as named arguments, but the same field cannot be provided both ways.
+
+**Array args (positional):**
+- `instanceId` (optional, static): Instance identifier to use when multiple plugin instances are initialized
+- `name` (optional): Name of the ConfigMap resource. Required unless `defaultConfigMap` is set on `@initKubernetes()`
+- `key` (optional): Key inside the ConfigMap to fetch. If omitted, uses the item key (variable name)
+
+**Named args:**
+- `id` (optional, static): same as positional `instanceId`
+- `name` (optional): same as positional `name`
+- `key` (optional): same as positional `key`
+
+```env-spec /k8sConfigMap\(.*\)/
+# Auto-infer key from item name
+PUBLIC_API_HOST=k8sConfigMap(app-config)
+
+# Explicit key name
+API_HOST=k8sConfigMap(app-config, PUBLIC_API_HOST)
+
+# Named args
+API_HOST=k8sConfigMap(name=app-config, key=PUBLIC_API_HOST)
+
+# With instance ID
+DEV_HOST=k8sConfigMap(dev, app-config, PUBLIC_API_HOST)
+```
+</div>
+
+<div>
+#### `k8sSecretBulk()`
+
+Fetch all keys from a Kubernetes Secret as a JSON object string. Designed to be used with `@setValuesBulk(..., format=json)`.
+
+**Array args (positional):**
+- `instanceId` (optional, static): Instance identifier to use when multiple plugin instances are initialized
+- `name` (optional): Name of the Secret resource. Required unless `defaultSecret` is set on `@initKubernetes()`
+
+**Named args:**
+- `id` (optional, static): same as positional `instanceId`
+- `name` (optional): same as positional `name`
+
+```env-spec /k8sSecretBulk\(.*\)/
+# Uses defaultSecret from @initKubernetes
+# @setValuesBulk(k8sSecretBulk(), format=json)
+
+# Explicit name
+# @setValuesBulk(k8sSecretBulk(app-secrets), format=json)
+
+# With instance ID
+# @setValuesBulk(k8sSecretBulk(prod, app-secrets), format=json)
+```
+</div>
+
+<div>
+#### `k8sConfigMapBulk()`
+
+Fetch all keys from a Kubernetes ConfigMap as a JSON object string. Designed to be used with `@setValuesBulk(..., format=json)`.
+
+**Array args (positional):**
+- `instanceId` (optional, static): Instance identifier to use when multiple plugin instances are initialized
+- `name` (optional): Name of the ConfigMap resource. Required unless `defaultConfigMap` is set on `@initKubernetes()`
+
+**Named args:**
+- `id` (optional, static): same as positional `instanceId`
+- `name` (optional): same as positional `name`
+
+```env-spec /k8sConfigMapBulk\(.*\)/
+# @setValuesBulk(k8sConfigMapBulk(app-config), format=json)
+
+# @setValuesBulk(k8sConfigMapBulk(prod, app-config), format=json)
+```
+</div>
+</div>
+
+---
+
+## Troubleshooting
+
+### Secret or ConfigMap not found (404)
+- Verify the resource exists: `kubectl get secret <name> -n <namespace>` or `kubectl get configmap <name> -n <namespace>`
+- Double-check the namespace — the plugin reads only from the configured namespace
+- Resource names are case-sensitive and namespace-scoped
+- If the resource is genuinely optional, set `allowMissing=true` on `@initKubernetes()` and `@required=false` on the item
+
+### Permission denied (403)
+- Check that the active identity has the required RBAC: `kubectl auth can-i get secrets -n <namespace>`
+- For in-cluster use, verify the pod's `serviceAccountName` is set and bound to a `Role`/`ClusterRole` that grants `get` on `secrets`/`configmaps`
+- The error message includes the exact `Role` snippet you need to grant
+
+### Authentication failed (401)
+- **Local dev:** Run `kubectl config current-context` and verify it points to the right cluster; run `kubectl get secrets` to confirm your kubeconfig works
+- **Explicit token:** Verify the token isn't expired or revoked. Service account tokens created from `kubernetes.io/service-account-token` Secrets are long-lived, but TokenRequest-issued tokens have shorter TTLs
+- **In-cluster:** Check the pod's mounted service account token at `/var/run/secrets/kubernetes.io/serviceaccount/token`
+
+### Connection refused or TLS errors
+- Verify the cluster API URL is reachable from your machine/pod
+- For clusters with self-signed certificates and explicit auth, set `skipTlsVerify=true` (development only)
+- If using `kubectl` works but the plugin doesn't, your kubeconfig may rely on an [exec credential plugin](https://kubernetes.io/docs/reference/config-api/client-authentication.v1beta1/) (e.g., `aws eks get-token`, `gke-gcloud-auth-plugin`, `kubelogin`) — ensure the helper binary is on your `$PATH`
+
+### Wrong namespace
+- The plugin uses (in order): the explicit `namespace` argument, the current kubeconfig context's namespace, the pod's mounted SA namespace, or `default`
+- To force a specific namespace, pass it explicitly: `@initKubernetes(namespace=my-ns)`
+
+## Resources
+
+- [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)
+- [Kubernetes ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/)
+- [Kubernetes RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [Service Account Tokens](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/)
+- [`@kubernetes/client-node`](https://github.com/kubernetes-client/javascript)

--- a/packages/varlock-website/src/content/docs/plugins/overview.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/overview.mdx
@@ -25,6 +25,7 @@ For now, only official Varlock plugins under the `@varlock` npm scope are suppor
 | [Infisical](/plugins/infisical/) | <Badge npmPackage="@varlock/infisical-plugin" /> |
 | [KeePass](/plugins/keepass/) | <Badge npmPackage="@varlock/keepass-plugin" /> |
 | [Keeper](/plugins/keeper/) | <Badge npmPackage="@varlock/keeper-plugin" /> |
+| [Kubernetes](/plugins/kubernetes/) (Secrets & ConfigMaps) | <Badge npmPackage="@varlock/kubernetes-plugin" /> |
 | [macOS Keychain](/plugins/macos-keychain/)| N/A - built-in |
 | [Pass](/plugins/pass/) (unix password manager) | <Badge npmPackage="@varlock/pass-plugin" /> |
 | [Passbolt](/plugins/passbolt/) | <Badge npmPackage="@varlock/passbolt-plugin" /> |


### PR DESCRIPTION
## Summary

  Adds `@varlock/kubernetes-plugin`, a read-only Varlock plugin for loading values from Kubernetes Secrets and ConfigMaps.

  ## What changed

  - Added `packages/plugins/kubernetes`
  - Added `@initKubernetes()`
  - Added resolver functions:
    - `k8sSecret()`
    - `k8sConfigMap()`
    - `k8sSecretBulk()`
    - `k8sConfigMapBulk()`
  - Supports local kubeconfig, in-cluster service account auth, explicit `clusterServer`/`token`, namespaces, contexts, named instances, and `allowMissing`
  - Added mocked Kubernetes API tests
  - Added README and website docs
  - Added plugin listings
  - Added bumpy changeset for initial `0.1.0` release

  ## Security

  The plugin is read-only. It only performs Kubernetes `get` requests for Secrets and ConfigMaps and does not create, update, or delete cluster resources.

  ## Verification

  - `npx --yes bun@1.3.11 run lint`
  - `npx --yes bun@1.3.11 run build:libs`
  - `npx --yes bun@1.3.11 run --filter @varlock/kubernetes-plugin test`
  - `npx --yes bun@1.3.11 run --filter @varlock/kubernetes-plugin typecheck`
  - `node_modules/.bin/bumpy check --hook pre-push`

  Also ran a read-only live smoke test against an existing Kubernetes context by reading the standard `kube-root-ca.crt` ConfigMap.