### PR TITLE
feat(parser): multi-line object/array literals with comments

### DIFF
--- a/.bumpy/multiline-array-object-literals.md
+++ b/.bumpy/multiline-array-object-literals.md
@@ -1,0 +1,6 @@
+---
+"@env-spec/parser": minor
+varlock: minor
+---
+
+Object and array literals can now span multiple lines. Inside decorators each continuation line is prefixed with `#` (like multi-line function calls), e.g. a long `@import(./.env.shared, pick=[ ... ])` key list; literals nested in item-value function calls use plain newlines. Single-line literals are unchanged.

--- a/.bumpy/multiline-array-object-literals.md
+++ b/.bumpy/multiline-array-object-literals.md
@@ -1,6 +1,11 @@
 ---
 "@env-spec/parser": minor
 varlock: minor
+env-spec-language: patch
 ---
 
 Object and array literals can now span multiple lines. Inside decorators each continuation line is prefixed with `#` (like multi-line function calls), e.g. a long `@import(./.env.shared, pick=[ ... ])` key list; literals nested in item-value function calls use plain newlines. Single-line literals are unchanged.
+
+Multi-line literals and function calls also support `#` comments — full-line entries can be commented out (`# # OLD_KEY,`) and individual entries annotated with trailing comments (`# KEY, # note`).
+
+The VSCode extension's syntax highlighting now understands object/array literals (single- and multi-line) and these inline comments.

--- a/.bumpy/multiline-array-object-literals.md
+++ b/.bumpy/multiline-array-object-literals.md
@@ -1,6 +1,6 @@
 ---
 "@env-spec/parser": minor
-varlock: minor
+varlock: patch
 env-spec-language: patch
 ---
 

--- a/.bumpy/multiline-array-object-literals.md
+++ b/.bumpy/multiline-array-object-literals.md
@@ -1,5 +1,5 @@
 ---
-"@env-spec/parser": minor
+"@env-spec/parser": patch
 varlock: patch
 env-spec-language: patch
 ---

--- a/packages/env-spec-parser/grammar.peggy
+++ b/packages/env-spec-parser/grammar.peggy
@@ -128,7 +128,7 @@ Decorator =
 DecoratorName = $([a-zA-Z] [^ \t\n=()#@]*)
 // ObjectLiteral / ArrayLiteral must come first so a value starting with `{` or `[`
 // parses as a literal rather than an unquoted string.
-DecoratorValue = ObjectLiteral / ArrayLiteral / DecoratorFunctionCall / quotedString / unquotedStringWithoutSpaces
+DecoratorValue = DecoratorObjectLiteral / DecoratorArrayLiteral / DecoratorFunctionCall / quotedString / unquotedStringWithoutSpaces
 
 // Decorator-specific function call (supports multi-line with # continuation)
 DecoratorFunctionCall =
@@ -161,18 +161,33 @@ DecoratorFunctionArgs =
   }
 
 DecoratorFunctionArgValue =
-  ObjectLiteral
-  / ArrayLiteral
+  DecoratorObjectLiteral
+  / DecoratorArrayLiteral
   / DecoratorFunctionCall
   / quotedString
   / $([^ \n,)]+) { return new ParsedEnvSpecStaticValue({ rawValue: text(), _location: location() }) }
 
-// Whitespace within decorator function args - allows newline followed by # continuation
-_decWs = ([ \t] / "\n" [ \t]* "#" [ \t]*)*
+// Whitespace within decorator function args / literals - allows newline + `#`
+// continuation. A `#` after content (or a continuation line whose content is itself
+// `#`-prefixed) is treated as a comment to end-of-line and skipped, so entries can be
+// commented out (`# # OLD_KEY,`) or annotated (`# KEY, # note`). Continuation across a
+// newline still REQUIRES the leading `#` (so a missing `#` can't silently swallow lines).
+_decWs = ([ \t] / ("#" [^\n]*)? "\n" [ \t]* "#" [ \t]*)*
 
 // Standalone object/array literals — usable as decorator/function-arg values.
 // `{ key=value, ... }` is an object, `[ value, ... ]` is an array.
-// Single-line only for now (no multi-line `#` continuation inside the brackets).
+//
+// Multi-line is supported, and (like function args) the continuation convention
+// depends on context: literals on item-value lines use plain newlines, while
+// literals inside decorator comments require a leading `#` on each line. There are
+// therefore two parallel rule sets — `ObjectLiteral`/`ArrayLiteral` (value context,
+// `_valWs`) and `DecoratorObjectLiteral`/`DecoratorArrayLiteral` (decorator context,
+// `_decWs`) — mirroring `FunctionArgs` vs `DecoratorFunctionArgs`.
+//
+//   KEY=fn([          # @import(./.env, pick=[
+//     a,              #   KEY1,
+//     b,              #   KEY2,
+//   ])                # ])
 //
 // DESIGN NOTE: only reach for these where there is no function-call `()` already
 // carrying the structure — i.e. (1) the value of a non-function decorator
@@ -182,23 +197,25 @@ _decWs = ([ \t] / "\n" [ \t]* "#" [ \t]*)*
 // Prefer positional forms for ordered pairs (`remap`, `ifs`) and value lists (`enum`) —
 // remap match keys can be regexes/non-identifier strings that can't be object keys.
 // See docs: env-spec/reference "When to reach for a literal".
+
+// ~ value-context literals (multi-line via plain newlines, like FunctionArgs) ~
 ObjectLiteral =
-  "{" _
+  "{" _valWs
   values:(
     (key:FunctionArgKeyName _ "=" _ val:LiteralElementValue { return new ParsedEnvSpecKeyValuePair({ key, val }) })
-    |0.., _ "," _|
+    |0.., _valWs "," _valWs|
   )
-  (_ ",")?
-  _ "}"
+  (_valWs ",")?
+  _valWs "}"
   {
     return new ParsedEnvSpecObjectLiteral({ values, _location: location() });
   }
 
 ArrayLiteral =
-  "[" _
-  values:( LiteralElementValue |0.., _ "," _| )
-  (_ ",")?
-  _ "]"
+  "[" _valWs
+  values:( LiteralElementValue |0.., _valWs "," _valWs| )
+  (_valWs ",")?
+  _valWs "]"
   {
     return new ParsedEnvSpecArrayLiteral({ values, _location: location() });
   }
@@ -208,6 +225,35 @@ LiteralElementValue =
   ObjectLiteral
   / ArrayLiteral
   / FunctionCall
+  / quotedString
+  / $([^ \n,)}\]]+) { return new ParsedEnvSpecStaticValue({ rawValue: text(), _location: location() }) }
+
+// ~ decorator-context literals (multi-line via `#` continuation, like DecoratorFunctionArgs) ~
+DecoratorObjectLiteral =
+  "{" _decWs
+  values:(
+    (key:FunctionArgKeyName _ "=" _ val:DecoratorLiteralElementValue { return new ParsedEnvSpecKeyValuePair({ key, val }) })
+    |0.., _decWs "," _decWs|
+  )
+  (_decWs ",")?
+  _decWs "}"
+  {
+    return new ParsedEnvSpecObjectLiteral({ values, _location: location() });
+  }
+
+DecoratorArrayLiteral =
+  "[" _decWs
+  values:( DecoratorLiteralElementValue |0.., _decWs "," _decWs| )
+  (_decWs ",")?
+  _decWs "]"
+  {
+    return new ParsedEnvSpecArrayLiteral({ values, _location: location() });
+  }
+
+DecoratorLiteralElementValue =
+  DecoratorObjectLiteral
+  / DecoratorArrayLiteral
+  / DecoratorFunctionCall
   / quotedString
   / $([^ \n,)}\]]+) { return new ParsedEnvSpecStaticValue({ rawValue: text(), _location: location() }) }
 
@@ -254,8 +300,9 @@ FunctionArgValue =
   // slightly different here - can contain "#", cannot contain ")" or "," or newline
   / $([^ \n,)]+) { return new ParsedEnvSpecStaticValue({ rawValue: text(), _location: location() }) }
 
-// Whitespace within item value function args - allows plain newlines
-_valWs = [ \t\n]*
+// Whitespace within item-value function args / literals - allows plain newlines, plus
+// `#` comments (full-line entries and trailing post-comments) which are skipped.
+_valWs = ([ \t\n] / "#" [^\n]*)*
 
 Divider =
   "#" leadingSpace:$_ contents:$([-=*#]|3..| [^\n]*) _n

--- a/packages/env-spec-parser/test/decorators.test.ts
+++ b/packages/env-spec-parser/test/decorators.test.ts
@@ -125,6 +125,139 @@ describe('decorator parsing', () => {
     });
   });
 
+  describe('multi-line object/array literals (`#` continuation)', () => {
+    it('parses a multi-line array literal', () => {
+      const result = parseEnvSpecDotEnvFile(outdent`
+        # @dec=[
+        #   a,
+        #   b,
+        #   c,
+        # ]
+        VAL=
+      `);
+      const dec = result.configItems[0].decoratorsObject.dec;
+      expectInstanceOf(dec.value, ParsedEnvSpecArrayLiteral);
+      expect((dec.value as ParsedEnvSpecArrayLiteral).simplifiedValue).toEqual(['a', 'b', 'c']);
+    });
+
+    it('parses a multi-line array without a trailing comma', () => {
+      const result = parseEnvSpecDotEnvFile(outdent`
+        # @dec=[
+        #   a,
+        #   b
+        # ]
+        VAL=
+      `);
+      const dec = result.configItems[0].decoratorsObject.dec;
+      expect((dec.value as ParsedEnvSpecArrayLiteral).simplifiedValue).toEqual(['a', 'b']);
+    });
+
+    it('parses a multi-line object literal', () => {
+      const result = parseEnvSpecDotEnvFile(outdent`
+        # @sensitive={
+        #   preventLeaks=false,
+        #   foo=bar,
+        # }
+        VAL=
+      `);
+      const dec = result.configItems[0].decoratorsObject.sensitive;
+      expectInstanceOf(dec.value, ParsedEnvSpecObjectLiteral);
+      expect((dec.value as ParsedEnvSpecObjectLiteral).simplifiedValue).toEqual({ preventLeaks: false, foo: 'bar' });
+    });
+
+    it('parses a multi-line array passed as a function arg (e.g. `@import(..., pick=[...])`)', () => {
+      const result = parseEnvSpecDotEnvFile(outdent`
+        # @import(
+        #   ./.env.shared,
+        #   pick=[
+        #     KEY1,
+        #     KEY2,
+        #     KEY3,
+        #   ],
+        # )
+        VAL=
+      `);
+      const dec = result.configItems[0].decoratorsObject.import;
+      expect(dec.isBareFnCall).toBe(true);
+      const args = dec.bareFnArgs!;
+      expectInstanceOf(args.values[0], ParsedEnvSpecStaticValue);
+      expect((args.values[0] as ParsedEnvSpecStaticValue).value).toBe('./.env.shared');
+      const pick = args.values[1] as any;
+      expect(pick.key).toBe('pick');
+      expectInstanceOf(pick.value, ParsedEnvSpecArrayLiteral);
+      expect((pick.value as ParsedEnvSpecArrayLiteral).simplifiedValue).toEqual(['KEY1', 'KEY2', 'KEY3']);
+    });
+
+    it('parses nested multi-line literals', () => {
+      const result = parseEnvSpecDotEnvFile(outdent`
+        # @dec={
+        #   items=[
+        #     1,
+        #     2,
+        #   ],
+        #   opts={
+        #     retry=true,
+        #   },
+        # }
+        VAL=
+      `);
+      const dec = result.configItems[0].decoratorsObject.dec;
+      expect((dec.value as ParsedEnvSpecObjectLiteral).simplifiedValue).toEqual({
+        items: [1, 2],
+        opts: { retry: true },
+      });
+    });
+
+    it('round-trips a multi-line literal to a single-line toString()', () => {
+      const result = parseEnvSpecDotEnvFile(outdent`
+        # @dec=[
+        #   a,
+        #   b,
+        # ]
+        VAL=
+      `);
+      expect(result.configItems[0].decoratorsObject.dec.toString()).toBe('@dec=[a, b]');
+    });
+
+    it('skips commented-out entries and trailing post-comments inside a multi-line literal', () => {
+      const result = parseEnvSpecDotEnvFile(outdent`
+        # @dec=[
+        #   VAL1,
+        # # COMMENTED_VAL,
+        #   VAL3, # post comment
+        # ]
+        VAL=
+      `);
+      const dec = result.configItems[0].decoratorsObject.dec;
+      expect((dec.value as ParsedEnvSpecArrayLiteral).simplifiedValue).toEqual(['VAL1', 'VAL3']);
+    });
+
+    it('skips comments inside a multi-line object literal', () => {
+      const result = parseEnvSpecDotEnvFile(outdent`
+        # @sensitive={
+        #   preventLeaks=false, # leaves the system intentionally
+        #   # enabled=false,
+        # }
+        VAL=
+      `);
+      const dec = result.configItems[0].decoratorsObject.sensitive;
+      expect((dec.value as ParsedEnvSpecObjectLiteral).simplifiedValue).toEqual({ preventLeaks: false });
+    });
+
+    it('does not swallow following config items when continuation lines omit `#`', () => {
+      // a `[` without `#`-prefixed continuation lines can't form a multi-line array,
+      // so it falls back to a plain string value and the following lines remain
+      // independent config items rather than being absorbed into the literal.
+      const result = parseEnvSpecDotEnvFile(outdent`
+        # @dec=[
+        KEY1=v1
+        KEY2=v2
+        VAL=
+      `);
+      expect(result.configItems.map((i) => i.key)).toEqual(['KEY1', 'KEY2', 'VAL']);
+    });
+  });
+
   describe('multi-line function calls', basicDecoratorTests([
     {
       label: 'multi-line @dec() call',
@@ -200,7 +333,7 @@ describe('decorator parsing', () => {
       expected: new Error(),
     },
     {
-      label: 'multi-line dec fn with commented interior line',
+      label: 'multi-line dec fn skips a commented-out interior line',
       comments: outdent`
         # @import(
         #   ./.env.import,
@@ -208,7 +341,18 @@ describe('decorator parsing', () => {
         #   ITEM2,
         # )
       `,
-      expected: new Error(),
+      expected: { import: { fnName: undefined, fnArgs: ['./.env.import', 'ITEM2'] } },
+    },
+    {
+      label: 'multi-line dec fn skips a trailing post-comment on an arg',
+      comments: outdent`
+        # @import(
+        #   ./.env.import,
+        #   ITEM1, # primary
+        #   ITEM2,
+        # )
+      `,
+      expected: { import: { fnName: undefined, fnArgs: ['./.env.import', 'ITEM1', 'ITEM2'] } },
     },
   ]));
 

--- a/packages/env-spec-parser/test/decorators.test.ts
+++ b/packages/env-spec-parser/test/decorators.test.ts
@@ -188,6 +188,24 @@ describe('decorator parsing', () => {
       expect((pick.value as ParsedEnvSpecArrayLiteral).simplifiedValue).toEqual(['KEY1', 'KEY2', 'KEY3']);
     });
 
+    it('skips comments inside a multi-line array nested in a decorator fn call (`@import(pick=[...])`)', () => {
+      const result = parseEnvSpecDotEnvFile(outdent`
+        # @import(
+        #   ./.env.shared,
+        #   pick=[
+        #     KEY1,
+        #     # KEY2 disabled for now,
+        #     KEY3, # primary
+        #   ],
+        # )
+        VAL=
+      `);
+      const args = result.configItems[0].decoratorsObject.import.bareFnArgs!;
+      const pick = args.values[1] as any;
+      expect(pick.key).toBe('pick');
+      expect((pick.value as ParsedEnvSpecArrayLiteral).simplifiedValue).toEqual(['KEY1', 'KEY3']);
+    });
+
     it('parses nested multi-line literals', () => {
       const result = parseEnvSpecDotEnvFile(outdent`
         # @dec={

--- a/packages/env-spec-parser/test/functions.test.ts
+++ b/packages/env-spec-parser/test/functions.test.ts
@@ -2,6 +2,9 @@
 import { describe, it, expect } from 'vitest';
 import outdent from 'outdent';
 import { parseEnvSpecDotEnvFile } from '../src';
+import {
+  ParsedEnvSpecFunctionCall, ParsedEnvSpecArrayLiteral, ParsedEnvSpecObjectLiteral,
+} from '../src/classes';
 import { simpleResolver } from '../src/simple-resolver';
 
 function functionValueTests(
@@ -251,4 +254,84 @@ describe('multi-line function calls in values', functionValueTests({
     `,
     expected: { ITEM1: 'ab', ITEM2: 'simple' },
   },
+  'multi-line with a commented-out arg and trailing post-comments': {
+    input: outdent`
+      ITEM=concat(
+        "a", # first part
+        # "b" is disabled,
+        "c",
+      )
+    `,
+    expected: { ITEM: 'ac' },
+  },
+  'commented-out arg via double hash': {
+    input: outdent`
+      ITEM=concat(
+        "x",
+        ## "y",
+        "z"
+      )
+    `,
+    expected: { ITEM: 'xz' },
+  },
 }));
+
+// Object/array literals inside item values use plain-newline continuation (NOT `#`),
+// and `#` introduces a comment to end-of-line. These assert the parsed AST directly
+// since the test resolver has no built-in function that consumes a literal.
+describe('object/array literals in item values (multi-line + comments)', () => {
+  function literalArg(input: string) {
+    const file = parseEnvSpecDotEnvFile(input);
+    const fn = file.configItems[0].value as ParsedEnvSpecFunctionCall;
+    expect(fn).toBeInstanceOf(ParsedEnvSpecFunctionCall);
+    return fn.data.args.values[0];
+  }
+
+  it('array literal: skips a commented-out entry and a trailing post-comment', () => {
+    const arg = literalArg(outdent`
+      ITEM=fn([
+        ALPHA,
+        # BETA disabled,
+        GAMMA, # primary
+      ])
+    `);
+    expect(arg).toBeInstanceOf(ParsedEnvSpecArrayLiteral);
+    expect((arg as ParsedEnvSpecArrayLiteral).simplifiedValue).toEqual(['ALPHA', 'GAMMA']);
+  });
+
+  it('object literal: skips a commented-out entry and a trailing post-comment', () => {
+    const arg = literalArg(outdent`
+      ITEM=fn({
+        count=3, # retries
+        # backoff=2,
+        timeout=30,
+      })
+    `);
+    expect(arg).toBeInstanceOf(ParsedEnvSpecObjectLiteral);
+    expect((arg as ParsedEnvSpecObjectLiteral).simplifiedValue).toEqual({ count: 3, timeout: 30 });
+  });
+
+  it('comment-only and blank interior lines do not break the array', () => {
+    const arg = literalArg(outdent`
+      ITEM=fn([
+        ONE,
+        # just a comment
+        TWO,
+      ])
+    `);
+    expect((arg as ParsedEnvSpecArrayLiteral).simplifiedValue).toEqual(['ONE', 'TWO']);
+  });
+
+  it('nested literal inside a multi-line literal, with comments', () => {
+    const arg = literalArg(outdent`
+      ITEM=fn({
+        items=[
+          1,
+          # 2 disabled,
+          3,
+        ], # the list
+      })
+    `);
+    expect((arg as ParsedEnvSpecObjectLiteral).simplifiedValue).toEqual({ items: [1, 3] });
+  });
+});

--- a/packages/varlock-website/src/content/docs/env-spec/reference.mdx
+++ b/packages/varlock-website/src/content/docs/env-spec/reference.mdx
@@ -214,7 +214,7 @@ Standalone objects and arrays use distinct brackets, keeping them unambiguous fr
 - `{ key=value, ... }` is an **object** — keys use `=` (as elsewhere in the spec), not `:`
 - `[ value, ... ]` is an **array**
 - they may be nested, and used as decorator values or as function-call arguments
-- they are parsed using the common value-handling rules; currently single-line only
+- they are parsed using the common value-handling rules, and may span multiple lines (see [Multi-line literals](#multi-line-literals) below)
 - they are **not yet supported as standalone config item values** (e.g. `ITEM={...}`) — for now an item value that starts with `{`/`[` is still treated as a string
 
 ```env-spec
@@ -246,7 +246,58 @@ Also prefer the existing positional/comma forms for:
 - **ordered pairs** — `ifs(cond1, val1, cond2, val2, default)` and `remap($VAR, match1, result1, ...)` read like a spreadsheet `IFS()`/lookup and stay flat. Crucially, `remap` match keys may be **regexes or non-identifier strings**, which cannot be object keys (keys must match `/[a-zA-Z][a-zA-Z0-9_]*/`), so an object would be strictly less expressive.
 - **value lists** — `@type=enum(dev, staging, prod)` already reads as a list; `enum([...])` only adds brackets.
 
-(There is also no multi-line literal support yet, so anything that would want to span lines should stay a function call.)
+#### Multi-line literals
+
+Object and array literals may span multiple lines, which is handy for long key lists
+(e.g. picking many keys to import). The continuation convention matches function calls
+and depends on where the literal lives:
+
+- **Inside a decorator** (which lives in a `#` comment), every continuation line must
+  start with `#`:
+
+  ```env-spec
+  # @import(./.env.shared, pick=[
+  #   DATABASE_URL,
+  #   REDIS_URL,
+  #   STRIPE_KEY,
+  # ])
+  DATABASE_URL=
+  ```
+
+  ```env-spec
+  # @sensitive={
+  #   preventLeaks=false,
+  # }
+  SECRET=
+  ```
+
+- **On an item value line**, where the literal is nested in a function call, plain
+  newlines are used (no `#`):
+
+  ```env-spec
+  ALLOWED=fn([
+    dev,
+    staging,
+    prod,
+  ])
+  ```
+
+A trailing comma is allowed. If a `#`-prefixed continuation is omitted in a decorator,
+the bracket simply falls back to a plain string value and the following lines remain
+independent config items — they are never silently absorbed into the literal.
+
+Within a multi-line literal (or function call), `#` introduces a comment that runs to the
+end of the line, so entries can be commented out or annotated. This applies the same way
+to multi-line function-call arguments.
+
+```env-spec
+# @import(./.env.shared, pick=[
+#   DATABASE_URL,
+#   # REDIS_URL,        ← commented out, skipped
+#   STRIPE_KEY, # primary payment key
+# ])
+DATABASE_URL=
+```
 
 ### String expansion ||expansion||
 While the parser itself does not include any implemention of specific functions, it does handle _expansion_ of strings - and it uses several function calls under the hood to do so. This means a few basic function calls, while not implemented, have specific inherent meaning and must be implemented similarly across all tools that support this spec.

--- a/packages/varlock/src/env-graph/test/set-values-bulk.test.ts
+++ b/packages/varlock/src/env-graph/test/set-values-bulk.test.ts
@@ -208,6 +208,24 @@ describe('@setValuesBulk() root decorator', () => {
       },
     }));
 
+    test('pick accepts a multi-line array literal', envFilesTest({
+      envFile: outdent`
+        # @setValuesBulk('{"A":"bulk","B":"bulk","C":"bulk"}', format=json, pick=[
+        #   A,
+        #   C,
+        # ])
+        # ---
+        A=schema
+        B=schema
+        C=schema
+      `,
+      expectValues: {
+        A: 'bulk',
+        B: 'schema',
+        C: 'bulk',
+      },
+    }));
+
     test('omit (denylist) injects everything except listed keys', envFilesTest({
       envFile: outdent`
         # @setValuesBulk('{"API_KEY":"from-bulk","OTHER":"from-bulk"}', format=json, omit=[OTHER])

--- a/packages/vscode-plugin/language/env-spec.tmLanguage.json
+++ b/packages/vscode-plugin/language/env-spec.tmLanguage.json
@@ -283,6 +283,12 @@
       "end": "$",
       "name": "meta.function-call.env-spec",
       "patterns": [
+        {
+          "comment": "comment inside a multi-line item-value fn call / literal",
+          "match": "#.*$",
+          "name": "comment.line.env-spec"
+        },
+        { "include": "#bracket-literal" },
         { "include": "#literal-value" },
         { "include": "#quoted-value" },
         { "include": "#key-value-pair" },
@@ -390,8 +396,87 @@
         },
         "literal-value--numeric": {
           "comment": "Numeric item value",
-          "match": "[0-9]+(\\.[0-9]+)?(?=[\n ,)])",
+          "match": "[0-9]+(\\.[0-9]+)?(?=[\n ,)\\]}])",
           "name": "constant.numeric.env-spec"
+        }
+      }
+    },
+
+    "bracket-literal": {
+      "comment": "Object `{...}` and array `[...]` literals — multi-line and comment-aware",
+      "patterns": [
+        { "include": "#bracket-literal--object" },
+        { "include": "#bracket-literal--array" }
+      ],
+      "repository": {
+        "bracket-literal--object": {
+          "comment": "Object literal { key=value, ... }",
+          "begin": "(\\{)",
+          "end": "(\\})",
+          "beginCaptures": {
+            "1": { "name": "punctuation.definition.dictionary.begin.env-spec" }
+          },
+          "endCaptures": {
+            "1": { "name": "punctuation.definition.dictionary.end.env-spec" }
+          },
+          "name": "meta.structure.dictionary.env-spec",
+          "patterns": [{ "include": "#bracket-literal--contents" }]
+        },
+        "bracket-literal--array": {
+          "comment": "Array literal [ value, ... ]",
+          "begin": "(\\[)",
+          "end": "(\\])",
+          "beginCaptures": {
+            "1": { "name": "punctuation.definition.array.begin.env-spec" }
+          },
+          "endCaptures": {
+            "1": { "name": "punctuation.definition.array.end.env-spec" }
+          },
+          "name": "meta.structure.array.env-spec",
+          "patterns": [{ "include": "#bracket-literal--contents" }]
+        },
+        "bracket-literal--contents": {
+          "comment": "Shared inner patterns for object/array literals (both contexts)",
+          "patterns": [
+            {
+              "comment": "structural # continuation marker (decorator context)",
+              "match": "^\\s*#\\s*",
+              "name": "comment.line.env-spec punctuation.definition.comment"
+            },
+            {
+              "comment": "comment inside a literal (commented-out entry or trailing note)",
+              "match": "#.*$",
+              "name": "comment.line.env-spec"
+            },
+            { "include": "#bracket-literal" },
+            { "include": "#key-value-pair" },
+            { "include": "#env-item-value-fn-call" },
+            { "include": "#quoted-value" },
+            { "include": "#expansion" },
+            { "include": "#literal-value" },
+            { "include": "#unquoted-string-within-literal" },
+            {
+              "comment": "extra $",
+              "match": "\\$",
+              "name": "string.unquoted.env-spec"
+            },
+            {
+              "comment": "literal element separator",
+              "match": "\\s*,\\s*",
+              "name": "punctuation.separator.comma.env-spec"
+            }
+          ]
+        }
+      }
+    },
+
+    "unquoted-string-within-literal": {
+      "comment": "unquoted value within a {}/[] literal (stops at , ) } ] and whitespace)",
+      "match": "([^ \n,)$\\]}]+)",
+      "name": "string.unquoted.env-spec",
+      "captures": {
+        "1": {
+          "patterns": [{ "include": "#escape-characters" }]
         }
       }
     },
@@ -527,6 +612,12 @@
               "match": "^\\s*#\\s*",
               "name": "comment.line.env-spec punctuation.definition.comment"
             },
+            {
+              "comment": "comment inside a multi-line decorator fn call (commented-out arg or trailing note)",
+              "match": "#.*$",
+              "name": "comment.line.env-spec"
+            },
+            { "include": "#bracket-literal" },
             { "include": "#literal-value" },
             { "include": "#quoted-value" },
             { "include": "#key-value-pair" },
@@ -559,6 +650,7 @@
             { "include": "#literal-value" },
             { "include": "#quoted-value" },
             { "include": "#decorator-fn-call-value" },
+            { "include": "#bracket-literal" },
             {
               "comment": "unquoted decorator value",
               "match": "([^ \n#]+)",
@@ -609,6 +701,12 @@
           "match": "^\\s*#\\s*",
           "name": "comment.line.env-spec punctuation.definition.comment"
         },
+        {
+          "comment": "comment inside a multi-line decorator fn call (commented-out arg or trailing note)",
+          "match": "#.*$",
+          "name": "comment.line.env-spec"
+        },
+        { "include": "#bracket-literal" },
         { "include": "#literal-value" },
         { "include": "#quoted-value" },
         { "include": "#key-value-pair" },
@@ -640,7 +738,7 @@
 
     "key-value-pair": {
       "begin": "([a-zA-Z][a-zA-Z0-9]+)(=)",
-      "end": "(?=[,\n#)])",
+      "end": "(?=[,\n#)\\]}])",
       "beginCaptures": {
         "1": {
           "name": "entity.other.attribute-name.env-spec"
@@ -650,6 +748,7 @@
         }
       },
       "patterns": [
+        { "include": "#bracket-literal" },
         { "include": "#env-item-value-fn-call" },
         { "include": "#literal-value" },
         { "include": "#quoted-value" },
@@ -693,6 +792,7 @@
     "env-item-value-fn-call-arg": {
       "comment": "env item value fn call arg",
       "patterns": [
+        { "include": "#bracket-literal" },
         { "include": "#literal-value" },
         { "include": "#key-value-pair" },
         { "include": "#env-item-value-fn-call" },

--- a/packages/vscode-plugin/language/env-spec.tmLanguage.json
+++ b/packages/vscode-plugin/language/env-spec.tmLanguage.json
@@ -439,8 +439,8 @@
           "comment": "Shared inner patterns for object/array literals (both contexts)",
           "patterns": [
             {
-              "comment": "structural # continuation marker (decorator context)",
-              "match": "^\\s*#\\s*",
+              "comment": "structural # continuation marker (decorator context); only a column-0 #, so indented item-value comment lines fall through to the comment rule below",
+              "match": "^\\s?#\\s*",
               "name": "comment.line.env-spec punctuation.definition.comment"
             },
             {

--- a/packages/vscode-plugin/test/fixtures/.env.literals
+++ b/packages/vscode-plugin/test/fixtures/.env.literals
@@ -27,8 +27,9 @@ OBJ_ML=x
 # @dec={ items=[1, 2], opts={ retry=true } }
 NESTED=x
 
-# Item-value array nested in a function call (plain-newline continuation)
-LIST=oneOf([
+# Item-value array nested in a function call (plain-newline continuation, with comments)
+LIST=fn([
   one,
-  two,
+  # two is disabled
+  three, # primary
 ])

--- a/packages/vscode-plugin/test/fixtures/.env.literals
+++ b/packages/vscode-plugin/test/fixtures/.env.literals
@@ -1,0 +1,34 @@
+# Test file for object/array literals (single & multi-line, with comments)
+
+# Single-line array literal as a decorator value
+# @dec=[a, b, c]
+ARR_VAL=x
+
+# Single-line object literal as a decorator value
+# @sensitive={ preventLeaks=false }
+OBJ_VAL=x
+
+# Multi-line array passed as a function arg, with commented-out + trailing notes
+# @import(./.env.shared, pick=[
+#   ALPHA,
+#   # BETA is disabled,
+#   GAMMA, # primary
+# ])
+IMPORT_ML=x
+
+# Multi-line object literal value
+# @sensitive={
+#   preventLeaks=false,
+#   # enabled=false,
+# }
+OBJ_ML=x
+
+# Nested literals
+# @dec={ items=[1, 2], opts={ retry=true } }
+NESTED=x
+
+# Item-value array nested in a function call (plain-newline continuation)
+LIST=oneOf([
+  one,
+  two,
+])

--- a/packages/vscode-plugin/test/fixtures/.env.literals.snap
+++ b/packages/vscode-plugin/test/fixtures/.env.literals.snap
@@ -1,0 +1,171 @@
+># Test file for object/array literals (single & multi-line, with comments)
+#^ source.env-spec comment.line.env-spec punctuation.definition.comment
+# ^ source.env-spec comment.line.env-spec
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.env-spec comment.line.env-spec
+>
+># Single-line array literal as a decorator value
+#^ source.env-spec comment.line.env-spec punctuation.definition.comment
+# ^ source.env-spec comment.line.env-spec
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.env-spec comment.line.env-spec
+># @dec=[a, b, c]
+#^ source.env-spec punctuation.definition.comment comment.line.env-spec
+# ^ source.env-spec
+#  ^ source.env-spec variable.annotation.env-spec punctuation.definition.annotation.env-spec
+#   ^^^ source.env-spec variable.annotation.env-spec
+#      ^ source.env-spec keyword.operator.assignment.env-spec
+#       ^ source.env-spec meta.structure.array.env-spec punctuation.definition.array.begin.env-spec
+#        ^ source.env-spec meta.structure.array.env-spec string.unquoted.env-spec
+#         ^^ source.env-spec meta.structure.array.env-spec punctuation.separator.comma.env-spec
+#           ^ source.env-spec meta.structure.array.env-spec string.unquoted.env-spec
+#            ^^ source.env-spec meta.structure.array.env-spec punctuation.separator.comma.env-spec
+#              ^ source.env-spec meta.structure.array.env-spec string.unquoted.env-spec
+#               ^ source.env-spec meta.structure.array.env-spec punctuation.definition.array.end.env-spec
+>ARR_VAL=x
+#^^^^^^^ source.env-spec entity.name.tag.env-spec
+#       ^ source.env-spec keyword.operator.assignment.env-spec
+#        ^^ source.env-spec string.unquoted.env-spec
+>
+># Single-line object literal as a decorator value
+#^ source.env-spec comment.line.env-spec punctuation.definition.comment
+# ^ source.env-spec comment.line.env-spec
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.env-spec comment.line.env-spec
+># @sensitive={ preventLeaks=false }
+#^ source.env-spec punctuation.definition.comment comment.line.env-spec
+# ^ source.env-spec
+#  ^ source.env-spec variable.annotation.env-spec punctuation.definition.annotation.env-spec
+#   ^^^^^^^^^ source.env-spec variable.annotation.env-spec
+#            ^ source.env-spec keyword.operator.assignment.env-spec
+#             ^ source.env-spec meta.structure.dictionary.env-spec punctuation.definition.dictionary.begin.env-spec
+#              ^ source.env-spec meta.structure.dictionary.env-spec
+#               ^^^^^^^^^^^^ source.env-spec meta.structure.dictionary.env-spec entity.other.attribute-name.env-spec
+#                           ^ source.env-spec meta.structure.dictionary.env-spec keyword.operator.assignment.env-spec
+#                            ^^^^^ source.env-spec meta.structure.dictionary.env-spec constant.language.boolean.env-spec
+#                                 ^ source.env-spec meta.structure.dictionary.env-spec
+#                                  ^ source.env-spec meta.structure.dictionary.env-spec punctuation.definition.dictionary.end.env-spec
+>OBJ_VAL=x
+#^^^^^^^ source.env-spec entity.name.tag.env-spec
+#       ^ source.env-spec keyword.operator.assignment.env-spec
+#        ^^ source.env-spec string.unquoted.env-spec
+>
+># Multi-line array passed as a function arg, with commented-out + trailing notes
+#^ source.env-spec comment.line.env-spec punctuation.definition.comment
+# ^ source.env-spec comment.line.env-spec
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.env-spec comment.line.env-spec
+># @import(./.env.shared, pick=[
+#^ source.env-spec punctuation.definition.comment comment.line.env-spec
+# ^ source.env-spec
+#  ^ source.env-spec meta.function-call.env-spec variable.annotation.env-spec punctuation.definition.annotation.env-spec
+#   ^^^^^^ source.env-spec meta.function-call.env-spec variable.annotation.env-spec
+#         ^ source.env-spec meta.function-call.env-spec punctuation.section.parens.begin.env-spec
+#          ^^^^^^^^^^^^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec string.unquoted.env-spec
+#                       ^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec punctuation.separator.comma.env-spec
+#                         ^^^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec entity.other.attribute-name.env-spec
+#                             ^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec keyword.operator.assignment.env-spec
+#                              ^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec meta.structure.array.env-spec punctuation.definition.array.begin.env-spec
+>#   ALPHA,
+#^^^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec meta.structure.array.env-spec comment.line.env-spec punctuation.definition.comment
+#    ^^^^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec meta.structure.array.env-spec string.unquoted.env-spec
+#         ^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec meta.structure.array.env-spec punctuation.separator.comma.env-spec
+>#   # BETA is disabled,
+#^^^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec meta.structure.array.env-spec comment.line.env-spec punctuation.definition.comment
+#    ^^^^^^^^^^^^^^^^^^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec meta.structure.array.env-spec comment.line.env-spec
+>#   GAMMA, # primary
+#^^^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec meta.structure.array.env-spec comment.line.env-spec punctuation.definition.comment
+#    ^^^^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec meta.structure.array.env-spec string.unquoted.env-spec
+#         ^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec meta.structure.array.env-spec punctuation.separator.comma.env-spec
+#           ^^^^^^^^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec meta.structure.array.env-spec comment.line.env-spec
+># ])
+#^^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec meta.structure.array.env-spec comment.line.env-spec punctuation.definition.comment
+#  ^ source.env-spec meta.function-call.env-spec variable.parameters.env-spec meta.structure.array.env-spec punctuation.definition.array.end.env-spec
+#   ^ source.env-spec meta.function-call.env-spec punctuation.section.parens.end.env-spec
+>IMPORT_ML=x
+#^^^^^^^^^ source.env-spec entity.name.tag.env-spec
+#         ^ source.env-spec keyword.operator.assignment.env-spec
+#          ^^ source.env-spec string.unquoted.env-spec
+>
+># Multi-line object literal value
+#^ source.env-spec comment.line.env-spec punctuation.definition.comment
+# ^ source.env-spec comment.line.env-spec
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.env-spec comment.line.env-spec
+># @sensitive={
+#^ source.env-spec punctuation.definition.comment comment.line.env-spec
+# ^ source.env-spec
+#  ^ source.env-spec variable.annotation.env-spec punctuation.definition.annotation.env-spec
+#   ^^^^^^^^^ source.env-spec variable.annotation.env-spec
+#            ^ source.env-spec keyword.operator.assignment.env-spec
+#             ^ source.env-spec meta.structure.dictionary.env-spec punctuation.definition.dictionary.begin.env-spec
+>#   preventLeaks=false,
+#^^^^ source.env-spec meta.structure.dictionary.env-spec comment.line.env-spec punctuation.definition.comment
+#    ^^^^^^^^^^^^ source.env-spec meta.structure.dictionary.env-spec entity.other.attribute-name.env-spec
+#                ^ source.env-spec meta.structure.dictionary.env-spec keyword.operator.assignment.env-spec
+#                 ^^^^^ source.env-spec meta.structure.dictionary.env-spec constant.language.boolean.env-spec
+#                      ^^ source.env-spec meta.structure.dictionary.env-spec punctuation.separator.comma.env-spec
+>#   # enabled=false,
+#^^^^ source.env-spec meta.structure.dictionary.env-spec comment.line.env-spec punctuation.definition.comment
+#    ^^^^^^^^^^^^^^^^ source.env-spec meta.structure.dictionary.env-spec comment.line.env-spec
+># }
+#^^ source.env-spec meta.structure.dictionary.env-spec comment.line.env-spec punctuation.definition.comment
+#  ^ source.env-spec meta.structure.dictionary.env-spec punctuation.definition.dictionary.end.env-spec
+>OBJ_ML=x
+#^^^^^^ source.env-spec entity.name.tag.env-spec
+#      ^ source.env-spec keyword.operator.assignment.env-spec
+#       ^^ source.env-spec string.unquoted.env-spec
+>
+># Nested literals
+#^ source.env-spec comment.line.env-spec punctuation.definition.comment
+# ^ source.env-spec comment.line.env-spec
+#  ^^^^^^^^^^^^^^^ source.env-spec comment.line.env-spec
+># @dec={ items=[1, 2], opts={ retry=true } }
+#^ source.env-spec punctuation.definition.comment comment.line.env-spec
+# ^ source.env-spec
+#  ^ source.env-spec variable.annotation.env-spec punctuation.definition.annotation.env-spec
+#   ^^^ source.env-spec variable.annotation.env-spec
+#      ^ source.env-spec keyword.operator.assignment.env-spec
+#       ^ source.env-spec meta.structure.dictionary.env-spec punctuation.definition.dictionary.begin.env-spec
+#        ^ source.env-spec meta.structure.dictionary.env-spec
+#         ^^^^^ source.env-spec meta.structure.dictionary.env-spec entity.other.attribute-name.env-spec
+#              ^ source.env-spec meta.structure.dictionary.env-spec keyword.operator.assignment.env-spec
+#               ^ source.env-spec meta.structure.dictionary.env-spec meta.structure.array.env-spec punctuation.definition.array.begin.env-spec
+#                ^ source.env-spec meta.structure.dictionary.env-spec meta.structure.array.env-spec constant.numeric.env-spec
+#                 ^^ source.env-spec meta.structure.dictionary.env-spec meta.structure.array.env-spec punctuation.separator.comma.env-spec
+#                   ^ source.env-spec meta.structure.dictionary.env-spec meta.structure.array.env-spec constant.numeric.env-spec
+#                    ^ source.env-spec meta.structure.dictionary.env-spec meta.structure.array.env-spec punctuation.definition.array.end.env-spec
+#                     ^^ source.env-spec meta.structure.dictionary.env-spec punctuation.separator.comma.env-spec
+#                       ^^^^ source.env-spec meta.structure.dictionary.env-spec entity.other.attribute-name.env-spec
+#                           ^ source.env-spec meta.structure.dictionary.env-spec keyword.operator.assignment.env-spec
+#                            ^ source.env-spec meta.structure.dictionary.env-spec meta.structure.dictionary.env-spec punctuation.definition.dictionary.begin.env-spec
+#                             ^ source.env-spec meta.structure.dictionary.env-spec meta.structure.dictionary.env-spec
+#                              ^^^^^ source.env-spec meta.structure.dictionary.env-spec meta.structure.dictionary.env-spec entity.other.attribute-name.env-spec
+#                                   ^ source.env-spec meta.structure.dictionary.env-spec meta.structure.dictionary.env-spec keyword.operator.assignment.env-spec
+#                                    ^^^^ source.env-spec meta.structure.dictionary.env-spec meta.structure.dictionary.env-spec constant.language.boolean.env-spec
+#                                        ^ source.env-spec meta.structure.dictionary.env-spec meta.structure.dictionary.env-spec
+#                                         ^ source.env-spec meta.structure.dictionary.env-spec meta.structure.dictionary.env-spec punctuation.definition.dictionary.end.env-spec
+#                                          ^ source.env-spec meta.structure.dictionary.env-spec
+#                                           ^ source.env-spec meta.structure.dictionary.env-spec punctuation.definition.dictionary.end.env-spec
+>NESTED=x
+#^^^^^^ source.env-spec entity.name.tag.env-spec
+#      ^ source.env-spec keyword.operator.assignment.env-spec
+#       ^^ source.env-spec string.unquoted.env-spec
+>
+># Item-value array nested in a function call (plain-newline continuation)
+#^ source.env-spec comment.line.env-spec punctuation.definition.comment
+# ^ source.env-spec comment.line.env-spec
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.env-spec comment.line.env-spec
+>LIST=oneOf([
+#^^^^ source.env-spec entity.name.tag.env-spec
+#    ^ source.env-spec keyword.operator.assignment.env-spec
+#     ^^^^^ source.env-spec meta.function-call.env-spec variable.function.env-spec
+#          ^ source.env-spec meta.function-call.env-spec punctuation.definition.parameters.begin.env-spec
+#           ^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec punctuation.definition.array.begin.env-spec
+>  one,
+#^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec
+#  ^^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec string.unquoted.env-spec
+#     ^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec punctuation.separator.comma.env-spec
+>  two,
+#^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec
+#  ^^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec string.unquoted.env-spec
+#     ^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec punctuation.separator.comma.env-spec
+>])
+#^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec punctuation.definition.array.end.env-spec
+# ^ source.env-spec meta.function-call.env-spec punctuation.definition.parameters.end.env-spec
+>

--- a/packages/vscode-plugin/test/fixtures/.env.literals.snap
+++ b/packages/vscode-plugin/test/fixtures/.env.literals.snap
@@ -147,24 +147,28 @@
 #      ^ source.env-spec keyword.operator.assignment.env-spec
 #       ^^ source.env-spec string.unquoted.env-spec
 >
-># Item-value array nested in a function call (plain-newline continuation)
+># Item-value array nested in a function call (plain-newline continuation, with comments)
 #^ source.env-spec comment.line.env-spec punctuation.definition.comment
 # ^ source.env-spec comment.line.env-spec
-#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.env-spec comment.line.env-spec
->LIST=oneOf([
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.env-spec comment.line.env-spec
+>LIST=fn([
 #^^^^ source.env-spec entity.name.tag.env-spec
 #    ^ source.env-spec keyword.operator.assignment.env-spec
-#     ^^^^^ source.env-spec meta.function-call.env-spec variable.function.env-spec
-#          ^ source.env-spec meta.function-call.env-spec punctuation.definition.parameters.begin.env-spec
-#           ^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec punctuation.definition.array.begin.env-spec
+#     ^^ source.env-spec meta.function-call.env-spec variable.function.env-spec
+#       ^ source.env-spec meta.function-call.env-spec punctuation.definition.parameters.begin.env-spec
+#        ^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec punctuation.definition.array.begin.env-spec
 >  one,
 #^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec
 #  ^^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec string.unquoted.env-spec
 #     ^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec punctuation.separator.comma.env-spec
->  two,
+>  # two is disabled
 #^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec
-#  ^^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec string.unquoted.env-spec
-#     ^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec punctuation.separator.comma.env-spec
+#  ^^^^^^^^^^^^^^^^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec comment.line.env-spec
+>  three, # primary
+#^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec
+#  ^^^^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec string.unquoted.env-spec
+#       ^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec punctuation.separator.comma.env-spec
+#         ^^^^^^^^^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec comment.line.env-spec
 >])
 #^ source.env-spec meta.function-call.env-spec meta.structure.array.env-spec punctuation.definition.array.end.env-spec
 # ^ source.env-spec meta.function-call.env-spec punctuation.definition.parameters.end.env-spec

--- a/packages/vscode-plugin/test/grammar.test.txt
+++ b/packages/vscode-plugin/test/grammar.test.txt
@@ -157,6 +157,23 @@ KEYS=fn([a, b])
 #            ^ punctuation.definition.array.end.env-spec
 #             ^ punctuation.definition.parameters.end.env-spec
 
+
+# Item-value array (plain-newline continuation) with comments
+LIST_ML=fn([
+#          ^ punctuation.definition.array.begin.env-spec
+  ONE,
+# ^^^ string.unquoted.env-spec
+  # TWO disabled
+# ^^^^^^^^^^^^^^ comment.line.env-spec
+  THREE, # last
+# ^^^^^ string.unquoted.env-spec
+#        ^^^^^^ comment.line.env-spec
+])
+# <- punctuation.definition.array.end.env-spec
+#^ punctuation.definition.parameters.end.env-spec
+AFTER_LIST=ok
+#^^^^^^^^^ entity.name.tag.env-spec
+
 # @import(pick=[
 #   ALPHA,
 #   ^^^^^ string.unquoted.env-spec

--- a/packages/vscode-plugin/test/grammar.test.txt
+++ b/packages/vscode-plugin/test/grammar.test.txt
@@ -129,6 +129,49 @@ UNDEFINED_VAL=undefined
 #             ^^^^^^^^^ constant.language.undefined.env-spec
 
 # ======================
+# Object & array literals
+# ======================
+
+# @dec=[a, b]
+#      ^ punctuation.definition.array.begin.env-spec
+#       ^ string.unquoted.env-spec
+#          ^ string.unquoted.env-spec
+#           ^ punctuation.definition.array.end.env-spec
+
+ARR_DEC=test
+#^^^^^^ entity.name.tag.env-spec
+
+# @sensitive={ preventLeaks=false }
+#            ^ punctuation.definition.dictionary.begin.env-spec
+#              ^^^^^^^^^^^^ entity.other.attribute-name.env-spec
+#                          ^ keyword.operator.assignment.env-spec
+#                           ^^^^^ constant.language.boolean.env-spec
+#                                 ^ punctuation.definition.dictionary.end.env-spec
+
+OBJ_DEC=test
+#^^^^^^ entity.name.tag.env-spec
+
+KEYS=fn([a, b])
+#       ^ punctuation.definition.array.begin.env-spec
+#        ^ string.unquoted.env-spec
+#            ^ punctuation.definition.array.end.env-spec
+#             ^ punctuation.definition.parameters.end.env-spec
+
+# @import(pick=[
+#   ALPHA,
+#   ^^^^^ string.unquoted.env-spec
+#   # disabled,
+#   ^^^^^^^^^^^ comment.line.env-spec
+#   BETA, # primary
+#   ^^^^ string.unquoted.env-spec
+#         ^^^^^^^^^ comment.line.env-spec
+# ])
+# ^ punctuation.definition.array.end.env-spec
+#  ^ punctuation.section.parens.end.env-spec
+IMPORT_ML=test
+#^^^^^^^^ entity.name.tag.env-spec
+
+# ======================
 # Edge cases
 # ======================
 


### PR DESCRIPTION
Follow-up to the object/array literals work: literals can now span multiple lines, so long key lists (e.g. a big `@import(..., pick=[...])`) don't have to live on one line.

## What changed

- **Multi-line literals** in both contexts, mirroring how function-call args already work:
  - Inside decorators (which live in `#` comments), each continuation line is prefixed with `#`.
  - Literals nested in item-value function calls use plain newlines.
- **Comments inside multi-line literals and function calls** — `#` starts a comment to end-of-line, so individual entries can be commented out (`# # OLD_KEY,`) or annotated (`# KEY, # note`).
- **VSCode extension syntax highlighting** updated to match — object/array literals (single- and multi-line) and these inline comments are now properly scoped (previously literals were highlighted as plain strings).

```env-spec
# @import(./.env.shared, pick=[
#   DATABASE_URL,
#   # REDIS_URL,        ← commented out, skipped
#   STRIPE_KEY, # primary payment key
# ])
DATABASE_URL=
```

## Safety

Continuation across a newline still **requires** the leading `#` in decorator context, so a missing `#` can never silently swallow following config items — a malformed bracket falls back to a plain string and the lines below stay independent config items.

## Implementation

- **Parser:** split the literal grammar into value-context (`_valWs`) and decorator-context (`_decWs`) rule sets, matching the existing `FunctionArgs` / `DecoratorFunctionArgs` split, and taught both whitespace rules to skip `#` comments.
- **TextMate grammar:** added `bracket-literal` rules (object/array, multi-line via begin/end, comment-aware) wired into every arg context; `key-value-pair` and the literal-scoped unquoted/numeric rules now terminate at `}`/`]` so closing brackets aren't swallowed.

## Tests

- Parser: multi-line arrays/objects, nesting, `import pick=[...]`, comments/post-comments, trailing-comma handling, and the no-swallow safety property; plus an end-to-end `@setValuesBulk pick=[...]` test.
- VSCode grammar: scope assertions in `grammar.test.txt` (CI-checked) for single- and multi-line literals + inline comments, plus a new `.env.literals` snapshot fixture.

Docs updated in `env-spec/reference`.