### PR TITLE
fix: share biometric session across parallel task runners; prevent duplicate daemons

### DIFF
--- a/.bumpy/fix-turbo-session-and-daemon-race.md
+++ b/.bumpy/fix-turbo-session-and-daemon-race.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+fix biometric session fragmentation under turborepo and prevent duplicate daemons from parallel-spawn races

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/IPCServer.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/IPCServer.swift
@@ -25,6 +25,70 @@ final class IPCServer {
         self.socketPath = socketPath
     }
 
+    // MARK: - Stuck-daemon Recovery
+
+    /// Lock-age threshold below which a flock failure is treated as a
+    /// parallel-spawn race rather than a stuck holder. See `start()`.
+    static let freshLockThresholdSeconds: Double = 5.0
+
+    /// Age of the lock file in seconds (since its mtime). Returns +Infinity
+    /// if the file can't be stat'd, which makes callers treat it as "old".
+    static func lockFileAgeSeconds(path: String) -> Double {
+        var st = stat()
+        guard stat(path, &st) == 0 else { return .infinity }
+        return max(0, Double(time(nil)) - Double(st.st_mtimespec.tv_sec))
+    }
+
+    /// Probe the daemon's IPC socket with a framed `ping` request. Returns
+    /// true if any bytes come back within `timeoutMs`. We don't parse the
+    /// response — receipt of a reply is sufficient evidence the daemon is
+    /// alive and serving requests.
+    static func existingDaemonResponsive(socketPath: String, timeoutMs: Int32) -> Bool {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+
+        var tv = timeval(
+            tv_sec: __darwin_time_t(timeoutMs / 1000),
+            tv_usec: __darwin_suseconds_t((timeoutMs % 1000) * 1000)
+        )
+        _ = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+        _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            socketPath.withCString { cstr in
+                _ = strcpy(UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self), cstr)
+            }
+        }
+        let connectResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                connect(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connectResult == 0 else { return false }
+
+        let json = #"{"id":"lock-probe","action":"ping"}"#
+        guard let body = json.data(using: .utf8) else { return false }
+        let lenBytes = withUnsafeBytes(of: UInt32(body.count).littleEndian) { Array($0) }
+
+        let sentLen = lenBytes.withUnsafeBufferPointer { buf in
+            send(fd, buf.baseAddress, buf.count, 0)
+        }
+        guard sentLen == 4 else { return false }
+        let sentBody = body.withUnsafeBytes { buf in
+            send(fd, buf.baseAddress, buf.count, 0)
+        }
+        guard sentBody == body.count else { return false }
+
+        var rxBuf = [UInt8](repeating: 0, count: 16)
+        let received = rxBuf.withUnsafeMutableBufferPointer { ptr in
+            recv(fd, ptr.baseAddress, ptr.count, 0)
+        }
+        return received > 0
+    }
+
     // MARK: - Server Lifecycle
 
     func start() throws {
@@ -36,15 +100,35 @@ final class IPCServer {
         // Acquire an exclusive lock to prevent race conditions during socket setup.
         // Without this, a malicious process could create a fake socket at our path
         // between unlink() and bind(), intercepting client connections.
+        //
+        // Flock failures are triaged by lock age and existing-daemon responsiveness:
+        //   - Fresh lock (< 5s)         → parallel-spawn race; exit cleanly.
+        //   - Old + socket responds     → healthy long-running daemon; exit cleanly.
+        //   - Old + socket unresponsive → kernel-stuck daemon (e.g. Secure Enclave
+        //                                  wedge survives SIGKILL); take over by
+        //                                  recreating the lock file inode.
+        // The two-signal check prevents the original "always bypass" behavior from
+        // spawning duplicate daemons during parallel-spawn races, while preserving
+        // recovery from genuinely stuck daemons that even the TS-side
+        // killDaemonProcess can't bring down.
         let lockPath = socketPath + ".lock"
         lockFD = open(lockPath, O_CREAT | O_RDWR, 0o600)
         guard lockFD >= 0 else {
             throw IPCError.socketCreationFailed("Failed to create lock file: \(String(cString: strerror(errno)))")
         }
         if flock(lockFD, LOCK_EX | LOCK_NB) != 0 {
-            // Lock held by another process (possibly stuck in UE state).
-            // Delete the lock file and reopen — the new file gets a fresh inode
-            // so the old process's flock (tied to the old inode) doesn't block us.
+            let lockAgeSeconds = IPCServer.lockFileAgeSeconds(path: lockPath)
+            let isFresh = lockAgeSeconds < IPCServer.freshLockThresholdSeconds
+
+            if isFresh || IPCServer.existingDaemonResponsive(socketPath: socketPath, timeoutMs: 1500) {
+                close(lockFD)
+                lockFD = -1
+                throw IPCError.lockHeld
+            }
+
+            // Old + unresponsive: previous daemon is wedged in the kernel and
+            // can't be signaled away. Recreate the lock file so we get a fresh
+            // inode whose flock is independent of the stuck holder's.
             close(lockFD)
             unlink(lockPath)
             lockFD = open(lockPath, O_CREAT | O_RDWR, 0o600)
@@ -54,7 +138,7 @@ final class IPCServer {
             guard flock(lockFD, LOCK_EX | LOCK_NB) == 0 else {
                 close(lockFD)
                 lockFD = -1
-                throw IPCError.socketCreationFailed("Another daemon instance holds the lock")
+                throw IPCError.socketCreationFailed("Failed to take over stuck daemon's lock")
             }
         }
 
@@ -262,12 +346,14 @@ enum IPCError: LocalizedError {
     case socketCreationFailed(String)
     case bindFailed(String)
     case listenFailed(String)
+    case lockHeld
 
     var errorDescription: String? {
         switch self {
         case .socketCreationFailed(let msg): return "Socket creation failed: \(msg)"
         case .bindFailed(let msg): return "Socket bind failed: \(msg)"
         case .listenFailed(let msg): return "Socket listen failed: \(msg)"
+        case .lockHeld: return "Another daemon instance is already running"
         }
     }
 }

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/PeerIdentity.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/PeerIdentity.swift
@@ -82,26 +82,85 @@ private func getParentSessionIdentifier(forPid pid: pid_t, processInfo info: kin
     return getProcessTreeSessionIdentifier(forPid: pid)
 }
 
+/// Env vars set by terminal multiplexers on every descendant. When present they
+/// signal "the user is interactively driving this pane", so per-pane PTYs should
+/// remain a session boundary even though they look identical (structurally) to
+/// PTYs allocated by fan-out task runners like turbo.
+private let multiplexerEnvKeys: [String] = [
+    "TMUX",                // tmux: "<socket>,<server_pid>,<session_id>"
+    "STY",                 // GNU screen: "<pid>.<tty>.<host>"
+    "ZELLIJ",              // zellij
+    "ZELLIJ_SESSION_NAME", // zellij (alt)
+]
+
+private func detectMultiplexerSignal(env: [String: String]?) -> (key: String, value: String)? {
+    guard let env else { return nil }
+    for key in multiplexerEnvKeys {
+        guard let raw = env[key]?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            continue
+        }
+        return (key, raw)
+    }
+    return nil
+}
+
 private func getTtySessionIdentifier(forPid pid: pid_t, processInfo info: kinfo_proc) -> String? {
     // e_tdev is dev_t (Int32). NODEV is -1 in signed representation
     // (0xFFFFFFFF unsigned). Comparing Int32(-1) != UInt32.max is true in
     // Swift's BinaryInteger comparison, so we must compare in the same type.
-    let ttyDev = info.kp_eproc.e_tdev
-    guard ttyDev > 0 else { return nil }
+    let peerTty = info.kp_eproc.e_tdev
+    guard peerTty > 0 else { return nil }
 
-    // TTY-based identity: device name + session leader start time
-    guard let namePtr = devname(dev_t(ttyDev), S_IFCHR) else { return nil }
+    // Pick the anchor process for TTY scoping. Walking up past per-task PTYs
+    // prevents fan-out task runners (turbo, nx, pnpm/npm parallel scripts,
+    // concurrently, etc.) from fragmenting biometric sessions across what the
+    // user perceives as a single command. Multiplexers (tmux, screen, zellij)
+    // are detected via env vars and treated as a session boundary so panes the
+    // user split for independent work remain separate.
+    let peerEnv = getProcessEnvironment(pid: pid)
+    let multiplexer = detectMultiplexerSignal(env: peerEnv)
+
+    var anchorPid = pid
+    var anchorTty = peerTty
+    var current = pid
+    for _ in 0..<64 {
+        guard let ppid = getParentPid(pid: current), ppid > 1,
+              let parentInfo = getProcessInfo(pid: ppid),
+              parentInfo.kp_eproc.e_tdev > 0 else { break }
+
+        // Multiplexer present: only walk up while the parent still carries the
+        // same multiplexer value. That keeps us inside the pane (still walking
+        // past any inner turbo-style wrapper PTYs) but stops at the pane's
+        // outermost shell, never crossing into the host shell that launched
+        // the multiplexer.
+        if let mux = multiplexer {
+            let parentEnv = getProcessEnvironment(pid: ppid)
+            let parentValue = parentEnv?[mux.key]?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if parentValue != mux.value { break }
+        }
+
+        anchorPid = ppid
+        anchorTty = parentInfo.kp_eproc.e_tdev
+        current = ppid
+    }
+
+    guard let namePtr = devname(dev_t(anchorTty), S_IFCHR) else { return nil }
     let ttyName = String(cString: namePtr)
 
-    let sessionLeaderPid = getsid(pid)
+    let sessionLeaderPid = getsid(anchorPid)
     var startTimestamp: Int = 0
     if sessionLeaderPid > 0, let leaderInfo = getProcessInfo(pid: sessionLeaderPid) {
         startTimestamp = Int(leaderInfo.kp_proc.p_starttime.tv_sec)
     }
     if startTimestamp == 0 {
-        startTimestamp = Int(info.kp_proc.p_starttime.tv_sec)
+        startTimestamp = getStartTime(pid: anchorPid)
     }
 
+    if let mux = multiplexer {
+        // Include the multiplexer value so separate tmux servers / sessions
+        // stay distinct even if a TTY device name happens to collide.
+        return "tty:\(ttyName):\(startTimestamp):\(mux.key)=\(mux.value)"
+    }
     return "tty:\(ttyName):\(startTimestamp)"
 }
 

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/main.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/main.swift
@@ -392,6 +392,14 @@ case "daemon":
         sigIntSource.resume()
 
         app.run()
+    } catch IPCError.lockHeld {
+        // Another daemon won the race (parallel spawn — e.g. turbo tasks).
+        // Emit a marker the JS launcher can recognize and exit cleanly without
+        // touching any shared state. We deliberately skip removing pidPath here
+        // since the existing daemon owns it.
+        jsonOutput(["alreadyRunning": true])
+        fflush(stdout)
+        _exit(0)
     } catch {
         jsonError("Failed to start daemon: \(error.localizedDescription)")
     }

--- a/packages/varlock/src/lib/local-encrypt/daemon-client.ts
+++ b/packages/varlock/src/lib/local-encrypt/daemon-client.ts
@@ -617,6 +617,15 @@ export class DaemonClient {
             child.stdout!.destroy();
             child.stderr!.destroy();
             resolve();
+          } else if (parsed.alreadyRunning) {
+            // Another daemon won the lock (parallel-spawn race). The existing
+            // daemon owns pidPath / daemon.info, so we just resolve and let
+            // the caller connect to it.
+            clearTimeout(timeout);
+            child.unref();
+            child.stdout!.destroy();
+            child.stderr!.destroy();
+            resolve();
           }
         } catch {
           // Incomplete JSON, keep buffering


### PR DESCRIPTION
## Summary

Two related fixes uncovered by running varlock through turborepo. When parallel tasks spawned `varlock` simultaneously, each task fired its own biometric prompt AND each spawned its own daemon (visible as multiple menu bar icons sticking around).

### 1. TTY session scoping walks past PTY-allocating wrappers

`PeerIdentity.swift` previously used the peer's immediate controlling TTY. Turborepo (and similar fan-out task runners like nx, pnpm/npm parallel scripts, `concurrently`, etc.) allocate a fresh PTY per task, so two parallel turbo tasks each resolved to a distinct `tty:ttysXXX:…` session — meaning each one triggered its own biometric prompt.

Fix: walk up the ancestry chain to the **outermost ancestor that still has a TTY** and anchor on that. In a plain shell this is a no-op (whole chain shares one TTY until the GUI terminal app, which has no TTY). With turbo et al. in the chain, we walk past their per-task PTYs to the user's terminal TTY. Terminal multiplexers (`tmux`, `screen`, `zellij`) are detected via env vars (`TMUX`, `STY`, `ZELLIJ`) and treated as a session boundary so per-pane scoping is preserved.

### 2. Daemon flock failure no longer unconditionally bypasses the lock

`IPCServer.swift` previously detected `flock` failure and recovered by unlinking the lock file + opening a fresh inode. The comment said this was for "stuck UE state" recovery, but it also defeats the lock entirely during a parallel-spawn race — both daemons end up running.

Fix: triage flock failures by two signals:
- **Lock age < 5s** → parallel-spawn race; exit cleanly with `{"alreadyRunning": true}` so the TS launcher resolves immediately and connects to the winner's socket.
- **Old + socket responds** → healthy long-running daemon; exit cleanly.
- **Old + socket unresponsive** → kernel-stuck daemon (Secure Enclave wedge, survives even SIGKILL); take over by recreating the lock file inode.

The two-signal check restores the stuck-daemon recovery path (the original intent) while no longer regressing the much more common parallel-spawn case.

`daemon-client.ts` learns to recognize the `alreadyRunning` marker on stdout and resolves the spawn promise immediately instead of hanging until the 10s spawn timeout fires.

## Test plan

- [x] Reproduced original bug locally: `pnpm turbo run dev` in a 2-app workspace prompted twice and left two menu bar icons
- [x] After fix: same command produces **one** biometric prompt and **one** menu bar icon
- [x] After fix: `varlock lock && pnpm turbo run dev` still produces one prompt (no regression on locked-state)
- [x] After fix: `tmux` with `varlock load` in two panes still prompts separately (multiplexer env-var detection preserves per-pane scoping)
- [x] After fix: plain `varlock run` in a single shell unchanged (TTY-walk is a no-op when whole chain shares one TTY)
- [ ] Worth verifying on CI / older macOS versions if available
- [ ] Worth verifying the "old + unresponsive" stuck-daemon path manually if you can reliably reproduce a stuck daemon