### PR TITLE
fix(proton-pass): reduce duplicate auth prompts

### DIFF
--- a/.bumpy/proton-pass-auth-prompt-reduction.md
+++ b/.bumpy/proton-pass-auth-prompt-reduction.md
@@ -1,0 +1,5 @@
+---
+"@varlock/proton-pass-plugin": patch
+---
+
+Reduce extra Proton Pass auth prompts by removing preflight info checks and using auth-retry reads.

--- a/packages/plugins/proton-pass/src/plugin.ts
+++ b/packages/plugins/proton-pass/src/plugin.ts
@@ -109,9 +109,6 @@ class ProtonPassPluginInstance {
   // Login batching / deduping for parallel resolutions.
   private loginInFlight: Promise<void> | undefined;
 
-  private loggedInAtMs?: number;
-  private loggedInTtlMs = 60_000;
-
   constructor(readonly id: string) {}
 
   configure(opts: {
@@ -138,86 +135,47 @@ class ProtonPassPluginInstance {
   }
 
   private async ensureCliLoggedIn(): Promise<void> {
-    // fast path: info is assumed ok for a short time window
-    if (this.loggedInAtMs && Date.now() - this.loggedInAtMs < this.loggedInTtlMs) return;
-
     if (this.loginInFlight) {
       await this.loginInFlight;
       return;
     }
 
     this.loginInFlight = (async () => {
+      // Attempt login
+      if (!this.username) {
+        throw new ResolutionError('Proton Pass CLI not authenticated and no username configured', {
+          tip: [
+            NOT_LOGGED_IN_TIP,
+            'Initialize the plugin with a username: @initProtonPass(username=..., ...)',
+          ].join('\n'),
+        });
+      }
+
+      if (!this.password) {
+        throw new ResolutionError('Proton Pass CLI not authenticated and no password configured', {
+          tip: [
+            NOT_LOGGED_IN_TIP,
+            LOGIN_HELP_TIP,
+            'Provide `password` via `@initProtonPass(password=...)` or set `PROTON_PASS_PASSWORD`.',
+          ].join('\n'),
+        });
+      }
+
+      debug('logging into proton pass via `pass-cli login --interactive`');
       try {
-        debug('checking proton pass login via `pass-cli info`');
-        await spawnAsync('pass-cli', ['info']);
-        this.loggedInAtMs = Date.now();
-        return;
-      } catch (err) {
-        // fall through to login attempt
-        const errMsg = err instanceof ExecError ? (err.data || err.message) : String(err);
-        debug('pass-cli info failed:', errMsg);
-
-        if (err instanceof ExecError && (err as any).code === 'ENOENT') {
-          throw new ResolutionError('`pass-cli` command not found', {
-            tip: PASS_CLI_NOT_FOUND_TIP,
-          });
-        }
-
-        const needsLogin = [
-          'not logged',
-          'not authenticated',
-          'unauthorized',
-          'login required',
-          'authentication',
-          'session',
-        ].some((t) => errMsg.toLowerCase().includes(t));
-
-        if (!needsLogin) {
-          throw new ResolutionError(`Proton Pass CLI error: ${errMsg}`, {
-            tip: ['Try running `pass-cli info` to inspect the CLI state.'].join('\n'),
-          });
-        }
-
-        // Attempt login
-        if (!this.username) {
-          throw new ResolutionError('Proton Pass CLI not authenticated and no username configured', {
-            tip: [
-              NOT_LOGGED_IN_TIP,
-              'Initialize the plugin with a username: @initProtonPass(username=..., ...)',
-            ].join('\n'),
-          });
-        }
-
-        if (!this.password) {
-          throw new ResolutionError('Proton Pass CLI not authenticated and no password configured', {
-            tip: [
-              NOT_LOGGED_IN_TIP,
-              LOGIN_HELP_TIP,
-              'Provide `password` via `@initProtonPass(password=...)` or set `PROTON_PASS_PASSWORD`.',
-            ].join('\n'),
-          });
-        }
-
-        debug('logging into proton pass via `pass-cli login --interactive`');
-        try {
-          await spawnAsync(
-            'pass-cli',
-            ['login', '--interactive', this.username],
-            this.loginEnv ? { env: { ...(process.env as Record<string, string>), ...this.loginEnv } } : undefined,
-          );
-        } catch (loginErr) {
-          const loginMsg = loginErr instanceof ExecError ? (loginErr.data || loginErr.message) : String(loginErr);
-          throw new ResolutionError(`Proton Pass CLI login failed: ${loginMsg}`, {
-            tip: [
-              NOT_LOGGED_IN_TIP,
-              LOGIN_HELP_TIP,
-            ].join('\n'),
-          });
-        }
-
-        // Verify after login
-        await spawnAsync('pass-cli', ['info']);
-        this.loggedInAtMs = Date.now();
+        await spawnAsync(
+          'pass-cli',
+          ['login', '--interactive', this.username],
+          this.loginEnv ? { env: { ...(process.env as Record<string, string>), ...this.loginEnv } } : undefined,
+        );
+      } catch (loginErr) {
+        const loginMsg = loginErr instanceof ExecError ? (loginErr.data || loginErr.message) : String(loginErr);
+        throw new ResolutionError(`Proton Pass CLI login failed: ${loginMsg}`, {
+          tip: [
+            NOT_LOGGED_IN_TIP,
+            LOGIN_HELP_TIP,
+          ].join('\n'),
+        });
       }
     })();
 
@@ -228,11 +186,45 @@ class ProtonPassPluginInstance {
     }
   }
 
+  private isAuthError(err: unknown): boolean {
+    if (!(err instanceof ExecError)) return false;
+    const errMsg = err.data || err.message;
+    const lower = errMsg.toLowerCase();
+    return [
+      'not logged',
+      'not authenticated',
+      'unauthorized',
+      'login required',
+      'authentication',
+      'session',
+    ].some((t) => lower.includes(t));
+  }
+
+  private async spawnWithAuthRetry(
+    args: Array<string>,
+    opts?: { env?: Record<string, string> },
+  ): Promise<string> {
+    try {
+      return await spawnAsync('pass-cli', args, opts);
+    } catch (err) {
+      if (err instanceof ExecError && (err as any).code === 'ENOENT') {
+        throw new ResolutionError('`pass-cli` command not found', {
+          tip: PASS_CLI_NOT_FOUND_TIP,
+        });
+      }
+
+      if (!this.isAuthError(err)) throw err;
+
+      debug('pass-cli command requires auth, attempting login and retry', args.join(' '));
+      await this.ensureCliLoggedIn();
+
+      return spawnAsync('pass-cli', args, opts);
+    }
+  }
+
   private async getSecretDirect(secretRef: string): Promise<string> {
     const cached = this.cache.get(secretRef);
     if (cached !== undefined) return cached;
-
-    await this.ensureCliLoggedIn();
 
     const fieldName = getSecretFieldNameFromRef(secretRef);
     if (!fieldName) {
@@ -240,8 +232,7 @@ class ProtonPassPluginInstance {
     }
 
     debug('fetching proton pass secret via item view', secretRef);
-    const result = await spawnAsync(
-      'pass-cli',
+    const result = await this.spawnWithAuthRetry(
       ['item', 'view', '--output', 'json', secretRef],
     );
     const cliStdout = result.trim();
@@ -277,16 +268,13 @@ class ProtonPassPluginInstance {
     const batchSecretRefs = Object.keys(batchToExecute);
     debug('executing proton pass batch read', batchSecretRefs);
     try {
-      await this.ensureCliLoggedIn();
-
       const envMap: Record<string, string> = {};
       let i = 1;
       for (const secretRef of batchSecretRefs) {
         envMap[`VARLOCK_PROTON_PASS_INJECT_${i++}`] = secretRef;
       }
 
-      const result = await spawnAsync(
-        'pass-cli',
+      const result = await this.spawnWithAuthRetry(
         ['run', '--no-masking', '--', 'env', '-0'],
         {
           env: {

--- a/packages/plugins/proton-pass/test/proton-pass.test.ts
+++ b/packages/plugins/proton-pass/test/proton-pass.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import {
-  afterAll, beforeAll, describe, test,
+  afterAll, beforeAll, describe, expect, test,
 } from 'vitest';
 import { pluginTest } from 'varlock/test-helpers';
 
@@ -14,6 +14,7 @@ const FAKE_PASS_CLI_SRC = path.join(__dirname, 'fake-pass-cli.cjs');
 const FAKE_PASS_CLI = path.join(FAKE_BIN_DIR, 'pass-cli');
 const CONFIG_PATH = path.join(FAKE_BIN_DIR, 'config.json');
 const STATE_PATH = path.join(FAKE_BIN_DIR, 'state.json');
+const LOG_PATH = path.join(FAKE_BIN_DIR, 'calls.log');
 
 type FakePassConfig = {
   refs?: Record<string, string>;
@@ -30,6 +31,14 @@ function resetFakeCli(config: FakePassConfig) {
   fs.mkdirSync(FAKE_BIN_DIR, { recursive: true });
   fs.writeFileSync(CONFIG_PATH, JSON.stringify(config), 'utf8');
   fs.writeFileSync(STATE_PATH, JSON.stringify({ loggedIn: false }), 'utf8');
+  fs.rmSync(LOG_PATH, { force: true });
+}
+
+function getFakeCliCalls(): Array<Array<string>> {
+  if (!fs.existsSync(LOG_PATH)) return [];
+  const content = fs.readFileSync(LOG_PATH, 'utf8').trim();
+  if (!content) return [];
+  return content.split('\n').map((line) => JSON.parse(line) as Array<string>);
 }
 
 async function runProtonPassTest(opts: {
@@ -181,5 +190,28 @@ SECRET=protonPass(pass://Production/Database/password)
         SECRET: Error,
       },
     });
+  });
+
+  test('lazy auth retry avoids extra preflight info checks', async () => {
+    await runProtonPassTest({
+      config: {
+        refs: {
+          'pass://Production/Database/password': 'db-secret',
+        },
+      },
+      schemaItems: `
+DB_PASS=protonPass(pass://Production/Database/password)
+`,
+      expectValues: {
+        DB_PASS: 'db-secret',
+      },
+    });
+
+    const calls = getFakeCliCalls();
+    const commandNames = calls.map((args) => args[0]);
+
+    // First read attempts run, then logs in and retries run once.
+    // No `info` preflight means fewer interactive auth prompts.
+    expect(commandNames).toEqual(['run', 'login', 'run']);
   });
 });

--- a/packages/varlock-website/src/content/docs/plugins/proton-pass.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/proton-pass.mdx
@@ -76,6 +76,17 @@ If `pass-cli` is already logged in, you can also omit credentials and just rely 
 This mostly applies to local development, in CI, you will probably want static credentials.
 :::
 
+### Reducing local login prompts
+
+For local development, especially with multi-process task runners like Turbo, these patterns help reduce repeated prompts:
+
+- Store Proton Pass credentials in local config items (for example `.env.local`), wire them into `@initProtonPass(...)`, and encrypt sensitive values using [Varlock local encryption](/guides/local-encryption/).
+- Reuse an existing `pass-cli` session when possible (`pass-cli login` once in your terminal before starting your dev tasks).
+
+:::note[TOTP in local config]
+If your account requires TOTP, a static value in config will expire quickly. For fully non-interactive workflows, consider using a Proton Pass personal access token instead.
+:::
+
 ## Loading secrets
 
 Use the `protonPass()` resolver function to fetch a field value from a Proton Pass secret reference.
@@ -164,7 +175,6 @@ DB_PASSWORD=protonPass(prod, pass://Production/Database/password)
 ### Under the hood
 
 This resolver uses:
-- `pass-cli info` to check authentication state
-- `pass-cli login --interactive <username>` when login is required
 - `pass-cli run --no-masking -- env -0` to batch multiple `pass://...` refs in one CLI invocation
+- `pass-cli login --interactive <username>` only when an auth error occurs, then retries the original command
 - `pass-cli item view --output json <secretRef>` as a fallback for per-secret retries/error handling

--- a/packages/varlock-website/src/content/docs/plugins/proton-pass.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/proton-pass.mdx
@@ -135,12 +135,12 @@ Initialize a Proton Pass plugin instance for `protonPass()` resolver.
 
 ```env-spec "@initProtonPass"
 # @initProtonPass(
-  id=prod, 
-  username=$PROTON_PASS_USERNAME, 
-  password=$PROTON_PASS_PASSWORD,
-  totp=$PROTON_PASS_TOTP,
-  extraPassword=$PROTON_PASS_EXTRA_PASSWORD
-)
+#   id=prod, 
+#   username=$PROTON_PASS_USERNAME, 
+#   password=$PROTON_PASS_PASSWORD,
+#   totp=$PROTON_PASS_TOTP,
+#   extraPassword=$PROTON_PASS_EXTRA_PASSWORD
+# )
 ```
 </div>
 </div>


### PR DESCRIPTION
## Summary
- remove preflight `pass-cli info` login checks in the Proton Pass plugin
- switch to lazy auth retry: run the real command first, then login+retry only on auth errors
- add a regression test that validates no `info` preflight command is used
- add required bumpy patch entry for `@varlock/proton-pass-plugin`

## Validation
- bun run --filter @varlock/proton-pass-plugin build
- bun run --filter @varlock/proton-pass-plugin test
- bun run lint:fix
- pre-push hooks: turbo typecheck + bumpy

## Context
This reduces unnecessary interactive login prompts, especially in workflows where frontend/backend each run separate processes (e.g. Turbo).
