### PR TITLE
fix(parser): treat whitespace-only lines as blank lines

### DIFF
--- a/.bumpy/parser-whitespace-blank-line.md
+++ b/.bumpy/parser-whitespace-blank-line.md
@@ -1,0 +1,6 @@
+---
+"@env-spec/parser": patch
+"varlock": patch
+---
+
+fix: treat whitespace-only lines as blank lines instead of throwing a parse error

--- a/packages/env-spec-parser/grammar.peggy
+++ b/packages/env-spec-parser/grammar.peggy
@@ -17,7 +17,8 @@ EnvSpecFile =
     ConfigItem
     / Divider
     / CommentBlock
-    / "\n" { return new ParsedEnvSpecBlankLine({ _location: location() }); }
+    / _ "\n" { return new ParsedEnvSpecBlankLine({ _location: location() }); }
+    / __ !. { return new ParsedEnvSpecBlankLine({ _location: location() }); }
   )*
   {
     return new ParsedEnvSpecFile(contents)
@@ -279,7 +280,9 @@ tripleBQuotedMultiLineString = // 3x backtick wrapped multi-line string
   "```"
   { return new ParsedEnvSpecStaticValue({ quote, isMultiLine: true, rawValue: text(), _location: location() }) }
 
-_n = "\n" / !.
+// line terminator — tolerates trailing horizontal whitespace before the newline / EOF
+// so a whitespace-only line (e.g. after a comment) does not dead-end the parse
+_n = _ ("\n" / !.)
 _ = [ \t]*
 __ = [ \t]+
 

--- a/packages/env-spec-parser/test/general.test.ts
+++ b/packages/env-spec-parser/test/general.test.ts
@@ -1,6 +1,6 @@
 
 import { it, expect } from 'vitest';
-import { parseEnvSpecDotEnvFile } from '../src';
+import { parseEnvSpecDotEnvFile, ParsedEnvSpecBlankLine, ParsedEnvSpecConfigItem } from '../src';
 import { simpleResolver } from '../src/simple-resolver';
 
 function generalTest(spec: {
@@ -31,3 +31,61 @@ it('supports \\r\\n style newlines', generalTest({
     BAR: 'bar',
   },
 }));
+
+it('treats whitespace-only lines as blank lines', generalTest({
+  // line with only spaces/tabs between items must not break parsing
+  input: 'FOO=foo\n   \nBAR=bar\n\t \nBAZ=baz\n',
+  expected: {
+    FOO: 'foo',
+    BAR: 'bar',
+    BAZ: 'baz',
+  },
+}));
+
+it('parses a whitespace-only line into a ParsedEnvSpecBlankLine', () => {
+  const parsed = parseEnvSpecDotEnvFile('FOO=foo\n  \t \nBAR=bar\n');
+  const [first, second, third] = parsed.contents;
+  expect(first).toBeInstanceOf(ParsedEnvSpecConfigItem);
+  expect(second).toBeInstanceOf(ParsedEnvSpecBlankLine);
+  expect(third).toBeInstanceOf(ParsedEnvSpecConfigItem);
+});
+
+it('handles a trailing whitespace-only line with no final newline', generalTest({
+  // last line is whitespace-only and the file does not end in a newline
+  input: 'FOO=foo\nBAR=bar\n   ',
+  expected: {
+    FOO: 'foo',
+    BAR: 'bar',
+  },
+}));
+
+it('parses a trailing whitespace-only line (no newline) into a ParsedEnvSpecBlankLine', () => {
+  const parsed = parseEnvSpecDotEnvFile('FOO=foo\n  \t');
+  const [first, second] = parsed.contents;
+  expect(first).toBeInstanceOf(ParsedEnvSpecConfigItem);
+  expect(second).toBeInstanceOf(ParsedEnvSpecBlankLine);
+});
+
+it('handles consecutive, leading, and CRLF whitespace-only lines', generalTest({
+  input: '  \n\t\nFOO=foo\n   \n  \nBAR=bar\r\n \r\nBAZ=baz\n',
+  expected: {
+    FOO: 'foo',
+    BAR: 'bar',
+    BAZ: 'baz',
+  },
+}));
+
+it('allows a whitespace-only line directly after a comment line', generalTest({
+  // the comment-line terminator must tolerate the trailing whitespace blank line
+  input: '# a comment\n   \nFOO=foo\n',
+  expected: {
+    FOO: 'foo',
+  },
+}));
+
+it('allows a whitespace-only line directly after a decorator comment', () => {
+  // a whitespace blank line detaches the decorator just like a plain blank line does
+  const parsed = parseEnvSpecDotEnvFile('# @required\n   \nFOO=foo\n');
+  const last = parsed.contents[parsed.contents.length - 1];
+  expect(last).toBeInstanceOf(ParsedEnvSpecConfigItem);
+});

--- a/packages/env-spec-parser/test/general.test.ts
+++ b/packages/env-spec-parser/test/general.test.ts
@@ -89,3 +89,47 @@ it('allows a whitespace-only line directly after a decorator comment', () => {
   const last = parsed.contents[parsed.contents.length - 1];
   expect(last).toBeInstanceOf(ParsedEnvSpecConfigItem);
 });
+
+// --- multi-line string interior whitespace ---
+// The whitespace-only-blank-line rules above operate only at file scope. A
+// multi-line string greedily consumes all of its interior content into its
+// value, so blank lines, whitespace-only lines, and trailing whitespace inside
+// a multi-line string must be preserved verbatim and never treated as blanks.
+
+it('preserves a blank line inside a triple-double-quoted multi-line string', generalTest({
+  input: 'FOO="""\nline1\n\nline2\n"""\nBAR=bar\n',
+  expected: {
+    FOO: '\nline1\n\nline2\n',
+    BAR: 'bar',
+  },
+}));
+
+it('preserves a whitespace-only line inside a triple-double-quoted multi-line string', generalTest({
+  input: 'FOO="""\nline1\n   \nline2\n"""\n',
+  expected: {
+    FOO: '\nline1\n   \nline2\n',
+  },
+}));
+
+it('preserves a whitespace-only line inside a triple-backtick multi-line string', generalTest({
+  input: 'FOO=```\nline1\n\t \nline2\n```\n',
+  expected: {
+    FOO: '\nline1\n\t \nline2\n',
+  },
+}));
+
+it('preserves a whitespace-only line inside a single-double-quoted multi-line string', generalTest({
+  input: 'FOO="line1\n  \nline2"\n',
+  expected: {
+    FOO: 'line1\n  \nline2',
+  },
+}));
+
+it('preserves trailing whitespace on lines inside a multi-line string', () => {
+  // assert on the raw value so the trailing-whitespace bytes are checked exactly
+  const parsed = parseEnvSpecDotEnvFile('FOO="""\nline1   \nline2\t\n"""\n');
+  const [item] = parsed.contents;
+  expect(item).toBeInstanceOf(ParsedEnvSpecConfigItem);
+  expect((item as ParsedEnvSpecConfigItem).value?.data?.rawValue)
+    .toBe('"""\nline1   \nline2\t\n"""');
+});


### PR DESCRIPTION
## Problem

A `.env` line containing only spaces/tabs dead-ended the parser. On varlock@1.4.0 this surfaced as a raw `Error: expected dataType to be set` crash; on newer versions it surfaces as a parse error. Standard dotenv parsers tolerate whitespace-only blank lines.

## Fix

Three grammar changes in `packages/env-spec-parser/grammar.peggy`:

- `_ "\n"` — whitespace-then-newline blank line (strict superset of the old `"\n"`)
- `__ !.` — whitespace-only final line at EOF with no trailing newline (uses `__` = one-or-more, so ≥1 char is consumed → no zero-width infinite loop)
- `_n = _ ("\n" / !.)` — line terminator now tolerates trailing horizontal whitespace, so a whitespace blank line directly after a comment/decorator line no longer dead-ends the parse

`src/grammar.js` is generated from `grammar.peggy` via `build:grammar` (peggy) and is gitignored, so it is not in the diff — CI regenerates it.

## Tests

7 new tests in `test/general.test.ts`: mid-file, trailing (no final newline), consecutive, leading, CRLF, post-comment, and post-decorator whitespace lines. All 7 fail on the unpatched grammar (load-bearing).

- `@env-spec/parser`: 217 passed
- `varlock`: 507 passed
- lint clean

Changeset: patch bump for `@env-spec/parser` + `varlock` (varlock bundles the parser).