### PR TITLE
feat: per-item leak-detection opt-out via `@sensitive={preventLeaks=false}`

### DIFF
--- a/.bumpy/sensitive-prevent-leaks-opt-out.md
+++ b/.bumpy/sensitive-prevent-leaks-opt-out.md
@@ -3,6 +3,6 @@
 varlock: minor
 ---
 
-Add per-item leak-detection opt-out via `@sensitive={preventLeaks=false}`. Secrets that legitimately leave the system (e.g. an API endpoint that returns a secret to another service) can be excluded from runtime leak detection while still being redacted in logs.
+Add per-item leak-detection opt-out via `@sensitive={preventLeaks=false}`. Secrets that legitimately leave the system (e.g. an API endpoint that returns a secret to another service) can be excluded from runtime leak detection while still being redacted in logs. The options form also accepts `enabled` to toggle sensitivity (including dynamically, e.g. `@sensitive={enabled=forEnv(production)}`).
 
 Adds standalone object (`{key=value}`) and array (`[a, b, c]`) literals to the env-spec grammar, usable as decorator values and function-call arguments (including nested). `()` remains reserved for function calls.

--- a/.bumpy/sensitive-prevent-leaks-opt-out.md
+++ b/.bumpy/sensitive-prevent-leaks-opt-out.md
@@ -1,0 +1,8 @@
+---
+"@env-spec/parser": minor
+varlock: minor
+---
+
+Add per-item leak-detection opt-out via `@sensitive={preventLeaks=false}`. Secrets that legitimately leave the system (e.g. an API endpoint that returns a secret to another service) can be excluded from runtime leak detection while still being redacted in logs.
+
+Adds standalone object (`{key=value}`) and array (`[a, b, c]`) literals to the env-spec grammar, usable as decorator values and function-call arguments (including nested). `()` remains reserved for function calls.

--- a/packages/env-spec-parser/grammar.peggy
+++ b/packages/env-spec-parser/grammar.peggy
@@ -9,6 +9,7 @@ import {
   ParsedEnvSpecDivider, ParsedEnvSpecDecoratorComment, ParsedEnvSpecComment,
   ParsedEnvSpecDecorator, ParsedEnvSpecStaticValue, ParsedEnvSpecFunctionCall,
   ParsedEnvSpecBlankLine, ParsedEnvSpecFunctionArgs, ParsedEnvSpecKeyValuePair,
+  ParsedEnvSpecObjectLiteral, ParsedEnvSpecArrayLiteral,
 } from './classes';
 }}
 
@@ -125,7 +126,9 @@ Decorator =
 // except characters that have syntactic meaning (=, (, ), #, @).
 // Invalid names are flagged downstream as warnings.
 DecoratorName = $([a-zA-Z] [^ \t\n=()#@]*)
-DecoratorValue = DecoratorFunctionCall / quotedString / unquotedStringWithoutSpaces
+// ObjectLiteral / ArrayLiteral must come first so a value starting with `{` or `[`
+// parses as a literal rather than an unquoted string.
+DecoratorValue = ObjectLiteral / ArrayLiteral / DecoratorFunctionCall / quotedString / unquotedStringWithoutSpaces
 
 // Decorator-specific function call (supports multi-line with # continuation)
 DecoratorFunctionCall =
@@ -158,12 +161,55 @@ DecoratorFunctionArgs =
   }
 
 DecoratorFunctionArgValue =
-  DecoratorFunctionCall
+  ObjectLiteral
+  / ArrayLiteral
+  / DecoratorFunctionCall
   / quotedString
   / $([^ \n,)]+) { return new ParsedEnvSpecStaticValue({ rawValue: text(), _location: location() }) }
 
 // Whitespace within decorator function args - allows newline followed by # continuation
 _decWs = ([ \t] / "\n" [ \t]* "#" [ \t]*)*
+
+// Standalone object/array literals — usable as decorator/function-arg values.
+// `{ key=value, ... }` is an object, `[ value, ... ]` is an array.
+// Single-line only for now (no multi-line `#` continuation inside the brackets).
+//
+// DESIGN NOTE: only reach for these where there is no function-call `()` already
+// carrying the structure — i.e. (1) the value of a non-function decorator
+// (`@sensitive={preventLeaks=false}`), or (2) a nested object/list passed as one
+// argument among others (`fn(retry={count=3})`). Do NOT wrap a function's own named
+// args in a literal (`string({minLength=3})`); the parens are already the options bag.
+// Prefer positional forms for ordered pairs (`remap`, `ifs`) and value lists (`enum`) —
+// remap match keys can be regexes/non-identifier strings that can't be object keys.
+// See docs: env-spec/reference "When to reach for a literal".
+ObjectLiteral =
+  "{" _
+  values:(
+    (key:FunctionArgKeyName _ "=" _ val:LiteralElementValue { return new ParsedEnvSpecKeyValuePair({ key, val }) })
+    |0.., _ "," _|
+  )
+  (_ ",")?
+  _ "}"
+  {
+    return new ParsedEnvSpecObjectLiteral({ values, _location: location() });
+  }
+
+ArrayLiteral =
+  "[" _
+  values:( LiteralElementValue |0.., _ "," _| )
+  (_ ",")?
+  _ "]"
+  {
+    return new ParsedEnvSpecArrayLiteral({ values, _location: location() });
+  }
+
+// Values inside `{}`/`[]` — like function-arg values but must also stop at `}`/`]`
+LiteralElementValue =
+  ObjectLiteral
+  / ArrayLiteral
+  / FunctionCall
+  / quotedString
+  / $([^ \n,)}\]]+) { return new ParsedEnvSpecStaticValue({ rawValue: text(), _location: location() }) }
 
 
 FunctionCall =
@@ -201,7 +247,9 @@ FunctionArgs =
 
 FunctionArgKeyName = $([a-zA-Z] [a-zA-Z0-9_]*)
 FunctionArgValue =
-  FunctionCall
+  ObjectLiteral
+  / ArrayLiteral
+  / FunctionCall
   / quotedString
   // slightly different here - can contain "#", cannot contain ")" or "," or newline
   / $([^ \n,)]+) { return new ParsedEnvSpecStaticValue({ rawValue: text(), _location: location() }) }

--- a/packages/env-spec-parser/src/classes.ts
+++ b/packages/env-spec-parser/src/classes.ts
@@ -68,7 +68,8 @@ export class ParsedEnvSpecStaticValue {
 export class ParsedEnvSpecKeyValuePair {
   constructor(public data: {
     key: string;
-    val: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall,
+    val: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall
+      | ParsedEnvSpecObjectLiteral | ParsedEnvSpecArrayLiteral,
   }) {}
 
   get key() {
@@ -79,7 +80,7 @@ export class ParsedEnvSpecKeyValuePair {
     return this.data.val;
   }
 
-  toString() {
+  toString(): string {
     return `${this.key}=${this.data.val.toString()}`;
   }
 }
@@ -150,14 +151,70 @@ export class ParsedEnvSpecFunctionCall {
 }
 
 
+// A standalone object literal `{ key=value, ... }` used as a value (e.g. `@sensitive={preventLeaks=false}`)
+export class ParsedEnvSpecObjectLiteral {
+  constructor(public data: {
+    values: Array<ParsedEnvSpecKeyValuePair>;
+    _location?: any;
+  }) {}
+
+  get values() {
+    return this.data.values;
+  }
+
+  /** the object as plain JS, for entries with statically-known values */
+  get simplifiedValue(): Record<string, any> {
+    const obj = {} as Record<string, any>;
+    for (const kv of this.data.values) {
+      if (kv.value instanceof ParsedEnvSpecStaticValue) {
+        obj[kv.key] = kv.value.value;
+      // eslint-disable-next-line no-use-before-define
+      } else if (kv.value instanceof ParsedEnvSpecObjectLiteral || kv.value instanceof ParsedEnvSpecArrayLiteral) {
+        obj[kv.key] = kv.value.simplifiedValue;
+      }
+    }
+    return obj;
+  }
+
+  toString(): string {
+    return `{${this.data.values.map((v) => v.toString()).join(', ')}}`;
+  }
+}
+
+// A standalone array literal `[ value, ... ]` used as a value
+export class ParsedEnvSpecArrayLiteral {
+  constructor(public data: {
+    values: Array<ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall
+      | ParsedEnvSpecObjectLiteral | ParsedEnvSpecArrayLiteral>;
+    _location?: any;
+  }) {}
+
+  get values() {
+    return this.data.values;
+  }
+
+  /** the array as plain JS, for entries with statically-known values */
+  get simplifiedValue(): Array<any> {
+    return this.data.values.map((v) => {
+      if (v instanceof ParsedEnvSpecStaticValue) return v.value;
+      if (v instanceof ParsedEnvSpecObjectLiteral || v instanceof ParsedEnvSpecArrayLiteral) return v.simplifiedValue;
+      return undefined;
+    });
+  }
+
+  toString(): string {
+    return `[${this.data.values.map((v) => v.toString()).join(', ')}]`;
+  }
+}
+
 export class ParsedEnvSpecDecorator {
   value?: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall
-    | ParsedEnvSpecFunctionArgs;
+    | ParsedEnvSpecFunctionArgs | ParsedEnvSpecObjectLiteral | ParsedEnvSpecArrayLiteral;
 
   constructor(public data: {
     name: string;
     value: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall
-      | ParsedEnvSpecFunctionArgs | undefined;
+      | ParsedEnvSpecFunctionArgs | ParsedEnvSpecObjectLiteral | ParsedEnvSpecArrayLiteral | undefined;
     isBareFnCall?: boolean; // true if decorator is a bare fn call (eg: @import(...))
     strayText?: string; // unexpected text found after this decorator
     _location?: any;
@@ -336,6 +393,8 @@ export class ParsedEnvSpecConfigItem {
         throw new Error('Nested key-value pair found in config item');
       } else if (expanded instanceof ParsedEnvSpecFunctionArgs) {
         throw new Error('Top-level config item cannot be a bare function args');
+      } else if (expanded instanceof ParsedEnvSpecObjectLiteral || expanded instanceof ParsedEnvSpecArrayLiteral) {
+        throw new Error('Top-level config item value cannot be a bare object or array literal');
       }
       this.value = expanded;
     }

--- a/packages/env-spec-parser/src/expand.ts
+++ b/packages/env-spec-parser/src/expand.ts
@@ -1,6 +1,6 @@
 import {
   ParsedEnvSpecFunctionArgs, ParsedEnvSpecFunctionCall, ParsedEnvSpecKeyValuePair,
-  ParsedEnvSpecStaticValue,
+  ParsedEnvSpecStaticValue, ParsedEnvSpecObjectLiteral, ParsedEnvSpecArrayLiteral,
 } from './classes';
 
 // const EXPAND_VAR_REGEX_WITH_SIMPLE = /\$({([a-zA-Z_][a-zA-Z0-9_.]*)}|([a-zA-Z_][a-zA-Z0-9_]*))/g;
@@ -123,7 +123,8 @@ function expandRefs(staticVal: ParsedEnvSpecStaticValue, mode: 'simple' | 'brack
 
 
 type ParsedEnvSpecValueNode = ParsedEnvSpecStaticValue
-| ParsedEnvSpecFunctionCall | ParsedEnvSpecFunctionArgs | ParsedEnvSpecKeyValuePair;
+| ParsedEnvSpecFunctionCall | ParsedEnvSpecFunctionArgs | ParsedEnvSpecKeyValuePair
+| ParsedEnvSpecObjectLiteral | ParsedEnvSpecArrayLiteral;
 
 /**
  * helper used by expansion to recursively expand values
@@ -164,6 +165,20 @@ function expandHelper(
     const newArgs = val.data.values.map((v) => expandHelper(v, expandStaticFn));
     return new ParsedEnvSpecFunctionArgs({
       values: newArgs as any,
+      _location: val.data._location,
+    });
+  } else if (val instanceof ParsedEnvSpecObjectLiteral) {
+    // expand each entry's value
+    const newValues = val.data.values.map((v) => expandHelper(v, expandStaticFn));
+    return new ParsedEnvSpecObjectLiteral({
+      values: newValues as any,
+      _location: val.data._location,
+    });
+  } else if (val instanceof ParsedEnvSpecArrayLiteral) {
+    // expand each element
+    const newValues = val.data.values.map((v) => expandHelper(v, expandStaticFn));
+    return new ParsedEnvSpecArrayLiteral({
+      values: newValues as any,
       _location: val.data._location,
     });
   // if key-value pair, expand value

--- a/packages/env-spec-parser/test/decorators.test.ts
+++ b/packages/env-spec-parser/test/decorators.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import outdent from 'outdent';
 import {
   ParsedEnvSpecFunctionCall, ParsedEnvSpecFunctionArgs, ParsedEnvSpecStaticValue,
+  ParsedEnvSpecObjectLiteral, ParsedEnvSpecArrayLiteral,
   parseEnvSpecDotEnvFile,
 } from '../src';
 import { expectInstanceOf } from './test-utils';
@@ -94,6 +95,35 @@ describe('decorator parsing', () => {
     ['# @enableFoo(bar)', { enableFoo: { fnName: undefined, fnArgs: ['bar'] } }],
     ['# @import(../some/path)', { import: { fnName: undefined, fnArgs: ['../some/path'] } }],
   ]));
+
+  describe('object/array literal values `@dec={k=v}` / `@dec=[a,b]`', () => {
+    it('parses `{k=v}` as an object literal (not a bare fn call)', () => {
+      const result = parseEnvSpecDotEnvFile('# @sensitive={preventLeaks=false}\nVAL=');
+      const dec = result.configItems[0].decoratorsObject.sensitive;
+      expect(dec.isBareFnCall).toBe(false);
+      expectInstanceOf(dec.value, ParsedEnvSpecObjectLiteral);
+      expect((dec.value as ParsedEnvSpecObjectLiteral).simplifiedValue).toEqual({ preventLeaks: false });
+    });
+
+    it('parses `[a, b, c]` as an array literal', () => {
+      const result = parseEnvSpecDotEnvFile('# @dec=[a, b, c]\nVAL=');
+      const dec = result.configItems[0].decoratorsObject.dec;
+      expectInstanceOf(dec.value, ParsedEnvSpecArrayLiteral);
+      expect((dec.value as ParsedEnvSpecArrayLiteral).simplifiedValue).toEqual(['a', 'b', 'c']);
+    });
+
+    it('supports nesting inside function args', () => {
+      const result = parseEnvSpecDotEnvFile('# @dec=fn(opts={x=1}, items=[1, 2])\nVAL=');
+      const dec = result.configItems[0].decoratorsObject.dec;
+      expectInstanceOf(dec.value, ParsedEnvSpecFunctionCall);
+      expect(dec.toString()).toBe('@dec=fn(opts={x=1}, items=[1, 2])');
+    });
+
+    it('round-trips via toString()', () => {
+      const result = parseEnvSpecDotEnvFile('# @sensitive={preventLeaks=false}\nVAL=');
+      expect(result.configItems[0].decoratorsObject.sensitive.toString()).toBe('@sensitive={preventLeaks=false}');
+    });
+  });
 
   describe('multi-line function calls', basicDecoratorTests([
     {

--- a/packages/varlock-website/src/content/docs/env-spec/reference.mdx
+++ b/packages/varlock-website/src/content/docs/env-spec/reference.mdx
@@ -60,7 +60,8 @@ BAZ= # @dec # this is @ignored too
 Decorators are used within comments to attach structured data to specific config items, or within a standalone comment block to alter a group of items or the entire document and loading process.
 
 - Each decorator has a name and optional value (`@name=value`) or is a bare function call `@func()`
-- Decorators with values may only be used once per comment block, while function calls may be used multiple times
+- The two forms carry a meaning: **bare function calls `@func(...)` may be used multiple times** (their args accumulate, e.g. multiple `@docs(...)` links), while **decorators with a value `@name=value` are single-use**
+- A decorator value may itself be a function call (`@name=func(args)`), an object literal (`@name={key=value}`), or an array literal (`@name=[a, b, c]`) — these are all single-use values, not bare function calls
 - Using the name only is equivalent to setting the value to true -- `@required` === `@required=true`
 - Multiple decorators may be specified on the same line
 - Decorator values will be parsed using the common value-handling rules (see below)
@@ -72,6 +73,7 @@ Decorators are used within comments to attach structured data to specific config
 # @doubleQuoted="with spaces" @singleQuote='hi' @backTickQuote=`hi`
 # @unquoted=this-works-too @withNewline="new\nline"
 # @funcCallNoArgs=func() @dec=funcCallArray(val1, "val2") @dec=funcCallObj(k1=v1, k2="v2")
+# @objectLiteral={k1=v1, k2="v2"} @arrayLiteral=[a, b, c]  # standalone object/array values
 # @anotherOne # and some comments, this @decorator is ignored
 # this is a comment and this @decorator is ignored
 ```
@@ -204,6 +206,47 @@ KEY_VALUE_ARGS=fn(key1=v1, key2="v2", key3=true)
 MIXED_ARGS=fn(item1, item2, key1=v1, key2="v2", key3=true)
 NOT_FN_CALL="fn()" # treated as string
 ```
+
+### Object & array literals
+
+Standalone objects and arrays use distinct brackets, keeping them unambiguous from function calls (which use `()`):
+
+- `{ key=value, ... }` is an **object** — keys use `=` (as elsewhere in the spec), not `:`
+- `[ value, ... ]` is an **array**
+- they may be nested, and used as decorator values or as function-call arguments
+- they are parsed using the common value-handling rules; currently single-line only
+- they are **not yet supported as standalone config item values** (e.g. `ITEM={...}`) — for now an item value that starts with `{`/`[` is still treated as a string
+
+```env-spec
+# @dec={ key1=v1, key2="v2", nested={ a=1 } }
+# @dec=[a, b, c]
+# @dec=fn(opts={ retries=3 }, tags=[x, y])
+ITEM=
+```
+
+This is why per-item options are written `@sensitive={preventLeaks=false}` rather than `@sensitive(...)` — the latter (a bare function call) is reserved for repeatable decorators.
+
+#### When to reach for a literal (and when not to)
+
+Object/array literals earn their place only where there is **no function-call `()` already carrying the structure**. In practice that means two situations:
+
+1. **The value of a non-function decorator** — e.g. `@sensitive={preventLeaks=false}`. These decorators can't take bare `()` args (that syntax is reserved for repeatable decorators), so an object value is the only way to attach options.
+2. **A single argument that is itself a nested object or list**, sitting alongside other args — e.g. `fn(retry={count=3, backoff=2})`.
+
+Do **not** wrap a function's (or function-decorator's) own named arguments in a literal — the parentheses already _are_ the options bag. The following are correct as written, and the literal-wrapped versions are redundant:
+
+| Prefer | Avoid |
+| --- | --- |
+| `@type=string(minLength=3, maxLength=50)` | `@type=string({minLength=3, maxLength=50})` |
+| `@generateTypes(lang=ts, path=env.d.ts)` | `@generateTypes({lang=ts, path=env.d.ts})` |
+| `cache(fn, ttl=1h, key=k)` | `cache(fn, {ttl=1h, key=k})` |
+
+Also prefer the existing positional/comma forms for:
+
+- **ordered pairs** — `ifs(cond1, val1, cond2, val2, default)` and `remap($VAR, match1, result1, ...)` read like a spreadsheet `IFS()`/lookup and stay flat. Crucially, `remap` match keys may be **regexes or non-identifier strings**, which cannot be object keys (keys must match `/[a-zA-Z][a-zA-Z0-9_]*/`), so an object would be strictly less expressive.
+- **value lists** — `@type=enum(dev, staging, prod)` already reads as a list; `enum([...])` only adds brackets.
+
+(There is also no multi-line literal support yet, so anything that would want to span lines should stay a function call.)
 
 ### String expansion ||expansion||
 While the parser itself does not include any implemention of specific functions, it does handle _expansion_ of strings - and it uses several function calls under the hood to do so. This means a few basic function calls, while not implemented, have specific inherent meaning and must be implemented similarly across all tools that support this spec.

--- a/packages/varlock-website/src/content/docs/reference/item-decorators.mdx
+++ b/packages/varlock-website/src/content/docs/reference/item-decorators.mdx
@@ -76,6 +76,15 @@ SERVICE_X_PRIVATE_KEY=
 # @sensitive=false
 SERVICE_X_CLIENT_ID=
 ```
+
+**Per-item options:** pass an object value to tune runtime protection for a single sensitive item:
+
+- `preventLeaks` (`boolean`, default `true`) — when `false`, this item's value is excluded from [leak detection](/reference/root-decorators/#preventleaks), so it will _not_ trigger an error if it appears in a response. Useful when an endpoint legitimately returns a secret to another system. The value is still redacted in logs. Using the options form implies `@sensitive=true`.
+
+```env-spec
+# @sensitive={preventLeaks=false}
+TOKEN_FORWARDED_TO_PARTNER=
+```
 </div>
 
 <div>

--- a/packages/varlock-website/src/content/docs/reference/item-decorators.mdx
+++ b/packages/varlock-website/src/content/docs/reference/item-decorators.mdx
@@ -77,13 +77,18 @@ SERVICE_X_PRIVATE_KEY=
 SERVICE_X_CLIENT_ID=
 ```
 
-**Per-item options:** pass an object value to tune runtime protection for a single sensitive item:
+**Per-item options:** pass an object value to tune protection for a single sensitive item:
 
-- `preventLeaks` (`boolean`, default `true`) — when `false`, this item's value is excluded from [leak detection](/reference/root-decorators/#preventleaks), so it will _not_ trigger an error if it appears in a response. Useful when an endpoint legitimately returns a secret to another system. The value is still redacted in logs. Using the options form implies `@sensitive=true`.
+- `enabled` (`boolean`, default `true`) — whether the item is sensitive. Lets you keep options while toggling sensitivity, including dynamically via a function (e.g. `enabled=forEnv(production)`). `@sensitive={enabled=false}` is equivalent to `@sensitive=false`.
+- `preventLeaks` (`boolean`, default `true`) — when `false`, this item's value is excluded from [leak detection](/reference/root-decorators/#preventleaks), so it will _not_ trigger an error if it appears in a response. Useful when an endpoint legitimately returns a secret to another system. The value is still redacted in logs.
 
 ```env-spec
 # @sensitive={preventLeaks=false}
 TOKEN_FORWARDED_TO_PARTNER=
+
+# sensitive only in production, and allowed to leave the system
+# @sensitive={enabled=forEnv(production), preventLeaks=false}
+PARTNER_TOKEN=
 ```
 </div>
 

--- a/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
+++ b/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
@@ -351,6 +351,8 @@ _Only applies in JavaScript based projects where varlock runtime code is importe
 SECRET_KEY=my-secret-value # @sensitive
 ```
 
+To opt out leak detection for a _single_ item (for example a secret an endpoint legitimately returns to another system) while keeping it enabled everywhere else, use the [`@sensitive` options form](/reference/item-decorators/#sensitive): `@sensitive={preventLeaks=false}`. The value is still redacted in logs.
+
 ![Leak prevention](../../../assets/demo-images/leak.png)
 _a sample leak detection warning in an [Astro project](/integrations/astro/)_
 

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -1,6 +1,7 @@
 import _ from '@env-spec/utils/my-dash';
 import {
-  ParsedEnvSpecDecorator, ParsedEnvSpecFunctionCall, ParsedEnvSpecStaticValue,
+  ParsedEnvSpecDecorator, ParsedEnvSpecArrayLiteral, ParsedEnvSpecObjectLiteral,
+  ParsedEnvSpecFunctionCall, ParsedEnvSpecStaticValue,
 } from '@env-spec/parser';
 
 import { EnvGraphDataType } from './data-types';
@@ -433,6 +434,18 @@ export class ConfigItem {
   get isSensitive(): boolean {
     return this._isSensitive;
   }
+
+  /**
+   * Whether runtime leak detection scans output (responses, etc.) for this item's value.
+   * Defaults to true for sensitive items; can be disabled per-item via
+   * `@sensitive={preventLeaks=false}` for secrets that legitimately leave the system
+   * (e.g. an API endpoint that returns a secret to another service).
+   * Note: this only opts out of leak detection — the value is still redacted in logs.
+   */
+  _preventLeaks: boolean = true;
+  get preventLeaks(): boolean {
+    return this._preventLeaks;
+  }
   private async processSensitive() {
     const sensitiveFromDataType = this.dataType?.isSensitive;
 
@@ -443,10 +456,32 @@ export class ConfigItem {
       if (!sensitiveDec) continue;
 
       const usingPublic = sensitiveDec.name === 'public';
+
+      // options-object form: `@sensitive={preventLeaks=false}` — implies sensitive=true
+      // and carries per-item runtime-protection options
+      if (sensitiveDec.parsedDecorator.value instanceof ParsedEnvSpecObjectLiteral) {
+        if (usingPublic) {
+          this._schemaErrors.push(new SchemaError('@public does not accept options - use @sensitive={...} on sensitive items'));
+          return;
+        }
+        const resolved = await sensitiveDec.resolve() as Record<string, any> | undefined;
+        if (sensitiveDec.schemaErrors.some((e) => !e.isWarning)) return;
+        this.applySensitiveOptions(resolved ?? {});
+        this._isSensitive = true;
+        this._sensitiveExplicitlySet = true;
+        return;
+      }
+      // an array literal is never valid here — guide toward the object form
+      if (sensitiveDec.parsedDecorator.value instanceof ParsedEnvSpecArrayLiteral) {
+        this._schemaErrors.push(new SchemaError('@sensitive expects options as an object, e.g. @sensitive={preventLeaks=false}'));
+        return;
+      }
+
       const sensitiveDecValue = await sensitiveDec.resolve();
       if (sensitiveDec.schemaErrors.some((e) => !e.isWarning)) return;
       if (![true, false, undefined].includes(sensitiveDecValue)) {
-        throw new SchemaError('@sensitive/@public must resolve to a boolean or undefined');
+        this._schemaErrors.push(new SchemaError('@sensitive/@public must resolve to a boolean or undefined'));
+        return;
       }
       if (sensitiveDecValue !== undefined) {
         this._isSensitive = usingPublic ? !sensitiveDecValue : sensitiveDecValue;
@@ -483,6 +518,21 @@ export class ConfigItem {
     }
 
     if (sensitiveFromDataType !== undefined) this._isSensitive = sensitiveFromDataType;
+  }
+
+  /** apply named options from the `@sensitive={...}` options-object form */
+  private applySensitiveOptions(opts: Record<string, any>) {
+    for (const optKey of Object.keys(opts)) {
+      if (optKey === 'preventLeaks') {
+        if (typeof opts[optKey] !== 'boolean') {
+          this._schemaErrors.push(new SchemaError('@sensitive preventLeaks option must be a boolean'));
+          continue;
+        }
+        this._preventLeaks = opts[optKey];
+      } else {
+        this._schemaErrors.push(new SchemaError(`@sensitive: unknown option "${optKey}". Valid options: preventLeaks`));
+      }
+    }
   }
 
 

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -457,8 +457,9 @@ export class ConfigItem {
 
       const usingPublic = sensitiveDec.name === 'public';
 
-      // options-object form: `@sensitive={preventLeaks=false}` — implies sensitive=true
-      // and carries per-item runtime-protection options
+      // options-object form: `@sensitive={preventLeaks=false}` — carries per-item
+      // runtime-protection options. `enabled` toggles sensitivity itself (defaults to
+      // true, and may be a function for dynamic control, e.g. enabled=forEnv(prod)).
       if (sensitiveDec.parsedDecorator.value instanceof ParsedEnvSpecObjectLiteral) {
         if (usingPublic) {
           this._schemaErrors.push(new SchemaError('@public does not accept options - use @sensitive={...} on sensitive items'));
@@ -466,8 +467,7 @@ export class ConfigItem {
         }
         const resolved = await sensitiveDec.resolve() as Record<string, any> | undefined;
         if (sensitiveDec.schemaErrors.some((e) => !e.isWarning)) return;
-        this.applySensitiveOptions(resolved ?? {});
-        this._isSensitive = true;
+        this._isSensitive = this.applySensitiveOptions(resolved ?? {});
         this._sensitiveExplicitlySet = true;
         return;
       }
@@ -520,19 +520,31 @@ export class ConfigItem {
     if (sensitiveFromDataType !== undefined) this._isSensitive = sensitiveFromDataType;
   }
 
-  /** apply named options from the `@sensitive={...}` options-object form */
-  private applySensitiveOptions(opts: Record<string, any>) {
+  /**
+   * Apply named options from the `@sensitive={...}` form.
+   * Returns whether the item is sensitive (the `enabled` option, defaulting to true) —
+   * `enabled` may be static or a function, allowing dynamic control of sensitivity.
+   */
+  private applySensitiveOptions(opts: Record<string, any>): boolean {
+    let enabled = true;
     for (const optKey of Object.keys(opts)) {
-      if (optKey === 'preventLeaks') {
+      if (optKey === 'enabled') {
+        if (typeof opts[optKey] !== 'boolean') {
+          this._schemaErrors.push(new SchemaError('@sensitive enabled option must resolve to a boolean'));
+          continue;
+        }
+        enabled = opts[optKey];
+      } else if (optKey === 'preventLeaks') {
         if (typeof opts[optKey] !== 'boolean') {
           this._schemaErrors.push(new SchemaError('@sensitive preventLeaks option must be a boolean'));
           continue;
         }
         this._preventLeaks = opts[optKey];
       } else {
-        this._schemaErrors.push(new SchemaError(`@sensitive: unknown option "${optKey}". Valid options: preventLeaks`));
+        this._schemaErrors.push(new SchemaError(`@sensitive: unknown option "${optKey}". Valid options: enabled, preventLeaks`));
       }
     }
+    return enabled;
   }
 
 

--- a/packages/varlock/src/env-graph/lib/decorators.ts
+++ b/packages/varlock/src/env-graph/lib/decorators.ts
@@ -112,6 +112,17 @@ export abstract class DecoratorInstance {
         );
       }
       if (!this.decoratorDef.isFunction && this.isFunctionCall) {
+        // bare fn-call syntax `@name(...)` is reserved for repeatable decorators (e.g. @docs()).
+        // @sensitive is single-use but accepts an options-object value — guide users who tried
+        // to pass options as a bare call toward the object form `@sensitive={...}`.
+        if (this.name === 'sensitive') {
+          const optsStr = this.parsedDecorator.bareFnArgs
+            ? `{${this.parsedDecorator.bareFnArgs.values.map((v) => v.toString()).join(', ')}}`
+            : '{preventLeaks=false}';
+          throw new SchemaError(
+            `@sensitive is single-use and cannot be called like @sensitive(...). To pass options, use an object value: @sensitive=${optsStr}`,
+          );
+        }
         throw new SchemaError(
           `@${this.name} cannot be used as a function call - use @${this.name}=value instead of @${this.name}(...)`,
         );

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -55,6 +55,8 @@ export type SerializedEnvGraph = {
   config: Record<string, {
     value: any;
     isSensitive: boolean;
+    /** false = opted out of runtime leak detection (still redacted in logs). Omitted when true (the default). */
+    preventLeaks?: boolean;
   }>;
   /** provenance metadata for process.env overrides across nested invocations */
   __varlockOverrideMeta?: OverrideProvenanceMetadata;
@@ -672,6 +674,8 @@ export class EnvGraph {
       serializedGraph.config[itemKey] = {
         value: item.resolvedValue,
         isSensitive: item.isSensitive,
+        // only emit when opted out — keeps the common-case blob smaller
+        ...item.isSensitive && !item.preventLeaks ? { preventLeaks: false } : {},
       };
     }
     // Only process.env keys that correspond to a config item can actually act as overrides.

--- a/packages/varlock/src/env-graph/lib/resolver.ts
+++ b/packages/varlock/src/env-graph/lib/resolver.ts
@@ -7,7 +7,7 @@ import {
 import _ from '@env-spec/utils/my-dash';
 import {
   ParsedEnvSpecFunctionArgs, ParsedEnvSpecFunctionCall, ParsedEnvSpecKeyValuePair,
-  ParsedEnvSpecStaticValue,
+  ParsedEnvSpecStaticValue, ParsedEnvSpecObjectLiteral, ParsedEnvSpecArrayLiteral,
 } from '@env-spec/parser';
 
 import { ConfigItem } from './config-item';
@@ -67,7 +67,7 @@ export class Resolver {
   inferredType?: string;
   /** reference to the parsed node that created this resolver, used for error location tracking */
   _parsedNode?: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall
-    | ParsedEnvSpecFunctionArgs;
+    | ParsedEnvSpecFunctionArgs | ParsedEnvSpecObjectLiteral | ParsedEnvSpecArrayLiteral;
   _errors: Array<SchemaError> = [];
   private _depsObj: Record<string, boolean> = {};
 
@@ -299,6 +299,47 @@ export class FunctionArgsResolver extends Resolver {
       arr: resolvedArrayArgs,
       obj: resolvedObjArgs,
     };
+  }
+}
+
+// resolver for a standalone object literal `{ k=v, ... }` — resolves to a plain object
+export class ObjectLiteralResolver extends Resolver {
+  static def = {
+    name: '\0objectLiteral', // used internally, so we add the extra \0
+    label: 'object literal',
+    icon: 'bi:braces',
+    resolve() { return undefined; },
+  };
+  get isStatic() {
+    // static when every value is static
+    return Object.values(this.objArgs ?? {}).every((r) => r.isStatic);
+  }
+  async resolve() {
+    const obj = {} as Record<string, any>;
+    for (const key in this.objArgs) {
+      obj[key] = await this.objArgs[key].resolve();
+    }
+    return obj;
+  }
+}
+
+// resolver for a standalone array literal `[ v, ... ]` — resolves to a plain array
+export class ArrayLiteralResolver extends Resolver {
+  static def = {
+    name: '\0arrayLiteral', // used internally, so we add the extra \0
+    label: 'array literal',
+    icon: 'bi:bracket',
+    resolve() { return undefined; },
+  };
+  get isStatic() {
+    return (this.arrArgs ?? []).every((r) => r.isStatic);
+  }
+  async resolve() {
+    const arr = [] as Array<any>;
+    for (const arg of this.arrArgs ?? []) {
+      arr.push(await arg.resolve());
+    }
+    return arr;
   }
 }
 
@@ -1003,7 +1044,7 @@ export const BaseResolvers: Array<ResolverChildClass> = [
 
 export function convertParsedValueToResolvers(
   value: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall
-    | ParsedEnvSpecFunctionArgs | undefined,
+    | ParsedEnvSpecFunctionArgs | ParsedEnvSpecObjectLiteral | ParsedEnvSpecArrayLiteral | undefined,
   dataSource: EnvGraphDataSource | undefined,
   registeredResolvers: Record<string, ResolverChildClass>,
 ): Resolver | undefined {
@@ -1011,6 +1052,25 @@ export function convertParsedValueToResolvers(
     return undefined;
   } else if (value instanceof ParsedEnvSpecStaticValue) {
     return new StaticValueResolver(value.unescapedValue);
+  } else if (value instanceof ParsedEnvSpecObjectLiteral) {
+    const objArgs: Record<string, Resolver> = {};
+    for (const kv of value.values) {
+      const valResolver = convertParsedValueToResolvers(kv.value, dataSource, registeredResolvers);
+      if (!valResolver) throw new Error('Did not expect to find undefined resolver in object literal');
+      objArgs[kv.key] = valResolver;
+    }
+    const resolver = new ObjectLiteralResolver(undefined, objArgs, dataSource);
+    resolver._parsedNode = value;
+    return resolver;
+  } else if (value instanceof ParsedEnvSpecArrayLiteral) {
+    const arrArgs = value.values.map((v) => {
+      const argResolver = convertParsedValueToResolvers(v, dataSource, registeredResolvers);
+      if (!argResolver) throw new Error('Did not expect to find undefined resolver in array literal');
+      return argResolver;
+    });
+    const resolver = new ArrayLiteralResolver(arrArgs, undefined, dataSource);
+    resolver._parsedNode = value;
+    return resolver;
   } else if (
     value instanceof ParsedEnvSpecFunctionCall
     // this is used only for bare decorator fn calls `@fn(arr1, arr2, k1=v1)`

--- a/packages/varlock/src/env-graph/test/sensitive-decorator.test.ts
+++ b/packages/varlock/src/env-graph/test/sensitive-decorator.test.ts
@@ -394,6 +394,40 @@ describe('per-item @sensitive={preventLeaks=false}', () => {
     },
   }));
 
+  test('enabled=false toggles the item to not sensitive', envFilesTest({
+    envFile: outdent`
+      OFF=val   # @sensitive={enabled=false}
+      ON=val    # @sensitive={enabled=true, preventLeaks=false}
+    `,
+    expectSensitive: { OFF: false, ON: true },
+    expectSerializedMatches: {
+      config: {
+        ON: { isSensitive: true, preventLeaks: false },
+      },
+    },
+  }));
+
+  test('enabled can be a function for dynamic sensitivity (forEnv)', envFilesTest({
+    files: {
+      '.env.schema': outdent`
+        # @currentEnv=$APP_ENV
+        # ---
+        APP_ENV=production
+        SENSITIVE_IN_PROD=  # @sensitive={enabled=forEnv(production), preventLeaks=false}
+        SENSITIVE_IN_DEV=   # @sensitive={enabled=forEnv(dev)}
+      `,
+    },
+    expectSensitive: {
+      SENSITIVE_IN_PROD: true,
+      SENSITIVE_IN_DEV: false,
+    },
+  }));
+
+  test('non-boolean enabled is rejected', envFilesTest({
+    envFile: 'FOO=val   # @sensitive={enabled=nope}',
+    expectValues: { FOO: SchemaError },
+  }));
+
   test('@public does not accept options', envFilesTest({
     envFile: 'FOO=val   # @public={preventLeaks=false}',
     expectValues: { FOO: SchemaError },

--- a/packages/varlock/src/env-graph/test/sensitive-decorator.test.ts
+++ b/packages/varlock/src/env-graph/test/sensitive-decorator.test.ts
@@ -4,7 +4,7 @@ import {
 import path from 'node:path';
 import outdent from 'outdent';
 import { envFilesTest } from './helpers/generic-test';
-import { EnvGraph, DotEnvFileDataSource } from '../index';
+import { EnvGraph, DotEnvFileDataSource, SchemaError } from '../index';
 import { createEnvGraphDataType } from '../lib/data-types';
 
 describe('@sensitive and @defaultSensitive tests', () => {
@@ -363,4 +363,70 @@ describe('@redactLogs and @preventLeaks', () => {
       },
     },
   }));
+});
+
+describe('per-item @sensitive={preventLeaks=false}', () => {
+  test('opts an item out of leak detection while keeping it sensitive', envFilesTest({
+    envFile: outdent`
+      LEAKY=val      # @sensitive={preventLeaks=false}
+      NORMAL=val     # @sensitive
+    `,
+    expectSensitive: { LEAKY: true, NORMAL: true },
+    expectSerializedMatches: {
+      config: {
+        // opted-out item carries the flag so the runtime scanner can skip it
+        LEAKY: { isSensitive: true, preventLeaks: false },
+      },
+    },
+  }));
+
+  test('preventLeaks=true is the default and is not emitted in the serialized graph', envFilesTest({
+    envFile: outdent`
+      A=val   # @sensitive={preventLeaks=true}
+      B=val   # @sensitive
+    `,
+    expectSensitive: { A: true, B: true },
+    expectSerializedMatches: {
+      config: {
+        A: { isSensitive: true },
+        B: { isSensitive: true },
+      },
+    },
+  }));
+
+  test('@public does not accept options', envFilesTest({
+    envFile: 'FOO=val   # @public={preventLeaks=false}',
+    expectValues: { FOO: SchemaError },
+  }));
+
+  test('unknown options are rejected', envFilesTest({
+    envFile: 'FOO=val   # @sensitive={redactLogs=false}',
+    expectValues: { FOO: SchemaError },
+  }));
+
+  test('non-boolean preventLeaks is rejected', envFilesTest({
+    envFile: 'FOO=val   # @sensitive={preventLeaks=nope}',
+    expectValues: { FOO: SchemaError },
+  }));
+
+  test('an array literal is rejected (options must be an object)', envFilesTest({
+    envFile: 'FOO=val   # @sensitive=[preventLeaks]',
+    expectValues: { FOO: SchemaError },
+  }));
+
+  test('bare fn-call form @sensitive(...) is rejected (reserved for repeatable decorators)', envFilesTest({
+    envFile: 'FOO=val   # @sensitive(preventLeaks=false)',
+    expectValues: { FOO: SchemaError },
+  }));
+
+  test('the bare fn-call error points users to the object value form', async () => {
+    const g = new EnvGraph();
+    await g.setRootDataSource(new DotEnvFileDataSource('.env.schema', {
+      overrideContents: 'FOO=val   # @sensitive(preventLeaks=false)',
+    }));
+    await g.finishLoad();
+    await g.resolveEnvValues();
+    const messages = g.configSchema.FOO.errors.map((e) => e.message);
+    expect(messages.some((m) => m.includes('@sensitive={preventLeaks=false}'))).toBe(true);
+  });
 });

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -21,7 +21,8 @@ const UNMASK_STR = '👁';
 // Without this, the module instance that patches console.log may have an empty map
 // while a different instance has the populated one.
 type RedactionState = {
-  sensitiveSecretsMap: Record<string, { key: string, redacted: string }>,
+  // `preventLeaks: false` means the value is still redacted in logs but skipped by the leak scanner
+  sensitiveSecretsMap: Record<string, { key: string, redacted: string, preventLeaks: boolean }>,
   redactorFindReplace: undefined | { find: RegExp, replace: ReplaceFn },
 };
 type ReplaceFn = (match: string, pre: string, val: string, post: string) => string;
@@ -46,7 +47,13 @@ export function resetRedactionMap(graph: SerializedEnvGraph) {
     if (item.isSensitive && item.value && isString(item.value)) {
       // TODO: we want to respect masking settings from the schema (once added)
       const redacted = redactString(item.value);
-      if (redacted) state.sensitiveSecretsMap[item.value] = { key: itemKey, redacted };
+      // preventLeaks defaults to true; `@sensitive={preventLeaks=false}` opts the item
+      // out of leak scanning while still keeping it redacted in logs
+      if (redacted) {
+        state.sensitiveSecretsMap[item.value] = {
+          key: itemKey, redacted, preventLeaks: item.preventLeaks !== false,
+        };
+      }
     }
   }
   // if no sensitive items exist, we dont need to do any redaction, but the redact fn is checking for undefined
@@ -185,6 +192,8 @@ export function scanForLeaks(
 
     // TODO: probably should use a single regex
     for (const sensitiveValue in sensitiveSecretsMap) {
+      // items opted out via `@sensitive={preventLeaks=false}` are skipped by the scanner
+      if (!sensitiveSecretsMap[sensitiveValue].preventLeaks) continue;
       if (strToScan.includes(sensitiveValue)) {
         const itemKey = sensitiveSecretsMap[sensitiveValue].key;
 

--- a/packages/varlock/src/runtime/test/scan-for-leaks.test.ts
+++ b/packages/varlock/src/runtime/test/scan-for-leaks.test.ts
@@ -1,7 +1,7 @@
 import {
   describe, it, expect, beforeEach,
 } from 'vitest';
-import { scanForLeaks, resetRedactionMap } from '../env';
+import { scanForLeaks, resetRedactionMap, redactSensitiveConfig } from '../env';
 import type { SerializedEnvGraph } from '../../env-graph';
 
 /** helper to set up redaction state with a known secret */
@@ -88,5 +88,33 @@ describe('scanForLeaks', () => {
   // --- null / undefined ---
   it('returns null for null input', () => {
     expect(scanForLeaks(null)).toBeNull();
+  });
+});
+
+describe('scanForLeaks with per-item preventLeaks opt-out', () => {
+  const LEAKY_VALUE = 'allowed-to-leave-67890';
+  const NORMAL_VALUE = 'still-protected-12345';
+
+  beforeEach(() => {
+    resetRedactionMap({
+      config: {
+        LEAKY: { isSensitive: true, value: LEAKY_VALUE, preventLeaks: false },
+        NORMAL: { isSensitive: true, value: NORMAL_VALUE },
+      },
+    } as unknown as SerializedEnvGraph);
+  });
+
+  it('does not throw when an opted-out secret appears in output', () => {
+    const out = `response body contains ${LEAKY_VALUE}`;
+    expect(scanForLeaks(out)).toBe(out);
+  });
+
+  it('still throws for other sensitive values that did not opt out', () => {
+    expect(() => scanForLeaks(`oops ${NORMAL_VALUE}`))
+      .toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('still redacts the opted-out secret in logs (opt-out is leak-detection only)', () => {
+    expect(redactSensitiveConfig(`logging ${LEAKY_VALUE}`)).not.toContain(LEAKY_VALUE);
   });
 });


### PR DESCRIPTION
## What

Lets a user opt a single secret out of runtime **leak detection** while keeping it sensitive everywhere else. Motivating case: an API endpoint that legitimately returns a secret to another system — today that trips varlock's response leak scanner.

```sh
# @sensitive={preventLeaks=false}
TOKEN_FORWARDED_TO_PARTNER=
```

The opt-out is **leak-detection only** — the value is still redacted in logs. Leak detection and log redaction previously shared one secrets map; this decouples them per-secret (the scanner skips opted-out entries, redaction still masks them).

## The `@sensitive={...}` options form

| option | type | default | meaning |
| --- | --- | --- | --- |
| `enabled` | boolean | `true` | whether the item is sensitive. May be a function for dynamic control (`enabled=forEnv(production)`); `{enabled=false}` ≡ `@sensitive=false`. |
| `preventLeaks` | boolean | `true` | when `false`, excluded from the response leak scanner (still redacted in logs). |

```sh
# sensitive only in production, and allowed to leave the system
# @sensitive={enabled=forEnv(production), preventLeaks=false}
PARTNER_TOKEN=
```

## How it flows

- **Schema** → `@sensitive={…}` parses to an object literal.
- **Graph** (`config-item.ts`) → reads `enabled` (→ sensitivity) and `preventLeaks` onto the item; rejects invalid uses (`@public={…}`, unknown option, non-boolean, array literal, bare `@sensitive(…)`).
- **Serialization** (`env-graph.ts`) → emits `preventLeaks: false` only when opted out.
- **Runtime** (`runtime/env.ts`) → `scanForLeaks` skips opted-out secrets; `redactSensitiveConfig` still masks them.

## New syntax: `{}` / `[]` literals

Carrying options on `@sensitive` required a value syntax. We chose **distinct brackets** — `{key=value}` objects and `[a, b, c]` arrays — keeping `()` reserved for function calls. Rationale (mainstream langs keep objects in `{}` not `()`; Lisp's all-`()` was walked back by Clojure; ML-family records already use `{k=v}`). Usable as decorator values and function-call args, including nested (`fn(retry={count=3})`).

Guidance on **when to use literals vs. not** (don't wrap a function's own named args) is documented in the env-spec reference and a grammar `DESIGN NOTE`.

## Deliberately deferred (documented)

- Standalone literals as **item values** (`FOO={…}`) — gated on object/array value handling (coercion/validation/redaction-of-objects), not a blocker but its own change.
- **Multi-line** literals.

## Tests

- Parser: object/array literal parse, nesting, round-trip.
- env-graph: opt-out keeps item sensitive + serializes the flag; static + dynamic (`forEnv`) `enabled`; rejection cases.
- Runtime: opted-out value passes the scanner, other secrets still throw, opted-out value still redacted.

All green: varlock + `@env-spec/parser` suites, typecheck, lint. Changeset included (`minor` for both packages).