### PR TITLE
feat(varlock): pick/omit key filters for @setValuesBulk and @import

### DIFF
--- a/.bumpy/set-values-bulk-key-filters.md
+++ b/.bumpy/set-values-bulk-key-filters.md
@@ -1,0 +1,8 @@
+---
+varlock: minor
+env-spec-language: patch
+---
+
+`@setValuesBulk` supports key filters.
+
+Filter which keys get injected with `pick` (allowlist) or `omit` (denylist) array args: `@setValuesBulk(opLoadEnvironment(env-id), pick=[API_KEY, DB_*])` or `@setValuesBulk(infisicalBulk(), omit=[LEGACY_TOKEN])`. By default every key is injected; `pick` and `omit` can't be combined. Both accept simple globs (`*`, `?`).

--- a/.bumpy/set-values-bulk-key-filters.md
+++ b/.bumpy/set-values-bulk-key-filters.md
@@ -3,6 +3,8 @@ varlock: minor
 env-spec-language: patch
 ---
 
-`@setValuesBulk` supports key filters.
+`@setValuesBulk` and `@import` support `pick`/`omit` key filters.
 
-Filter which keys get injected with `pick` (allowlist) or `omit` (denylist) array args: `@setValuesBulk(opLoadEnvironment(env-id), pick=[API_KEY, DB_*])` or `@setValuesBulk(infisicalBulk(), omit=[LEGACY_TOKEN])`. By default every key is injected; `pick` and `omit` can't be combined. Both accept simple globs (`*`, `?`).
+Filter which keys are brought in with `pick` (allowlist) or `omit` (denylist) array args — e.g. `@setValuesBulk(opLoadEnvironment(env-id), pick=[API_KEY, DB_*])` or `@import(./.env.shared, omit=[LEGACY_TOKEN])`. By default every key is included; `pick` and `omit` can't be combined, and both accept simple globs (`*`, `?`).
+
+For `@import`, listing keys as positional args (`@import(./.env.shared, KEY1, KEY2)`) is now deprecated in favor of `pick=[...]` — it still works but warns.

--- a/packages/varlock-website/src/content/docs/guides/import.mdx
+++ b/packages/varlock-website/src/content/docs/guides/import.mdx
@@ -7,10 +7,10 @@ The [`@import()` root decorator](/reference/root-decorators/#import) allows you 
 
 **Basic examples:**
 ```env-spec
-# @import(./.env.imported)              # import specific file
-# @import(./env-dir/)                   # import directory
-# @import(./.env.partial, KEY1, KEY2)   # import specific keys
-# @import(~/.env.shared)                # import from home directory
+# @import(./.env.imported)                 # import specific file
+# @import(./env-dir/)                      # import directory
+# @import(./.env.partial, pick=[K1, K2])   # import specific keys
+# @import(~/.env.shared)                   # import from home directory
 ```
 
 ## Import source types
@@ -70,13 +70,22 @@ A registry (npm, jsr, etc.), package name, version, and path can be used to impo
 
 ## Partial imports
 
-By default, all items will be imported, but you may add a list of specific keys to import as additional args after the first.
+By default, all items will be imported, but you can restrict which keys are brought in:
 
-- If there is a chain of imports, an item is only imported if every ancestor import includes it (or imports all items)
+- `pick=[...]` imports only an allowlist of keys
+- `omit=[...]` imports everything except a denylist of keys
+- You can't use both in one import, and both accept simple globs (`*`, `?`)
+- If there is a chain of imports, an item is only imported if every ancestor import includes it (filters intersect)
 
 ```env-spec
-# @import(./.env.imported, KEY1, KEY2)
+# @import(./.env.imported, pick=[KEY1, KEY2])   # allowlist
+# @import(./.env.imported, pick=[API_*])        # globs work too
+# @import(./.env.imported, omit=[SECRET])       # denylist
 ```
+
+:::caution[Positional keys are deprecated]
+Older docs and configs list keys as positional args (`@import(./.env.imported, KEY1, KEY2)`). This still works but is deprecated and will warn — use `pick=[KEY1, KEY2]` instead.
+:::
 
 ## Conditional imports
 
@@ -87,7 +96,7 @@ The `enabled` parameter accepts any expression that evaluates to a boolean. It c
 **Example:**
 ```env-spec title=".env.schema" /\(enabled=.*\)\\)/
 # Combine with partial imports
-# @import(./.env.features, FEATURE_X, enabled=eq($ENABLE_X, "true"))
+# @import(./.env.features, pick=[FEATURE_X], enabled=eq($ENABLE_X, "true"))
 # ---
 ENABLE_X=true
 ```
@@ -107,7 +116,7 @@ The `allowMissing` parameter accepts a boolean value (defaults to `false`). It c
 **Combine with other parameters:**
 ```env-spec title=".env.schema"
 # Optional partial import with conditional loading
-# @import(./.env.features, FEATURE_X, enabled=true, allowMissing=true)
+# @import(./.env.features, pick=[FEATURE_X], enabled=true, allowMissing=true)
 ```
 
 ## Import precedence and merging multiple sources

--- a/packages/varlock-website/src/content/docs/guides/secrets.mdx
+++ b/packages/varlock-website/src/content/docs/guides/secrets.mdx
@@ -114,8 +114,13 @@ For example, using 1Password, you could store a .env style blob within a text fi
 # load Infisical secrets filtered by path or tag
 # @setValuesBulk(infisicalBulk(path="/database", tag="backend"))
 #
-# Fetch all secrets from HashiCorp Vault as JSON
-# @setValuesBulk(exec("vault kv get -format=json secret/myapp"), format=json)
+# load all key/value pairs from a HashiCorp Vault path
+# @setValuesBulk(vaultSecret("secret/myapp/config", raw=true))
+#
+# inject only specific keys (pick allowlist), or everything except some (omit denylist)
+# both accept simple globs like API_*
+# @setValuesBulk(opLoadEnvironment(your-environment-id), pick=[API_KEY, DB_*])
+# @setValuesBulk(infisicalBulk(), omit=[LEGACY_TOKEN])
 ```
 
 The bulk values are injected at the precedence level of the file containing the decorator — so `.env.local` and `process.env` will still override them as expected. See the [reference docs](/reference/root-decorators/#setvaluesbulk) for full details.

--- a/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
+++ b/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
@@ -131,8 +131,8 @@ FOO=bar  # will be ignored
 
 <div>
 ### `@import()`
-**Arg types:** `[ path: string, ...keys?: string[] ]`  
-**Named args:** `enabled?: boolean`, `allowMissing?: boolean`
+**Arg types:** `[ path: string ]`  
+**Named args:** `enabled?: boolean`, `allowMissing?: boolean`, `pick?: string[]`, `omit?: string[]`
 
 Imports other `.env` file(s) - useful for sharing config across monorepos and splitting up large schemas. _Can be called multiple times._
 
@@ -142,11 +142,19 @@ The optional `enabled` parameter allows conditional imports based on boolean exp
 
 The optional `allowMissing` parameter makes the import optional - if set to `true`, the import will be silently skipped if the file or directory doesn't exist instead of causing a loading error. It defaults to `false` if not specified.
 
+**Filtering keys:** by default every key from the imported file(s) is brought in. Use `pick` to import only an allowlist of keys, or `omit` to import everything except a denylist. You can't use both in one import, and both accept simple globs (`*`, `?`). Across nested imports, filters intersect — a key must pass every filter in the chain.
+
+:::caution[Positional keys are deprecated]
+Listing keys as positional args (`@import(./.env.other, KEY1, KEY2)`) is **deprecated** — use `pick=[KEY1, KEY2]` instead. The positional form still works (exact-match only, no globs) but will warn.
+:::
+
 See the [imports guide](/guides/import/) for more details and advanced usage.
 
 ```env-spec
 # @import(./.env.imported)                        # import a specific file
-# @import(./.env.other, KEY1, KEY2)               # import specific keys
+# @import(./.env.other, pick=[KEY1, KEY2])        # import only these keys (allowlist)
+# @import(./.env.other, pick=[API_*])             # globs are supported
+# @import(./.env.other, omit=[SECRET])            # import everything except these (denylist)
 # @import(../shared-env/)                         # import a directory
 # @import(~/.env.shared)                          # import from home directory
 # @import(./.env.dev, enabled=eq($ENV, "dev"))    # conditional import

--- a/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
+++ b/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
@@ -161,9 +161,9 @@ IMPORTED_ITEM=overridden-value
 <div>
 ### `@setValuesBulk()`
 **Arg types:** `[ data: string ]`
-**Named args:** `format?: "json" | "env"`, `createMissing?: boolean`, `enabled?: boolean`
+**Named args:** `format?: "json" | "env"`, `createMissing?: boolean`, `enabled?: boolean`, `pick?: string[]`, `omit?: string[]`
 
-Injects multiple config values at once from an external data source. The first argument is a resolver that produces a string (e.g., `exec()` calling a secrets manager), which is parsed and injected as definitions within the file containing the decorator.
+Injects multiple config values at once from an external data source. The first argument is a resolver that produces a string — typically a bulk resolver from a [secrets provider plugin](/plugins/overview/) such as [`opLoadEnvironment()`](/plugins/1password/#oploadenvironment) (1Password), [`infisicalBulk()`](/plugins/infisical/), or [`vaultSecret(…, raw=true)`](/plugins/hashicorp-vault/) (HashiCorp Vault) — which is parsed and injected as definitions within the file containing the decorator.
 
 Bulk values participate in the normal file override chain — `process.env` still overrides everything, higher-precedence files (`.env.local`, `.env.production`, etc.) override bulk values, and bulk values override schema-defined defaults in the same file. You control precedence by choosing which file to put `@setValuesBulk` in.
 
@@ -171,37 +171,60 @@ Bulk values participate in the normal file override chain — `process.env` stil
 - `format`: How to parse the data string. `json` expects a flat JSON object, `env` expects `.env` file format. If not specified, auto-detected by checking if the string starts with `{`.
 - `createMissing`: If `true`, keys in the bulk data that don't already exist in your schema will be created as new config items. Defaults to `false` (unknown keys are silently skipped).
 - `enabled`: If `false`, the bulk data resolver is skipped entirely. Accepts any boolean expression, including dynamic references to other config items. Defaults to `true`.
+- `pick`: An array of key names to inject — an **allowlist**. Only matching keys are injected; everything else from the source is ignored.
+- `omit`: An array of key names to skip — a **denylist**. Every key _except_ the matches is injected.
+
+By default (neither `pick` nor `omit`) every key from the source is injected. You can't use `pick` and `omit` together. Both accept simple glob patterns — `*` matches any run of characters and `?` matches a single character (e.g. `pick=[API_*]`).
 
 _Can be called multiple times — later calls overwrite earlier ones for the same keys._
 
 ```env-spec title=".env.schema"
-# Inject secrets from a vault as JSON
-# @setValuesBulk(exec("vault kv get -format=json secret/myapp"), format=json)
+# Load all values from a 1Password environment
+# @plugin(@varlock/1password-plugin)
+# @initOp(token=$OP_TOKEN, allowAppAuth=forEnv(dev))
+# @setValuesBulk(opLoadEnvironment(your-environment-id))
+# ---
+# @type=opServiceAccountToken @sensitive
+OP_TOKEN=
+API_KEY=
+DB_PASSWORD=
+```
+
+```env-spec title=".env.schema"
+# Inject from a .env-style blob stored in a single 1Password field
+# @setValuesBulk(op("op://vault/app-secrets/dotenv"), format=env)
 # ---
 API_KEY=
 DB_PASSWORD=
 ```
 
 ```env-spec title=".env.schema"
-# Inject from a secrets file as .env format
-# @setValuesBulk(exec("cat /run/secrets/env"), format=env)
+# Allowlist — only inject these keys (globs allowed, e.g. API_*)
+# @setValuesBulk(opLoadEnvironment(your-environment-id), pick=[API_KEY, DB_PASSWORD])
 # ---
 API_KEY=
 DB_PASSWORD=
+```
+
+```env-spec title=".env.schema"
+# Denylist — inject everything except these keys
+# @setValuesBulk(infisicalBulk(), omit=[LEGACY_TOKEN, DEBUG_*])
 ```
 
 ```env-spec title=".env.schema"
 # Create items not already in the schema
-# @setValuesBulk(exec("vault kv get -format=json secret/myapp"), format=json, createMissing=true)
+# @setValuesBulk(infisicalBulk(), createMissing=true)
 ```
 
 ```env-spec title=".env.schema"
-# Only fetch from the vault in non-production environments
-# @setValuesBulk(exec("vault kv get -format=json secret/dev"), format=json, enabled=eq($APP_ENV, "dev"))
+# Only fetch from the source in non-production environments
+# @setValuesBulk(opLoadEnvironment(dev-environment-id), enabled=eq($APP_ENV, "dev"))
 # ---
 API_KEY=
 APP_ENV=dev
 ```
+
+If a plugin doesn't exist for your provider, any CLI tool works via [`exec()`](/reference/functions/#exec) — e.g. `@setValuesBulk(exec("vault kv get -format=json secret/myapp"), format=json)`.
 
 :::note
 When using `format=env`, function calls like `$VAR` references in unquoted values are not supported and will cause an error. Use single quotes for literal `$` signs (e.g., `'$LITERAL'`) or use `format=json` instead.

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -84,10 +84,10 @@ export class ConfigItem {
     // we may want to cache the definition list at some point when loading is complete
     // although we need it to be dynamic during the loading process when doing any early resolution of the envFlag
     const defs: Array<ConfigItemDefAndSource> = [];
-    for (const { source, importKeys } of this.envGraph.sortedDefinitionSources) {
+    for (const { source, filterNode } of this.envGraph.sortedDefinitionSources) {
       if (!source.configItemDefs[this.key]) continue;
       if (source.disabled) continue;
-      if (importKeys && !importKeys.includes(this.key)) continue;
+      if (filterNode && !filterNode.isKeyImported(this.key)) continue;
       defs.push({ itemDef: source.configItemDefs[this.key], source });
     }
     defs.push(...this._internalDefs);

--- a/packages/varlock/src/env-graph/lib/data-source.ts
+++ b/packages/varlock/src/env-graph/lib/data-source.ts
@@ -18,28 +18,20 @@ import { pathExists } from '@env-spec/utils/fs-utils';
 import { processPluginInstallDecorators } from './plugins';
 import { RootDecoratorInstance } from './decorators';
 import { isBuiltinVar } from './builtin-vars';
-import { globToRegExp } from './glob';
-
-/** A `@import` key filter — `pick` is an allowlist, `omit` a denylist. Patterns support globs. */
-export type ImportFilter = { mode: 'pick' | 'omit', patterns: Array<string> };
+import { type KeyFilter, keyMatchesFilter, parseKeyFilterArgs } from './key-filter';
 
 /**
  * Whether `key` passes a single import's filter — the deprecated positional allowlist
- * (`importKeys`, exact match) and/or a pick/omit filter (glob-aware). Returns true when
- * no filter is set.
+ * (`importKeys`, exact match) and/or a pick/omit {@link KeyFilter} (glob-aware). Returns
+ * true when no filter is set.
  */
 export function keyPassesImportFilter(
   key: string,
   importKeys?: Array<string>,
-  importFilter?: ImportFilter,
+  importFilter?: KeyFilter,
 ): boolean {
   if (importKeys?.length && !importKeys.includes(key)) return false;
-  if (importFilter) {
-    const matched = importFilter.patterns.some((p) => globToRegExp(p).test(key));
-    if (importFilter.mode === 'pick' && !matched) return false;
-    if (importFilter.mode === 'omit' && matched) return false;
-  }
-  return true;
+  return keyMatchesFilter(key, importFilter);
 }
 
 const DATA_SOURCE_TYPES = Object.freeze({
@@ -83,7 +75,7 @@ export abstract class EnvGraphDataSource {
     /** deprecated positional allowlist (exact match) - prefer `importFilter` */
     importKeys?: Array<string>,
     /** pick/omit key filter (glob-aware) */
-    importFilter?: ImportFilter,
+    importFilter?: KeyFilter,
     /** true when the @import had a non-static `enabled` parameter (e.g. `enabled=forEnv("dev")`) */
     isConditionallyEnabled?: boolean,
   };
@@ -393,25 +385,17 @@ export abstract class EnvGraphDataSource {
             throw new Error('expected @import keys to all be strings');
           }
 
-          // build the key filter: positional keys (deprecated) or pick/omit (preferred)
-          const pickVal = importArgs.obj.pick;
-          const omitVal = importArgs.obj.omit;
-          if (pickVal !== undefined && omitVal !== undefined) {
-            throw new Error('@import: cannot use both pick and omit - choose one');
-          }
-          if ((pickVal !== undefined || omitVal !== undefined) && positionalKeys.length) {
+          // build the key filter: pick/omit (preferred) or positional keys (deprecated)
+          const importFilter = parseKeyFilterArgs(
+            importDec.decValueResolver?.objArgs?.pick,
+            importDec.decValueResolver?.objArgs?.omit,
+            '@import',
+          );
+          let importKeys: Array<string> | undefined;
+          if (importFilter && positionalKeys.length) {
             throw new Error('@import: cannot combine positional keys with pick/omit - put all keys in pick=[...]');
           }
-          let importFilter: ImportFilter | undefined;
-          let importKeys: Array<string> | undefined;
-          if (pickVal !== undefined || omitVal !== undefined) {
-            const mode = pickVal !== undefined ? 'pick' : 'omit';
-            const patterns = pickVal !== undefined ? pickVal : omitVal;
-            if (!Array.isArray(patterns) || !patterns.length || !patterns.every(_.isString)) {
-              throw new Error(`@import: ${mode} must be a non-empty array of key names, e.g. ${mode}=[API_KEY, DB_*]`);
-            }
-            importFilter = { mode, patterns };
-          } else if (positionalKeys.length) {
+          if (!importFilter && positionalKeys.length) {
             this._errors.push(new SchemaError(
               'Listing @import keys as positional args is deprecated - use pick=[...] instead'
               + ` (e.g. @import("${importPath}", pick=[${positionalKeys.join(', ')}]))`,

--- a/packages/varlock/src/env-graph/lib/data-source.ts
+++ b/packages/varlock/src/env-graph/lib/data-source.ts
@@ -18,6 +18,29 @@ import { pathExists } from '@env-spec/utils/fs-utils';
 import { processPluginInstallDecorators } from './plugins';
 import { RootDecoratorInstance } from './decorators';
 import { isBuiltinVar } from './builtin-vars';
+import { globToRegExp } from './glob';
+
+/** A `@import` key filter — `pick` is an allowlist, `omit` a denylist. Patterns support globs. */
+export type ImportFilter = { mode: 'pick' | 'omit', patterns: Array<string> };
+
+/**
+ * Whether `key` passes a single import's filter — the deprecated positional allowlist
+ * (`importKeys`, exact match) and/or a pick/omit filter (glob-aware). Returns true when
+ * no filter is set.
+ */
+export function keyPassesImportFilter(
+  key: string,
+  importKeys?: Array<string>,
+  importFilter?: ImportFilter,
+): boolean {
+  if (importKeys?.length && !importKeys.includes(key)) return false;
+  if (importFilter) {
+    const matched = importFilter.patterns.some((p) => globToRegExp(p).test(key));
+    if (importFilter.mode === 'pick' && !matched) return false;
+    if (importFilter.mode === 'omit' && matched) return false;
+  }
+  return true;
+}
 
 const DATA_SOURCE_TYPES = Object.freeze({
   schema: {
@@ -57,32 +80,41 @@ export abstract class EnvGraphDataSource {
    * */
   importMeta?: {
     isImport?: boolean,
+    /** deprecated positional allowlist (exact match) - prefer `importFilter` */
     importKeys?: Array<string>,
+    /** pick/omit key filter (glob-aware) */
+    importFilter?: ImportFilter,
     /** true when the @import had a non-static `enabled` parameter (e.g. `enabled=forEnv("dev")`) */
     isConditionallyEnabled?: boolean,
   };
   get isImport(): boolean {
     return !!this.importMeta?.isImport || !!this.parent?.isImport;
   }
-  get isPartialImport() {
-    return (this.importKeys || []).length > 0;
-  }
-  get importKeys(): Array<string> | undefined {
-    const importKeysArrays = [];
+  /** true when any import in this source's chain restricts which keys are brought in */
+  get isPartialImport(): boolean {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let currentSource: EnvGraphDataSource | undefined = this;
     while (currentSource) {
-      if (currentSource.importMeta?.importKeys && currentSource.importMeta.importKeys.length) {
-        importKeysArrays.push(currentSource.importMeta.importKeys);
+      if (currentSource.importMeta?.importKeys?.length || currentSource.importMeta?.importFilter) {
+        return true;
       }
       currentSource = currentSource.parent;
     }
-
-    // in most cases we import all keys, but if there have been specific keys imported we walk up the chain
-    if (importKeysArrays.length) {
-      const keysToImport = _.intersection(...importKeysArrays);
-      return keysToImport;
+    return false;
+  }
+  /**
+   * Whether `key` is visible through this source's full import chain. A key must pass every
+   * import filter between this source and the root (nested imports intersect).
+   */
+  isKeyImported(key: string): boolean {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let currentSource: EnvGraphDataSource | undefined = this;
+    while (currentSource) {
+      const meta = currentSource.importMeta;
+      if (meta && !keyPassesImportFilter(key, meta.importKeys, meta.importFilter)) return false;
+      currentSource = currentSource.parent;
     }
+    return true;
   }
 
   /** shared child-setup logic: wire up parent/graph refs, finishInit (but no import processing) */
@@ -222,7 +254,8 @@ export abstract class EnvGraphDataSource {
     if (this.disabled) return;
 
     // create config items, or add additional definitions if they already exist
-    for (const itemKey of this.importKeys || _.keys(this.configItemDefs)) {
+    for (const itemKey of _.keys(this.configItemDefs)) {
+      if (!this.isKeyImported(itemKey)) continue;
       const itemDef = this.configItemDefs[itemKey];
       if (!itemDef) continue;
 
@@ -270,7 +303,7 @@ export abstract class EnvGraphDataSource {
           // If this is a partial import and the ref target is not importable, skip processing
           // but still set the envFlagKey so directories can check it
           // For files, @currentEnv won't take effect and forEnv will fall back to parent's env setting
-          if (this.isPartialImport && !this.importKeys?.includes(envFlagItemKey)) {
+          if (this.isPartialImport && !this.isKeyImported(envFlagItemKey)) {
             skipCurrentEnvProcessing = true;
           }
         }
@@ -355,9 +388,36 @@ export abstract class EnvGraphDataSource {
 
           const importArgs = await importDec.resolve();
           const importPath = importArgs.arr[0];
-          const importKeys = importArgs.arr.slice(1);
-          if (!importKeys.every(_.isString)) {
+          const positionalKeys = importArgs.arr.slice(1);
+          if (!positionalKeys.every(_.isString)) {
             throw new Error('expected @import keys to all be strings');
+          }
+
+          // build the key filter: positional keys (deprecated) or pick/omit (preferred)
+          const pickVal = importArgs.obj.pick;
+          const omitVal = importArgs.obj.omit;
+          if (pickVal !== undefined && omitVal !== undefined) {
+            throw new Error('@import: cannot use both pick and omit - choose one');
+          }
+          if ((pickVal !== undefined || omitVal !== undefined) && positionalKeys.length) {
+            throw new Error('@import: cannot combine positional keys with pick/omit - put all keys in pick=[...]');
+          }
+          let importFilter: ImportFilter | undefined;
+          let importKeys: Array<string> | undefined;
+          if (pickVal !== undefined || omitVal !== undefined) {
+            const mode = pickVal !== undefined ? 'pick' : 'omit';
+            const patterns = pickVal !== undefined ? pickVal : omitVal;
+            if (!Array.isArray(patterns) || !patterns.length || !patterns.every(_.isString)) {
+              throw new Error(`@import: ${mode} must be a non-empty array of key names, e.g. ${mode}=[API_KEY, DB_*]`);
+            }
+            importFilter = { mode, patterns };
+          } else if (positionalKeys.length) {
+            this._errors.push(new SchemaError(
+              'Listing @import keys as positional args is deprecated - use pick=[...] instead'
+              + ` (e.g. @import("${importPath}", pick=[${positionalKeys.join(', ')}]))`,
+              { isWarning: true },
+            ));
+            importKeys = positionalKeys;
           }
 
           // determine the full import path based on path type
@@ -390,6 +450,10 @@ export abstract class EnvGraphDataSource {
           const enabledResolver = importDec.decValueResolver?.objArgs?.enabled;
           const isConditionallyEnabled = !!enabledResolver && !enabledResolver.isStatic;
 
+          const importMeta = {
+            isImport: true, importKeys, importFilter, isConditionallyEnabled,
+          };
+
           // Check if missing imports should be allowed (defaults to false if not specified)
           const allowMissing = importArgs.obj.allowMissing ?? false;
           if (!_.isBoolean(allowMissing)) {
@@ -405,10 +469,8 @@ export abstract class EnvGraphDataSource {
             const existingSource = this.graph.getLoadedImportSource(fullImportPath);
             if (existingSource) {
               // eslint-disable-next-line no-use-before-define
-              await this.addChild(new ImportAliasSource(existingSource), {
-                isImport: true, importKeys, isConditionallyEnabled,
-              });
-              this.graph.registerItemsForImport(existingSource, this, importKeys);
+              await this.addChild(new ImportAliasSource(existingSource), importMeta);
+              this.graph.registerItemsForImport(existingSource, this, importMeta);
               continue;
             }
 
@@ -422,9 +484,7 @@ export abstract class EnvGraphDataSource {
                 }
                 // eslint-disable-next-line no-use-before-define
                 const dirChild = new DirectoryDataSource(fullImportPath);
-                await this.addChild(dirChild, {
-                  isImport: true, importKeys, isConditionallyEnabled,
-                });
+                await this.addChild(dirChild, importMeta);
                 this.graph.recordLoadedImportPath(fullImportPath, dirChild);
               } else {
                 const fileExists = this.graph.virtualImports[fullImportPath];
@@ -437,7 +497,7 @@ export abstract class EnvGraphDataSource {
                 const fileChild = new DotEnvFileDataSource(fullImportPath, {
                   overrideContents: this.graph.virtualImports[fullImportPath],
                 });
-                await this.addChild(fileChild, { isImport: true, importKeys, isConditionallyEnabled });
+                await this.addChild(fileChild, importMeta);
                 this.graph.recordLoadedImportPath(fullImportPath, fileChild);
               }
             } else {
@@ -476,9 +536,7 @@ export abstract class EnvGraphDataSource {
                 // TODO: once we have more file types, here we would detect the type and import it correctly
                 // eslint-disable-next-line no-use-before-define
                 const fileChild = new DotEnvFileDataSource(fullImportPath);
-                await this.addChild(fileChild, {
-                  isImport: true, importKeys, isConditionallyEnabled,
-                });
+                await this.addChild(fileChild, importMeta);
                 this.graph.recordLoadedImportPath(fullImportPath, fileChild);
               }
             }
@@ -859,7 +917,7 @@ export class DirectoryDataSource extends EnvGraphDataSource {
       const envFlagKey = this.schemaDataSource._envFlagKey;
       // Check if this is a partial import that forgot to include the env flag key
       // (only for directories - files can fall back to parent's env setting for forEnv)
-      if (this.isPartialImport && !this.importKeys?.includes(envFlagKey)) {
+      if (this.isPartialImport && !this.isKeyImported(envFlagKey)) {
         this._errors.push(new LoadingError(
           `Imported directory has @currentEnv set to $${envFlagKey}, `
           + `but "${envFlagKey}" is not included in the import list. `

--- a/packages/varlock/src/env-graph/lib/decorators.ts
+++ b/packages/varlock/src/env-graph/lib/decorators.ts
@@ -7,12 +7,10 @@ import {
 } from '@env-spec/parser';
 import { EnvGraphDataSource } from './data-source';
 import type { ConfigItem } from './config-item';
-import {
-  StaticValueResolver, ArrayLiteralResolver, type Resolver, convertParsedValueToResolvers,
-} from './resolver';
+import { StaticValueResolver, type Resolver, convertParsedValueToResolvers } from './resolver';
 import { ResolutionError, SchemaError, type VarlockError } from './errors';
 import type { EnvGraph } from './env-graph';
-import { globToRegExp } from './glob';
+import { parseKeyFilterArgs, applyKeyFilter, type KeyFilter } from './key-filter';
 
 
 export abstract class DecoratorInstance {
@@ -405,49 +403,24 @@ export const builtInRootDecorators: Array<RootDecoratorDef<any>> = [
         }
       }
 
-      // key filters: `pick=[...]` is an allowlist, `omit=[...]` a denylist. Default (neither)
-      // injects every key. The two can't be combined. Patterns support simple globs (`*`, `?`).
-      const pickResolver = argsVal.objArgs?.pick;
-      const omitResolver = argsVal.objArgs?.omit;
-      if (pickResolver && omitResolver) {
-        throw new SchemaError('@setValuesBulk: cannot use both pick and omit - choose one');
-      }
-      let filterMode: 'pick' | 'omit' | undefined;
-      let filterPatterns: Array<string> | undefined;
-      const filterResolver = pickResolver ?? omitResolver;
-      if (filterResolver) {
-        filterMode = pickResolver ? 'pick' : 'omit';
-        if (!(filterResolver instanceof ArrayLiteralResolver)) {
-          throw new SchemaError(`@setValuesBulk: ${filterMode} must be an array literal, e.g. ${filterMode}=[API_KEY, DB_*]`);
-        }
-        filterPatterns = (filterResolver.arrArgs ?? []).map((el) => {
-          if (!el.isStatic || typeof el.staticValue !== 'string' || !el.staticValue.trim()) {
-            throw new SchemaError(`@setValuesBulk: ${filterMode} entries must be non-empty static key names or globs`);
-          }
-          return el.staticValue.trim();
-        });
-        if (!filterPatterns.length) {
-          throw new SchemaError(`@setValuesBulk: ${filterMode} list cannot be empty`);
-        }
-      }
+      // key filters: `pick=[...]` (allowlist) / `omit=[...]` (denylist). Default injects every key.
+      const keyFilter = parseKeyFilterArgs(argsVal.objArgs?.pick, argsVal.objArgs?.omit, '@setValuesBulk');
 
       return {
         graph: argsVal.dataSource!.graph!,
         dataSource: argsVal.dataSource!,
         argsResolver: argsVal,
-        filterMode,
-        filterPatterns,
+        keyFilter,
       };
     },
     async execute(processedData) {
       const {
-        graph, dataSource, argsResolver, filterMode, filterPatterns,
+        graph, dataSource, argsResolver, keyFilter,
       } = processedData as {
         graph: EnvGraph;
         dataSource: EnvGraphDataSource;
         argsResolver: Resolver;
-        filterMode?: 'pick' | 'omit';
-        filterPatterns?: Array<string>;
+        keyFilter?: KeyFilter;
       };
 
       // check enabled before resolving data - important so disabled sources don't trigger data fetching
@@ -485,16 +458,8 @@ export const builtInRootDecorators: Array<RootDecoratorDef<any>> = [
         entries = parseEnvBulkValues(dataString);
       }
 
-      // apply key filters - pick keeps only matching keys, omit drops them.
-      // patterns support simple globs (`*`, `?`); no filter means inject everything.
-      if (filterMode && filterPatterns) {
-        const matchers = filterPatterns.map(globToRegExp);
-        const matches = (key: string) => matchers.some((re) => re.test(key));
-        for (const key of Object.keys(entries)) {
-          const keep = filterMode === 'pick' ? matches(key) : !matches(key);
-          if (!keep) delete entries[key];
-        }
-      }
+      // apply pick/omit key filter (no filter means inject everything)
+      applyKeyFilter(entries, keyFilter);
 
       // dynamic import to avoid circular dependency
       const { ConfigItem } = await import('./config-item');

--- a/packages/varlock/src/env-graph/lib/decorators.ts
+++ b/packages/varlock/src/env-graph/lib/decorators.ts
@@ -7,7 +7,9 @@ import {
 } from '@env-spec/parser';
 import { EnvGraphDataSource } from './data-source';
 import type { ConfigItem } from './config-item';
-import { StaticValueResolver, type Resolver, convertParsedValueToResolvers } from './resolver';
+import {
+  StaticValueResolver, ArrayLiteralResolver, type Resolver, convertParsedValueToResolvers,
+} from './resolver';
 import { ResolutionError, SchemaError, type VarlockError } from './errors';
 import type { EnvGraph } from './env-graph';
 
@@ -219,6 +221,17 @@ function detectBulkFormat(data: string): 'json' | 'env' {
   return data.trimStart().startsWith('{') ? 'json' : 'env';
 }
 
+// Compile a simple glob pattern into an anchored regex. Supports `*` (any run of chars)
+// and `?` (single char); all other characters are matched literally. Used by @setValuesBulk
+// pick/omit filters. Matching is case-sensitive (env keys are case-sensitive).
+function globToRegExp(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape regex specials (leaving * and ?)
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
+  return new RegExp(`^${escaped}$`);
+}
+
 function parseJsonBulkValues(data: string): Record<string, { value: string | number | boolean }> {
   let parsed: any;
   try {
@@ -372,13 +385,16 @@ export const builtInRootDecorators: Array<RootDecoratorDef<any>> = [
         throw new SchemaError('@setValuesBulk requires at least one argument - the data resolver');
       }
       if (argsVal.arrArgs.length > 1) {
-        throw new SchemaError('@setValuesBulk expects only one positional argument - the data resolver');
+        throw new SchemaError(
+          '@setValuesBulk expects only one positional argument - the data resolver.'
+          + ' Use pick=[...] / omit=[...] to filter keys.',
+        );
       }
       if (argsVal.objArgs) {
-        const validOptions = new Set(['format', 'createMissing', 'enabled']);
+        const validOptions = new Set(['format', 'createMissing', 'enabled', 'pick', 'omit']);
         for (const key of Object.keys(argsVal.objArgs)) {
           if (!validOptions.has(key)) {
-            throw new SchemaError(`@setValuesBulk: unknown option "${key}". Valid options: format, createMissing, enabled`);
+            throw new SchemaError(`@setValuesBulk: unknown option "${key}". Valid options: format, createMissing, enabled, pick, omit`);
           }
         }
         // validate format option if static
@@ -399,17 +415,49 @@ export const builtInRootDecorators: Array<RootDecoratorDef<any>> = [
         }
       }
 
+      // key filters: `pick=[...]` is an allowlist, `omit=[...]` a denylist. Default (neither)
+      // injects every key. The two can't be combined. Patterns support simple globs (`*`, `?`).
+      const pickResolver = argsVal.objArgs?.pick;
+      const omitResolver = argsVal.objArgs?.omit;
+      if (pickResolver && omitResolver) {
+        throw new SchemaError('@setValuesBulk: cannot use both pick and omit - choose one');
+      }
+      let filterMode: 'pick' | 'omit' | undefined;
+      let filterPatterns: Array<string> | undefined;
+      const filterResolver = pickResolver ?? omitResolver;
+      if (filterResolver) {
+        filterMode = pickResolver ? 'pick' : 'omit';
+        if (!(filterResolver instanceof ArrayLiteralResolver)) {
+          throw new SchemaError(`@setValuesBulk: ${filterMode} must be an array literal, e.g. ${filterMode}=[API_KEY, DB_*]`);
+        }
+        filterPatterns = (filterResolver.arrArgs ?? []).map((el) => {
+          if (!el.isStatic || typeof el.staticValue !== 'string' || !el.staticValue.trim()) {
+            throw new SchemaError(`@setValuesBulk: ${filterMode} entries must be non-empty static key names or globs`);
+          }
+          return el.staticValue.trim();
+        });
+        if (!filterPatterns.length) {
+          throw new SchemaError(`@setValuesBulk: ${filterMode} list cannot be empty`);
+        }
+      }
+
       return {
         graph: argsVal.dataSource!.graph!,
         dataSource: argsVal.dataSource!,
         argsResolver: argsVal,
+        filterMode,
+        filterPatterns,
       };
     },
     async execute(processedData) {
-      const { graph, dataSource, argsResolver } = processedData as {
+      const {
+        graph, dataSource, argsResolver, filterMode, filterPatterns,
+      } = processedData as {
         graph: EnvGraph;
         dataSource: EnvGraphDataSource;
         argsResolver: Resolver;
+        filterMode?: 'pick' | 'omit';
+        filterPatterns?: Array<string>;
       };
 
       // check enabled before resolving data - important so disabled sources don't trigger data fetching
@@ -445,6 +493,17 @@ export const builtInRootDecorators: Array<RootDecoratorDef<any>> = [
         entries = parseJsonBulkValues(dataString);
       } else {
         entries = parseEnvBulkValues(dataString);
+      }
+
+      // apply key filters - pick keeps only matching keys, omit drops them.
+      // patterns support simple globs (`*`, `?`); no filter means inject everything.
+      if (filterMode && filterPatterns) {
+        const matchers = filterPatterns.map(globToRegExp);
+        const matches = (key: string) => matchers.some((re) => re.test(key));
+        for (const key of Object.keys(entries)) {
+          const keep = filterMode === 'pick' ? matches(key) : !matches(key);
+          if (!keep) delete entries[key];
+        }
       }
 
       // dynamic import to avoid circular dependency

--- a/packages/varlock/src/env-graph/lib/decorators.ts
+++ b/packages/varlock/src/env-graph/lib/decorators.ts
@@ -12,6 +12,7 @@ import {
 } from './resolver';
 import { ResolutionError, SchemaError, type VarlockError } from './errors';
 import type { EnvGraph } from './env-graph';
+import { globToRegExp } from './glob';
 
 
 export abstract class DecoratorInstance {
@@ -219,17 +220,6 @@ export class RootDecoratorInstance extends DecoratorInstance {
 
 function detectBulkFormat(data: string): 'json' | 'env' {
   return data.trimStart().startsWith('{') ? 'json' : 'env';
-}
-
-// Compile a simple glob pattern into an anchored regex. Supports `*` (any run of chars)
-// and `?` (single char); all other characters are matched literally. Used by @setValuesBulk
-// pick/omit filters. Matching is case-sensitive (env keys are case-sensitive).
-function globToRegExp(pattern: string): RegExp {
-  const escaped = pattern
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape regex specials (leaving * and ?)
-    .replace(/\*/g, '.*')
-    .replace(/\?/g, '.');
-  return new RegExp(`^${escaped}$`);
 }
 
 function parseJsonBulkValues(data: string): Record<string, { value: string | number | boolean }> {

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -3,8 +3,9 @@ import path from 'node:path';
 import { ConfigItem } from './config-item';
 import {
   EnvGraphDataSource, FileBasedDataSource, ImportAliasSource,
-  keyPassesImportFilter, type ImportFilter,
+  keyPassesImportFilter,
 } from './data-source';
+import { type KeyFilter } from './key-filter';
 
 import { BaseResolvers, createResolver, type ResolverChildClass } from './resolver';
 import { BaseDataTypes, type EnvGraphDataTypeFactory } from './data-types';
@@ -124,7 +125,7 @@ export class EnvGraph {
   registerItemsForImport(
     source: EnvGraphDataSource,
     importSite: EnvGraphDataSource,
-    importMeta?: { importKeys?: Array<string>, importFilter?: ImportFilter },
+    importMeta?: { importKeys?: Array<string>, importFilter?: KeyFilter },
   ) {
     // A key is visible only if it passes both this import's own filter and the
     // importSite's full import chain (nested imports intersect).

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -1,7 +1,10 @@
 import _ from '@env-spec/utils/my-dash';
 import path from 'node:path';
 import { ConfigItem } from './config-item';
-import { EnvGraphDataSource, FileBasedDataSource, ImportAliasSource } from './data-source';
+import {
+  EnvGraphDataSource, FileBasedDataSource, ImportAliasSource,
+  keyPassesImportFilter, type ImportFilter,
+} from './data-source';
 
 import { BaseResolvers, createResolver, type ResolverChildClass } from './resolver';
 import { BaseDataTypes, type EnvGraphDataTypeFactory } from './data-types';
@@ -30,12 +33,12 @@ export type SerializedEnvGraphErrors = {
   root?: Array<string>;
 };
 
-/** Entry in the sorted definition sources list — pairs a data source with the importKeys
- * filter that applies at that specific position in the precedence chain */
+/** Entry in the sorted definition sources list — pairs a data source with the node whose
+ * import chain filters which keys are visible at that specific position in the precedence chain */
 export type DefinitionSourceEntry = {
   source: EnvGraphDataSource;
-  /** importKeys filter for this position (undefined = all keys visible) */
-  importKeys?: Array<string>;
+  /** node whose import chain decides key visibility for this position (undefined = all keys visible) */
+  filterNode?: EnvGraphDataSource;
 };
 
 export type SerializedEnvGraph = {
@@ -121,24 +124,14 @@ export class EnvGraph {
   registerItemsForImport(
     source: EnvGraphDataSource,
     importSite: EnvGraphDataSource,
-    importKeys?: Array<string>,
+    importMeta?: { importKeys?: Array<string>, importFilter?: ImportFilter },
   ) {
-    // Compute effective importKeys: intersection of import filter and importSite's parent chain
-    const siteKeys = importSite.importKeys;
-    let effectiveKeys: Array<string> | undefined;
-    const hasFilter = importKeys && importKeys.length > 0;
-    if (hasFilter && siteKeys?.length) {
-      effectiveKeys = importKeys.filter((k) => siteKeys.includes(k));
-    } else if (hasFilter) {
-      effectiveKeys = importKeys;
-    } else {
-      effectiveKeys = siteKeys;
-    }
-
+    // A key is visible only if it passes both this import's own filter and the
+    // importSite's full import chain (nested imports intersect).
     for (const s of this._getDescendants(source)) {
-      const keys = effectiveKeys || _.keys(s.configItemDefs);
-      for (const itemKey of keys) {
-        if (!s.configItemDefs[itemKey]) continue;
+      for (const itemKey of _.keys(s.configItemDefs)) {
+        if (importMeta && !keyPassesImportFilter(itemKey, importMeta.importKeys, importMeta.importFilter)) continue;
+        if (!importSite.isKeyImported(itemKey)) continue;
         this.configSchema[itemKey] ??= new ConfigItem(this, itemKey);
       }
     }
@@ -186,14 +179,13 @@ export class EnvGraph {
 
     for (const source of this.sortedDataSources) {
       if (source instanceof ImportAliasSource) {
-        // Alias: expand to the original source's subtree at this position,
-        // using the alias's importKeys (derived from its own parent chain)
-        const importKeys = source.importKeys;
+        // Alias: expand to the original source's subtree at this position, applying the
+        // alias node's import chain (its own filter + the importing context) for visibility.
         for (const descendant of this._getDescendants(source.original)) {
-          result.push({ source: descendant, importKeys });
+          result.push({ source: descendant, filterNode: source });
         }
       } else {
-        result.push({ source, importKeys: source.importKeys });
+        result.push({ source, filterNode: source });
       }
     }
 

--- a/packages/varlock/src/env-graph/lib/glob.ts
+++ b/packages/varlock/src/env-graph/lib/glob.ts
@@ -1,0 +1,13 @@
+/**
+ * Compile a simple glob pattern into an anchored regex. Supports `*` (any run of
+ * characters) and `?` (single character); every other character matches literally.
+ * Used by key filters (`@setValuesBulk` and `@import` pick/omit). Matching is
+ * case-sensitive, since env keys are case-sensitive.
+ */
+export function globToRegExp(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape regex specials (leaving * and ?)
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
+  return new RegExp(`^${escaped}$`);
+}

--- a/packages/varlock/src/env-graph/lib/key-filter.ts
+++ b/packages/varlock/src/env-graph/lib/key-filter.ts
@@ -1,0 +1,60 @@
+import { SchemaError } from './errors';
+import { ArrayLiteralResolver, type Resolver } from './resolver';
+import { globToRegExp } from './glob';
+
+/**
+ * A reusable allow/deny key filter, shared by any decorator that selects a subset of keys
+ * via `pick=[...]` / `omit=[...]` named args (e.g. `@setValuesBulk`, `@import`).
+ *
+ * `pick` keeps only matching keys; `omit` drops them. Patterns support simple globs
+ * (`*`, `?`) via {@link globToRegExp} and match case-sensitively.
+ */
+export type KeyFilter = { mode: 'pick' | 'omit', patterns: Array<string> };
+
+/**
+ * Parse `pick`/`omit` named-arg resolvers into a {@link KeyFilter}.
+ *
+ * Both must be static array literals of non-empty strings, and the two are mutually
+ * exclusive. Returns `undefined` when neither is set (meaning "all keys"). `label` is
+ * used to prefix error messages (e.g. `"@import"`).
+ */
+export function parseKeyFilterArgs(
+  pick: Resolver | undefined,
+  omit: Resolver | undefined,
+  label: string,
+): KeyFilter | undefined {
+  if (pick && omit) {
+    throw new SchemaError(`${label}: cannot use both pick and omit - choose one`);
+  }
+  const resolver = pick ?? omit;
+  if (!resolver) return undefined;
+  const mode = pick ? 'pick' : 'omit';
+  if (!(resolver instanceof ArrayLiteralResolver)) {
+    throw new SchemaError(`${label}: ${mode} must be an array literal, e.g. ${mode}=[API_KEY, DB_*]`);
+  }
+  const patterns = (resolver.arrArgs ?? []).map((el) => {
+    if (!el.isStatic || typeof el.staticValue !== 'string' || !el.staticValue.trim()) {
+      throw new SchemaError(`${label}: ${mode} entries must be non-empty static key names or globs`);
+    }
+    return el.staticValue.trim();
+  });
+  if (!patterns.length) {
+    throw new SchemaError(`${label}: ${mode} list cannot be empty`);
+  }
+  return { mode, patterns };
+}
+
+/** Whether `key` passes the filter. An `undefined` filter matches every key. */
+export function keyMatchesFilter(key: string, filter: KeyFilter | undefined): boolean {
+  if (!filter) return true;
+  const matched = filter.patterns.some((p) => globToRegExp(p).test(key));
+  return filter.mode === 'pick' ? matched : !matched;
+}
+
+/** Remove keys from a record that don't pass the filter (mutates in place). */
+export function applyKeyFilter<T>(entries: Record<string, T>, filter: KeyFilter | undefined): void {
+  if (!filter) return;
+  for (const key of Object.keys(entries)) {
+    if (!keyMatchesFilter(key, filter)) delete entries[key];
+  }
+}

--- a/packages/varlock/src/env-graph/test/import.test.ts
+++ b/packages/varlock/src/env-graph/test/import.test.ts
@@ -145,6 +145,139 @@ describe('@import', () => {
     }));
   });
 
+  describe('pick / omit filters', () => {
+    test('pick=[...] only imports listed keys', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @import(./.env.import, pick=[IMPORTED1, IMPORTED2])
+          # ---
+        `,
+        '.env.import': outdent`
+          IMPORTED1=a
+          IMPORTED2=b
+          SKIP=c
+        `,
+      },
+      expectValues: { IMPORTED1: 'a', IMPORTED2: 'b' },
+      expectNotInSchema: ['SKIP'],
+    }));
+
+    test('omit=[...] imports everything except listed keys', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @import(./.env.import, omit=[SECRET])
+          # ---
+        `,
+        '.env.import': outdent`
+          IMPORTED1=a
+          IMPORTED2=b
+          SECRET=c
+        `,
+      },
+      expectValues: { IMPORTED1: 'a', IMPORTED2: 'b' },
+      expectNotInSchema: ['SECRET'],
+    }));
+
+    test('pick supports globs', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @import(./.env.import, pick=[API_*])
+          # ---
+        `,
+        '.env.import': outdent`
+          API_KEY=a
+          API_URL=b
+          DB_HOST=c
+        `,
+      },
+      expectValues: { API_KEY: 'a', API_URL: 'b' },
+      expectNotInSchema: ['DB_HOST'],
+    }));
+
+    test('omit supports globs', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @import(./.env.import, omit=[DEBUG_*])
+          # ---
+        `,
+        '.env.import': outdent`
+          API_KEY=a
+          DEBUG_A=b
+          DEBUG_B=c
+        `,
+      },
+      expectValues: { API_KEY: 'a' },
+      expectNotInSchema: ['DEBUG_A', 'DEBUG_B'],
+    }));
+
+    test('pick intersects across nested imports', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @import(./.env.import, pick=[ITEM1])
+          # ---
+        `,
+        '.env.import': outdent`
+          # @import(./.env.import2, pick=[ITEM1, ITEM2])
+          # ---
+        `,
+        '.env.import2': outdent`
+          ITEM1=a
+          ITEM2=b
+        `,
+      },
+      expectValues: { ITEM1: 'a' },
+      expectNotInSchema: ['ITEM2'],
+    }));
+
+    test('deprecated positional keys still work', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @import(./.env.import, IMPORTED1)
+          # ---
+        `,
+        '.env.import': outdent`
+          IMPORTED1=a
+          SKIP=b
+        `,
+      },
+      expectValues: { IMPORTED1: 'a' },
+      expectNotInSchema: ['SKIP'],
+    }));
+
+    test('using both pick and omit is an error', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @import(./.env.import, pick=[A], omit=[B])
+          # ---
+        `,
+        '.env.import': 'A=1\nB=2',
+      },
+      expectError: true,
+    }));
+
+    test('combining positional keys with pick is an error', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @import(./.env.import, A, pick=[B])
+          # ---
+        `,
+        '.env.import': 'A=1\nB=2',
+      },
+      expectError: true,
+    }));
+
+    test('non-array pick is an error', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @import(./.env.import, pick=A)
+          # ---
+        `,
+        '.env.import': 'A=1',
+      },
+      expectError: true,
+    }));
+  });
+
   describe('errors', () => {
     test('importing non .env.* file triggers an error', envFilesTest({
       files: {

--- a/packages/varlock/src/env-graph/test/set-values-bulk.test.ts
+++ b/packages/varlock/src/env-graph/test/set-values-bulk.test.ts
@@ -166,6 +166,130 @@ describe('@setValuesBulk() root decorator', () => {
     }));
   });
 
+  describe('key filters', () => {
+    test('no filter args injects every key', envFilesTest({
+      envFile: outdent`
+        # @setValuesBulk('{"API_KEY":"from-bulk","OTHER":"from-bulk"}', format=json)
+        # ---
+        API_KEY=from-schema
+        OTHER=from-schema
+      `,
+      expectValues: {
+        API_KEY: 'from-bulk',
+        OTHER: 'from-bulk',
+      },
+    }));
+
+    test('pick (allowlist) only injects listed keys', envFilesTest({
+      envFile: outdent`
+        # @setValuesBulk('{"API_KEY":"from-bulk","OTHER":"from-bulk"}', format=json, pick=[API_KEY])
+        # ---
+        API_KEY=from-schema
+        OTHER=from-schema
+      `,
+      expectValues: {
+        API_KEY: 'from-bulk',
+        OTHER: 'from-schema',
+      },
+    }));
+
+    test('pick with multiple keys', envFilesTest({
+      envFile: outdent`
+        # @setValuesBulk('{"A":"bulk","B":"bulk","C":"bulk"}', format=json, pick=[A, C])
+        # ---
+        A=schema
+        B=schema
+        C=schema
+      `,
+      expectValues: {
+        A: 'bulk',
+        B: 'schema',
+        C: 'bulk',
+      },
+    }));
+
+    test('omit (denylist) injects everything except listed keys', envFilesTest({
+      envFile: outdent`
+        # @setValuesBulk('{"API_KEY":"from-bulk","OTHER":"from-bulk"}', format=json, omit=[OTHER])
+        # ---
+        API_KEY=from-schema
+        OTHER=from-schema
+      `,
+      expectValues: {
+        API_KEY: 'from-bulk',
+        OTHER: 'from-schema',
+      },
+    }));
+
+    test('pick supports glob patterns', envFilesTest({
+      envFile: outdent`
+        # @setValuesBulk('{"API_KEY":"bulk","API_URL":"bulk","DB_HOST":"bulk"}', format=json, pick=[API_*])
+        # ---
+        API_KEY=schema
+        API_URL=schema
+        DB_HOST=schema
+      `,
+      expectValues: {
+        API_KEY: 'bulk',
+        API_URL: 'bulk',
+        DB_HOST: 'schema',
+      },
+    }));
+
+    test('omit supports glob patterns', envFilesTest({
+      envFile: outdent`
+        # @setValuesBulk('{"API_KEY":"bulk","DEBUG_A":"bulk","DEBUG_B":"bulk"}', format=json, omit=[DEBUG_*])
+        # ---
+        API_KEY=schema
+        DEBUG_A=schema
+        DEBUG_B=schema
+      `,
+      expectValues: {
+        API_KEY: 'bulk',
+        DEBUG_A: 'schema',
+        DEBUG_B: 'schema',
+      },
+    }));
+
+    test('pick combines with createMissing', envFilesTest({
+      envFile: outdent`
+        # @setValuesBulk('{"A":"bulk","B":"bulk"}', format=json, createMissing=true, pick=[A])
+        # ---
+      `,
+      expectValues: {
+        A: 'bulk',
+      },
+      expectNotInSchema: ['B'],
+    }));
+
+    test('using both pick and omit is an error', envFilesTest({
+      envFile: outdent`
+        # @setValuesBulk('{"A":"bulk"}', format=json, pick=[A], omit=[B])
+        # ---
+        A=schema
+      `,
+      expectError: true,
+    }));
+
+    test('empty pick list is an error', envFilesTest({
+      envFile: outdent`
+        # @setValuesBulk('{"A":"bulk"}', format=json, pick=[])
+        # ---
+        A=schema
+      `,
+      expectError: true,
+    }));
+
+    test('non-array pick is an error', envFilesTest({
+      envFile: outdent`
+        # @setValuesBulk('{"A":"bulk"}', format=json, pick=A)
+        # ---
+        A=schema
+      `,
+      expectError: true,
+    }));
+  });
+
   describe('error cases', () => {
     test('no arguments', envFilesTest({
       envFile: outdent`

--- a/packages/vscode-plugin/src/intellisense-catalog.ts
+++ b/packages/vscode-plugin/src/intellisense-catalog.ts
@@ -112,8 +112,8 @@ export const ROOT_DECORATORS: Array<DecoratorInfo> = [
     name: 'setValuesBulk',
     scope: 'root',
     summary: 'Injects many config values from a single data source.',
-    documentation: 'Common usage: `# @setValuesBulk(exec("vault kv get ..."), format=json)`.',
-    insertText: '@setValuesBulk(${1:exec("command")}, format=${2|json,env|})',
+    documentation: 'Common usage: `# @setValuesBulk(opLoadEnvironment(env-id))`. Filter keys with `pick=[API_*]` (allowlist) or `omit=[LEGACY_*]` (denylist); globs supported.',
+    insertText: '@setValuesBulk(${1:opLoadEnvironment(env-id)})',
     isFunction: true,
   },
   {

--- a/packages/vscode-plugin/src/intellisense-catalog.ts
+++ b/packages/vscode-plugin/src/intellisense-catalog.ts
@@ -82,7 +82,7 @@ export const ROOT_DECORATORS: Array<DecoratorInfo> = [
     name: 'import',
     scope: 'root',
     summary: 'Imports schema and values from another file or directory.',
-    documentation: 'Takes a path as the first positional arg. Optional named args include `enabled` and `allowMissing`.',
+    documentation: 'Takes a path as the first positional arg. Optional named args include `enabled`, `allowMissing`, and `pick`/`omit` to filter imported keys (globs supported).',
     insertText: '@import(${1:./.env.shared})',
     isFunction: true,
   },


### PR DESCRIPTION
Adds `pick`/`omit` key filters to the two decorators that pull in groups of keys, so you can control exactly which keys get injected.

## What

```env-spec
# allowlist — only these keys (globs supported)
# @setValuesBulk(opLoadEnvironment(env-id), pick=[API_KEY, DB_*])
# @import(./.env.shared, pick=[API_KEY, DB_*])

# denylist — everything except these
# @setValuesBulk(infisicalBulk(), omit=[LEGACY_TOKEN])
# @import(./.env.shared, omit=[SECRET, DEBUG_*])
```

- **Default** (neither) imports/injects every key.
- `pick` = allowlist, `omit` = denylist; the two can't be combined.
- Both accept simple globs (`*`, `?`), matched case-sensitively.
- For nested `@import` chains, filters intersect — a key must pass every filter in the chain.

## `@import` deprecation

The previously released positional-key form (`@import(./.env.shared, KEY1, KEY2)`) is **deprecated** in favor of `pick=[…]`. It still works (exact-match only, no globs) but now emits a deprecation warning. `@setValuesBulk`'s filtering is new, so it only supports the `pick`/`omit` form.

## Implementation

- New shared `key-filter.ts` module (`KeyFilter` type, `parseKeyFilterArgs`, `keyMatchesFilter`, `applyKeyFilter`) built on a small `globToRegExp` helper — reusable for any future key-filtering decorator.
- `@import`'s filter was generalized from a resolved allowlist array (matched via `.includes()`/`_.intersection()`) to an `isKeyImported(key)` predicate that walks the import chain, so glob + omit + nested intersection all compose.

Docs (`@import` + `@setValuesBulk` reference, imports + secrets guides), vscode intellisense catalog, and tests updated.