### PR TITLE
Fix nested varlock override provenance

### DIFF
--- a/.bumpy/nested-run-override-provenance.md
+++ b/.bumpy/nested-run-override-provenance.md
@@ -2,4 +2,10 @@
 varlock: patch
 ---
 
-Preserve override provenance across nested varlock run invocations and fix local smoke-test CLI resolution
+Preserve process.env override provenance across nested invocations so `varlock run`-injected resolved values are no longer treated as true overrides by inner `varlock` loads.
+
+Only real upstream overrides now propagate through nesting, while inner command-local overrides still win as expected.
+
+Also fixes smoke-test CLI resolution to use the workspace-local varlock CLI instead of any globally installed binary.
+
+Note: `__VARLOCK_ENV` now includes override provenance metadata (`__varlockOverrideMeta`). Tooling that strictly validates that blob shape should allow unknown/new fields.

--- a/.bumpy/nested-run-override-provenance.md
+++ b/.bumpy/nested-run-override-provenance.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Preserve override provenance across nested varlock run invocations and fix local smoke-test CLI resolution

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -7,6 +7,7 @@ import { checkForConfigErrors, checkForNoEnvFiles, checkForSchemaErrors } from '
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { CliExitError } from '../helpers/exit-error';
 import { resetRedactionMap, redactSensitiveConfig } from '../../runtime/env';
+import { buildRunInjectedEnvBlob, parseRunInjectionMetadata } from '../../lib/injected-env-provenance';
 
 export const commandSpec = define({
   name: 'run',
@@ -118,12 +119,20 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   }
   const injectVars = injectMode === 'all' || injectMode === 'vars';
   const injectBlob = injectMode === 'all' || injectMode === 'blob';
+  const parentRunMetadata = parseRunInjectionMetadata(process.env.__VARLOCK_ENV);
+  const inheritedOverrideKeys = parentRunMetadata?.overrideKeys ?? Object.keys(process.env);
+  const injectedBlob = injectBlob
+    ? buildRunInjectedEnvBlob({
+      serializedGraph,
+      overrideKeys: inheritedOverrideKeys,
+    })
+    : undefined;
 
   const fullInjectedEnv: NodeJS.ProcessEnv = {
     ...process.env,
     ...(injectVars ? resolvedEnv : {}),
     __VARLOCK_RUN: '1', // flag for a child process to detect it is running via `varlock run`
-    ...(injectBlob ? { __VARLOCK_ENV: JSON.stringify(serializedGraph) } : {}),
+    ...(injectedBlob ? { __VARLOCK_ENV: injectedBlob } : {}),
   };
 
   // when only injecting the blob, also inject the encryption key so the

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -6,8 +6,6 @@ import { loadVarlockEnvGraph } from '../../lib/load-graph';
 import { checkForConfigErrors, checkForNoEnvFiles, checkForSchemaErrors } from '../helpers/error-checks';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { CliExitError } from '../helpers/exit-error';
-import { resetRedactionMap, redactSensitiveConfig } from '../../runtime/env';
-import { buildRunInjectedEnvBlob, parseRunInjectionMetadata } from '../../lib/injected-env-provenance';
 
 export const commandSpec = define({
   name: 'run',
@@ -104,6 +102,7 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
 
   const resolvedEnv = envGraph.getResolvedEnvObject();
   const serializedGraph = envGraph.getSerializedGraph();
+  const { resetRedactionMap, redactSensitiveConfig } = await import('../../runtime/env');
   // console.log(resolvedEnv);
 
   // handle deprecated --no-inject-graph flag
@@ -119,20 +118,12 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   }
   const injectVars = injectMode === 'all' || injectMode === 'vars';
   const injectBlob = injectMode === 'all' || injectMode === 'blob';
-  const parentRunMetadata = parseRunInjectionMetadata(process.env.__VARLOCK_ENV);
-  const inheritedOverrideKeys = parentRunMetadata?.overrideKeys ?? Object.keys(process.env);
-  const injectedBlob = injectBlob
-    ? buildRunInjectedEnvBlob({
-      serializedGraph,
-      overrideKeys: inheritedOverrideKeys,
-    })
-    : undefined;
 
   const fullInjectedEnv: NodeJS.ProcessEnv = {
     ...process.env,
     ...(injectVars ? resolvedEnv : {}),
     __VARLOCK_RUN: '1', // flag for a child process to detect it is running via `varlock run`
-    ...(injectedBlob ? { __VARLOCK_ENV: injectedBlob } : {}),
+    ...(injectBlob ? { __VARLOCK_ENV: JSON.stringify(serializedGraph) } : {}),
   };
 
   // when only injecting the blob, also inject the encryption key so the

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -16,6 +16,7 @@ import { getErrorLocation } from './error-location';
 import type { VarlockPlugin } from './plugins';
 import { getCiEnv, type CiEnvInfo } from '@varlock/ci-env-info';
 import { BUILTIN_VARS, isBuiltinVar } from './builtin-vars';
+import { buildOverrideProvenanceMetadata, type OverrideProvenanceMetadata } from '../../lib/injected-env-provenance';
 
 const processExists = !!globalThis.process;
 const originalProcessEnv = { ...processExists && process.env };
@@ -53,6 +54,8 @@ export type SerializedEnvGraph = {
     value: any;
     isSensitive: boolean;
   }>;
+  /** provenance metadata for process.env overrides across nested invocations */
+  __varlockOverrideMeta?: OverrideProvenanceMetadata;
   /** Present only when config has errors — consumers can check `if (data.errors)` */
   errors?: SerializedEnvGraphErrors;
 };
@@ -558,6 +561,7 @@ export class EnvGraph {
         isSensitive: item.isSensitive,
       };
     }
+    serializedGraph.__varlockOverrideMeta = buildOverrideProvenanceMetadata(Object.keys(this.overrideValues));
 
     // expose a few root level settings
     serializedGraph.settings.redactLogs = this.getRootDec('redactLogs')?.resolvedValue ?? true;

--- a/packages/varlock/src/env-graph/lib/loader.ts
+++ b/packages/varlock/src/env-graph/lib/loader.ts
@@ -8,6 +8,10 @@ export async function loadEnvGraph(opts?: {
   basePath?: string,
   /** Entry file path(s) — accepts a single path or array of paths */
   entryFilePaths?: string | Array<string>,
+  /** Explicit process.env override values used for config item override precedence */
+  overrideValues?: Record<string, string | undefined>,
+  /** Explicit process.env values used by builtin var detection */
+  processEnvOverride?: Record<string, string | undefined>,
   relativePaths?: Array<string>,
   checkGitIgnored?: boolean,
   excludeDirs?: Array<string>,
@@ -15,6 +19,8 @@ export async function loadEnvGraph(opts?: {
   afterInit?: (graph: EnvGraph) => Promise<void>,
 }) {
   const graph = new EnvGraph();
+  if (opts?.overrideValues) graph.overrideValues = opts.overrideValues;
+  if (opts?.processEnvOverride) graph.processEnvOverride = opts.processEnvOverride;
 
   let rawPaths: Array<string> | undefined;
   if (opts?.entryFilePaths) {
@@ -54,4 +60,3 @@ export async function loadEnvGraph(opts?: {
 
   return graph;
 }
-

--- a/packages/varlock/src/lib/injected-env-provenance.ts
+++ b/packages/varlock/src/lib/injected-env-provenance.ts
@@ -1,38 +1,39 @@
 import type { SerializedEnvGraph } from '../env-graph';
 
-const RUN_INJECTION_SOURCE = 'varlock-run';
-const RUN_INJECTION_VERSION = 1;
+const OVERRIDE_PROVENANCE_SOURCE = 'varlock';
+const OVERRIDE_PROVENANCE_VERSION = 1;
 
-type RunInjectionMetadata = {
-  source: typeof RUN_INJECTION_SOURCE;
-  version: typeof RUN_INJECTION_VERSION;
+export type OverrideProvenanceMetadata = {
+  source: typeof OVERRIDE_PROVENANCE_SOURCE;
+  version: typeof OVERRIDE_PROVENANCE_VERSION;
   overrideKeys: Array<string>;
 };
 
 type SerializedGraphWithRunMetadata = SerializedEnvGraph & {
-  __varlockRunMeta?: RunInjectionMetadata;
+  __varlockOverrideMeta?: OverrideProvenanceMetadata;
+  /** Legacy field written by previous implementation in run.command.ts */
+  __varlockRunMeta?: {
+    source: 'varlock-run';
+    version: 1;
+    overrideKeys: Array<string>;
+  };
 };
 
 function normalizeOverrideKeys(overrideKeys: Array<string>) {
   return [...new Set(overrideKeys.filter((k) => typeof k === 'string'))];
 }
 
-export function buildRunInjectedEnvBlob(opts: {
-  serializedGraph: SerializedEnvGraph;
-  overrideKeys: Array<string>;
-}) {
-  const graphWithMeta: SerializedGraphWithRunMetadata = {
-    ...opts.serializedGraph,
-    __varlockRunMeta: {
-      source: RUN_INJECTION_SOURCE,
-      version: RUN_INJECTION_VERSION,
-      overrideKeys: normalizeOverrideKeys(opts.overrideKeys),
-    },
+export function buildOverrideProvenanceMetadata(
+  overrideKeys: Array<string>,
+): OverrideProvenanceMetadata {
+  return {
+    source: OVERRIDE_PROVENANCE_SOURCE,
+    version: OVERRIDE_PROVENANCE_VERSION,
+    overrideKeys: normalizeOverrideKeys(overrideKeys),
   };
-  return JSON.stringify(graphWithMeta);
 }
 
-export function parseRunInjectionMetadata(blob?: string): RunInjectionMetadata | undefined {
+export function parseOverrideProvenanceMetadata(blob?: string): OverrideProvenanceMetadata | undefined {
   if (!blob) return undefined;
 
   let parsed: unknown;
@@ -43,16 +44,17 @@ export function parseRunInjectionMetadata(blob?: string): RunInjectionMetadata |
   }
 
   if (!parsed || typeof parsed !== 'object') return undefined;
-  const metadata = (parsed as SerializedGraphWithRunMetadata).__varlockRunMeta;
+  const parsedGraph = parsed as SerializedGraphWithRunMetadata;
+  const metadata = parsedGraph.__varlockOverrideMeta ?? parsedGraph.__varlockRunMeta;
   if (!metadata || typeof metadata !== 'object') return undefined;
-  if (metadata.source !== RUN_INJECTION_SOURCE) return undefined;
-  if (metadata.version !== RUN_INJECTION_VERSION) return undefined;
+  if (metadata.source !== OVERRIDE_PROVENANCE_SOURCE && metadata.source !== 'varlock-run') return undefined;
+  if (metadata.version !== OVERRIDE_PROVENANCE_VERSION) return undefined;
   if (!Array.isArray(metadata.overrideKeys)) return undefined;
   if (metadata.overrideKeys.some((k) => typeof k !== 'string')) return undefined;
 
   return {
-    source: metadata.source,
-    version: metadata.version,
+    source: OVERRIDE_PROVENANCE_SOURCE,
+    version: OVERRIDE_PROVENANCE_VERSION,
     overrideKeys: normalizeOverrideKeys(metadata.overrideKeys),
   };
 }
@@ -67,4 +69,3 @@ export function selectOverrideValuesFromEnv(
   }
   return selected;
 }
-

--- a/packages/varlock/src/lib/injected-env-provenance.ts
+++ b/packages/varlock/src/lib/injected-env-provenance.ts
@@ -1,0 +1,70 @@
+import type { SerializedEnvGraph } from '../env-graph';
+
+const RUN_INJECTION_SOURCE = 'varlock-run';
+const RUN_INJECTION_VERSION = 1;
+
+type RunInjectionMetadata = {
+  source: typeof RUN_INJECTION_SOURCE;
+  version: typeof RUN_INJECTION_VERSION;
+  overrideKeys: Array<string>;
+};
+
+type SerializedGraphWithRunMetadata = SerializedEnvGraph & {
+  __varlockRunMeta?: RunInjectionMetadata;
+};
+
+function normalizeOverrideKeys(overrideKeys: Array<string>) {
+  return [...new Set(overrideKeys.filter((k) => typeof k === 'string'))];
+}
+
+export function buildRunInjectedEnvBlob(opts: {
+  serializedGraph: SerializedEnvGraph;
+  overrideKeys: Array<string>;
+}) {
+  const graphWithMeta: SerializedGraphWithRunMetadata = {
+    ...opts.serializedGraph,
+    __varlockRunMeta: {
+      source: RUN_INJECTION_SOURCE,
+      version: RUN_INJECTION_VERSION,
+      overrideKeys: normalizeOverrideKeys(opts.overrideKeys),
+    },
+  };
+  return JSON.stringify(graphWithMeta);
+}
+
+export function parseRunInjectionMetadata(blob?: string): RunInjectionMetadata | undefined {
+  if (!blob) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(blob);
+  } catch {
+    return undefined;
+  }
+
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const metadata = (parsed as SerializedGraphWithRunMetadata).__varlockRunMeta;
+  if (!metadata || typeof metadata !== 'object') return undefined;
+  if (metadata.source !== RUN_INJECTION_SOURCE) return undefined;
+  if (metadata.version !== RUN_INJECTION_VERSION) return undefined;
+  if (!Array.isArray(metadata.overrideKeys)) return undefined;
+  if (metadata.overrideKeys.some((k) => typeof k !== 'string')) return undefined;
+
+  return {
+    source: metadata.source,
+    version: metadata.version,
+    overrideKeys: normalizeOverrideKeys(metadata.overrideKeys),
+  };
+}
+
+export function selectOverrideValuesFromEnv(
+  env: Record<string, string | undefined>,
+  overrideKeys: Array<string>,
+) {
+  const selected: Record<string, string | undefined> = {};
+  for (const key of overrideKeys) {
+    if (key in env) selected[key] = env[key];
+  }
+  return selected;
+}
+

--- a/packages/varlock/src/lib/load-graph.ts
+++ b/packages/varlock/src/lib/load-graph.ts
@@ -7,8 +7,15 @@ import { CliExitError } from '../cli/helpers/exit-error';
 import { runWithWorkspaceInfo } from './workspace-utils';
 import { readVarlockPackageJsonConfig } from './package-json-config';
 import { createDebug } from './debug';
+import { parseRunInjectionMetadata, selectOverrideValuesFromEnv } from './injected-env-provenance';
 
 const debug = createDebug('varlock:load');
+
+function getGraphEnvOverridesFromRuntimeEnv() {
+  const runMetadata = parseRunInjectionMetadata(process.env.__VARLOCK_ENV);
+  if (!runMetadata) return undefined;
+  return selectOverrideValuesFromEnv(process.env, runMetadata.overrideKeys);
+}
 
 function normalizePkgLoadPath(pkgLoadPath: string | Array<string>): Array<string> {
   if (Array.isArray(pkgLoadPath)) return pkgLoadPath;
@@ -22,6 +29,7 @@ function loadFromPaths(
     errorPrefix: string,
     errorSuggestion: string,
     currentEnvFallback?: string,
+    overrideValues?: Record<string, string | undefined>,
   },
 ) {
   const resolvedPaths = rawPaths.map((p) => path.resolve(p));
@@ -43,6 +51,8 @@ function loadFromPaths(
   return runWithWorkspaceInfo(() => loadEnvGraph({
     currentEnvFallback: config.currentEnvFallback,
     entryFilePaths: resolvedPaths,
+    overrideValues: config.overrideValues,
+    processEnvOverride: config.overrideValues,
     afterInit: async (g) => {
       g.registerResolver(VarlockResolver);
       g.registerResolver(KeychainResolver);
@@ -55,6 +65,7 @@ export function loadVarlockEnvGraph(opts?: {
   /** Explicit entry file paths from --path flag(s) - overrides package.json config */
   entryFilePaths?: Array<string>,
 }) {
+  const runtimeOverrideValues = getGraphEnvOverridesFromRuntimeEnv();
   const cliPaths = opts?.entryFilePaths?.filter(Boolean);
 
   // If --path flag(s) provided, they take precedence over package.json config
@@ -65,6 +76,7 @@ export function loadVarlockEnvGraph(opts?: {
       errorPrefix: 'The --path value does not exist',
       errorSuggestion: 'Use `--path` to specify a valid file or directory.',
       currentEnvFallback: opts?.currentEnvFallback,
+      overrideValues: runtimeOverrideValues,
     });
   }
 
@@ -78,6 +90,7 @@ export function loadVarlockEnvGraph(opts?: {
       errorPrefix: 'A path in `varlock.loadPath` configured in package.json does not exist',
       errorSuggestion: 'Update `varlock.loadPath` in your package.json to point to valid files or directories.',
       currentEnvFallback: opts?.currentEnvFallback,
+      overrideValues: runtimeOverrideValues,
     });
   }
 
@@ -85,6 +98,8 @@ export function loadVarlockEnvGraph(opts?: {
 
   return runWithWorkspaceInfo(() => loadEnvGraph({
     currentEnvFallback: opts?.currentEnvFallback,
+    overrideValues: runtimeOverrideValues,
+    processEnvOverride: runtimeOverrideValues,
     afterInit: async (g) => {
       g.registerResolver(VarlockResolver);
       g.registerResolver(KeychainResolver);

--- a/packages/varlock/src/lib/load-graph.ts
+++ b/packages/varlock/src/lib/load-graph.ts
@@ -7,14 +7,14 @@ import { CliExitError } from '../cli/helpers/exit-error';
 import { runWithWorkspaceInfo } from './workspace-utils';
 import { readVarlockPackageJsonConfig } from './package-json-config';
 import { createDebug } from './debug';
-import { parseRunInjectionMetadata, selectOverrideValuesFromEnv } from './injected-env-provenance';
+import { parseOverrideProvenanceMetadata, selectOverrideValuesFromEnv } from './injected-env-provenance';
 
 const debug = createDebug('varlock:load');
 
 function getGraphEnvOverridesFromRuntimeEnv() {
-  const runMetadata = parseRunInjectionMetadata(process.env.__VARLOCK_ENV);
-  if (!runMetadata) return undefined;
-  return selectOverrideValuesFromEnv(process.env, runMetadata.overrideKeys);
+  const provenance = parseOverrideProvenanceMetadata(process.env.__VARLOCK_ENV);
+  if (!provenance) return undefined;
+  return selectOverrideValuesFromEnv(process.env, provenance.overrideKeys);
 }
 
 function normalizePkgLoadPath(pkgLoadPath: string | Array<string>): Array<string> {

--- a/packages/varlock/src/lib/test/exec.test.ts
+++ b/packages/varlock/src/lib/test/exec.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { Readable } from 'node:stream';
+import { stripVTControlCharacters } from 'node:util';
 import { exec } from '../exec.js';
 
 /**
@@ -31,7 +32,7 @@ describe('exec', () => {
 
     // All pipe data must be available once the Promise resolves (close event)
     const output = await stdoutData;
-    expect(output.trim()).toBe('2');
+    expect(stripVTControlCharacters(output).trim()).toBe('2');
   });
 
   it('should propagate non-zero exit code', async () => {

--- a/packages/varlock/src/lib/test/injected-env-provenance.test.ts
+++ b/packages/varlock/src/lib/test/injected-env-provenance.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'vitest';
+import {
+  buildRunInjectedEnvBlob,
+  parseRunInjectionMetadata,
+  selectOverrideValuesFromEnv,
+} from '../injected-env-provenance';
+
+describe('injected env provenance', () => {
+  test('builds and parses run metadata', () => {
+    const blob = buildRunInjectedEnvBlob({
+      serializedGraph: {
+        config: {},
+        settings: {},
+        sources: [],
+      },
+      overrideKeys: ['A', 'B', 'A'],
+    });
+
+    const parsed = parseRunInjectionMetadata(blob);
+    expect(parsed?.source).toBe('varlock-run');
+    expect(parsed?.version).toBe(1);
+    expect(parsed?.overrideKeys).toEqual(['A', 'B']);
+  });
+
+  test('returns undefined for missing metadata', () => {
+    expect(parseRunInjectionMetadata(JSON.stringify({
+      config: {},
+      settings: {},
+      sources: [],
+    }))).toBeUndefined();
+  });
+
+  test('returns undefined for malformed blob', () => {
+    expect(parseRunInjectionMetadata('{not-json')).toBeUndefined();
+  });
+
+  test('returns undefined for invalid metadata shape', () => {
+    expect(parseRunInjectionMetadata(JSON.stringify({
+      __varlockRunMeta: {
+        source: 'varlock-run',
+        version: 2,
+        overrideKeys: ['A'],
+      },
+      config: {},
+      settings: {},
+      sources: [],
+    }))).toBeUndefined();
+  });
+
+  test('selects only declared override keys from env', () => {
+    const selected = selectOverrideValuesFromEnv(
+      {
+        A: '1',
+        B: '2',
+      },
+      ['B', 'MISSING'],
+    );
+
+    expect(selected).toEqual({
+      B: '2',
+    });
+  });
+});
+

--- a/packages/varlock/src/lib/test/injected-env-provenance.test.ts
+++ b/packages/varlock/src/lib/test/injected-env-provenance.test.ts
@@ -1,46 +1,56 @@
 import { describe, expect, test } from 'vitest';
 import {
-  buildRunInjectedEnvBlob,
-  parseRunInjectionMetadata,
+  buildOverrideProvenanceMetadata,
+  parseOverrideProvenanceMetadata,
   selectOverrideValuesFromEnv,
 } from '../injected-env-provenance';
 
 describe('injected env provenance', () => {
-  test('builds and parses run metadata', () => {
-    const blob = buildRunInjectedEnvBlob({
-      serializedGraph: {
-        config: {},
-        settings: {},
-        sources: [],
-      },
-      overrideKeys: ['A', 'B', 'A'],
-    });
+  test('builds override metadata', () => {
+    const metadata = buildOverrideProvenanceMetadata(['A', 'B', 'A']);
+    expect(metadata.source).toBe('varlock');
+    expect(metadata.version).toBe(1);
+    expect(metadata.overrideKeys).toEqual(['A', 'B']);
+  });
 
-    const parsed = parseRunInjectionMetadata(blob);
-    expect(parsed?.source).toBe('varlock-run');
+  test('parses current metadata shape', () => {
+    const parsed = parseOverrideProvenanceMetadata(JSON.stringify({
+      __varlockOverrideMeta: {
+        source: 'varlock',
+        version: 1,
+        overrideKeys: ['A', 'B', 'A'],
+      },
+      config: {},
+      settings: {},
+      sources: [],
+    }));
+    expect(parsed?.source).toBe('varlock');
     expect(parsed?.version).toBe(1);
     expect(parsed?.overrideKeys).toEqual(['A', 'B']);
   });
 
-  test('returns undefined for missing metadata', () => {
-    expect(parseRunInjectionMetadata(JSON.stringify({
+  test('parses legacy run metadata shape', () => {
+    const parsed = parseOverrideProvenanceMetadata(JSON.stringify({
+      __varlockRunMeta: {
+        source: 'varlock-run',
+        version: 1,
+        overrideKeys: ['A'],
+      },
       config: {},
       settings: {},
       sources: [],
-    }))).toBeUndefined();
+    }));
+    expect(parsed?.source).toBe('varlock');
+    expect(parsed?.version).toBe(1);
+    expect(parsed?.overrideKeys).toEqual(['A']);
   });
 
   test('returns undefined for malformed blob', () => {
-    expect(parseRunInjectionMetadata('{not-json')).toBeUndefined();
+    expect(parseOverrideProvenanceMetadata('{not-json')).toBeUndefined();
   });
 
-  test('returns undefined for invalid metadata shape', () => {
-    expect(parseRunInjectionMetadata(JSON.stringify({
-      __varlockRunMeta: {
-        source: 'varlock-run',
-        version: 2,
-        overrideKeys: ['A'],
-      },
+  test('returns undefined for missing metadata', () => {
+    expect(parseOverrideProvenanceMetadata(JSON.stringify({
       config: {},
       settings: {},
       sources: [],
@@ -61,4 +71,3 @@ describe('injected env provenance', () => {
     });
   });
 });
-

--- a/smoke-tests/helpers/run-varlock.ts
+++ b/smoke-tests/helpers/run-varlock.ts
@@ -1,7 +1,8 @@
-import { execSync, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 
 const SMOKE_TESTS_DIR = join(import.meta.dirname, '..');
+const LOCAL_VARLOCK_CLI = join(SMOKE_TESTS_DIR, '..', 'packages', 'varlock', 'bin', 'cli.js');
 
 export function runVarlock(args: Array<string>, options?: {
   cwd?: string;
@@ -10,46 +11,18 @@ export function runVarlock(args: Array<string>, options?: {
 }) {
   const cwd = options?.cwd ? join(SMOKE_TESTS_DIR, options.cwd) : SMOKE_TESTS_DIR;
   const env = { ...process.env, ...options?.env };
+  const result = spawnSync(process.execPath, [LOCAL_VARLOCK_CLI, ...args], {
+    cwd,
+    env,
+    encoding: 'utf-8',
+  });
 
-  if (options?.captureOutput) {
-    const result = spawnSync('pnpm', ['exec', 'varlock', ...args], {
-      cwd,
-      env,
-      encoding: 'utf-8',
-      // On Windows, shell is needed to invoke pnpm.cmd. On Unix, avoid shell so that
-      // argument strings like "process.exit(0)" are not misinterpreted as subshell syntax.
-      shell: process.platform === 'win32',
-    });
-
-    return {
-      stdout: result.stdout,
-      stderr: result.stderr,
-      exitCode: result.status ?? 1,
-      output: result.stdout + result.stderr,
-    };
-  }
-
-  try {
-    const output = execSync(`pnpm exec varlock ${args.join(' ')}`, {
-      cwd,
-      env,
-      encoding: 'utf-8',
-      stdio: 'pipe',
-    });
-    return {
-      stdout: output,
-      stderr: '',
-      exitCode: 0,
-      output,
-    };
-  } catch (error: any) {
-    return {
-      stdout: error.stdout || '',
-      stderr: error.stderr || '',
-      exitCode: error.status || 1,
-      output: (error.stdout || '') + (error.stderr || ''),
-    };
-  }
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    exitCode: result.status ?? 1,
+    output: (result.stdout ?? '') + (result.stderr ?? ''),
+  };
 }
 
 export function varlockLoad(options?: { cwd?: string; format?: string; paths?: Array<string> }) {

--- a/smoke-tests/tests/cli.test.ts
+++ b/smoke-tests/tests/cli.test.ts
@@ -163,6 +163,8 @@ describe('CLI Commands', () => {
   });
 
   describe('run command', () => {
+    const LOCAL_VARLOCK_CLI = '../../../packages/varlock/bin/cli.js';
+
     test('varlock run should forward child stdout', () => {
       const result = varlockRun(['node', '-p', '1+1'], { cwd: 'smoke-test-basic' });
       expect(result.exitCode).toBe(0);
@@ -183,6 +185,55 @@ describe('CLI Commands', () => {
       );
       expect(result.exitCode).toBe(0);
       expect(result.output).toContain('error-output');
+    });
+
+    test('nested varlock run does not treat injected vars as process.env overrides', () => {
+      const result = runVarlock([
+        'run',
+        '--inject',
+        'all',
+        '--',
+        'node',
+        LOCAL_VARLOCK_CLI,
+        'load',
+        '--format',
+        'json',
+        '--path',
+        '../overrides/.env.schema',
+      ], {
+        cwd: 'smoke-test-multi-path/base',
+        captureOutput: true,
+      });
+
+      expect(result.exitCode).toBe(0);
+      const vars = JSON.parse(result.stdout);
+      expect(vars.SHARED_VAR).toBe('from-overrides');
+    });
+
+    test('nested varlock run preserves real outer shell overrides', () => {
+      const result = runVarlock([
+        'run',
+        '--inject',
+        'all',
+        '--',
+        'node',
+        LOCAL_VARLOCK_CLI,
+        'load',
+        '--format',
+        'json',
+        '--path',
+        '../overrides/.env.schema',
+      ], {
+        cwd: 'smoke-test-multi-path/base',
+        captureOutput: true,
+        env: {
+          SHARED_VAR: 'from-shell',
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      const vars = JSON.parse(result.stdout);
+      expect(vars.SHARED_VAR).toBe('from-shell');
     });
   });
 

--- a/smoke-tests/tests/cli.test.ts
+++ b/smoke-tests/tests/cli.test.ts
@@ -235,6 +235,28 @@ describe('CLI Commands', () => {
       const vars = JSON.parse(result.stdout);
       expect(vars.SHARED_VAR).toBe('from-shell');
     });
+
+    test('nested varlock run keeps inner command-local overrides over outer shell overrides', () => {
+      const result = runVarlock([
+        'run',
+        '--inject',
+        'all',
+        '--',
+        'sh',
+        '-c',
+        `SHARED_VAR=from-shell-inner node ${LOCAL_VARLOCK_CLI} load --format json --path ../overrides/.env.schema`,
+      ], {
+        cwd: 'smoke-test-multi-path/base',
+        captureOutput: true,
+        env: {
+          SHARED_VAR: 'from-shell-outer',
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      const vars = JSON.parse(result.stdout);
+      expect(vars.SHARED_VAR).toBe('from-shell-inner');
+    });
   });
 
   describe('type generation', () => {


### PR DESCRIPTION
## Summary
- preserve process env override provenance across nested `varlock run` calls by encoding run metadata in `__VARLOCK_ENV`
- apply override filtering during graph load when valid run metadata is present
- extend loader options to accept explicit override/process env sources
- add a patch bumpy file for `varlock`

## Bonus / side-quests
- fix smoke test CLI invocation to use the workspace local varlock CLI (avoid global `pnpm exec varlock` resolution)
- make `exec` stdout assertion resilient to VT color/control sequences in environments that force color

## Testing
- `bun run lint:fix`
- `bun run --filter varlock typecheck`
- `bun run --filter varlock test src/lib/test/exec.test.ts src/lib/test/injected-env-provenance.test.ts`
