### PR TITLE
feat(proton-pass): support personal access token login

### DIFF
--- a/.bumpy/proton-pass-pat-login.md
+++ b/.bumpy/proton-pass-pat-login.md
@@ -1,0 +1,5 @@
+---
+"@varlock/proton-pass-plugin": minor
+---
+
+Add Proton Pass personal access token login (PROTON_PASS_PERSONAL_ACCESS_TOKEN) as a non-interactive alternative to username/password

--- a/packages/plugins/proton-pass/src/plugin.ts
+++ b/packages/plugins/proton-pass/src/plugin.ts
@@ -13,6 +13,7 @@ plugin.icon = PROTON_PASS_ICON;
 plugin.standardVars = {
   initDecorator: '@initProtonPass',
   params: {
+    personalAccessToken: { key: 'PROTON_PASS_PERSONAL_ACCESS_TOKEN', dataType: 'protonPassPersonalAccessToken' },
     password: { key: 'PROTON_PASS_PASSWORD', dataType: 'protonPassPassword' },
     totp: { key: 'PROTON_PASS_TOTP', dataType: 'protonPassTotp' },
     extraPassword: { key: 'PROTON_PASS_EXTRA_PASSWORD', dataType: 'protonPassExtraPassword' },
@@ -37,6 +38,11 @@ const LOGIN_HELP_TIP = [
   '  PROTON_PASS_PASSWORD',
   '  PROTON_PASS_TOTP (if 2FA/TOTP is enabled)',
   '  PROTON_PASS_EXTRA_PASSWORD (if your account requires an extra password)',
+  '',
+  'Or use a personal access token (recommended for CI):',
+  '  PROTON_PASS_PERSONAL_ACCESS_TOKEN',
+  'Create one with `pass-cli pat create --name <name> --expiration <1d|1w|1m|3m|6m|1y>`',
+  'and grant it access with `pass-cli pat access grant ...`.',
 ].join('\n');
 
 function getSecretFieldNameFromRef(secretRef: string): string | undefined {
@@ -96,6 +102,7 @@ class ProtonPassPluginInstance {
   private password?: string;
   private totp?: string;
   private extraPassword?: string;
+  private personalAccessToken?: string;
 
   // Cache decrypted values for the current resolution session.
   private cache = new Map<string, string>();
@@ -116,17 +123,23 @@ class ProtonPassPluginInstance {
     password?: string;
     totp?: string;
     extraPassword?: string;
+    personalAccessToken?: string;
   }) {
     if (opts.username && typeof opts.username === 'string') this.username = opts.username;
     if (opts.password && typeof opts.password === 'string') this.password = opts.password;
     if (opts.totp && typeof opts.totp === 'string') this.totp = opts.totp;
     if (opts.extraPassword && typeof opts.extraPassword === 'string') this.extraPassword = opts.extraPassword;
+    if (opts.personalAccessToken && typeof opts.personalAccessToken === 'string') {
+      this.personalAccessToken = opts.personalAccessToken;
+    }
 
     debug('proton-pass instance', this.id, 'configured');
   }
 
   private get loginEnv(): Record<string, string> | undefined {
     const env: Record<string, string> = {};
+    // A personal access token is a self-contained credential and does not need a username.
+    if (this.personalAccessToken) env.PROTON_PASS_PERSONAL_ACCESS_TOKEN = this.personalAccessToken;
     if (this.password) env.PROTON_PASS_PASSWORD = this.password;
     if (this.totp) env.PROTON_PASS_TOTP = this.totp;
     if (this.extraPassword) env.PROTON_PASS_EXTRA_PASSWORD = this.extraPassword;
@@ -141,6 +154,31 @@ class ProtonPassPluginInstance {
     }
 
     this.loginInFlight = (async () => {
+      // Prefer a personal access token when configured — it is non-interactive,
+      // needs no username/password, and is the recommended path for CI.
+      // PATs have a fixed expiration (set at creation); when one expires the user
+      // mints a new token via `pass-cli pat renew` and updates their config — there
+      // is nothing for us to refresh or persist here.
+      if (this.personalAccessToken) {
+        debug('logging into proton pass via personal access token');
+        try {
+          await spawnAsync(
+            'pass-cli',
+            ['login'],
+            { env: { ...(process.env as Record<string, string>), ...this.loginEnv } },
+          );
+        } catch (loginErr) {
+          const loginMsg = loginErr instanceof ExecError ? (loginErr.data || loginErr.message) : String(loginErr);
+          throw new ResolutionError(`Proton Pass CLI login (personal access token) failed: ${loginMsg}`, {
+            tip: [
+              NOT_LOGGED_IN_TIP,
+              'The token may be invalid or expired — check with `pass-cli pat list` and renew if needed.',
+            ].join('\n'),
+          });
+        }
+        return;
+      }
+
       // Attempt login
       if (!this.username) {
         throw new ResolutionError('Proton Pass CLI not authenticated and no username configured', {
@@ -429,6 +467,27 @@ plugin.registerDataType({
   },
 });
 
+plugin.registerDataType({
+  name: 'protonPassPersonalAccessToken',
+  sensitive: true,
+  typeDescription: 'Proton Pass personal access token used by `pass-cli login` (non-interactive, recommended for CI)',
+  icon: PROTON_PASS_ICON,
+  docs: [
+    {
+      description: 'Proton Pass CLI personal access token login',
+      url: 'https://protonpass.github.io/pass-cli/commands/login/#personal-access-token-login',
+    },
+  ],
+  async validate(val): Promise<true> {
+    if (!val || typeof val !== 'string') throw new ValidationError('Personal access token must be a non-empty string');
+    // Tokens are issued in the shape `pst_xxxx...xxxx::TOKENKEY`.
+    if (!val.includes('::')) {
+      throw new ValidationError('Personal access token looks malformed - expected `pst_...::TOKENKEY`');
+    }
+    return true;
+  },
+});
+
 plugin.registerRootDecorator({
   name: 'initProtonPass',
   description: 'Initialize a Proton Pass plugin instance for protonPass() resolver',
@@ -456,21 +515,24 @@ plugin.registerRootDecorator({
       passwordResolver: objArgs?.password,
       totpResolver: objArgs?.totp,
       extraPasswordResolver: objArgs?.extraPassword,
+      personalAccessTokenResolver: objArgs?.personalAccessToken,
     };
   },
   async execute({
-    id, usernameResolver, passwordResolver, totpResolver, extraPasswordResolver,
+    id, usernameResolver, passwordResolver, totpResolver, extraPasswordResolver, personalAccessTokenResolver,
   }) {
     const username = await usernameResolver?.resolve();
     const password = await passwordResolver?.resolve();
     const totp = await totpResolver?.resolve();
     const extraPassword = await extraPasswordResolver?.resolve();
+    const personalAccessToken = await personalAccessTokenResolver?.resolve();
 
     pluginInstances[id].configure({
       username: typeof username === 'string' ? username : undefined,
       password: typeof password === 'string' ? password : undefined,
       totp: typeof totp === 'string' ? totp : undefined,
       extraPassword: typeof extraPassword === 'string' ? extraPassword : undefined,
+      personalAccessToken: typeof personalAccessToken === 'string' ? personalAccessToken : undefined,
     });
   },
 });

--- a/packages/plugins/proton-pass/test/fake-pass-cli.cjs
+++ b/packages/plugins/proton-pass/test/fake-pass-cli.cjs
@@ -66,6 +66,13 @@ if (args[0] === 'info') {
 }
 
 if (args[0] === 'login') {
+  // A personal access token is a self-contained credential — no username/password needed.
+  if (process.env.PROTON_PASS_PERSONAL_ACCESS_TOKEN) {
+    if (config.invalidToken) fail('personal access token invalid or expired');
+    state.loggedIn = true;
+    writeJson(statePath, state);
+    process.exit(0);
+  }
   const needsPassword = config.requirePassword !== false;
   if (needsPassword && !process.env.PROTON_PASS_PASSWORD) {
     fail('password missing');

--- a/packages/plugins/proton-pass/test/proton-pass.test.ts
+++ b/packages/plugins/proton-pass/test/proton-pass.test.ts
@@ -25,6 +25,7 @@ type FakePassConfig = {
   requirePassword?: boolean;
   runErrorMessage?: string;
   itemViewErrors?: Record<string, string>;
+  invalidToken?: boolean;
 };
 
 function resetFakeCli(config: FakePassConfig) {
@@ -184,6 +185,54 @@ MISSING=protonPass(pass://Production/Database/missing)
 # @plugin(${PLUGIN_PATH})
 # @initProtonPass(username=test@example.com)
 # ---
+SECRET=protonPass(pass://Production/Database/password)
+`,
+      expectValues: {
+        SECRET: Error,
+      },
+    });
+  });
+
+  test('logs in via personal access token (no username/password required)', async () => {
+    await runProtonPassTest({
+      config: {
+        refs: {
+          'pass://Production/Database/password': 'db-secret',
+        },
+        requirePassword: true,
+      },
+      fullSchema: `
+# @plugin(${PLUGIN_PATH})
+# @initProtonPass(personalAccessToken=$PROTON_PASS_PERSONAL_ACCESS_TOKEN)
+# ---
+# @type=protonPassPersonalAccessToken @sensitive
+PROTON_PASS_PERSONAL_ACCESS_TOKEN=pst_abc123::TOKENKEY
+DB_PASS=protonPass(pass://Production/Database/password)
+`,
+      expectValues: {
+        DB_PASS: 'db-secret',
+      },
+    });
+
+    const calls = getFakeCliCalls();
+    // run fails (not logged in) -> login via token -> run succeeds.
+    expect(calls.map((args) => args[0])).toEqual(['run', 'login', 'run']);
+    // login is invoked without `--interactive` or a username when using a token.
+    const loginCall = calls.find((args) => args[0] === 'login');
+    expect(loginCall).toEqual(['login']);
+  });
+
+  test('surfaces an error when the personal access token is invalid/expired', async () => {
+    await runProtonPassTest({
+      config: {
+        invalidToken: true,
+      },
+      fullSchema: `
+# @plugin(${PLUGIN_PATH})
+# @initProtonPass(personalAccessToken=$PROTON_PASS_PERSONAL_ACCESS_TOKEN)
+# ---
+# @type=protonPassPersonalAccessToken @sensitive
+PROTON_PASS_PERSONAL_ACCESS_TOKEN=pst_expired::TOKENKEY
 SECRET=protonPass(pass://Production/Database/password)
 `,
       expectValues: {

--- a/packages/varlock-website/src/content/docs/plugins/proton-pass.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/proton-pass.mdx
@@ -17,7 +17,8 @@ It shells out to the official Proton Pass CLI (`pass-cli`) to resolve secret ref
 ## Features
 
 - **Secret references via `pass://` URIs** (`pass://vault/item/field`)
-- **Non-interactive login for CI** using environment variables (`PROTON_PASS_PASSWORD`, `PROTON_PASS_TOTP`, `PROTON_PASS_EXTRA_PASSWORD`)
+- **Personal access token login** for CI (`PROTON_PASS_PERSONAL_ACCESS_TOKEN`) — non-interactive, scoped, no full account credentials
+- **Non-interactive password login** using environment variables (`PROTON_PASS_PASSWORD`, `PROTON_PASS_TOTP`, `PROTON_PASS_EXTRA_PASSWORD`)
 - **In-session caching** per resolution run
 - **Helpful error messages** with resolution tips
 
@@ -40,13 +41,53 @@ See: [Proton Pass CLI overview](https://protonpass.github.io/pass-cli/).
 
 ### Configure the plugin
 
-In production/CI you typically want a fully non-interactive login.
+In production/CI you typically want a fully non-interactive login. The plugin supports two
+authentication methods — a **personal access token** (recommended) or a **username + password**.
+
+#### Personal access token (recommended)
+
+A [personal access token](https://protonpass.github.io/pass-cli/commands/login/#personal-access-token-login)
+is a scoped, non-interactive credential — it never needs a username, password, or TOTP, which makes it
+the cleanest option for CI.
+
+Create one with the Proton Pass CLI, then grant it access to the vaults/items it needs:
+
+```bash
+# Create a token (the full value is only shown once — save it somewhere safe)
+pass-cli pat create --name "deploy-bot" --expiration 3m
+# PROTON_PASS_PERSONAL_ACCESS_TOKEN=pst_xxxx...xxxx::TOKENKEY
+
+# Grant it access to a vault or item
+pass-cli pat access grant ...
+```
 
 ```env-spec title=".env.schema"
 # 1. Load the plugin
 # @plugin(@varlock/proton-pass-plugin)
 #
 # 2. Initialize Proton Pass plugin instance
+# @initProtonPass(
+#   id=prod,
+#   personalAccessToken=$PROTON_PASS_PERSONAL_ACCESS_TOKEN
+# )
+# ---
+
+# @type=protonPassPersonalAccessToken @sensitive
+PROTON_PASS_PERSONAL_ACCESS_TOKEN=
+```
+
+When a `personalAccessToken` is provided it takes precedence — the plugin runs `pass-cli login`
+with the token and ignores `username`/`password`/`totp`/`extraPassword`.
+
+:::note[Token expiration]
+Personal access tokens have a **mandatory expiration** set when you create them (`1d`, `1w`, `1m`, `3m`, `6m`, or `1y`)
+and do **not** auto-renew. When a token expires, mint a new one with `pass-cli pat renew` (or `pat create`) and update
+the value in your config — there is nothing for the plugin to refresh or cache on your behalf.
+:::
+
+#### Username + password
+
+```env-spec title=".env.schema"
 # @initProtonPass(
 #   id=prod,
 #   username=$PROTON_PASS_USERNAME,
@@ -84,7 +125,7 @@ For local development, especially with multi-process task runners like Turbo, th
 - Reuse an existing `pass-cli` session when possible (`pass-cli login` once in your terminal before starting your dev tasks).
 
 :::note[TOTP in local config]
-If your account requires TOTP, a static value in config will expire quickly. For fully non-interactive workflows, consider using a Proton Pass personal access token instead.
+If your account requires TOTP, a static value in config will expire quickly. For fully non-interactive workflows, use a [personal access token](#personal-access-token-recommended) instead.
 :::
 
 ## Loading secrets
@@ -128,6 +169,7 @@ Initialize a Proton Pass plugin instance for `protonPass()` resolver.
 **Key/value args:**
 
 - `id` (optional): instance identifier for multiple instances
+- `personalAccessToken` (optional): personal access token (maps to `PROTON_PASS_PERSONAL_ACCESS_TOKEN`). When set, takes precedence over username/password.
 - `username` (optional): login username/email passed to `pass-cli login --interactive`
 - `password` (optional): `pass-cli` password (maps to `PROTON_PASS_PASSWORD`)
 - `totp` (optional): `pass-cli` TOTP code (maps to `PROTON_PASS_TOTP`)
@@ -135,11 +177,8 @@ Initialize a Proton Pass plugin instance for `protonPass()` resolver.
 
 ```env-spec "@initProtonPass"
 # @initProtonPass(
-#   id=prod, 
-#   username=$PROTON_PASS_USERNAME, 
-#   password=$PROTON_PASS_PASSWORD,
-#   totp=$PROTON_PASS_TOTP,
-#   extraPassword=$PROTON_PASS_EXTRA_PASSWORD
+#   id=prod,
+#   personalAccessToken=$PROTON_PASS_PERSONAL_ACCESS_TOKEN
 # )
 ```
 </div>
@@ -176,4 +215,4 @@ DB_PASSWORD=protonPass(prod, pass://Production/Database/password)
 
 This resolver uses:
 - `pass-cli item view --output json <secretRef>` to fetch the requested field
-- `pass-cli login --interactive <username>` only when an auth error occurs, then retries the original command
+- `pass-cli login` only when an auth error occurs, then retries the original command. With a `personalAccessToken` it runs `pass-cli login` with `PROTON_PASS_PERSONAL_ACCESS_TOKEN` set; otherwise it runs `pass-cli login --interactive <username>` with the password env vars.


### PR DESCRIPTION
## What

Adds **personal access token (PAT)** login to the Proton Pass plugin as a non-interactive alternative to username/password.

Set `personalAccessToken` on `@initProtonPass(...)` (maps to `PROTON_PASS_PERSONAL_ACCESS_TOKEN`). When present it takes precedence over username/password and runs `pass-cli login` with the token — no username, password, or TOTP required, which makes it the cleanest option for CI.

```env-spec
# @initProtonPass(personalAccessToken=$PROTON_PASS_PERSONAL_ACCESS_TOKEN)
# ---
# @type=protonPassPersonalAccessToken @sensitive
PROTON_PASS_PERSONAL_ACCESS_TOKEN=
```

## Why

PATs are Proton Pass's recommended scoped, non-interactive credential. They don't need a username/password/TOTP, so they avoid the TOTP-expiry problem with fully static config.

## Token lifecycle

The plugin does **not** renew or persist anything. PATs have a mandatory expiration set at creation (`1d`–`1y`) and do not auto-renew; renewing mints a new token string the user saves manually. `pass-cli` owns its own session storage after login, exactly as it does for password login — the plugin just forwards the token.

## Details

- New `protonPassPersonalAccessToken` sensitive data type (light `pst_...::TOKENKEY` shape check), wired into `standardVars` for detection warnings.
- Dedicated PAT error path pointing at `pass-cli pat list` / renew when the token is invalid/expired.
- Tests for PAT login (asserts `pass-cli login` runs with no username) and the invalid/expired-token case.
- Docs updated with a "Personal access token (recommended)" section and the expiration/no-renewal note.
