### PR TITLE
Scope CI audit to changed workspaces and add nightly full audit

### DIFF
--- a/.github/workflows/nightly-audit.yaml
+++ b/.github/workflows/nightly-audit.yaml
@@ -1,0 +1,20 @@
+name: Nightly dependency audit
+on:
+  schedule:
+    - cron: '15 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install js deps (w/ bun)
+        run: bun install
+      - name: Full dependency audit
+        run: bun run audit:full

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install js deps (w/ bun)
         run: bun install
       - name: Audit dependencies
-        run: bun audit --audit-level=moderate
+        run: bun run audit:changed
       - name: Enable turborepo build cache
         uses: rharkor/caching-for-turbo@56219402aacc0d06b650d898c222996dbc1191ec # v2.3.14
 

--- a/bun.lock
+++ b/bun.lock
@@ -512,6 +512,7 @@
   "overrides": {
     "@modelcontextprotocol/sdk": ">=1.29.0",
     "@xmldom/xmldom": ">=0.9.10",
+    "hono": ">=4.12.21",
     "postcss": ">=8.5.10",
     "qs": "^6.15.2",
     "tmp": ">=0.2.6",
@@ -2165,7 +2166,7 @@
 
     "headers-polyfill": ["headers-polyfill@5.0.1", "", { "dependencies": { "@types/set-cookie-parser": "^2.4.10", "set-cookie-parser": "^3.0.1" } }, "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA=="],
 
-    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
+    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
 
     "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript-eslint": "^8.56.1",
     "varlock": "workspace:*"
   },
-  "packageManager": "bun@1.3.11",
+  "packageManager": "bun@1.3.14",
   "engines": {
     "node": ">=22"
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "dev": "turbo run dev --concurrency=40 --parallel --filter=\"!smoke-test-*\"",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "audit:changed": "bun run scripts/audit-changed-packages.ts --audit-level=moderate",
+    "audit:full": "bun audit --audit-level=moderate",
     "bumpy:add": "bumpy add",
     "release:create-missing-tags": "node scripts/create-missing-release-tags.js",
     "prepare": "lefthook install"
@@ -60,6 +62,7 @@
   "overrides": {
     "@xmldom/xmldom": ">=0.9.10",
     "@modelcontextprotocol/sdk": ">=1.29.0",
+    "hono": ">=4.12.21",
     "postcss": ">=8.5.10",
     "qs": "^6.15.2",
     "ws": ">=8.20.1",

--- a/scripts/audit-changed-packages.ts
+++ b/scripts/audit-changed-packages.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env bun
+import { execSync, spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { listWorkspaces } from './list-workspaces';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MONOREPO_ROOT = path.resolve(__dirname, '..');
+
+type Workspace = { name: string; version: string; path: string };
+
+function runGitCommand(cmd: string) {
+  return execSync(cmd, {
+    cwd: MONOREPO_ROOT,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function safeRunGitCommand(cmd: string): string | null {
+  try {
+    return runGitCommand(cmd);
+  } catch {
+    return null;
+  }
+}
+
+function fetchRefIfNeeded(ref: string) {
+  if (!ref.startsWith('origin/')) return;
+  const branch = ref.slice('origin/'.length);
+  if (!branch) return;
+
+  try {
+    execSync(`git fetch origin ${branch} --depth=1`, {
+      cwd: MONOREPO_ROOT,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch {
+    // If fetch fails, later diff will fail and we fall back safely.
+  }
+}
+
+function parseAuditLevel(args: Array<string>) {
+  const flag = args.find((arg) => arg.startsWith('--audit-level='));
+  return flag?.split('=')[1] || 'moderate';
+}
+
+function resolveBaseRef() {
+  const baseRef = process.env.GITHUB_BASE_REF;
+  if (baseRef) return `origin/${baseRef}`;
+
+  const beforeSha = process.env.GITHUB_EVENT_BEFORE;
+  if (beforeSha && !/^0+$/.test(beforeSha)) return beforeSha;
+
+  const mergeBase = safeRunGitCommand('git merge-base HEAD origin/main');
+  if (mergeBase) return mergeBase;
+
+  const previousCommit = safeRunGitCommand('git rev-parse HEAD~1');
+  if (previousCommit) return previousCommit;
+
+  return null;
+}
+
+function getChangedFiles(baseRef: string) {
+  const diff = runGitCommand(`git diff --name-only ${baseRef}...HEAD`);
+  return diff.split('\n').filter(Boolean);
+}
+
+function isWithinDir(filePath: string, directory: string) {
+  return filePath === directory || filePath.startsWith(`${directory}/`);
+}
+
+function getChangedWorkspaces(changedFiles: Array<string>, workspaces: Array<Workspace>) {
+  const changed = new Map<string, Workspace>();
+
+  for (const filePath of changedFiles) {
+    for (const ws of workspaces) {
+      const relativeWsDir = path.relative(MONOREPO_ROOT, ws.path).replace(/\\/g, '/');
+      if (isWithinDir(filePath, relativeWsDir)) {
+        changed.set(ws.path, ws);
+        break;
+      }
+    }
+  }
+
+  return [...changed.values()];
+}
+
+function shouldAuditRoot(changedFiles: Array<string>) {
+  const rootTriggers = new Set([
+    'package.json',
+    '.npmrc',
+  ]);
+  return changedFiles.some((filePath) => rootTriggers.has(filePath));
+}
+
+function runAudit(cwd: string, label: string, auditLevel: string) {
+  console.log(`\n--- bun audit (${label}) ---`);
+  const result = spawnSync('bun', ['audit', `--audit-level=${auditLevel}`], {
+    cwd,
+    stdio: 'inherit',
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+async function main() {
+  const auditLevel = parseAuditLevel(process.argv.slice(2));
+  const baseRef = resolveBaseRef();
+
+  if (!baseRef) {
+    console.log('Could not determine a git base ref. Running full root audit as fallback.');
+    runAudit(MONOREPO_ROOT, 'repo-root (fallback)', auditLevel);
+    return;
+  }
+
+  fetchRefIfNeeded(baseRef);
+
+  let changedFiles: Array<string>;
+  try {
+    changedFiles = getChangedFiles(baseRef);
+  } catch (err) {
+    console.log(`Failed to diff against ${baseRef}. Running full root audit as fallback.`);
+    if (err instanceof Error && err.message) {
+      console.log(err.message);
+    }
+    runAudit(MONOREPO_ROOT, 'repo-root (fallback)', auditLevel);
+    return;
+  }
+
+  if (changedFiles.length === 0) {
+    console.log(`No changed files since ${baseRef}. Skipping audit.`);
+    return;
+  }
+
+  const workspaces = await listWorkspaces(MONOREPO_ROOT);
+  const changedWorkspaces = getChangedWorkspaces(changedFiles, workspaces);
+  const auditRoot = shouldAuditRoot(changedFiles);
+
+  console.log(`Base ref: ${baseRef}`);
+  console.log(`Changed files: ${changedFiles.length}`);
+  console.log(`Changed workspaces: ${changedWorkspaces.map((ws) => ws.name).join(', ') || '(none)'}`);
+  console.log(`Root audit required: ${auditRoot}`);
+
+  if (auditRoot) {
+    runAudit(MONOREPO_ROOT, 'repo-root', auditLevel);
+  }
+
+  if (changedWorkspaces.length === 0) {
+    if (!auditRoot) {
+      console.log('No changed workspace packages and no root dependency metadata changed. Skipping audit.');
+    }
+    return;
+  }
+
+  for (const ws of changedWorkspaces) {
+    runAudit(ws.path, ws.name, auditLevel);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- switch PR CI dependency audit from full-repo to changed-workspaces only
- add `scripts/audit-changed-packages.ts` to detect changed workspace packages and run targeted `bun audit`
- add nightly full dependency audit workflow (`.github/workflows/nightly-audit.yaml`)
- keep root audit in scoped flow only when root dependency metadata changes
- add `audit:changed` and `audit:full` scripts for consistency
- enforce safe transitive floor with `hono >= 4.12.21` override

## Why
`bun audit` was blocking unrelated PRs due to full-repo auditing. This keeps PR checks focused while preserving broad coverage via nightly full scans.

## Validation
- `bun run lint:fix`
- `bun run audit:full`
- `bun run audit:changed`
