### PR TITLE
feat(vscode-plugin): publish to Marketplace via Azure OIDC instead of VSCE_PAT

### DIFF
--- a/.bumpy/vscode-oidc-publishing.md
+++ b/.bumpy/vscode-oidc-publishing.md
@@ -1,0 +1,5 @@
+---
+env-spec-language: patch
+---
+
+Maintenance release — no functional changes (switches Marketplace publishing to OIDC)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,7 @@ jobs:
     outputs:
       mode: ${{ steps.plan.outputs.mode }}
       includes-varlock: ${{ contains(fromJSON(steps.plan.outputs.json).packageNames, 'varlock') }}
+      includes-vscode: ${{ contains(fromJSON(steps.plan.outputs.json).packageNames, 'env-spec-language') }}
       macos-cache-key: ${{ steps.keys.outputs.macos-cache-key }}
       rust-source-hash: ${{ steps.keys.outputs.rust-source-hash }}
       macos-cache-hit: ${{ steps.macos-cache.outputs.cache-hit }}
@@ -310,6 +311,32 @@ jobs:
         env:
           BUILD_TYPE: release
 
+      # Resolve the Azure identity ids from 1Password via varlock (schema lives in
+      # packages/vscode-plugin/.env.schema). Only OP_TOKEN is injected here; the
+      # AZURE_CLIENT_ID / AZURE_TENANT_ID values come from the VarlockCI vault and
+      # are exported to the job environment for the azure/login step below.
+      # (build:libs above provides the local varlock the action uses.)
+      - name: Load Azure identity from 1Password
+        if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-vscode == 'true'
+        uses: dmno-dev/varlock-action@v1.0.1
+        with:
+          working-directory: packages/vscode-plugin
+        env:
+          OP_TOKEN: ${{ secrets.OP_CI_TOKEN }}
+
+      # Authenticate to Azure via GitHub OIDC (workload identity federation) so the
+      # VS Code Marketplace publish (`vsce publish --azure-credential`) can mint a
+      # short-lived token instead of a long-lived VSCE_PAT. The federated credential
+      # on the Azure side is scoped to this repo's main branch; see docs below.
+      # Open VSX (ovsx) is a separate registry and still uses OVSX_PAT.
+      - name: Azure login (OIDC) for Marketplace publishing
+        if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-vscode == 'true'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
       - name: Create Release PR / Publish
         run: bunx @varlock/bumpy ci release
         env:
@@ -318,8 +345,8 @@ jobs:
           # (see https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow)
           BUMPY_GH_TOKEN: ${{ secrets.BUMPY_GH_TOKEN }}
           GH_TOKEN: ${{ github.token }}
-          # these are needed for vscode extension publishing
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          # VS Code Marketplace auth comes from the Azure OIDC login step above
+          # (vsce publish --azure-credential). Open VSX still needs a token.
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
 
       # TODO: send notifications?

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -312,7 +312,7 @@ jobs:
           BUILD_TYPE: release
 
       # Resolve the Azure identity ids from 1Password via varlock (schema lives in
-      # packages/vscode-plugin/.env.schema). Only OP_TOKEN is injected here; the
+      # packages/vscode-plugin/.env.schema). Only OP_CI_TOKEN is injected here; the
       # AZURE_CLIENT_ID / AZURE_TENANT_ID values come from the VarlockCI vault and
       # are exported to the job environment for the azure/login step below.
       # (build:libs above provides the local varlock the action uses.)
@@ -322,7 +322,7 @@ jobs:
         with:
           working-directory: packages/vscode-plugin
         env:
-          OP_TOKEN: ${{ secrets.OP_CI_TOKEN }}
+          OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN }}
 
       # Authenticate to Azure via GitHub OIDC (workload identity federation) so the
       # VS Code Marketplace publish (`vsce publish --azure-credential`) can mint a

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -311,12 +311,13 @@ jobs:
         env:
           BUILD_TYPE: release
 
-      # Resolve the Azure identity ids from 1Password via varlock (schema lives in
-      # packages/vscode-plugin/.env.schema). Only OP_CI_TOKEN is injected here; the
-      # AZURE_CLIENT_ID / AZURE_TENANT_ID values come from the VarlockCI vault and
-      # are exported to the job environment for the azure/login step below.
-      # (build:libs above provides the local varlock the action uses.)
-      - name: Load Azure identity from 1Password
+      # Resolve VS Code extension publishing secrets from 1Password via varlock
+      # (schema lives in packages/vscode-plugin/.env.schema). Only OP_CI_TOKEN is
+      # injected here; AZURE_CLIENT_ID / AZURE_TENANT_ID (for OIDC) and OVSX_PAT
+      # (for Open VSX) come from the VarlockCI vault and are exported to the job
+      # environment for the steps below. (build:libs above provides the local
+      # varlock the action uses.)
+      - name: Load extension publishing secrets from 1Password
         if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-vscode == 'true'
         uses: dmno-dev/varlock-action@v1.0.1
         with:
@@ -328,7 +329,6 @@ jobs:
       # VS Code Marketplace publish (`vsce publish --azure-credential`) can mint a
       # short-lived token instead of a long-lived VSCE_PAT. The federated credential
       # on the Azure side is scoped to this repo's main branch; see docs below.
-      # Open VSX (ovsx) is a separate registry and still uses OVSX_PAT.
       - name: Azure login (OIDC) for Marketplace publishing
         if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-vscode == 'true'
         uses: azure/login@v2
@@ -345,8 +345,7 @@ jobs:
           # (see https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow)
           BUMPY_GH_TOKEN: ${{ secrets.BUMPY_GH_TOKEN }}
           GH_TOKEN: ${{ github.token }}
-          # VS Code Marketplace auth comes from the Azure OIDC login step above
-          # (vsce publish --azure-credential). Open VSX still needs a token.
-          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          # VS Code Marketplace auth comes from the Azure OIDC login step above;
+          # Open VSX (OVSX_PAT) is loaded into the job env by the varlock step above.
 
       # TODO: send notifications?

--- a/.github/workflows/vscode-release.yaml
+++ b/.github/workflows/vscode-release.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # required for Azure OIDC login
     steps:
       - uses: actions/checkout@v6
       - name: Setup Bun
@@ -21,6 +22,27 @@ jobs:
       - name: Install node deps
         run: bun install
 
+      # Build varlock so the action can resolve secrets from 1Password
+      - name: Build libraries
+        run: bun run build:libs
+
+      # Resolve publishing secrets from 1Password via varlock: AZURE_CLIENT_ID /
+      # AZURE_TENANT_ID (for Marketplace OIDC) and OVSX_PAT (for Open VSX).
+      - name: Load extension publishing secrets from 1Password
+        uses: dmno-dev/varlock-action@v1.0.1
+        with:
+          working-directory: packages/vscode-plugin
+        env:
+          OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN }}
+
+      # OIDC login so `vsce publish --azure-credential` can mint a short-lived token
+      - name: Azure login (OIDC) for Marketplace publishing
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
       - name: Build and package extension
         working-directory: packages/vscode-plugin
         run: bun run package
@@ -28,12 +50,8 @@ jobs:
       - name: Publish to VS Code Marketplace
         working-directory: packages/vscode-plugin
         run: bun run publish:vsce
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
+      # OVSX_PAT was exported to the job env by the varlock step above
       - name: Publish to Open VSX
         working-directory: packages/vscode-plugin
         run: bun run publish:ovsx
-        env:
-          OVSX_PAT: ${{ secrets.OVSX_PAT }}
-

--- a/bun.lock
+++ b/bun.lock
@@ -501,9 +501,11 @@
       "devDependencies": {
         "@types/node": "catalog:",
         "@types/vscode": "^1.99.0",
+        "@varlock/1password-plugin": "workspace:*",
         "@vscode/vsce": "^3.6.2",
         "ovsx": "^0.10.6",
         "tsup": "catalog:",
+        "varlock": "workspace:*",
         "vitest": "catalog:",
         "vscode-tmgrammar-test": "^0.1.3",
       },

--- a/packages/vscode-plugin/.env.schema
+++ b/packages/vscode-plugin/.env.schema
@@ -1,0 +1,24 @@
+# @defaultSensitive=false @defaultRequired=infer
+# @plugin(@varlock/1password-plugin)
+# In CI, OP_TOKEN is injected and takes precedence; locally (no token) the
+# 1Password desktop app is used. (token wins over allowAppAuth when both apply.)
+# @initOp(token=$OP_TOKEN, allowAppAuth=not($VARLOCK_IS_CI))
+# ---
+
+# True when running in CI (auto-detected). Declared explicitly so it resolves as
+# a graph item (available early enough to gate the @initOp app-auth fallback).
+# @type=boolean
+VARLOCK_IS_CI=
+
+# 1Password service account token. Injected in CI (GitHub Actions secret).
+# Locally, leave it unset — 1Password desktop app auth is used instead
+# (@initOp falls back to app auth when not in CI).
+# @type=opServiceAccountToken @sensitive
+OP_TOKEN=
+
+# Azure identity used for OIDC publishing to the VS Code Marketplace
+# (vsce publish --azure-credential), instead of an expiring VSCE_PAT.
+# Referenced by item id (the "vscode-marketplace-publishing" item in the
+# VarlockCI vault) — stable across renames, per varlock guidance.
+AZURE_CLIENT_ID=op("op://VarlockCI/jqci36cap7pkq3kaen5toyu4n4/azure-identity-client-id")
+AZURE_TENANT_ID=op("op://VarlockCI/jqci36cap7pkq3kaen5toyu4n4/azure-identity-tenant-id")

--- a/packages/vscode-plugin/.env.schema
+++ b/packages/vscode-plugin/.env.schema
@@ -22,3 +22,9 @@ OP_CI_TOKEN=
 # VarlockCI vault) — stable across renames, per varlock guidance.
 AZURE_CLIENT_ID=op("op://VarlockCI/jqci36cap7pkq3kaen5toyu4n4/azure-identity-client-id")
 AZURE_TENANT_ID=op("op://VarlockCI/jqci36cap7pkq3kaen5toyu4n4/azure-identity-tenant-id")
+
+# Open VSX access token, for publishing to the Open VSX registry (ovsx publish).
+# Open VSX is a separate registry from the VS Code Marketplace and isn't covered
+# by Azure OIDC, so it still uses a token — now sourced from 1Password.
+# @sensitive
+OVSX_PAT=op("op://VarlockCI/jqci36cap7pkq3kaen5toyu4n4/OVSX registry/ovsx-pat")

--- a/packages/vscode-plugin/.env.schema
+++ b/packages/vscode-plugin/.env.schema
@@ -1,8 +1,8 @@
 # @defaultSensitive=false @defaultRequired=infer
 # @plugin(@varlock/1password-plugin)
-# In CI, OP_TOKEN is injected and takes precedence; locally (no token) the
+# In CI, OP_CI_TOKEN is injected and takes precedence; locally (no token) the
 # 1Password desktop app is used. (token wins over allowAppAuth when both apply.)
-# @initOp(token=$OP_TOKEN, allowAppAuth=not($VARLOCK_IS_CI))
+# @initOp(token=$OP_CI_TOKEN, allowAppAuth=not($VARLOCK_IS_CI))
 # ---
 
 # True when running in CI (auto-detected). Declared explicitly so it resolves as
@@ -14,7 +14,7 @@ VARLOCK_IS_CI=
 # Locally, leave it unset — 1Password desktop app auth is used instead
 # (@initOp falls back to app auth when not in CI).
 # @type=opServiceAccountToken @sensitive
-OP_TOKEN=
+OP_CI_TOKEN=
 
 # Azure identity used for OIDC publishing to the VS Code Marketplace
 # (vsce publish --azure-credential), instead of an expiring VSCE_PAT.

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -86,7 +86,7 @@
     "test:grammar": "vscode-tmgrammar-test -g ./language/env-spec.tmLanguage.json ./test/grammar.test.txt",
     "test:ci": "vitest --run && bun run test:grammar",
     "package": "bun run build && vsce package -o env-spec-language.vsix --no-dependencies",
-    "publish:vsce": "vsce publish -i env-spec-language.vsix",
+    "publish:vsce": "vsce publish -i env-spec-language.vsix --azure-credential",
     "publish:ovsx": "ovsx publish -i env-spec-language.vsix",
     "publish": "bun run package && bun run publish:vsce && bun run publish:ovsx",
     "typecheck": "tsc --noEmit"
@@ -94,9 +94,11 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@types/vscode": "^1.99.0",
+    "@varlock/1password-plugin": "workspace:*",
     "@vscode/vsce": "^3.6.2",
     "ovsx": "^0.10.6",
     "tsup": "catalog:",
+    "varlock": "workspace:*",
     "vitest": "catalog:",
     "vscode-tmgrammar-test": "^0.1.3"
   },


### PR DESCRIPTION
## What & why

The last release failed to publish the VS Code extension because the `VSCE_PAT` was invalid/expired (Azure DevOps PATs expire). This switches Marketplace publishing to **Microsoft Entra workload identity federation (OIDC)** — short-lived tokens, no PAT to rotate.

## Changes

- **`publish:vsce`** now passes `--azure-credential`, so `vsce` authenticates via `@azure/identity` instead of a PAT.
- **Release workflow** ([release.yaml](.github/workflows/release.yaml)):
  - A gated step loads `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` from 1Password via varlock (`dmno-dev/varlock-action`, `OP_CI_TOKEN` injected from the GitHub secret of the same name), only when the release actually publishes the extension (new `plan.includes-vscode` output).
  - `azure/login@v2` (OIDC) authenticates before bumpy runs the publish.
  - `VSCE_PAT` removed from the publish step. `OVSX_PAT` stays — Open VSX is a separate registry not covered by Azure OIDC.
- **`.env.schema`** for the extension package resolves the Azure ids from 1Password. In CI the injected `OP_TOKEN` is used; locally it falls back to 1Password desktop app auth (`allowAppAuth=not($VARLOCK_IS_CI)`). Azure ids are referenced by item **id** for rename stability.
- Added `varlock` + `@varlock/1password-plugin` workspace devDeps so the schema resolves.

## Verification

Resolved the full schema locally (via 1Password app auth) — both Azure ids resolve correctly and `OP_TOKEN` is optional locally. The patch changeset cuts `0.2.3`, which on merge exercises the new OIDC publish path end-to-end and unsticks the Marketplace (currently stranded at 0.2.1 after 0.2.2's publish failed).

## Before merging — one-time setup required
- Azure app registration + GitHub OIDC federated credential, and that identity added to the `varlock` Marketplace publisher as Contributor (done).
- 1Password `VarlockCI` vault item with `azure-identity-client-id` / `azure-identity-tenant-id` (done).
- The old `VSCE_PAT` secret can be deleted; no `AZURE_*` GitHub secrets are needed (sourced from 1Password).

## Also: OVSX_PAT moved to 1Password
Open VSX still needs a token (not covered by Azure OIDC), but it no longer lives in GitHub secrets — `OVSX_PAT` is now in the `VarlockCI` vault and loaded via the same varlock step. The manual fallback workflow (`vscode-release.yaml`) was also switched to OIDC + varlock and no longer references the dead `VSCE_PAT` or `secrets.OVSX_PAT`.

The `ovsx-pat` value already lives on the `vscode-marketplace-publishing` item (verified resolving). After merge, the `OVSX_PAT` GitHub secret can be deleted.