### PR TITLE
docs(nextjs): clarify @next/env override verification and troubleshooting

### DIFF
--- a/packages/varlock-website/src/content/docs/integrations/nextjs.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/nextjs.mdx
@@ -52,6 +52,10 @@ To integrate varlock into a Next.js application, you must use our [`@varlock/nex
         +  }
         }
         ```
+
+        :::caution[npm may not apply the override on a plain `npm install`]
+        npm can be inconsistent about applying `overrides` for nested scoped packages like `@next/env`, especially when an existing `package-lock.json` has it pinned to a stale location. If after installing you hit `Cannot find module '@next/env'` or don't see the varlock banner, you'll need to delete both `node_modules` and `package-lock.json` and reinstall — see [Troubleshooting](#troubleshooting).
+        :::
       </TabItem>
 
       <TabItem label="yarn">
@@ -156,7 +160,20 @@ To integrate varlock into a Next.js application, you must use our [`@varlock/nex
     +export default withVarlock(nextConfig);
     ```
 
+1. **Verify the override is active**
 
+    Start your dev server (or run a build) and look at the startup output. When the override is working, varlock reports the `.env` files it loaded with a banner:
+
+    ```bash title="next dev"
+    - Environments: .env.schema,
+                       ✨ loaded by varlock ✨
+    ```
+
+    If you **don't** see `✨ loaded by varlock ✨` — or you get `Cannot find module '@next/env'` or `__VARLOCK_ENV is not set` — the override didn't take effect. See [Troubleshooting](#troubleshooting) below.
+
+    :::note[The override only needs to apply at build/dev time]
+    On serverless platforms (e.g. Vercel, Cloudflare), the fully-resolved env is baked into your build output by the config plugin, so the production server does not re-load `.env` files. This means you only need the `@next/env` override to be active when you run `next dev` and `next build` — there is no separate runtime config to set on the platform.
+    :::
 
 </Steps>
 
@@ -336,10 +353,21 @@ When deploying to serverless platforms like Vercel, Varlock injects the fully re
 ---
 ## Troubleshooting
 
+Almost all setup issues come down to the `@next/env` override not being applied. The fixes below are ordered by the symptom you see — work top to bottom.
+
+- ❌ `Error: Cannot find module '@next/env'` (or no `✨ loaded by varlock ✨` banner)
+  <br/>💡 The override was recorded in your lockfile but your package manager didn't materialize it correctly. This is a known package-manager issue with `overrides`/`resolutions` for nested scoped packages — npm in particular can create a dangling symlink under `node_modules/next/node_modules/@next/env`, or skip it entirely, when installing against a stale lockfile.
+  - Delete **both** `node_modules` **and** your lockfile, then reinstall — deleting the lockfile alone is not enough:
+    - npm: `rm -rf node_modules package-lock.json && npm install`
+    - pnpm: `rm -rf node_modules pnpm-lock.yaml && pnpm install`
+    - yarn: `rm -rf node_modules yarn.lock && yarn install`
+    - bun: `rm -rf node_modules bun.lock bun.lockb && bun install`
+  - Commit the regenerated lockfile.
+  - Re-verify with the banner above, or directly: `cat node_modules/@next/env/package.json` should show `"name": "@varlock/nextjs-integration"`.
 - ❌ `process.env.__VARLOCK_ENV is not set`
-  <br/>💡 This error appears when the `@next/env` override has not been set up properly
-  - You may need to re-run your package manager's install command
-  - If using pnpm, check if you are using pnpm v9 or v10, because overrides config changed (see above)
+  <br/>💡 The override is missing or in the wrong place — Next loaded its own `@next/env` instead of ours.
+  - Confirm the override config is present and in the **correct file** for your package manager (see [step 3](#setup)) — for pnpm it must be in `pnpm-workspace.yaml` (v10) or `package.json#pnpm.overrides` (v9), and in a monorepo it must be at the repo root.
+  - Re-run your package manager's install command, then re-verify the banner.
 - ❌ `Error [ERR_REQUIRE_ESM]: require() of ES Module ...`
   <br/>💡 Varlock requires node v22 or higher - which has better CJS/ESM interoperability
 - ❌ `Property 'SOMEVAR' does not exist on type 'TypedEnvSchema'`


### PR DESCRIPTION
Improves the Next.js integration docs so the `@next/env` override setup is verifiable and self-healing, after debugging a repeated "Cannot find module '@next/env'" failure caused by npm materializing the override as a dangling nested symlink against a stale lockfile.

## Changes
- **New "Verify the override is active" step** — uses the `✨ loaded by varlock ✨` startup banner as the ground-truth signal that the override took effect (not just that install succeeded).
- **"Build/dev only, not runtime" note** — resolved env is baked into the build output by the config plugin, so there's no separate runtime env config to set on serverless platforms.
- **Troubleshooting rewritten as a symptom→fix map**, package-manager-agnostic:
  - `Cannot find module '@next/env'` / no banner → delete **both** `node_modules` and the lockfile, reinstall (exact command per PM), commit, re-verify. Deleting the lockfile alone is not enough.
  - `__VARLOCK_ENV is not set` → override missing/misplaced (right file per PM, monorepo root).
- Trimmed the npm-tab caution to point at the troubleshooting map.