### PR TITLE
add azure artifact signing, turn off upx, add binary checksums

### DIFF
--- a/.bumpy/windows-defender-fp-fixes.md
+++ b/.bumpy/windows-defender-fp-fixes.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Stop UPX on Windows native encrypt binary, sign via Azure Artifact Signing, and publish SHA256SUMS for native helpers

--- a/.github/workflows/binary-preview.yaml
+++ b/.github/workflows/binary-preview.yaml
@@ -42,6 +42,7 @@ jobs:
     uses: ./.github/workflows/build-native-rust.yaml
     with:
       artifact-name: native-bin-rust-preview
+    secrets: inherit
 
   # Build SEA binaries for all platforms and upload as artifacts
   build-sea-binaries:

--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -54,6 +54,7 @@ jobs:
     uses: ./.github/workflows/build-native-rust.yaml
     with:
       artifact-name: native-bin-rust
+    secrets: inherit
 
   release-binaries:
     needs: [notarize-native-macos, build-native-rust]
@@ -120,6 +121,18 @@ jobs:
           chmod +x packages/varlock/native-bins/linux-x64/varlock-local-encrypt
           chmod +x packages/varlock/native-bins/linux-arm64/varlock-local-encrypt
 
+      - name: Generate native binary SHA256 checksums
+        working-directory: packages/varlock
+        run: |
+          sha256sum \
+            native-bins/darwin/VarlockEnclave.app/Contents/MacOS/varlock-local-encrypt \
+            native-bins/linux-x64/varlock-local-encrypt \
+            native-bins/linux-arm64/varlock-local-encrypt \
+            native-bins/win32-x64/varlock-local-encrypt.exe \
+            > SHA256SUMS.txt
+          echo "Native binary checksums:"
+          cat SHA256SUMS.txt
+
       - name: build libs
         run: bun run build:libs
         env:
@@ -131,7 +144,7 @@ jobs:
           # default token works to update release on this repo
           GH_TOKEN: ${{ github.token }}
         working-directory: packages/varlock/dist-sea
-        run: gh release upload ${{ env.RELEASE_TAG }} *.{tar.gz,zip} checksums.txt --clobber
+        run: gh release upload ${{ env.RELEASE_TAG }} *.{tar.gz,zip} checksums.txt ../SHA256SUMS.txt --clobber
 
       # UPDATE HOMEBREW FORMULA ---
       - name: checkout homebrew tap repo

--- a/.github/workflows/build-native-macos.yaml
+++ b/.github/workflows/build-native-macos.yaml
@@ -65,7 +65,7 @@ jobs:
 
       # Load secrets from 1Password via varlock (scoped to the Swift package)
       - name: Load signing secrets
-        uses: dmno-dev/varlock-action@v1.0.1
+        uses: dmno-dev/varlock-action@v1.0.3
         with:
           working-directory: packages/encryption-binary-swift
         env:

--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -26,6 +26,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      id-token: write # Azure Artifact Signing via OIDC (Windows job only)
     strategy:
       matrix:
         include:
@@ -74,17 +77,45 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Install UPX
+        if: contains(matrix.os, 'ubuntu')
         shell: bash
-        run: |
-          if [[ "${{ matrix.os }}" == *"ubuntu"* ]]; then
-            sudo apt-get update && sudo apt-get install -y upx-ucl
-          elif [[ "${{ matrix.os }}" == *"windows"* ]]; then
-            choco install upx --yes
-          fi
+        run: sudo apt-get update && sudo apt-get install -y upx-ucl
 
       - name: Build release binary
         working-directory: packages/encryption-binary-rust
         run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Windows signing skipped (Azure not configured)
+        if: contains(matrix.os, 'windows') && secrets.AZURE_CLIENT_ID == ''
+        shell: bash
+        run: |
+          echo "Azure Artifact Signing skipped: configure AZURE_CLIENT_ID (and related secrets/vars) to sign the Windows binary"
+
+      - name: Azure login (OIDC)
+        if: >-
+          contains(matrix.os, 'windows')
+          && secrets.AZURE_CLIENT_ID != ''
+          && vars.AZURE_ARTIFACT_SIGNING_ENDPOINT != ''
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign Windows binary (Azure Artifact Signing)
+        if: >-
+          contains(matrix.os, 'windows')
+          && secrets.AZURE_CLIENT_ID != ''
+          && vars.AZURE_ARTIFACT_SIGNING_ENDPOINT != ''
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ vars.AZURE_ARTIFACT_SIGNING_PROFILE }}
+          files: ${{ github.workspace }}\packages\encryption-binary-rust\target\${{ matrix.target }}\release\${{ matrix.binary-name }}
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
 
       - name: Prepare artifact
         shell: bash
@@ -96,8 +127,12 @@ jobs:
           RAW_SIZE=$(stat --format=%s "$ARTIFACT_DIR/${{ matrix.binary-name }}" 2>/dev/null || stat -f%z "$ARTIFACT_DIR/${{ matrix.binary-name }}")
           echo "Size: $(( RAW_SIZE / 1024 )) KB ($RAW_SIZE bytes)"
           file "$ARTIFACT_DIR/${{ matrix.binary-name }}" || true
-          echo "=== UPX compress ==="
-          upx --best "$ARTIFACT_DIR/${{ matrix.binary-name }}" || echo "UPX compression failed, continuing with uncompressed binary"
+          if [[ "${{ matrix.native-bin-subdir }}" != "win32-x64" ]]; then
+            echo "=== UPX compress ==="
+            upx --best "$ARTIFACT_DIR/${{ matrix.binary-name }}" || echo "UPX compression failed, continuing with uncompressed binary"
+          else
+            echo "=== UPX skipped (Windows) ==="
+          fi
           FINAL_SIZE=$(stat --format=%s "$ARTIFACT_DIR/${{ matrix.binary-name }}" 2>/dev/null || stat -f%z "$ARTIFACT_DIR/${{ matrix.binary-name }}")
           echo "=== Binary info (after UPX) ==="
           echo "Size: $(( FINAL_SIZE / 1024 )) KB ($FINAL_SIZE bytes)"

--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -85,33 +85,54 @@ jobs:
         working-directory: packages/encryption-binary-rust
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Windows signing skipped (Azure not configured)
-        if: contains(matrix.os, 'windows') && secrets.AZURE_CLIENT_ID == ''
+      # --- Windows code signing (Azure Artifact Signing) ---
+      # Azure credentials are resolved from 1Password through varlock
+      # (see packages/encryption-binary-rust/.env.schema), mirroring the
+      # macOS Developer ID signing flow. Skipped when OP_CI_TOKEN is absent
+      # (e.g. fork PRs), leaving the Windows binary unsigned.
+      - name: Windows signing skipped (no OP_CI_TOKEN)
+        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN == ''
         shell: bash
         run: |
-          echo "Azure Artifact Signing skipped: configure AZURE_CLIENT_ID (and related secrets/vars) to sign the Windows binary"
+          echo "Azure Artifact Signing skipped: OP_CI_TOKEN not available (fork PR?) — Windows binary will be unsigned"
+
+      - name: Setup Bun (for varlock secret loading)
+        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install node deps (for varlock secret loading)
+        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        run: bun install
+
+      # Build varlock JS so we can use it to resolve secrets from 1Password
+      - name: Build varlock libs
+        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        run: bun run build:libs
+
+      # Load Azure signing secrets from 1Password via varlock (scoped to the Rust package)
+      - name: Load signing secrets
+        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        uses: dmno-dev/varlock-action@v1.0.3
+        with:
+          working-directory: packages/encryption-binary-rust
+        env:
+          OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN }}
 
       - name: Azure login (OIDC)
-        if: >-
-          contains(matrix.os, 'windows')
-          && secrets.AZURE_CLIENT_ID != ''
-          && vars.AZURE_ARTIFACT_SIGNING_ENDPOINT != ''
+        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Sign Windows binary (Azure Artifact Signing)
-        if: >-
-          contains(matrix.os, 'windows')
-          && secrets.AZURE_CLIENT_ID != ''
-          && vars.AZURE_ARTIFACT_SIGNING_ENDPOINT != ''
+        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
         uses: azure/artifact-signing-action@v2
         with:
-          endpoint: ${{ vars.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ vars.AZURE_ARTIFACT_SIGNING_ACCOUNT }}
-          certificate-profile-name: ${{ vars.AZURE_ARTIFACT_SIGNING_PROFILE }}
+          endpoint: ${{ env.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ env.AZURE_ARTIFACT_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ env.AZURE_ARTIFACT_SIGNING_PROFILE }}
           files: ${{ github.workspace }}\packages\encryption-binary-rust\target\${{ matrix.target }}\release\${{ matrix.binary-name }}
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com

--- a/.github/workflows/notarize-native-macos.yaml
+++ b/.github/workflows/notarize-native-macos.yaml
@@ -54,7 +54,7 @@ jobs:
 
       # Load secrets from 1Password via varlock (scoped to the Swift package)
       - name: Load signing secrets
-        uses: dmno-dev/varlock-action@v1.0.1
+        uses: dmno-dev/varlock-action@v1.0.3
         with:
           working-directory: packages/encryption-binary-swift
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -340,7 +340,7 @@ jobs:
       # varlock the action uses.)
       - name: Load extension publishing secrets from 1Password
         if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-vscode == 'true'
-        uses: dmno-dev/varlock-action@v1.0.1
+        uses: dmno-dev/varlock-action@v1.0.3
         with:
           working-directory: packages/vscode-plugin
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -191,6 +191,7 @@ jobs:
     with:
       artifact-name: native-bin-rust
       source-hash: ${{ needs.plan.outputs.rust-source-hash }}
+    secrets: inherit
 
   release:
     name: Release
@@ -304,6 +305,26 @@ jobs:
           check packages/varlock/native-bins/win32-x64/varlock-local-encrypt.exe
           if [ "$missing" = "1" ]; then exit 1; fi
           echo "All native binaries present"
+
+      - name: Generate native binary SHA256 checksums
+        if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
+        working-directory: packages/varlock
+        run: |
+          sha256sum \
+            native-bins/darwin/VarlockEnclave.app/Contents/MacOS/varlock-local-encrypt \
+            native-bins/linux-x64/varlock-local-encrypt \
+            native-bins/linux-arm64/varlock-local-encrypt \
+            native-bins/win32-x64/varlock-local-encrypt.exe \
+            > SHA256SUMS.txt
+          echo "Native binary checksums:"
+          cat SHA256SUMS.txt
+      - name: Upload native binary checksums
+        if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-bins-sha256sums
+          path: packages/varlock/SHA256SUMS.txt
+          retention-days: 90
 
       # ------------------------------------------------------------
       - name: Build libraries

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -160,6 +160,7 @@ jobs:
     with:
       artifact-name: native-bin-rust-ci
       source-hash: ${{ needs.build-and-test.outputs.rust-source-hash }}
+    secrets: inherit
 
   # Publish preview packages via pkg-pr-new
   release-preview-packages:

--- a/.github/workflows/vscode-release.yaml
+++ b/.github/workflows/vscode-release.yaml
@@ -29,7 +29,7 @@ jobs:
       # Resolve publishing secrets from 1Password via varlock: AZURE_CLIENT_ID /
       # AZURE_TENANT_ID (for Marketplace OIDC) and OVSX_PAT (for Open VSX).
       - name: Load extension publishing secrets from 1Password
-        uses: dmno-dev/varlock-action@v1.0.1
+        uses: dmno-dev/varlock-action@v1.0.3
         with:
           working-directory: packages/vscode-plugin
         env:

--- a/packages/encryption-binary-rust/.env.schema
+++ b/packages/encryption-binary-rust/.env.schema
@@ -1,0 +1,29 @@
+# @defaultSensitive=false @defaultRequired=infer
+# @plugin(@varlock/1password-plugin)
+# @initOp(allowAppAuth=true, token=$OP_CI_TOKEN)
+# ---
+#
+# Azure Artifact Signing — Windows native binary (varlock-local-encrypt.exe).
+# Used in CI by .github/workflows/build-native-rust.yaml.
+#
+# GitHub Actions secrets (Settings → Secrets): AZURE_CLIENT_ID, AZURE_TENANT_ID,
+# AZURE_SUBSCRIPTION_ID — or load via varlock-action + OP_CI_TOKEN like macOS signing.
+#
+# GitHub Actions variables (Settings → Variables): AZURE_ARTIFACT_SIGNING_* below.
+
+# Injected in GitHub Actions; locally leave unset to use 1Password desktop app auth.
+# @type=opServiceAccountToken @sensitive
+OP_CI_TOKEN=
+
+# App registration for GitHub Actions OIDC (azure/login before artifact-signing-action).
+# GitHub Actions: repository secret.
+AZURE_CLIENT_ID=op("op://VarlockCI/Azure Artifact Signing/AZURE_CLIENT_ID")
+AZURE_TENANT_ID=op("op://VarlockCI/Azure Artifact Signing/AZURE_TENANT_ID")
+# @sensitive
+AZURE_SUBSCRIPTION_ID=op("op://VarlockCI/Azure Artifact Signing/AZURE_SUBSCRIPTION_ID")
+
+# Artifact Signing account resources — region-specific endpoint from the Azure portal.
+# GitHub Actions: repository variables (non-secret).
+AZURE_ARTIFACT_SIGNING_ENDPOINT=op("op://VarlockCI/Azure Artifact Signing/AZURE_ARTIFACT_SIGNING_ENDPOINT")
+AZURE_ARTIFACT_SIGNING_ACCOUNT=op("op://VarlockCI/Azure Artifact Signing/AZURE_ARTIFACT_SIGNING_ACCOUNT")
+AZURE_ARTIFACT_SIGNING_PROFILE=op("op://VarlockCI/Azure Artifact Signing/AZURE_ARTIFACT_SIGNING_PROFILE")

--- a/packages/encryption-binary-rust/README.md
+++ b/packages/encryption-binary-rust/README.md
@@ -108,6 +108,8 @@ In the [Azure portal](https://portal.azure.com):
 
 **4. Configure GitHub repository**
 
+Store values in the **VarlockCI** 1Password vault (see `packages/encryption-binary-rust/.env.schema`) or set them directly in GitHub.
+
 Add **secrets** (Settings → Secrets and variables → Actions):
 
 | Secret | Value |

--- a/packages/encryption-binary-rust/README.md
+++ b/packages/encryption-binary-rust/README.md
@@ -21,14 +21,12 @@ Provides DPAPI key protection on Windows (with optional Windows Hello biometric)
   # Ubuntu/Debian
   sudo apt-get install musl-tools
   ```
-- **UPX** (optional, for binary compression):
+- **UPX** (optional, Linux binary compression only — not used on Windows):
   ```sh
   # Ubuntu/Debian
   sudo apt-get install upx-ucl
-  # macOS
+  # macOS (local dev only; CI does not UPX-compress macOS binaries)
   brew install upx
-  # Windows
-  choco install upx
   ```
 
 ## Building
@@ -46,7 +44,7 @@ bun run build:windows-arm64 # aarch64-pc-windows-msvc
 
 Output goes to `packages/varlock/native-bins/<platform>/`.
 
-The build script automatically applies UPX compression (except on macOS). Pass `--no-upx` to skip.
+The build script automatically applies UPX compression on Linux (not macOS or Windows). Pass `--no-upx` to skip.
 
 ## Architecture
 
@@ -69,4 +67,77 @@ When running from WSL2, the TypeScript side calls this Windows `.exe` directly (
 
 ## CI
 
-Binaries are built in CI via `.github/workflows/build-native-rust.yaml` on native runners for each platform. Linux targets use musl for fully static binaries that work on any Linux distribution.
+Binaries are built in CI via `.github/workflows/build-native-rust.yaml` on native runners for each platform. Linux targets use musl for fully static binaries that work on any Linux distribution. Linux binaries are UPX-compressed in CI; Windows binaries are not (UPX triggers common antivirus false positives).
+
+### Windows Authenticode signing (maintainers)
+
+CI signs the Windows `.exe` with [Azure Artifact Signing](https://learn.microsoft.com/en-us/azure/artifact-signing/) when GitHub secrets and variables are configured. Without them, the build continues unsigned and logs a skip message.
+
+Signed builds reduce Windows Defender false positives (`Wacatac.C!ml` and similar ML detections on unsigned helpers). You can also [submit a false-positive report](https://www.microsoft.com/en-us/wdsi/filesubmission) to Microsoft while rolling out signing.
+
+#### Setup walkthrough
+
+**1. Azure prerequisites**
+
+- An Azure subscription ([create one free](https://azure.microsoft.com/free/) if needed)
+- Your organization must be eligible for Artifact Signing identity verification (USA, Canada, EU, or UK — see [Microsoft's code signing options](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/code-signing-options))
+
+**2. Create Artifact Signing resources**
+
+In the [Azure portal](https://portal.azure.com):
+
+1. Search for **Artifact Signing** and create an **Artifact Signing account** (pick a region — note it for step 5)
+2. Inside the account, create a **Certificate profile** (e.g. `varlock-public`)
+3. Complete **identity verification** when prompted (may take a few business days)
+4. Note these values:
+   - **Endpoint** — `https://<region>.codesigning.azure.net/` (region must match the account, e.g. `https://eastus.codesigning.azure.net/`)
+   - **Signing account name** — the account resource name
+   - **Certificate profile name** — from step 2
+
+**3. Create an App Registration for GitHub Actions (OIDC)**
+
+1. **Microsoft Entra ID** → **App registrations** → **New registration** (e.g. `varlock-github-signing`)
+2. Note the **Application (client) ID** and **Directory (tenant) ID**
+3. **Certificates & secrets** → **Federated credentials** → **Add credential** (one per ref type):
+   - **Branch** — Organization: `dmno-dev`, Repository: `varlock`, Branch: `main`
+   - **Tag** — Tag: `varlock@*` (required for release builds)
+   - **Pull request** — optional, for `release-preview` PR builds
+4. Open your **Certificate profile** in the portal → **Access control (IAM)** → **Add role assignment**
+   - Role: **Artifact Signing Certificate Profile Signer**
+   - Assign to the app registration from step 1
+
+**4. Configure GitHub repository**
+
+Add **secrets** (Settings → Secrets and variables → Actions):
+
+| Secret | Value |
+|--------|-------|
+| `AZURE_CLIENT_ID` | App registration client ID |
+| `AZURE_TENANT_ID` | Entra tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
+
+Add **variables** (same settings page, Variables tab):
+
+| Variable | Value |
+|----------|-------|
+| `AZURE_ARTIFACT_SIGNING_ENDPOINT` | e.g. `https://eastus.codesigning.azure.net/` |
+| `AZURE_ARTIFACT_SIGNING_ACCOUNT` | Artifact Signing account name |
+| `AZURE_ARTIFACT_SIGNING_PROFILE` | Certificate profile name |
+
+OIDC is used by default (no client secret needed). The Windows job runs `azure/login` before signing; credentials from that step are picked up automatically.
+
+**5. Verify**
+
+Trigger a workflow that builds native Rust binaries (e.g. a release or a PR with the `release-preview` label). The Windows job should:
+
+1. Run **Azure login (OIDC)**
+2. Run **Sign Windows binary (Azure Artifact Signing)**
+3. Upload a signed `varlock-local-encrypt.exe`
+
+Download the artifact and verify locally on Windows:
+
+```powershell
+signtool verify /pa /v path\to\varlock-local-encrypt.exe
+```
+
+**Cost:** Artifact Signing Basic is ~$10/month. Certificates are short-lived and managed automatically — no `.pfx` or USB token required.

--- a/packages/encryption-binary-rust/package.json
+++ b/packages/encryption-binary-rust/package.json
@@ -8,5 +8,11 @@
     "build:linux-arm64": "bun run scripts/build-rust.ts --target aarch64-unknown-linux-musl",
     "build:windows-x64": "bun run scripts/build-rust.ts --target x86_64-pc-windows-msvc",
     "build:windows-arm64": "bun run scripts/build-rust.ts --target aarch64-pc-windows-msvc"
-  }
+  },
+  "devDependencies": {
+    "@varlock/1password-plugin": "workspace:*",
+    "varlock": "workspace:*"
+  },
+  "author": "dmno-dev",
+  "license": "MIT"
 }

--- a/packages/encryption-binary-rust/scripts/build-rust.ts
+++ b/packages/encryption-binary-rust/scripts/build-rust.ts
@@ -11,7 +11,7 @@
  * The binary is placed in packages/varlock/native-bins/<platform>[-<arch>]/
  */
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs';
 
@@ -107,10 +107,11 @@ if (process.platform !== 'win32') {
 const rawStats = fs.statSync(destBinary);
 const rawSizeKB = Math.round(rawStats.size / 1024);
 
-// UPX compress on Linux/Windows (macOS is not reliably supported)
+// UPX compress on Linux only (macOS is not reliably supported; Windows UPX triggers AV false positives)
 const skipUpx = args.includes('--no-upx');
 const isMacOS = !target ? process.platform === 'darwin' : (target.includes('darwin') || target.includes('apple'));
-if (!skipUpx && !isMacOS) {
+const isWindows = !target ? process.platform === 'win32' : target.includes('windows');
+if (!skipUpx && !isMacOS && !isWindows) {
   try {
     console.log('\nCompressing with UPX...');
     execSync(`upx --best "${destBinary}"`, { stdio: 'inherit' });

--- a/packages/varlock-website/src/content/docs/getting-started/installation.mdx
+++ b/packages/varlock-website/src/content/docs/getting-started/installation.mdx
@@ -57,6 +57,9 @@ Then run the setup wizard to help you get started:
 varlock init
 ```
 
+:::note[Windows Defender]
+If Windows flags `varlock-local-encrypt.exe`, see the [local encryption guide — Windows Defender false positives](/guides/local-encryption/#windows-defender-false-positives) for verification and recovery steps.
+:::
 
 ## Varlock skill
 

--- a/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
+++ b/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
@@ -113,6 +113,23 @@ If native capabilities are unavailable, varlock falls back to file-based local e
 
 ✅ No additional install/setup steps required
 
+#### Windows Defender false positives
+
+`varlock-local-encrypt.exe` is Varlock's official local-encryption helper (bundled with the npm package and standalone CLI). Windows Defender may flag it as `Trojan:Win32/Wacatac.C!ml` or similar — a common machine-learning false positive on new, unsigned executables. The binary is safe when obtained from official Varlock releases.
+
+**Verify the download:** each [GitHub release](https://github.com/dmno-dev/varlock/releases) includes `SHA256SUMS.txt` with hashes for all native helpers. After installing, compare your file:
+
+```powershell
+# PowerShell — run from the directory containing the .exe
+Get-FileHash varlock-local-encrypt.exe -Algorithm SHA256
+```
+
+Match the hash against the `native-bins/win32-x64/varlock-local-encrypt.exe` line in `SHA256SUMS.txt` for your release version.
+
+**If quarantined:** restore the file from Windows Security → Protection history, or add an exclusion for your project directory. Reinstall from npm or the official release if needed.
+
+**Permanent fix:** official builds are moving to Authenticode code signing, which greatly reduces these alerts. Until your installed version is signed, verification via `SHA256SUMS.txt` is the recommended way to confirm authenticity.
+
 ### Linux
 
 - Native Linux helper when available


### PR DESCRIPTION
Fixes [#810](https://github.com/dmno-dev/varlock/issues/810) — Windows Defender flagging varlock-local-encrypt.exe as Trojan:Win32/Wacatac.C!ml during npm install.

- Stop UPX-compressing the Windows native binary in CI and local builds. UPX is a common trigger for ML-based AV false positives; Linux builds are unchanged.
- Sign the Windows .exe via Azure Artifact Signing in build-native-rust.yaml using OIDC (azure/login + azure/artifact-signing-action). Azure credentials are loaded from 1Password through the varlock GitHub Action (scoped to encryption-binary-rust/.env.schema), mirroring the macOS Developer ID signing flow. Signing is optional — it runs only when OP_CI_TOKEN is available and the Windows binary is left unsigned otherwise (e.g. fork PRs).
- Bump dmno-dev/varlock-action to v1.0.3 across all workflows.
- Publish SHA256SUMS.txt for native helper binaries on release so users can verify integrity independently.
- Document the false positive in the local encryption and installation guides, plus a maintainer setup walkthrough in encryption-binary-rust/README.md.

## Test plan

- [ ] Merge and store the Azure Artifact Signing credentials in 1Password (op://VarlockCI/Azure Artifact Signing/*, see packages/encryption-binary-rust/README.md)
- [ ] Trigger a native Rust build; confirm the Windows job loads secrets via varlock and runs signing when OP_CI_TOKEN is present, skips gracefully when not
- [ ] Confirm SHA256SUMS.txt appears on the next varlock@* GitHub release
- [ ] `npm install varlock` on Windows — Defender should not flag the helper (unsigned builds should still improve vs UPX-compressed)
- [ ] `signtool verify /pa /v varlock-local-encrypt.exe` on a signed build artifact