### PR TITLE
docs: clarify plugin in `nextjs.mdx`

### DIFF
--- a/packages/varlock-website/src/content/docs/integrations/nextjs.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/nextjs.mdx
@@ -146,12 +146,14 @@ To integrate varlock into a Next.js application, you must use our [`@varlock/nex
     import type { NextConfig } from "next";
     +import { varlockNextConfigPlugin } from '@varlock/nextjs-integration/plugin';
 
+    const withVarlock = varlockNextConfigPlugin();
+
     const nextConfig: NextConfig = {
       // your existing config...
     };
 
     -export default nextConfig;
-    +export default varlockNextConfigPlugin()(nextConfig);
+    +export default withVarlock(nextConfig);
     ```
 
 


### PR DESCRIPTION
Make it a bit clearer that the plugin needs to be invoked before wrapping the config by splitting it on to its own line which is harder to miss than a `()`