### PR TITLE
fix(vscode-plugin): highlight URL fragments in @docs() decorator

### DIFF
--- a/.bumpy/fix-vscode-url-fragment-highlighting.md
+++ b/.bumpy/fix-vscode-url-fragment-highlighting.md
@@ -1,5 +1,6 @@
 ---
 env-spec-language: patch
+"@env-spec/parser": patch
 ---
 
 Fixed URL fragments in @docs() decorator not being highlighted correctly.

--- a/.bumpy/fix-vscode-url-fragment-highlighting.md
+++ b/.bumpy/fix-vscode-url-fragment-highlighting.md
@@ -1,0 +1,6 @@
+---
+env-spec-language: patch
+"@env-spec/parser": patch
+---
+
+Fixed URL fragments in @docs() decorator not being highlighted correctly.

--- a/.bumpy/fix-vscode-url-fragment-highlighting.md
+++ b/.bumpy/fix-vscode-url-fragment-highlighting.md
@@ -1,6 +1,5 @@
 ---
 env-spec-language: patch
-"@env-spec/parser": patch
 ---
 
 Fixed URL fragments in @docs() decorator not being highlighted correctly.

--- a/packages/env-spec-parser/README.md
+++ b/packages/env-spec-parser/README.md
@@ -10,7 +10,7 @@ _Here is a short illustrative example:_
 ```dotenv
 # Stripe secret api key
 # @required @sensitive @type=string(startsWith="sk_")
-# @docsUrl=https://docs.stripe.com/keys
+# @docs(https://docs.stripe.com/keys)
 STRIPE_SECRET_KEY=encrypted("asdfqwerqwe2374298374lksdjflksdjf981273948okjdfksdl")
 ```
 

--- a/packages/vscode-plugin/.env.example
+++ b/packages/vscode-plugin/.env.example
@@ -16,7 +16,7 @@ APP_ENV=remap($WORKERS_CI_BRANCH, "main", production, regex(.*), preview, undefi
 
 # OpenAI API Key
 # @required @sensitive @type=string(startsWith=sk-)
-# @docsUrl=https://platform.openai.com/docs/api-reference/authentication
+# @docs(https://developers.openai.com/api/reference/overview#authentication)
 OPENAI_API_KEY=exec('op read "op://api-config-prod/openai/api-key"')
 
 

--- a/packages/vscode-plugin/language/env-spec.tmLanguage.json
+++ b/packages/vscode-plugin/language/env-spec.tmLanguage.json
@@ -629,7 +629,7 @@
 
     "unquoted-string-within-fn-call": {
       "comment": "unquoted string value within fn call",
-      "match": "([^ \n#,)$]+)",
+      "match": "([^ \n,)$]+)",
       "name": "string.unquoted.env-spec",
       "captures": {
         "1": {

--- a/packages/vscode-plugin/test/grammar.test.txt
+++ b/packages/vscode-plugin/test/grammar.test.txt
@@ -61,6 +61,20 @@ EXAMPLE_VAR=test
 # <- comment.line.env-spec
 DEC_FN_VAR=test
 
+# @docs(https://varlock.dev/env-spec/overview/#a-short-example)
+# <- comment.line.env-spec
+#                                             ^^^^^^^^^^^^^^^^ string.unquoted.env-spec
+DOCS_FRAGMENT_VAR=test
+
+# @type(
+#   string,
+#   ^^^^^^ string.unquoted.env-spec
+#   number
+#   ^^^^^^ string.unquoted.env-spec
+# )
+# ^ punctuation.section.parens.end.env-spec
+MULTI_DEC_VAR=test
+
 # ======================
 # Variable expansion
 # ======================


### PR DESCRIPTION
## Summary

When adding the item decorator @docs() with a URL that had a fragment, the fragment symbol itself `#` fell out of the syntax scope: 
<img width="556" height="72" alt="image" src="https://github.com/user-attachments/assets/9c0b7644-d303-41c8-975d-d22a33bbce86" />

## Fix
Removed `#` from the `unquoted-string-within-fn-call`. Since this rule is bounded by parenthesis it should hold no special meaning, unless I've missed a special case 👀 

Added some tests to verify the behaviour, as well as multiline fn-calls.

Some examples containing the deprecated docsUrl decorator was changed to docs

After implementing the fix:
<img width="556" height="76" alt="image" src="https://github.com/user-attachments/assets/e60a8581-b3b3-4136-ba1e-dcd98afc3713" />

Let me know if I missed or need to change something!