### PR TITLE
fix(vscode-plugin): highlight nested decorator function calls correctly

### DIFF
--- a/.bumpy/fix-nested-decorator-fn-call-highlight.md
+++ b/.bumpy/fix-nested-decorator-fn-call-highlight.md
@@ -1,0 +1,5 @@
+---
+env-spec-language: patch
+---
+
+Fix syntax highlighting: closing paren in a nested decorator function call (e.g. @dec(fn())) no longer shows as an error

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -173,6 +173,7 @@ export default tseslint.config(
       'framework-tests/**',
       'packages/encryption-binary-swift/scripts/**',
       'packages/encryption-binary-rust/scripts/**',
+      'packages/vscode-plugin/scripts/**',
     ],
     rules: {
       'no-console': 0,

--- a/packages/vscode-plugin/language/env-spec.tmLanguage.json
+++ b/packages/vscode-plugin/language/env-spec.tmLanguage.json
@@ -530,6 +530,7 @@
             { "include": "#literal-value" },
             { "include": "#quoted-value" },
             { "include": "#key-value-pair" },
+            { "include": "#decorator-fn-call-value" },
             { "include": "#expansion" },
             { "include": "#unquoted-string-within-fn-call" },
             {

--- a/packages/vscode-plugin/package.json
+++ b/packages/vscode-plugin/package.json
@@ -82,6 +82,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
+    "install:local": "bun run build && bun run scripts/install-local.ts",
     "test": "vitest",
     "test:grammar": "vscode-tmgrammar-test -g ./language/env-spec.tmLanguage.json ./test/grammar.test.txt",
     "test:ci": "vitest --run && bun run test:grammar",

--- a/packages/vscode-plugin/scripts/install-local.ts
+++ b/packages/vscode-plugin/scripts/install-local.ts
@@ -1,0 +1,112 @@
+// Local dev installer for the @env-spec VSCode extension.
+//
+// VS Code / Cursor / Windsurf don't just scan the extensions folder — they
+// reconcile it against two bookkeeping files:
+//   - extensions.json : the registry of recognized user extensions
+//   - .obsolete       : folders to ignore / pending removal
+//
+// A hand-symlinked folder that isn't in extensions.json (or is stuck in
+// .obsolete) silently won't load. This script keeps a live-symlinked install
+// (so grammar/dist edits reflect on reload, no repackaging) while writing
+// correct, consistent bookkeeping in every editor.
+//
+// It is idempotent: safe to re-run any time.
+//
+// Run with: bun run install:local
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const PKG_DIR = path.resolve(__dirname, '..');
+const src = JSON.parse(fs.readFileSync(path.join(PKG_DIR, 'package.json'), 'utf8'));
+
+// Canonical extension identity. The package name (`env-spec-language`) is
+// already a legal extension name, so no rewriting is needed.
+const NAME = src.name;
+const PUBLISHER = src.publisher;
+const VERSION = src.version;
+const ID = `${PUBLISHER}.${NAME}`;
+const FOLDER = `${ID}-${VERSION}`;
+const ID_PREFIX = ID.toLowerCase();
+
+// Items symlinked into the install folder (everything the manifest references:
+// `main` → dist, language config + grammar → language, icons → images).
+const LINKS = ['dist', 'language', 'images', 'node_modules'];
+
+// Warn early if the extension hasn't been built — it would fail to activate.
+if (!fs.existsSync(path.join(PKG_DIR, 'dist', 'extension.js'))) {
+  console.warn('⚠  dist/extension.js missing — run `bun run build` first (continuing anyway).');
+}
+
+const EDITOR_DIRS = ['.vscode', '.cursor', '.windsurf']
+  .map((d) => path.join(os.homedir(), d, 'extensions'))
+  .filter((d) => fs.existsSync(d));
+
+if (!EDITOR_DIRS.length) {
+  console.log('No editor extensions directories found (.vscode/.cursor/.windsurf).');
+  process.exit(0);
+}
+
+const readJson = (f: string, fallback: unknown) => {
+  try {
+    return JSON.parse(fs.readFileSync(f, 'utf8'));
+  } catch {
+    return fallback;
+  }
+};
+
+for (const extDir of EDITOR_DIRS) {
+  // Remove any prior install folders for this extension (stale versions, the
+  // old whole-package symlink, etc.) so only one consistent copy remains.
+  for (const entry of fs.readdirSync(extDir)) {
+    if (entry.toLowerCase().startsWith(ID_PREFIX)) {
+      fs.rmSync(path.join(extDir, entry), { recursive: true, force: true });
+    }
+  }
+
+  const folderPath = path.join(extDir, FOLDER);
+
+  // 1. (Re)create the install folder with fresh symlinks + a copied manifest.
+  fs.mkdirSync(folderPath, { recursive: true });
+  for (const item of LINKS) {
+    const target = path.join(PKG_DIR, item);
+    if (fs.existsSync(target)) fs.symlinkSync(target, path.join(folderPath, item));
+  }
+  fs.writeFileSync(
+    path.join(folderPath, 'package.json'),
+    JSON.stringify(src, null, 2),
+  );
+
+  // 2. Clear any stale markers from .obsolete.
+  const obsoletePath = path.join(extDir, '.obsolete');
+  if (fs.existsSync(obsoletePath)) {
+    const obsolete = readJson(obsoletePath, {}) as Record<string, unknown>;
+    let changed = false;
+    for (const key of Object.keys(obsolete)) {
+      if (key.toLowerCase().startsWith(ID_PREFIX)) {
+        delete obsolete[key];
+        changed = true;
+      }
+    }
+    if (changed) fs.writeFileSync(obsoletePath, JSON.stringify(obsolete));
+  }
+
+  // 3. Register a single, correct entry in extensions.json (drop stale ones).
+  const regPath = path.join(extDir, 'extensions.json');
+  const reg = readJson(regPath, []);
+  const cleaned = Array.isArray(reg)
+    ? reg.filter((e: any) => !String(e?.identifier?.id ?? '').toLowerCase().startsWith(ID_PREFIX))
+    : [];
+  cleaned.push({
+    identifier: { id: ID },
+    version: VERSION,
+    location: { $mid: 1, path: folderPath, scheme: 'file' },
+    relativeLocation: FOLDER,
+  });
+  fs.writeFileSync(regPath, JSON.stringify(cleaned));
+
+  console.log(`✓ installed ${ID}@${VERSION} → ${extDir}`);
+}
+
+console.log('\nDone. Fully quit and reopen the editor (Cmd+Q, not just reload) to pick up the change.');

--- a/packages/vscode-plugin/test/grammar.test.txt
+++ b/packages/vscode-plugin/test/grammar.test.txt
@@ -75,6 +75,45 @@ DOCS_FRAGMENT_VAR=test
 # ^ punctuation.section.parens.end.env-spec
 MULTI_DEC_VAR=test
 
+# @dec(fn())
+#     ^ punctuation.section.parens.begin.env-spec
+#      ^^ variable.function.env-spec
+#        ^ punctuation.section.parens.begin.env-spec
+#         ^ punctuation.section.parens.end.env-spec
+#          ^ punctuation.section.parens.end.env-spec
+NESTED_FN_DEC_VAR=test
+
+# @dec(fn(arg))
+#     ^ punctuation.section.parens.begin.env-spec
+#      ^^ variable.function.env-spec
+#        ^ punctuation.section.parens.begin.env-spec
+#         ^^^ string.unquoted.env-spec
+#            ^ punctuation.section.parens.end.env-spec
+#             ^ punctuation.section.parens.end.env-spec
+NESTED_FN_ARG_DEC_VAR=test
+
+# @dec(key=fn())
+#     ^ punctuation.section.parens.begin.env-spec
+#      ^^^ entity.other.attribute-name.env-spec
+#         ^ keyword.operator.assignment.env-spec
+#          ^^ variable.function.env-spec
+#            ^ punctuation.definition.parameters.begin.env-spec
+#             ^ punctuation.definition.parameters.end.env-spec
+#              ^ punctuation.section.parens.end.env-spec
+KWARG_FN_DEC_VAR=test
+
+# @dec(a, fn(), b)
+#     ^ punctuation.section.parens.begin.env-spec
+#      ^ string.unquoted.env-spec
+#       ^ punctuation.separator.comma.env-spec
+#         ^^ variable.function.env-spec
+#           ^ punctuation.section.parens.begin.env-spec
+#            ^ punctuation.section.parens.end.env-spec
+#             ^ punctuation.separator.comma.env-spec
+#               ^ string.unquoted.env-spec
+#                ^ punctuation.section.parens.end.env-spec
+MULTI_ARG_FN_DEC_VAR=test
+
 # ======================
 # Variable expansion
 # ======================


### PR DESCRIPTION
## What

The closing `)` in a decorator function call with a nested function-call argument (e.g. `# @dec(fn())`) was rendered as a syntax error (red). The bare form `@dec(arg)` highlighted fine.

## Why

The `decorator--fn-call` rule in the TextMate grammar had no pattern for a nested function call as an argument. So for `@dec(fn())`:

1. the greedy `unquoted-string-within-fn-call` matcher (which doesn't exclude `(`) ate `fn(`
2. the **first** `)` matched the decorator's `end` and closed it early
3. the **second** `)` was orphaned and fell through to the top-level `invalid` rule → red

## Fix

Add a nested fn-call include (`#decorator-fn-call-value`) to `decorator--fn-call`, ordered ahead of the greedy unquoted matcher.

Adds grammar test coverage for the `@dec(...)` call form with nested, keyword-arg, and multiple-arg cases (`@dec(fn())`, `@dec(fn(arg))`, `@dec(key=fn())`, `@dec(a, fn(), b)`), asserting the scopes of both closing parens.

Also adds a local-dev install script (`scripts/install-local.ts` + `bun run install:local`) that live-symlinks the extension into VS Code/Cursor/Windsurf with correct bookkeeping.