### PR TITLE
fix(env-graph): detect circular @import() and fail cleanly

### DIFF
--- a/.bumpy/circular-import-detection.md
+++ b/.bumpy/circular-import-detection.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Detect circular @import() between schemas and fail with a clear error instead of crashing

--- a/.claude/hooks/git-push-notice.sh
+++ b/.claude/hooks/git-push-notice.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Claude Code PostToolUse hook (matcher: Bash).
+#
+# Reminds Claude to keep an open PR's description in sync after a `git push`.
+#
+# The hook runs on *every* Bash call, so we must inspect the actual command
+# ourselves and stay silent unless it was really a `git push`. (Hook command
+# objects have no per-command `if`/condition field — an `if` key is silently
+# ignored, which previously made this fire on every Bash invocation.)
+
+input=$(cat)
+
+# Extract the command that was run. Prefer jq; fall back to a sed extractor.
+if command -v jq >/dev/null 2>&1; then
+  cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+else
+  cmd=$(printf '%s' "$input" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p')
+fi
+
+# Only fire for a real `git push` invocation (start of command or after a
+# separator like ; && || |), not for arbitrary commands that mention the words.
+if printf '%s' "$cmd" | grep -Eq '(^|[;&|]|&&|[[:space:]])git[[:space:]]+(-[^[:space:]]+[[:space:]]+)*push'; then
+  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"git push ran. If this added commits to an open PR, check that the PR description still matches what changed and update it with gh pr edit if it is now stale."}}'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,8 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(git push*)",
-            "command": "printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"git push ran. If this added commits to an open PR, check that the PR description still matches what changed and update it with gh pr edit if it is now stale.\"}}'"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/git-push-notice.sh"
           }
         ]
       }

--- a/packages/varlock-website/src/content/docs/guides/import.mdx
+++ b/packages/varlock-website/src/content/docs/guides/import.mdx
@@ -154,6 +154,7 @@ Meaning if there was a value for `ITEM` in all 4 files, the final value used wou
 - Root decorators that affect individual items (e.g., `@defaultRequired`) affect only the items that are defined in the file, not those in imported files
 - An item with no value at all (e.g., `ITEM=`) will be skipped when looking for a value / function to use, but its presence can be used to add other decorators/description to the item
 - If an imported file is marked with [`@disable`](/reference/root-decorators/#disable), it and any files it imports are skipped entirely
+- Importing the same source from multiple places (a "diamond") is fine — it is loaded once and reused
 
 ## When things go wrong
 
@@ -190,3 +191,11 @@ MY_SERVICE_URL=...
 
 - Move `@currentEnv` to the shared schema where the flag is already defined
 - Import the full directory (omit the key list) if the sub-package should inherit the parent's `@currentEnv` handling
+
+### Circular imports
+
+A circular chain of imports (e.g. `a` imports `b` which imports `a`) is not allowed. Varlock detects the cycle and fails with an explicit error showing the chain:
+
+```txt
+Circular import detected: a/.env.schema -> b/.env.schema -> a/.env.schema
+```

--- a/packages/varlock-website/src/content/docs/guides/monorepos.mdx
+++ b/packages/varlock-website/src/content/docs/guides/monorepos.mdx
@@ -51,7 +51,7 @@ Use `@import()` to pull in a root or shared schema without copying keys, to spli
 You can also **import directly from a sibling package**, which lets you keep a config item with its logical owner instead of hoisting everything to the root. Define the item once in the package that owns it, then `pick` just what you need — like the `../api/` import in the example above.
 
 :::caution[Avoid circular imports]
-Imports must flow in one direction — if `web` imports `api` and `api` also imports `web` (directly or through a chain), varlock can't resolve the cycle and loading fails. Keep each shared item with a single owner and import one way; if two packages genuinely need each other's values, hoist those keys into a common file (e.g. the repo root) that both import.
+Imports must flow in one direction — if `web` imports `api` and `api` also imports `web` (directly or through a chain), varlock detects the cycle and loading fails with an explicit error naming the chain (e.g. `Circular import detected: web/.env.schema -> api/.env.schema -> web/.env.schema`). Keep each shared item with a single owner and import one way; if two packages genuinely need each other's values, hoist those keys into a common file (e.g. the repo root) that both import.
 :::
 
 :::note[Shared environment flag]

--- a/packages/varlock/src/env-graph/lib/data-source.ts
+++ b/packages/varlock/src/env-graph/lib/data-source.ts
@@ -376,7 +376,23 @@ export abstract class EnvGraphDataSource {
     if (!this.isValid || this.disabled) return;
 
     const importDecs = this.getRootDecFns('import');
-    if (importDecs.length) {
+    if (!importDecs.length) return;
+
+    // Detect circular imports before descending. If this source is already on the
+    // import-processing stack (an ancestor is mid-load and we've looped back to it),
+    // emit a clean error instead of recursing until the call stack overflows.
+    // eslint-disable-next-line no-use-before-define
+    const importStackKey = this instanceof FileBasedDataSource ? this.fullPath : this.label;
+    const importCycle = this.graph.beginImportProcessing(importStackKey);
+    if (importCycle) {
+      const chain = importCycle
+        .map((p) => `${path.basename(path.dirname(p))}/${path.basename(p)}`)
+        .join(' -> ');
+      this._errors.push(new LoadingError(`Circular import detected: ${chain}`));
+      return;
+    }
+
+    try {
       for (const importDec of importDecs) {
         try {
           // Process the import decorator to identify dependencies
@@ -558,6 +574,8 @@ export abstract class EnvGraphDataSource {
           return;
         }
       }
+    } finally {
+      this.graph.endImportProcessing(importStackKey);
     }
   }
 

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -119,6 +119,34 @@ export class EnvGraph {
   }
 
   /**
+   * Stack of sources whose imports are currently being processed (an ancestor chain).
+   * Used to detect circular imports: a path that re-enters while still on the stack is a cycle.
+   * Unlike `_loadedImportPaths` (recorded only after a child fully loads, for diamond dedup),
+   * this is recorded *before* descending, so a true cycle is caught before it recurses forever.
+   */
+  private _importProcessingStack: Array<string> = [];
+
+  /**
+   * Mark a source as being processed for imports.
+   * Returns the cycle chain (including the repeated entry) if `key` is already on the stack,
+   * otherwise pushes it and returns undefined.
+   */
+  beginImportProcessing(key: string): Array<string> | undefined {
+    const existingIndex = this._importProcessingStack.indexOf(key);
+    if (existingIndex !== -1) {
+      return [...this._importProcessingStack.slice(existingIndex), key];
+    }
+    this._importProcessingStack.push(key);
+    return undefined;
+  }
+
+  /** Pop a source off the import-processing stack once its imports are done. */
+  endImportProcessing(key: string) {
+    const index = this._importProcessingStack.lastIndexOf(key);
+    if (index !== -1) this._importProcessingStack.splice(index, 1);
+  }
+
+  /**
    * Register ConfigItems for keys visible through an import
    * that may not have been registered during the original source's finishInit.
    */

--- a/packages/varlock/src/env-graph/test/import.test.ts
+++ b/packages/varlock/src/env-graph/test/import.test.ts
@@ -1,5 +1,9 @@
-import { describe, test } from 'vitest';
+import {
+  describe, test, expect, vi,
+} from 'vitest';
+import path from 'node:path';
 import outdent from 'outdent';
+import { EnvGraph, DirectoryDataSource, LoadingError } from '../index';
 import { envFilesTest } from './helpers/generic-test';
 
 describe('@import', () => {
@@ -947,5 +951,71 @@ describe('@import', () => {
         Z: 'overlay-z', // overlay's own definition beats its import of common
       },
     }));
+  });
+
+  describe('circular imports', () => {
+    // a 2-node cycle (a -> b -> a) must fail with a clean error rather than
+    // recursing until the call stack overflows
+    test('2-node cycle fails cleanly', envFilesTest({
+      files: {
+        'a/.env.schema': outdent`
+          # @import(../b/)
+          # ---
+          A_VAR=1
+        `,
+        'b/.env.schema': outdent`
+          # @import(../a/)
+          # ---
+          B_VAR=2
+        `,
+      },
+      loadPaths: 'a/',
+      expectError: LoadingError,
+    }));
+
+    // a 3-node cycle (a -> b -> c -> a) must also fail cleanly
+    test('3-node cycle fails cleanly', envFilesTest({
+      files: {
+        'a/.env.schema': outdent`
+          # @import(../b/)
+          # ---
+          A_VAR=1
+        `,
+        'b/.env.schema': outdent`
+          # @import(../c/)
+          # ---
+          B_VAR=2
+        `,
+        'c/.env.schema': outdent`
+          # @import(../a/)
+          # ---
+          C_VAR=3
+        `,
+      },
+      loadPaths: 'a/',
+      expectError: LoadingError,
+    }));
+
+    // the error message should spell out the import chain that loops back
+    test('reports the import chain in the error message', async () => {
+      const currentDir = path.dirname(expect.getState().testPath!);
+      vi.spyOn(process, 'cwd').mockReturnValue(currentDir);
+
+      const g = new EnvGraph();
+      g.setVirtualImports(currentDir, {
+        'a/.env.schema': '# @import(../b/)\n# ---\nA_VAR=1\n',
+        'b/.env.schema': '# @import(../a/)\n# ---\nB_VAR=2\n',
+      });
+      await g.setRootDataSource(new DirectoryDataSource(`${path.resolve(currentDir, 'a')}${path.sep}`));
+      await g.finishLoad();
+
+      const cycleError = g.sortedDataSources
+        .flatMap((s) => s.errors)
+        .find((e) => e.message.includes('Circular import detected'));
+      expect(cycleError).toBeInstanceOf(LoadingError);
+      expect(cycleError!.message).toBe(
+        'Circular import detected: a/.env.schema -> b/.env.schema -> a/.env.schema',
+      );
+    });
   });
 });


### PR DESCRIPTION
## What

A circular chain of `@import()` between schemas (e.g. `a` imports `b` which imports `a`) recursed until the Node call stack overflowed, crashing with an uncaught `RangeError: Maximum call stack size exceeded` instead of a usable diagnostic.

## Why

The diamond-dedup check only recorded an import path *after* the child (and its transitive imports) finished loading, so a true cycle never short-circuited — it just kept descending.

## Fix

Track the set of import paths currently on the load stack, recorded *before* descending into a child. When a path is already in progress we emit a `LoadingError` naming the cycle and stop:

```
Circular import detected: a/.env.schema -> b/.env.schema -> a/.env.schema
```

Legitimate diamond imports (same source reached via multiple paths) still dedup correctly.

Added vitest coverage for 2-node and 3-node cycles plus the error message, and a note in the imports guide.

## Also included

A small unrelated tooling fix: the `git push` PostToolUse hook used an unsupported per-command `if` field, so it fired on every Bash call. Moved the check into a script that inspects the actual command.