### PR TITLE
chore: remind to sync PR description after git push

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,6 +32,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git push*)",
+            "command": "printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"git push ran. If this added commits to an open PR, check that the PR description still matches what changed and update it with gh pr edit if it is now stale.\"}}'"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Adds a `PostToolUse` hook to `.claude/settings.json` that fires after any `git push` (filtered via `if: "Bash(git push*)"`) and injects a reminder for Claude Code to check whether the PR description still matches the pushed changes — and update it with `gh pr edit` if stale.

This enforces the existing AGENTS.md convention ("When pushing new commits to an open PR, update the PR description if the changes alter what it says") that was easy to forget in practice.

Details:
- Non-blocking — it only injects context, never prevents the push.
- Merged alongside the existing `WorktreeCreate` hook; no other settings touched.
- Verified: JSON validates, and the hook fired correctly on this branch's own push.