### PR TITLE
fix(typegen): don't leak undeclared .env keys into generated types

### DIFF
--- a/.bumpy/typegen-env-key-leak.md
+++ b/.bumpy/typegen-env-key-leak.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Fix typegen leaking keys that exist only in a plain .env (not declared in .env.schema) into generated types. `varlock typegen` now also reports any such ignored keys.

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -526,7 +526,7 @@ See the [Caching guide](/guides/caching/) for cache mode strategy and troublesho
 <div>
 ### `varlock typegen` ||typegen||
 
-Generates type files according to [`@generateTypes`](/reference/root-decorators/#generatetypes) and your config schema. Uses only non-environment-specific schema info, so output is deterministic regardless of which environment is active.
+Generates type files according to [`@generateTypes`](/reference/root-decorators/#generatetypes) and your config schema. Uses only your schema definitions, so output is deterministic regardless of which environment is active. Keys (and decorators) that come only from value files like `.env` or `.env.local` are ignored — only items declared in your `.env.schema` (or imported into it) are included. When run directly, the command reports any keys found only in a plain `.env` so you can move them into your schema if they belong there.
 
 This command is particularly useful when you have set `auto=false` on the [`@generateTypes`](/reference/root-decorators/#generatetypes) decorator to disable automatic type generation during `varlock load` or `varlock run`.
 

--- a/packages/varlock/src/cli/commands/typegen.command.ts
+++ b/packages/varlock/src/cli/commands/typegen.command.ts
@@ -18,8 +18,9 @@ export const commandSpec = define({
   },
   examples: `
 Generates TypeScript type definitions from your .env schema files.
-Uses only non-environment-specific schema info, so output is deterministic
-regardless of which environment is active.
+Uses only your schema definitions, so output is deterministic regardless of
+which environment is active. Keys that come only from value files like .env or
+.env.local are ignored - only items declared in your schema are included.
 
 This is useful when you have \`@generateTypes(lang=ts, path=env.d.ts, auto=false)\`
 in your schema to disable automatic type generation during \`varlock load\` or \`varlock run\`.
@@ -48,4 +49,14 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   }
 
   console.log('✅ Types generated successfully');
+
+  // Nudge about keys that only live in a plain `.env` and were left out of the types.
+  // Only shown here (the explicit command), not during background auto-generation on load/run.
+  const excludedKeys = envGraph.getValueOnlyKeysExcludedFromTypes();
+  if (excludedKeys.length) {
+    console.log('');
+    console.log(`ℹ️  Ignored ${excludedKeys.length} key${excludedKeys.length === 1 ? '' : 's'} found only in .env (not declared in your schema):`);
+    console.log(`   ${excludedKeys.join(', ')}`);
+    console.log('   Declare them in your .env.schema to include them in generated types.');
+  }
 };

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -100,7 +100,16 @@ export class ConfigItem {
    * regardless of which environment is being loaded.
    */
   get defsForTypeGeneration() {
-    return this.defs.filter((def) => !def.source || !def.source.isEnvSpecific);
+    return this.defs.filter((def) => {
+      if (!def.source) return true;
+      // env-specific sources (e.g. `.env.local`, `.env.production`) must not affect types
+      if (def.source.isEnvSpecific) return false;
+      // a plain auto-loaded `.env` is a value source, not a schema source — keys defined
+      // only there should not leak into generated types (output stays deterministic
+      // regardless of an uncommitted local `.env`)
+      if (def.source.isAutoloadedValueSource) return false;
+      return true;
+    });
   }
 
   get description() {

--- a/packages/varlock/src/env-graph/lib/data-source.ts
+++ b/packages/varlock/src/env-graph/lib/data-source.ts
@@ -159,6 +159,25 @@ export abstract class EnvGraphDataSource {
     return false;
   }
 
+  /**
+   * Whether this source is an auto-loaded plain value file (e.g. `.env`) rather than a
+   * schema-defining source. Keys that exist only in such a file (not declared in
+   * `.env.schema`) should not leak into generated types — see {@link ConfigItem.defsForTypeGeneration}.
+   *
+   * This is true only for an auto-loaded `.env` that is NOT itself the schema source. When
+   * there is no `.env.schema`, the lone `.env` IS the schema source, so it still contributes.
+   * Imported files and standalone root entry points are always treated as schema sources.
+   */
+  get isAutoloadedValueSource(): boolean {
+    if (this.isImport) return false;
+    // env-specific value files (`.env.local`, `.env.production`, ...) are handled by isEnvSpecific
+    if (this.isEnvSpecific) return false;
+    // eslint-disable-next-line no-use-before-define
+    if (!(this.parent instanceof DirectoryDataSource)) return false;
+    if ((this.parent.schemaDataSource as EnvGraphDataSource | undefined) === this) return false;
+    return this.type === 'values';
+  }
+
   /** true when the source has a `@disable` decorator whose value is not static */
   _hasConditionalDisable?: boolean;
 

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -639,6 +639,28 @@ export class EnvGraph {
     return [...builtinKeys, ...userKeys];
   }
 
+  /**
+   * Keys that were excluded from generated types because they only exist in a plain `.env`
+   * value file (not declared in `.env.schema` or imported into it). These are usually drift —
+   * a stale or extra key, or one the user meant to declare in their schema. Type generation
+   * deliberately ignores them so output stays deterministic, but surfacing them lets the
+   * `typegen` command (or a future doctor check) nudge the user. Keys defined only in
+   * env-specific files (`.env.local`, `.env.production`, ...) are intentionally excluded here.
+   */
+  getValueOnlyKeysExcludedFromTypes() {
+    const keys: Array<string> = [];
+    for (const itemKey of this.sortedConfigKeys) {
+      if (isVarlockReservedKey(itemKey)) continue;
+      const item = this.configSchema[itemKey];
+      if (item.isBuiltin) continue;
+      // still has a schema-defining def → it's included in types, nothing to flag
+      if (item.defsForTypeGeneration.length) continue;
+      // only flag keys that actually appear in a plain `.env` (vs. only env-specific files)
+      if (item.defs.some((def) => def.source?.isAutoloadedValueSource)) keys.push(itemKey);
+    }
+    return keys;
+  }
+
   getResolvedEnvObject() {
     const envObject: Record<string, any> = {};
     for (const itemKey of this.sortedConfigKeys) {

--- a/packages/varlock/src/env-graph/test/type-generation.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation.test.ts
@@ -513,7 +513,7 @@ describe('type generation', () => {
       expect(infos2.ITEM1.isRequired).toBe(false);
     });
 
-    test('non-env-specific .env still contributes to type gen, but .env.local does not', async () => {
+    test('plain .env (a value source) does not affect type gen, nor does .env.local', async () => {
       const g = await loadGraph({
         files: {
           '.env.schema': outdent`
@@ -533,9 +533,88 @@ describe('type generation', () => {
 
       const infos = await getTypeGenInfoMap(g);
 
-      // .env is not env-specific, but .env.local is now skipped
-      expect(infos.ITEM1.isSensitive).toBe(true);
+      // neither .env nor .env.local should change the schema-derived types
+      expect(infos.ITEM1.isSensitive).toBe(false);
       expect(infos.ITEM2.isSensitive).toBe(false);
+    });
+
+    test('keys defined only in a plain .env are excluded from type gen (issue #796)', async () => {
+      const g = await loadGraph({
+        files: {
+          '.env.schema': outdent`
+            # @defaultSensitive=false @defaultRequired=optional
+            # ---
+            SOME_DECLARED_KEY=
+          `,
+          '.env': outdent`
+            SOME_DECLARED_KEY="value"
+            STALE_BOGUS_KEY="leakcheck"
+          `,
+        },
+      });
+
+      // declared in the schema → still included
+      expect(g.configSchema.SOME_DECLARED_KEY.defsForTypeGeneration.length).toBeGreaterThan(0);
+      // only present in the plain .env → must not leak into types
+      expect(g.configSchema.STALE_BOGUS_KEY).toBeDefined();
+      expect(g.configSchema.STALE_BOGUS_KEY.defsForTypeGeneration.length).toBe(0);
+
+      const items: Array<TypeGenItemInfo> = [];
+      for (const key of g.sortedConfigKeys) {
+        if (g.configSchema[key].defsForTypeGeneration.length) {
+          items.push(await g.configSchema[key].getTypeGenInfo());
+        }
+      }
+      const src = await generateTsTypesSrc(items);
+      expect(src).toContain('SOME_DECLARED_KEY');
+      expect(src).not.toContain('STALE_BOGUS_KEY');
+
+      // the excluded key is surfaced so the typegen command can nudge the user
+      expect(g.getValueOnlyKeysExcludedFromTypes()).toEqual(['STALE_BOGUS_KEY']);
+    });
+
+    test('getValueOnlyKeysExcludedFromTypes ignores keys only in env-specific files', async () => {
+      const g = await loadGraph({
+        overrideValues: { APP_ENV: 'production' },
+        files: {
+          '.env.schema': outdent`
+            # @currentEnv=$APP_ENV
+            # ---
+            APP_ENV=dev
+            DECLARED=val
+          `,
+          '.env': outdent`
+            ENV_ONLY=from-dot-env
+          `,
+          '.env.local': outdent`
+            LOCAL_ONLY=from-local
+          `,
+          '.env.production': outdent`
+            PROD_ONLY=from-prod
+          `,
+        },
+      });
+
+      // only the plain `.env` key is flagged — .env.local / .env.production are
+      // excluded by design and should not be reported as drift
+      expect(g.getValueOnlyKeysExcludedFromTypes()).toEqual(['ENV_ONLY']);
+    });
+
+    test('a lone .env (no .env.schema) is still the schema source for type gen', async () => {
+      const g = await loadGraph({
+        files: {
+          '.env': outdent`
+            # @defaultSensitive=false
+            # ---
+            ITEM1=val   # @required
+          `,
+        },
+      });
+
+      // with no .env.schema, the .env IS the schema source, so its keys belong in types
+      expect(g.configSchema.ITEM1.defsForTypeGeneration.length).toBeGreaterThan(0);
+      const infos = await getTypeGenInfoMap(g);
+      expect(infos.ITEM1.isRequired).toBe(true);
     });
 
     test('items only defined in env-specific sources are excluded from type gen', async () => {


### PR DESCRIPTION
Fixes #796

## Problem

`varlock typegen` included keys that exist only in a plain `.env` file (never declared in `.env.schema`) in the generated types. Since `.env` is typically local/uncommitted, this made the committed `env.d.ts` non-deterministic — a stale or extra key in someone's local `.env` would silently change the type output. `.env.local` didn't have this problem because it's classified as an env-specific override; the base `.env` was the gap.

## Fix

Value files (`.env`, `.env.local`, env-specific files) now only supply **values** — they never add keys or decorators to generated types. Types come solely from schema definitions (`.env.schema`, or a lone `.env` when it's the only file, plus anything imported into the schema). This is both more correct and more deterministic: a teammate without your local `.env` generates identical types.

- `EnvGraphDataSource.isAutoloadedValueSource` — identifies a plain, non-env-specific `.env` that isn't itself the schema source.
- `ConfigItem.defsForTypeGeneration` — also filters out those value-source defs.
- `EnvGraph.getValueOnlyKeysExcludedFromTypes()` — reusable helper listing keys dropped because they only live in a plain `.env` (ignores keys that only live in env-specific files, which are excluded by design).

## Notice

To avoid silently *dropping* drift the way it used to silently *leak* it, `varlock typegen` now reports ignored keys. This only fires on the explicit command — the background auto-generation path during `load`/`run` stays quiet.

```
✅ Types generated successfully

ℹ️  Ignored 1 key found only in .env (not declared in your schema):
   STALE_BOGUS_KEY
   Declare them in your .env.schema to include them in generated types.
```

The helper is a natural fit for the `doctor` command once that's built out.

## Tests

Added a regression test for the issue's repro, plus coverage for a lone `.env` still acting as the schema source and for the new helper. Existing env-graph suite passes (486 tests). Docs and `typegen --help` wording updated to match.