### PR TITLE
Friendlier init message when EXAMPLE_ITEM is left in schema

### DIFF
--- a/.bumpy/init-honesty-message.md
+++ b/.bumpy/init-honesty-message.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Friendlier init message when EXAMPLE_ITEM is left in the schema

--- a/.bumpy/init-honesty-message.md
+++ b/.bumpy/init-honesty-message.md
@@ -1,5 +1,3 @@
 ---
 varlock: patch
 ---
-
-Friendlier init message when EXAMPLE_ITEM is left in the schema

--- a/packages/varlock/src/cli/commands/init.command.ts
+++ b/packages/varlock/src/cli/commands/init.command.ts
@@ -267,8 +267,8 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
       if (reloadedSchemaFile.configItems.find((i) => i.key === 'EXAMPLE_ITEM')) {
         logLines([
           '',
-          ansis.bold(`🚨 Really? ${ansis.red("You didn't remove the EXAMPLE_ITEM!")}`),
-          `Please make sure your schema is all correct before using it...`,
+          ansis.bold(`🙏 Thanks for your honesty!`),
+          `Make sure to review your schema and remove the ${ansis.bold('EXAMPLE_ITEM')} before using it...`,
         ]);
       }
     }

--- a/packages/varlock/src/cli/commands/init.command.ts
+++ b/packages/varlock/src/cli/commands/init.command.ts
@@ -265,11 +265,17 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
       const reloadedSchemaFile = await parseEnvSpecDotEnvFile(await fs.readFile(schemaFilePath, 'utf-8'));
       // check if they removed the EXAMPLE_ITEM and warn them
       if (reloadedSchemaFile.configItems.find((i) => i.key === 'EXAMPLE_ITEM')) {
-        logLines([
-          '',
-          ansis.bold(`🙏 Thanks for your honesty!`),
-          `Make sure to review your schema and remove the ${ansis.bold('EXAMPLE_ITEM')} before using it...`,
-        ]);
+        logLines(confirmReviewed
+          ? [
+            '',
+            ansis.bold(`🚨 Really? ${ansis.red("You didn't remove the EXAMPLE_ITEM!")}`),
+            `Please make sure your schema is all correct before using it...`,
+          ]
+          : [
+            '',
+            ansis.bold(`🙏 Thanks for your honesty!`),
+            `Make sure to review your schema and remove the ${ansis.bold('EXAMPLE_ITEM')} before using it...`,
+          ]);
       }
     }
 


### PR DESCRIPTION
When a user runs `varlock init`, the post-review EXAMPLE_ITEM warning now depends on whether they said they reviewed the schema:

- **Claimed they reviewed** but `EXAMPLE_ITEM` is still present → keeps the cheeky callout: "🚨 Really? You didn't remove the EXAMPLE_ITEM!"
- **Admitted they didn't review** → friendlier nudge instead:

> 🙏 Thanks for your honesty!
> Make sure to review your schema and remove the EXAMPLE_ITEM before using it...

Previously it showed the accusatory message in both cases.