### PR TITLE
fix(varlock): preserve typed builtin vars referenced from root decorators

### DIFF
--- a/.bumpy/fix-builtin-var-type-preservation.md
+++ b/.bumpy/fix-builtin-var-type-preservation.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Fix typed builtin vars (e.g. boolean VARLOCK_IS_CI) being stringified when referenced from root decorators like @import/@initOp, which broke not()/if() logic

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -293,6 +293,12 @@ export class EnvGraph {
     const BuiltinVarResolver = createResolver({
       name: `\0builtin:${key}`,
       description: builtinDef.description,
+      // Advertise the builtin's declared type so that if the item gets a
+      // process() call (e.g. when registered early via a root-decorator
+      // reference), config-item type inference preserves it instead of
+      // defaulting back to 'string' — which would stringify a boolean/number
+      // builtin (e.g. VARLOCK_IS_CI false -> "false", breaking not()/if()).
+      inferredType: builtinType,
       async resolve() {
         return builtinDef.resolver(graph.ciEnvInfo, graph.processEnvForBuiltins);
       },

--- a/packages/varlock/src/env-graph/test/builtin-vars.test.ts
+++ b/packages/varlock/src/env-graph/test/builtin-vars.test.ts
@@ -1,6 +1,7 @@
 import {
   describe, test, vi, expect,
 } from 'vitest';
+import outdent from 'outdent';
 import { envFilesTest } from './helpers/generic-test';
 
 // We need to mock the child_process module used by builtin-vars.ts
@@ -40,6 +41,43 @@ describe('VARLOCK_* builtin variables', () => {
         VARLOCK_ENV: false,
         VARLOCK_IS_CI: false,
       },
+    }));
+  });
+
+  describe('type preservation', () => {
+    // Regression: when a typed builtin (e.g. boolean VARLOCK_IS_CI) is registered
+    // early via a root-decorator reference, the finishLoad process() pass used to
+    // recompute its type and default it back to 'string', stringifying `false` to
+    // "false" — which made not()/if() see a truthy string. The builtin resolver now
+    // advertises its declared type via inferredType so the type is preserved.
+    test('boolean builtin referenced in a root decorator keeps its boolean type', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @import(./.env.imported, enabled=not($VARLOCK_IS_CI))
+          # ---
+          LOCAL_VAR=local
+        `,
+        '.env.imported': 'IMPORTED_VAR=imported',
+      },
+      processEnv: {},
+      expectValues: {
+        VARLOCK_IS_CI: false, // boolean false, not the string "false"
+        IMPORTED_VAR: 'imported', // import is enabled because not(false) === true
+      },
+    }));
+
+    test('same root-decorator reference disables the import when in CI', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @import(./.env.imported, enabled=not($VARLOCK_IS_CI))
+          # ---
+          LOCAL_VAR=local
+        `,
+        '.env.imported': 'IMPORTED_VAR=imported',
+      },
+      processEnv: { CI: 'true', GITHUB_ACTIONS: 'true' },
+      expectValues: { VARLOCK_IS_CI: true },
+      expectNotInSchema: ['IMPORTED_VAR'],
     }));
   });
 


### PR DESCRIPTION
## What

Typed builtin vars (e.g. `VARLOCK_IS_CI`, which is declared `boolean`) were being stringified to `"false"`/`"true"` when referenced from a **root decorator** argument such as `@import(enabled=...)` or a plugin's `@initOp(...)`. Because a non-empty string is truthy, this silently broke boolean logic — e.g. `not($VARLOCK_IS_CI)` evaluated to `false` even when not in CI.

## Why

`registerBuiltinVar` sets the builtin item's `dataType` correctly, but only in the "create from scratch" branch, relying on the `finishLoad` loop not revisiting the new key. When a builtin is registered *early* (during root-decorator processing), the item later *does* get a `process()` call — and since the builtin's resolver had no `inferredType` and the item has no `@type` decorator, type inference defaulted it back to `string`, coercing the boolean to a string.

The fix: the builtin's resolver now advertises its declared type via `inferredType`, so config-item type inference preserves it. One-line change in `registerBuiltinVar`.

Referencing the same builtin from a normal item value already worked; this only affected the early/root-decorator registration path.

## Tests

Added regression tests in `builtin-vars.test.ts` covering a boolean builtin referenced from a root decorator (`@import(enabled=not($VARLOCK_IS_CI))`) in both CI and non-CI — verified they fail without the fix and pass with it. Full env-graph suite (482 tests) green.