### PR TITLE
fix(aws-secrets): resolve named profiles via full node provider chain

### DIFF
--- a/.bumpy/fix-aws-profile-credential-source.md
+++ b/.bumpy/fix-aws-profile-credential-source.md
@@ -1,0 +1,5 @@
+---
+"@varlock/aws-secrets-plugin": patch
+---
+
+fix: resolve named AWS profiles via the full node provider chain so credential_source entries (e.g. EcsContainer) work

--- a/packages/plugins/aws-secrets/src/plugin.ts
+++ b/packages/plugins/aws-secrets/src/plugin.ts
@@ -14,7 +14,7 @@ import {
   type GetParameterCommandOutput,
 } from '@aws-sdk/client-ssm';
 import { STSClient, AssumeRoleWithWebIdentityCommand } from '@aws-sdk/client-sts';
-import { fromIni } from '@aws-sdk/credential-providers';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { getOidcToken } from '@env-spec/utils/oidc-tokens';
 
 const { ValidationError, SchemaError, ResolutionError } = plugin.ERRORS;
@@ -200,8 +200,13 @@ class AwsPluginInstance {
     }
 
     if (this.profile) {
+      // Use the full node provider chain (scoped to the named profile) rather than `fromIni` alone.
+      // `fromIni` does not fully resolve `credential_source` entries (e.g. `EcsContainer` /
+      // `Ec2InstanceMetadata`) used by container/instance roles, whereas the node provider chain
+      // delegates to the appropriate container/instance-metadata providers - matching the behavior
+      // of the AWS CLI and the SDK's default credential resolution.
       return {
-        credentials: fromIni({ profile: this.profile }),
+        credentials: fromNodeProviderChain({ profile: this.profile }),
         credentialDescription: `AWS profile: ${this.profile}`,
       };
     }


### PR DESCRIPTION
## Summary

Fixes #772.

`@initAws(profile=...)` resolved credentials with `fromIni({ profile })`, which does **not** fully handle `credential_source` entries in `~/.aws/config` (e.g. `EcsContainer`, `Ec2InstanceMetadata`). Profiles backed by container/instance roles — like CodeBuild's `credential_source = EcsContainer` on AWS GovCloud — failed with `Authentication failed with provided credentials`, even though the same profile works with the AWS CLI and the SDK's default credential chain.

## Change

Switch the profile branch in `getCredentials()` from `fromIni` to `fromNodeProviderChain({ profile })`. This scopes resolution to the named profile while delegating to the container/instance-metadata providers, matching the behavior of the AWS CLI and the SDK's default credential resolution.

```diff
-import { fromIni } from '@aws-sdk/credential-providers';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';

   if (this.profile) {
     return {
-      credentials: fromIni({ profile: this.profile }),
+      credentials: fromNodeProviderChain({ profile: this.profile }),
       credentialDescription: `AWS profile: ${this.profile}`,
     };
   }
```

## Notes

- `fromNodeProviderChain` accepts the same `profile` init property and respects it, so explicit/OIDC/default-chain code paths are unchanged.
- Patch changeset added for `@varlock/aws-secrets-plugin`.
- `typecheck`, `build`, and `lint` pass. No existing unit tests for this plugin to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)