### PR TITLE
fix(infisical): restore OIDC auth flow for SDK v5

### DIFF
--- a/.bumpy/infisical-oidc-sdk-v5-fix.md
+++ b/.bumpy/infisical-oidc-sdk-v5-fix.md
@@ -1,0 +1,5 @@
+---
+"@varlock/infisical-plugin": patch
+---
+
+fix OIDC auth for @infisical/sdk v5 by exchanging JWT via oidc-auth login endpoint

--- a/packages/plugins/infisical/package.json
+++ b/packages/plugins/infisical/package.json
@@ -45,7 +45,7 @@
     "varlock": "workspace:^"
   },
   "devDependencies": {
-    "@infisical/sdk": "^5.0.0",
+    "@infisical/sdk": "^5.0.2",
     "@env-spec/utils": "workspace:^",
     "@types/node": "catalog:",
     "tsup": "catalog:",

--- a/packages/plugins/infisical/src/plugin.ts
+++ b/packages/plugins/infisical/src/plugin.ts
@@ -62,6 +62,35 @@ class InfisicalPluginInstance {
   }
 
   private infisicalClientPromise?: Promise<InfisicalSDK>;
+  private static readonly defaultSiteUrl = 'https://app.infisical.com';
+
+  private async exchangeOidcToken(identityId: string, jwt: string): Promise<string> {
+    const response = await fetch(
+      `${this.siteUrl || InfisicalPluginInstance.defaultSiteUrl}/api/v1/auth/oidc-auth/login`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          identityId,
+          jwt,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      const responseText = await response.text().catch(() => '');
+      throw new Error(responseText || `OIDC login failed with status ${response.status}`);
+    }
+
+    const payload = await response.json() as { accessToken?: string };
+    if (!payload.accessToken) {
+      throw new Error('OIDC login response did not include accessToken');
+    }
+
+    return payload.accessToken;
+  }
 
   private async initClient() {
     if (this.infisicalClientPromise) return this.infisicalClientPromise;
@@ -110,10 +139,8 @@ class InfisicalPluginInstance {
             });
           }
 
-          await (client.auth() as any).oidcAuth.login({
-            identityId: this.identityId,
-            jwt,
-          });
+          const accessToken = await this.exchangeOidcToken(this.identityId, jwt);
+          client.auth().accessToken(accessToken);
           debug('Infisical client initialized with OIDC Auth');
         }
 


### PR DESCRIPTION
## Summary
- replace the removed `client.auth().oidcAuth.login(...)` call with an explicit OIDC exchange against Infisical's `/api/v1/auth/oidc-auth/login` endpoint
- set the returned token on the SDK via `client.auth().accessToken(accessToken)`
- bump `@infisical/sdk` devDependency in the plugin package from `^5.0.0` to `^5.0.2`
- add a bumpy patch file for `@varlock/infisical-plugin`

## Validation
- `bun run --filter @varlock/infisical-plugin typecheck`
- `bun run --filter @varlock/infisical-plugin build`
- `bun run lint:fix`

## Context
Refs #746.

Could the reporter please validate this branch in the same GitHub Actions OIDC workflow from the issue?
