### PR TITLE
fix: don't emit encryption fallback warning on passive backend probes

### DIFF
--- a/.bumpy/fix-fallback-warning-noise.md
+++ b/.bumpy/fix-fallback-warning-noise.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+fix: only warn about file-based encryption fallback when encryption is actually used, not on every load

--- a/packages/varlock/src/lib/local-encrypt/index.ts
+++ b/packages/varlock/src/lib/local-encrypt/index.ts
@@ -351,11 +351,6 @@ export function getBackendInfo(): BackendInfo {
     }
   } else {
     debug(`getBackendInfo: using file backend (type=${type}, binaryPath=${binaryPath ?? 'none'}, isFileFallback=${isFileFallback})`);
-    if (isFileFallback && !process.env._VARLOCK_FORCE_FILE_ENCRYPTION_FALLBACK) {
-      process.stderr.write(
-        '[varlock] Warning: native encryption binary not found, falling back to file-based encryption (not hardware-backed)\n',
-      );
-    }
     cachedBackendInfo = {
       type,
       platform: process.platform,
@@ -379,6 +374,18 @@ export function getDaemonClient(): DaemonClient {
   return daemonClient;
 }
 
+// getBackendInfo() is called as a passive capability probe on every load (cache
+// auto-policy), so the fallback warning only fires when crypto ops actually run
+let warnedFileFallback = false;
+function warnIfFileFallback(backend: BackendInfo) {
+  if (warnedFileFallback || !backend.isFileFallback) return;
+  if (process.env._VARLOCK_FORCE_FILE_ENCRYPTION_FALLBACK) return;
+  warnedFileFallback = true;
+  process.stderr.write(
+    '[varlock] Warning: native encryption binary not found, falling back to file-based encryption (not hardware-backed)\n',
+  );
+}
+
 // ── Key management ─────────────────────────────────────────────────────
 
 /** Check if a key exists. */
@@ -400,6 +407,7 @@ export function keyExists(keyId: string = DEFAULT_KEY_ID): boolean {
 export async function generateKey(keyId: string = DEFAULT_KEY_ID): Promise<{ keyId: string; publicKey: string }> {
   const backend = getBackendInfo();
   if (backend.type === 'file') {
+    warnIfFileFallback(backend);
     return fileBackend.generateKey(keyId);
   }
   return runNativeBinaryJson<{ keyId: string; publicKey: string }>(['generate-key', '--key-id', keyId]);
@@ -423,6 +431,7 @@ export async function ensureKey(keyId: string = DEFAULT_KEY_ID): Promise<void> {
 export async function encryptValue(plaintext: string, keyId: string = DEFAULT_KEY_ID): Promise<string> {
   const backend = getBackendInfo();
   if (backend.type === 'file') {
+    warnIfFileFallback(backend);
     return fileBackend.encryptValue(plaintext, keyId);
   }
   // Native binary encrypt (one-shot, no biometric needed for encrypt).
@@ -454,6 +463,7 @@ export async function decryptValue(ciphertext: string, keyId: string = DEFAULT_K
   const backend = getBackendInfo();
   if (backend.type === 'file') {
     debug('decryptValue: using file backend');
+    warnIfFileFallback(backend);
     return fileBackend.decryptValue(ciphertext, keyId);
   }
 


### PR DESCRIPTION
## Problem

The release PR's cross-platform smoke tests are failing ([run 27259330618](https://github.com/dmno-dev/varlock/actions/runs/27259330618)) on all 3 platforms:

```
FAIL tests/cli.test.ts > CLI Commands > run command > varlock run should forward child stdout
expected '2\n[varlock] Warning: native encrypti…' to be '2'
```

The cache auto-policy (added in #577) calls `localEncrypt.getBackendInfo()` on every load to decide between disk and memory caching. `getBackendInfo()` had a side effect: it printed `[varlock] Warning: native encryption binary not found, falling back to file-based encryption` whenever the native binary is missing — so every plain `varlock run`/`load` with the installed npm package emitted the warning, even when encryption isn't used at all.

## Fix

Move the warning out of `getBackendInfo()` (now a pure capability probe) into a `warnIfFileFallback()` helper that fires once, only when file-fallback crypto operations actually run (`generateKey` / `encryptValue` / `decryptValue`).

## Verification

- All local-encrypt + cache-policy unit tests pass (45/45)
- Reproduced the smoke-test scenario locally (built CLI, no native binary available): `varlock run -- node -p 1+1` now outputs exactly `2`