### PR TITLE
fix(run): forward signals to child and propagate exit status

### DIFF
--- a/.bumpy/run-signal-forwarding.md
+++ b/.bumpy/run-signal-forwarding.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+varlock run now forwards termination signals (SIGTERM/SIGINT/SIGHUP/SIGQUIT) to the child process and propagates its exit status faithfully (128+N on signal death), making it safe to use as a container ENTRYPOINT / PID 1

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -220,7 +220,7 @@ Note: When `--no-inject-graph` is set, framework integrations that rely on `__VA
 
 This makes `varlock run` safe to use as a container `ENTRYPOINT` (including PID 1), so `docker stop` / pod termination reaches your app gracefully instead of waiting out the grace period and being `SIGKILL`ed.
 
-If the child ignores a forwarded signal, varlock escalates to `SIGKILL` after a grace period (10s by default, overridable via the `_VARLOCK_FORCE_KILL_TIMEOUT_MS` environment variable).
+By default varlock forwards and then waits indefinitely for the child — it does **not** impose its own kill deadline, leaving that decision to the orchestrator or operator (a forwarded signal isn't always terminal — e.g. many programs use `SIGHUP` to reload). If you want varlock to escalate to `SIGKILL` when the child hasn't exited within a grace period, set the `_VARLOCK_FORCE_KILL_TIMEOUT_MS` environment variable to a number of milliseconds.
 :::
 
 </div>

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -215,7 +215,7 @@ Note: When `--no-inject-graph` is set, framework integrations that rely on `__VA
 :::note[Signals and exit codes]
 `varlock run` stays resident while your command runs, but it gets out of the way of process termination:
 
-- Terminating signals (`SIGTERM`, `SIGINT`, `SIGHUP`, `SIGQUIT`) are **forwarded** to the child so it can run its own shutdown handlers, rather than being killed abruptly. When not attached to an interactive terminal (containers, CI, pipes), the child runs in its own process group and the signal is forwarded to the whole group, so grandchildren are terminated too.
+- Terminating signals (`SIGTERM`, `SIGINT`, `SIGHUP`, `SIGQUIT`) are **forwarded** to the child so it can run its own shutdown handlers, rather than being killed abruptly. When no terminal is attached (containers, CI, background/agent runs), the child runs in its own process group and the signal is forwarded to the whole group, so grandchildren are terminated too.
 - The child's exit status is **propagated faithfully**: a normal exit code passes through unchanged, and a child terminated by signal N exits with `128+N` (e.g. `143` for `SIGTERM`), matching shell conventions.
 
 This makes `varlock run` safe to use as a container `ENTRYPOINT` (including PID 1), so `docker stop` / pod termination reaches your app gracefully instead of waiting out the grace period and being `SIGKILL`ed.

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -212,6 +212,17 @@ varlock run --no-inject-graph -- claude
 Note: When `--no-inject-graph` is set, framework integrations that rely on `__VARLOCK_ENV` will need to fall back to re-invoking the CLI. `__VARLOCK_RUN=1` is always set regardless of this flag.
 :::
 
+:::note[Signals and exit codes]
+`varlock run` stays resident while your command runs, but it gets out of the way of process termination:
+
+- Terminating signals (`SIGTERM`, `SIGINT`, `SIGHUP`, `SIGQUIT`) are **forwarded** to the child so it can run its own shutdown handlers, rather than being killed abruptly. When not attached to an interactive terminal (containers, CI, pipes), the child runs in its own process group and the signal is forwarded to the whole group, so grandchildren are terminated too.
+- The child's exit status is **propagated faithfully**: a normal exit code passes through unchanged, and a child terminated by signal N exits with `128+N` (e.g. `143` for `SIGTERM`), matching shell conventions.
+
+This makes `varlock run` safe to use as a container `ENTRYPOINT` (including PID 1), so `docker stop` / pod termination reaches your app gracefully instead of waiting out the grace period and being `SIGKILL`ed.
+
+If the child ignores a forwarded signal, varlock escalates to `SIGKILL` after a grace period (10s by default, overridable via the `_VARLOCK_FORCE_KILL_TIMEOUT_MS` environment variable).
+:::
+
 </div>
 
 <div>

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -88,6 +88,43 @@ let commandProcess: ReturnType<typeof exec> | undefined;
 let childCommandKilledFromRestart = false;
 const isWatchModeRestart = false; // TODO: re-enable watch mode
 
+// whether the child was spawned in its own process group, so we can signal the
+// whole group (child + grandchildren) rather than just the immediate child
+let childInOwnProcessGroup = false;
+// once we begin forwarding a termination signal, we arm a single fallback timer
+// that escalates to SIGKILL if the child ignores it
+let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+
+// signals we forward to the child so it can shut down gracefully. these are the
+// terminating signals an orchestrator (docker stop, k8s, a shell) would send.
+const FORWARDED_SIGNALS: Array<NodeJS.Signals> = ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGQUIT'];
+
+// how long to wait for the child to exit after forwarding a termination signal
+// before escalating to SIGKILL. overridable for slow-draining workloads.
+const FORCE_KILL_TIMEOUT_MS = (() => {
+  const raw = Number(process.env._VARLOCK_FORCE_KILL_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 10_000;
+})();
+
+/**
+ * Forward a signal to the running child process. When the child lives in its own
+ * process group we signal the whole group (negative pid) so grandchildren are
+ * terminated too; otherwise we signal the child pid directly.
+ */
+function signalChild(signal: NodeJS.Signals | number) {
+  const child = commandProcess;
+  if (!child?.pid) return;
+  try {
+    if (childInOwnProcessGroup && process.platform !== 'win32') {
+      process.kill(-child.pid, signal);
+    } else {
+      child.kill(signal);
+    }
+  } catch {
+    // child (or its group) is already gone — nothing to forward to
+  }
+}
+
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   // if "--" is present, split the args into our command and the rest, which will be another external command
   const argv = process.argv.slice(2);
@@ -187,11 +224,20 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   const redactStdout = redactionEnabled && (forceRedact || !process.stdout.isTTY);
   const redactStderr = redactionEnabled && (forceRedact || !process.stderr.isTTY);
 
+  // run the child in its own process group when we're not attached to an interactive
+  // terminal (containers, CI, pipes). this lets us forward signals to the whole group
+  // so grandchildren shut down too — most valuable when `varlock run` is a container
+  // ENTRYPOINT / PID 1. when stdin IS a TTY we stay in the shared group so interactive
+  // tools (psql, vim, claude) keep receiving terminal job-control signals normally.
+  const useProcessGroup = !process.stdin.isTTY;
+  childInOwnProcessGroup = useProcessGroup && process.platform !== 'win32';
+
   if (!redactStdout && !redactStderr) {
     // full stdio inherit - no redaction needed on any stream
     commandProcess = exec(rawCommand, commandArgsOnly, {
       stdio: 'inherit',
       env: fullInjectedEnv,
+      detached: useProcessGroup,
     });
   } else {
     resetRedactionMap(serializedGraph);
@@ -201,6 +247,7 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
       stdout: redactStdout ? 'pipe' : 'inherit',
       stderr: redactStderr ? 'pipe' : 'inherit',
       env: fullInjectedEnv,
+      detached: useProcessGroup,
     });
 
     // pipe output through redaction writers, which buffer possible partial secrets
@@ -221,24 +268,30 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
 
   // if first run, we need to attach some extra exit handling
   if (!isWatchModeRestart) {
-    // try to make sure we shut down cleanly and kill the child process
-    process.on('exit', (_code: any, _signal: any) => {
-      // if (childCommandKilledFromRestart) {
-      //   childCommandKilledFromRestart = false;
-      //   return;
-      // }
-      // console.log('exit!', code, signal);
-      commandProcess?.kill(9);
+    // last-resort cleanup: if we exit while the child is somehow still alive, force-kill it
+    process.on('exit', () => {
+      signalChild('SIGKILL');
     });
 
-    ['SIGTERM', 'SIGINT'].forEach((signal) => {
-      process.on(signal, () => {
-        // console.log('SIGNAL = ', signal);
-        commandProcess?.kill(9);
-        gracefulExit(1);
-      });
+    // forward terminating signals to the child instead of killing it outright, so it can
+    // run its own shutdown handlers. we then wait (below, by awaiting commandProcess) for
+    // the child to exit and propagate its real status — rather than exiting immediately and
+    // losing both the graceful shutdown and the true exit code.
+    FORWARDED_SIGNALS.forEach((signal) => {
+      try {
+        process.on(signal, () => {
+          signalChild(signal);
+          // arm a single fallback that escalates to SIGKILL if the child ignores the signal
+          if (!forceKillTimer) {
+            forceKillTimer = setTimeout(() => signalChild('SIGKILL'), FORCE_KILL_TIMEOUT_MS);
+            // don't let the fallback timer keep the process alive on its own
+            forceKillTimer.unref();
+          }
+        });
+      } catch {
+        // some signals (e.g. SIGQUIT) can't be listened for on every platform — skip those
+      }
     });
-    // TODO: handle other signals?
   }
 
 
@@ -247,24 +300,30 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     const result = await commandProcess;
     exitCode = result.exitCode;
   } catch (error) {
+    const err = error as any;
     // console.log('child command error!', error);
-    if ((error as any).signal === 'SIGINT' && childCommandKilledFromRestart) {
+    if (err.signal === 'SIGINT' && childCommandKilledFromRestart) {
       // console.log('child command failed due to being killed form restart');
       childCommandKilledFromRestart = false;
       return;
     }
 
-    // console.log('child command result error', error);
-    if ((error as any).signal === 'SIGINT' || (error as any).signal === 'SIGKILL') {
-      gracefulExit(1);
+    if (err.signal) {
+      // the child was terminated by a signal (often one we just forwarded). this is a
+      // normal shutdown path, not a varlock failure — propagate the conventional 128+N
+      // status (already computed by exec) without printing the "varlock may be broken" noise.
+      exitCode = err.exitCode || 1;
     } else {
       console.log((error as Error).message);
       console.log(`command [${commandToRunStr}] failed`);
       console.log('try running the same command without varlock');
       console.log('if you get a different result, varlock may be the problem...');
       // console.log(`Please report issue here: <${REPORT_ISSUE_LINK}>`);
+      exitCode = err.exitCode || 1;
     }
-    exitCode = (error as any).exitCode || 1;
+  } finally {
+    // child has exited; cancel any pending force-kill escalation
+    if (forceKillTimer) clearTimeout(forceKillTimer);
   }
 
   if (isWatchEnabled) {

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -232,13 +232,57 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   const redactStdout = redactionEnabled && (forceRedact || !process.stdout.isTTY);
   const redactStderr = redactionEnabled && (forceRedact || !process.stderr.isTTY);
 
-  // run the child in its own process group when we're not attached to an interactive
-  // terminal (containers, CI, pipes). this lets us forward signals to the whole group
-  // so grandchildren shut down too — most valuable when `varlock run` is a container
-  // ENTRYPOINT / PID 1. when stdin IS a TTY we stay in the shared group so interactive
-  // tools (psql, vim, claude) keep receiving terminal job-control signals normally.
-  const useProcessGroup = !process.stdin.isTTY;
+  // Run the child in its own process group (setsid) only when NO std stream is a TTY —
+  // i.e. containers, CI, and background/agent invocations. Detaching is what lets us
+  // forward a signal to the whole group so grandchildren shut down too (most valuable
+  // when `varlock run` is a container ENTRYPOINT / PID 1).
+  //
+  // We deliberately gate on "no TTY anywhere" rather than just stdin so detaching never
+  // has a downside:
+  //  - No-TTY context: setsid changes neither env vars nor parent PIDs, and there's no
+  //    controlling terminal to lose, so the daemon's peer/session scoping (env-anchored
+  //    for agents, or process-tree) is unaffected.
+  //  - Any-TTY context: we stay in the shared group, preserving the child's controlling
+  //    terminal — needed for interactive tools (psql, vim, claude), /dev/tty access,
+  //    SIGWINCH, and the enclave's tty-based session scoping of any nested varlock.
+  const hasAnyTty = Boolean(process.stdin.isTTY || process.stdout.isTTY || process.stderr.isTTY);
+  const useProcessGroup = !hasAnyTty;
   childInOwnProcessGroup = useProcessGroup && process.platform !== 'win32';
+
+  // Install signal handling BEFORE spawning the child. This both (a) closes the window
+  // where a signal arriving between spawn and handler-registration would kill varlock
+  // without forwarding, and (b) ensures varlock holds a real handler for these signals at
+  // fork time, so the child inherits the default disposition (SIG_DFL) rather than an
+  // inherited "ignored" state — otherwise the child can't react to a forwarded signal.
+  if (!isWatchModeRestart) {
+    // last-resort cleanup: only if we exit while the child is somehow still alive (e.g. an
+    // unexpected error in varlock itself). once the child has exited, signalChild is a no-op,
+    // so a clean run never blasts SIGKILL at a reaped (possibly recycled) process group.
+    process.on('exit', () => {
+      signalChild('SIGKILL');
+    });
+
+    // forward terminating signals to the child instead of killing it outright, so it can
+    // run its own shutdown handlers. we then wait (below, by awaiting commandProcess) for
+    // the child to exit and propagate its real status — rather than exiting immediately and
+    // losing both the graceful shutdown and the true exit code. we deliberately do NOT
+    // impose our own kill deadline by default (see FORCE_KILL_TIMEOUT_MS).
+    FORWARDED_SIGNALS.forEach((signal) => {
+      try {
+        process.on(signal, () => {
+          signalChild(signal);
+          // opt-in only: escalate to SIGKILL if the child hasn't exited in time
+          if (FORCE_KILL_TIMEOUT_MS !== undefined && !forceKillTimer) {
+            forceKillTimer = setTimeout(() => signalChild('SIGKILL'), FORCE_KILL_TIMEOUT_MS);
+            // don't let the fallback timer keep the process alive on its own
+            forceKillTimer.unref();
+          }
+        });
+      } catch {
+        // some signals (e.g. SIGQUIT) can't be listened for on every platform — skip those
+      }
+    });
+  }
 
   if (!redactStdout && !redactStderr) {
     // full stdio inherit - no redaction needed on any stream
@@ -273,38 +317,6 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   }
   // console.log('PARENT PID = ', process.pid);
   // console.log('CHILD PID = ', commandProcess.pid);
-
-  // if first run, we need to attach some extra exit handling
-  if (!isWatchModeRestart) {
-    // last-resort cleanup: only if we exit while the child is somehow still alive (e.g. an
-    // unexpected error in varlock itself). once the child has exited, signalChild is a no-op,
-    // so a clean run never blasts SIGKILL at a reaped (possibly recycled) process group.
-    process.on('exit', () => {
-      signalChild('SIGKILL');
-    });
-
-    // forward terminating signals to the child instead of killing it outright, so it can
-    // run its own shutdown handlers. we then wait (below, by awaiting commandProcess) for
-    // the child to exit and propagate its real status — rather than exiting immediately and
-    // losing both the graceful shutdown and the true exit code. we deliberately do NOT
-    // impose our own kill deadline by default (see FORCE_KILL_TIMEOUT_MS).
-    FORWARDED_SIGNALS.forEach((signal) => {
-      try {
-        process.on(signal, () => {
-          signalChild(signal);
-          // opt-in only: escalate to SIGKILL if the child hasn't exited in time
-          if (FORCE_KILL_TIMEOUT_MS !== undefined && !forceKillTimer) {
-            forceKillTimer = setTimeout(() => signalChild('SIGKILL'), FORCE_KILL_TIMEOUT_MS);
-            // don't let the fallback timer keep the process alive on its own
-            forceKillTimer.unref();
-          }
-        });
-      } catch {
-        // some signals (e.g. SIGQUIT) can't be listened for on every platform — skip those
-      }
-    });
-  }
-
 
   let exitCode: any; // TODO: fix this any
   try {

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -1,3 +1,4 @@
+import { openSync, closeSync } from 'node:fs';
 import { define } from 'gunshi';
 import { gracefulExit } from 'exit-hook';
 
@@ -112,6 +113,28 @@ const FORCE_KILL_TIMEOUT_MS = (() => {
   const ms = Number(raw);
   return Number.isFinite(ms) && ms >= 0 ? ms : undefined;
 })();
+
+/**
+ * Whether this process is part of a terminal session — i.e. has a controlling terminal.
+ *
+ * We can't just check `isTTY` on the std streams: a process can keep its controlling
+ * terminal while its std fds are pipes (e.g. a task runner like turbo running
+ * interactively but piping a task's output instead of giving it a PTY). The daemon's
+ * session scoping keys off the controlling terminal (`e_tdev`), not fd tty-ness, so we
+ * use the canonical POSIX probe — `/dev/tty` opens iff a controlling terminal exists —
+ * with the std-stream check as a fast path.
+ */
+function hasControllingTerminal(): boolean {
+  if (process.stdin.isTTY || process.stdout.isTTY || process.stderr.isTTY) return true;
+  if (process.platform === 'win32') return false; // no /dev/tty; we never setsid on Windows anyway
+  try {
+    const fd = openSync('/dev/tty', 'r');
+    closeSync(fd);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Forward a signal to the running child process. When the child lives in its own
@@ -237,16 +260,16 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   // forward a signal to the whole group so grandchildren shut down too (most valuable
   // when `varlock run` is a container ENTRYPOINT / PID 1).
   //
-  // We deliberately gate on "no TTY anywhere" rather than just stdin so detaching never
-  // has a downside:
-  //  - No-TTY context: setsid changes neither env vars nor parent PIDs, and there's no
-  //    controlling terminal to lose, so the daemon's peer/session scoping (env-anchored
-  //    for agents, or process-tree) is unaffected.
-  //  - Any-TTY context: we stay in the shared group, preserving the child's controlling
+  // We deliberately gate on "no controlling terminal" rather than just stdin so detaching
+  // never has a downside:
+  //  - No-terminal context (containers, CI, agents): setsid changes neither env vars nor
+  //    parent PIDs, and there's no controlling terminal to lose, so the daemon's
+  //    peer/session scoping (env-anchored for agents, or process-tree) is unaffected.
+  //  - Terminal context: we stay in the shared group, preserving the child's controlling
   //    terminal — needed for interactive tools (psql, vim, claude), /dev/tty access,
-  //    SIGWINCH, and the enclave's tty-based session scoping of any nested varlock.
-  const hasAnyTty = Boolean(process.stdin.isTTY || process.stdout.isTTY || process.stderr.isTTY);
-  const useProcessGroup = !hasAnyTty;
+  //    SIGWINCH, and the enclave's tty-based session scoping of any nested varlock (incl.
+  //    fan-out runners like turbo whose per-task PTYs we must not sever).
+  const useProcessGroup = !hasControllingTerminal();
   childInOwnProcessGroup = useProcessGroup && process.platform !== 'win32';
 
   // Install signal handling BEFORE spawning the child. This both (a) closes the window

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -91,29 +91,37 @@ const isWatchModeRestart = false; // TODO: re-enable watch mode
 // whether the child was spawned in its own process group, so we can signal the
 // whole group (child + grandchildren) rather than just the immediate child
 let childInOwnProcessGroup = false;
-// once we begin forwarding a termination signal, we arm a single fallback timer
-// that escalates to SIGKILL if the child ignores it
+// set once the child has exited and been reaped, so we never signal a stale (and
+// possibly recycled) pid/process group afterwards
+let childExited = false;
+// optional opt-in fallback timer that escalates to SIGKILL (see FORCE_KILL_TIMEOUT_MS)
 let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
 
 // signals we forward to the child so it can shut down gracefully. these are the
 // terminating signals an orchestrator (docker stop, k8s, a shell) would send.
 const FORWARDED_SIGNALS: Array<NodeJS.Signals> = ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGQUIT'];
 
-// how long to wait for the child to exit after forwarding a termination signal
-// before escalating to SIGKILL. overridable for slow-draining workloads.
+// By default we forward-and-wait (like tini/dumb-init) and never impose our own kill
+// deadline — the orchestrator/operator owns SIGKILL, and a timer would wrongly assume
+// every forwarded signal is terminal (SIGHUP often means "reload") and could truncate a
+// legitimately-slow graceful shutdown. Opt in by setting _VARLOCK_FORCE_KILL_TIMEOUT_MS
+// to a number of milliseconds to escalate to SIGKILL that long after the first signal.
 const FORCE_KILL_TIMEOUT_MS = (() => {
-  const raw = Number(process.env._VARLOCK_FORCE_KILL_TIMEOUT_MS);
-  return Number.isFinite(raw) && raw >= 0 ? raw : 10_000;
+  const raw = process.env._VARLOCK_FORCE_KILL_TIMEOUT_MS;
+  if (raw === undefined) return undefined;
+  const ms = Number(raw);
+  return Number.isFinite(ms) && ms >= 0 ? ms : undefined;
 })();
 
 /**
  * Forward a signal to the running child process. When the child lives in its own
  * process group we signal the whole group (negative pid) so grandchildren are
- * terminated too; otherwise we signal the child pid directly.
+ * terminated too; otherwise we signal the child pid directly. Never signals once the
+ * child has exited, to avoid hitting a recycled pid/process group.
  */
 function signalChild(signal: NodeJS.Signals | number) {
   const child = commandProcess;
-  if (!child?.pid) return;
+  if (childExited || !child?.pid) return;
   try {
     if (childInOwnProcessGroup && process.platform !== 'win32') {
       process.kill(-child.pid, signal);
@@ -268,7 +276,9 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
 
   // if first run, we need to attach some extra exit handling
   if (!isWatchModeRestart) {
-    // last-resort cleanup: if we exit while the child is somehow still alive, force-kill it
+    // last-resort cleanup: only if we exit while the child is somehow still alive (e.g. an
+    // unexpected error in varlock itself). once the child has exited, signalChild is a no-op,
+    // so a clean run never blasts SIGKILL at a reaped (possibly recycled) process group.
     process.on('exit', () => {
       signalChild('SIGKILL');
     });
@@ -276,13 +286,14 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     // forward terminating signals to the child instead of killing it outright, so it can
     // run its own shutdown handlers. we then wait (below, by awaiting commandProcess) for
     // the child to exit and propagate its real status — rather than exiting immediately and
-    // losing both the graceful shutdown and the true exit code.
+    // losing both the graceful shutdown and the true exit code. we deliberately do NOT
+    // impose our own kill deadline by default (see FORCE_KILL_TIMEOUT_MS).
     FORWARDED_SIGNALS.forEach((signal) => {
       try {
         process.on(signal, () => {
           signalChild(signal);
-          // arm a single fallback that escalates to SIGKILL if the child ignores the signal
-          if (!forceKillTimer) {
+          // opt-in only: escalate to SIGKILL if the child hasn't exited in time
+          if (FORCE_KILL_TIMEOUT_MS !== undefined && !forceKillTimer) {
             forceKillTimer = setTimeout(() => signalChild('SIGKILL'), FORCE_KILL_TIMEOUT_MS);
             // don't let the fallback timer keep the process alive on its own
             forceKillTimer.unref();
@@ -322,7 +333,9 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
       exitCode = err.exitCode || 1;
     }
   } finally {
-    // child has exited; cancel any pending force-kill escalation
+    // child has exited and been reaped: stop forwarding (avoid signaling a recycled pid)
+    // and cancel any pending force-kill escalation
+    childExited = true;
     if (forceKillTimer) clearTimeout(forceKillTimer);
   }
 

--- a/packages/varlock/src/lib/exec.ts
+++ b/packages/varlock/src/lib/exec.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import { constants as osConstants } from 'node:os';
 import { Readable } from 'node:stream';
 import {
   join, delimiter, extname, isAbsolute,
@@ -13,6 +14,21 @@ interface ExecOptions {
   stdin?: 'inherit' | 'pipe';
   stdout?: 'inherit' | 'pipe';
   stderr?: 'inherit' | 'pipe';
+  /**
+   * Run the child in its own process group (POSIX `setsid`). Lets callers
+   * forward signals to the whole group (`process.kill(-pid, sig)`) so that
+   * grandchildren are terminated too. Ignored on Windows.
+   */
+  detached?: boolean;
+}
+
+/**
+ * Convert a signal name into the conventional shell exit status (128 + signal number),
+ * matching how shells report a process terminated by a signal.
+ */
+function signalExitCode(signal: NodeJS.Signals): number {
+  const signalNumber = osConstants.signals[signal];
+  return signalNumber ? 128 + signalNumber : 1;
 }
 
 interface ExecResult {
@@ -200,6 +216,8 @@ export function exec(
   const spawnOptions: any = {
     env: options.env || process.env,
     shell: false,
+    // process groups are a POSIX concept; on Windows we forward to the child pid directly
+    detached: options.detached === true && process.platform !== 'win32',
   };
 
   // On Windows, wrap .cmd/.bat (or unresolved commands) in cmd.exe
@@ -273,7 +291,8 @@ export function exec(
         return;
       }
 
-      const exitCode = code ?? (signal ? 1 : 0);
+      // a process killed by a signal has a null exit code; report it as 128+N like a shell does
+      const exitCode = code ?? (signal ? signalExitCode(signal) : 0);
       const exitResult: ExecResult = {
         exitCode,
         signal: signal || undefined,

--- a/smoke-tests/tests/signals.test.ts
+++ b/smoke-tests/tests/signals.test.ts
@@ -11,12 +11,13 @@ const BASIC_CWD = join(SMOKE_TESTS_DIR, 'smoke-test-basic');
  * send `signal` to the varlock process itself, and resolve once it exits.
  * stdin is left non-interactive so varlock runs the child in its own process group.
  */
-function runAndSignal(command: Array<string>, signal: NodeJS.Signals) {
+function runAndSignal(command: Array<string>, signal: NodeJS.Signals, env?: Record<string, string>) {
   return new Promise<{ output: string; code: number | null; signal: NodeJS.Signals | null }>(
     (resolve, reject) => {
       const child = spawn(process.execPath, [VARLOCK_CLI, 'run', '--', ...command], {
         cwd: BASIC_CWD,
         stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, ...env },
       });
 
       let output = '';
@@ -81,5 +82,31 @@ describe.skipIf(process.platform === 'win32')('Signal handling', () => {
   test('still propagates normal non-zero exit codes', () => {
     const result = varlockRun(['bash', '-c', 'exit 7'], { cwd: 'smoke-test-basic' });
     expect(result.exitCode).toBe(7);
+  });
+
+  // by default we forward-and-wait with no self-imposed kill deadline: a child that
+  // treats the signal as non-terminal (e.g. SIGHUP-as-reload, or simply ignores it)
+  // must be allowed to keep running rather than getting SIGKILLed out from under us.
+  test('does NOT force-kill a child that ignores the forwarded signal', async () => {
+    const result = await runAndSignal(
+      ['bash', '-c', 'trap "echo reloaded" HUP; echo ready; sleep 2; echo finished; exit 0'],
+      'SIGHUP',
+    );
+
+    expect(result.output).toContain('reloaded');
+    expect(result.output).toContain('finished');
+    expect(result.code).toBe(0);
+  });
+
+  // escalation is opt-in via _VARLOCK_FORCE_KILL_TIMEOUT_MS
+  test('escalates to SIGKILL when _VARLOCK_FORCE_KILL_TIMEOUT_MS is set and the child ignores the signal', async () => {
+    const result = await runAndSignal(
+      ['bash', '-c', 'trap "" TERM; echo ready; sleep 30'],
+      'SIGTERM',
+      { _VARLOCK_FORCE_KILL_TIMEOUT_MS: '1000' },
+    );
+
+    // killed by SIGKILL (signal 9) -> the wrapper reports 128+9 = 137
+    expect(result.code).toBe(137);
   });
 });

--- a/smoke-tests/tests/signals.test.ts
+++ b/smoke-tests/tests/signals.test.ts
@@ -38,7 +38,7 @@ function runAndSignal(command: Array<string>, signal: NodeJS.Signals, env?: Reco
       // safety net so a hung child can't wedge the suite
       const timeout = setTimeout(() => {
         child.kill('SIGKILL');
-        reject(new Error('varlock run did not exit after signal'));
+        reject(new Error(`varlock run did not exit after ${signal} (output: ${JSON.stringify(output)})`));
       }, 15_000);
       timeout.unref();
     },

--- a/smoke-tests/tests/signals.test.ts
+++ b/smoke-tests/tests/signals.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { varlockRun, VARLOCK_CLI } from '../helpers/run-varlock.js';
+
+const SMOKE_TESTS_DIR = join(import.meta.dirname, '..');
+const BASIC_CWD = join(SMOKE_TESTS_DIR, 'smoke-test-basic');
+
+/**
+ * Spawn `varlock run -- <command>`, wait until the child prints a `ready` marker,
+ * send `signal` to the varlock process itself, and resolve once it exits.
+ * stdin is left non-interactive so varlock runs the child in its own process group.
+ */
+function runAndSignal(command: Array<string>, signal: NodeJS.Signals) {
+  return new Promise<{ output: string; code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve, reject) => {
+      const child = spawn(process.execPath, [VARLOCK_CLI, 'run', '--', ...command], {
+        cwd: BASIC_CWD,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let output = '';
+      let signalSent = false;
+      const onData = (chunk: Buffer) => {
+        output += chunk.toString();
+        if (!signalSent && output.includes('ready')) {
+          signalSent = true;
+          child.kill(signal);
+        }
+      };
+      child.stdout.on('data', onData);
+      child.stderr.on('data', onData);
+
+      child.on('error', reject);
+      child.on('exit', (code, exitSignal) => resolve({ output, code, signal: exitSignal }));
+
+      // safety net so a hung child can't wedge the suite
+      const timeout = setTimeout(() => {
+        child.kill('SIGKILL');
+        reject(new Error('varlock run did not exit after signal'));
+      }, 15_000);
+      timeout.unref();
+    },
+  );
+}
+
+// signals / process groups are POSIX concepts
+describe.skipIf(process.platform === 'win32')('Signal handling', () => {
+  test('forwards SIGTERM to the child so its handler runs and the exit code is preserved', async () => {
+    const result = await runAndSignal(
+      ['bash', '-c', 'trap "echo bye; exit 0" TERM; echo ready; sleep 60'],
+      'SIGTERM',
+    );
+
+    // the child's TERM trap ran (graceful shutdown reached the app)
+    expect(result.output).toContain('bye');
+    // and we propagated its real exit status rather than a generic failure
+    expect(result.code).toBe(0);
+  });
+
+  test('forwards SIGINT to the child', async () => {
+    const result = await runAndSignal(
+      ['bash', '-c', 'trap "echo interrupted; exit 0" INT; echo ready; sleep 60'],
+      'SIGINT',
+    );
+
+    expect(result.output).toContain('interrupted');
+    expect(result.code).toBe(0);
+  });
+
+  test('propagates 128+N when the child is killed by a signal (SIGTERM -> 143)', () => {
+    const result = varlockRun(['bash', '-c', 'kill -TERM $$'], { cwd: 'smoke-test-basic' });
+    expect(result.exitCode).toBe(143);
+  });
+
+  test('propagates 128+N for SIGINT (-> 130)', () => {
+    const result = varlockRun(['bash', '-c', 'kill -INT $$'], { cwd: 'smoke-test-basic' });
+    expect(result.exitCode).toBe(130);
+  });
+
+  test('still propagates normal non-zero exit codes', () => {
+    const result = varlockRun(['bash', '-c', 'exit 7'], { cwd: 'smoke-test-basic' });
+    expect(result.exitCode).toBe(7);
+  });
+});


### PR DESCRIPTION
## What

`varlock run` stays resident (it pipes the child's stdout through redaction whenever output is piped/redirected — interactive terminals get raw pass-through), but it never forwarded terminating signals to the child and lost the child's signal-death status. As a container `ENTRYPOINT` / PID 1 this means `docker stop` / pod termination never reaches the app gracefully — the orchestrator waits out the grace period then `SIGKILL`s.

## Changes

- **Forward signals** (`SIGTERM`, `SIGINT`, `SIGHUP`, `SIGQUIT`) to the child instead of `SIGKILL`-ing it, so it can run its own shutdown handlers. Handlers are installed **before** the child is spawned, so the child inherits a clean default disposition and reliably reacts to a forwarded signal (installing them after spawn let the child inherit an ignored `SIGINT`, causing an intermittent hang).
- **Process-group forwarding when there's no controlling terminal** (containers, CI, background/agent runs): the child runs in its own group (`setsid`) and signals go to the whole group, so grandchildren terminate too. When a terminal is present we stay in the shared group — preserving the child's controlling terminal (`/dev/tty`, `SIGWINCH`) and the daemon's tty-based session scoping of any nested `varlock`. "Terminal present" is detected via the std streams *and* a `/dev/tty` probe, so it stays correct even when a runner (e.g. turbo) keeps a controlling terminal but pipes a task's std fds.
- **Forward-and-wait by default** — like `tini`/`dumb-init`, varlock does not impose its own kill deadline (a forwarded signal isn't always terminal; e.g. `SIGHUP` often means reload). Escalation to `SIGKILL` is opt-in via `_VARLOCK_FORCE_KILL_TIMEOUT_MS`.
- **Propagate exit status faithfully**: normal codes pass through unchanged; a child killed by signal N now exits `128+N` (e.g. `143` for SIGTERM) instead of `1`.
- Never signals the child once it has exited, so a clean run never blasts `SIGKILL` at a reaped (possibly recycled) pid/process group.

Existing redaction, env injection, and normal-exit-code behavior are unchanged. Adds smoke tests covering signal forwarding, `128+N` propagation, the no-force-kill default, and opt-in escalation, plus a docs note.

## Daemon session-scoping impact

None. The unlock-session/peer-identity scoping keys off the `varlock` process that connects to the enclave and its ancestry/env — all upstream of the spawned child. `setsid` is only applied when there's no controlling terminal (an env-anchored / process-tree context that `setsid` doesn't perturb), and never when a terminal is present (so tty-based scoping of nested `varlock` — including turbo per-task PTYs and the `varlock → claude → varlock` case — is untouched). `setsid` changes neither env vars nor parent PIDs. Verified empirically: a child is only made a session leader when no terminal exists; with a per-task PTY or an interactive terminal it stays in the shared group.

## Known tradeoff

In interactive (shared-group) mode the terminal delivers Ctrl-C to the child *and* varlock forwards it, so the child may see `SIGINT` twice. Still strictly better than the old immediate `SIGKILL`, and forwarding is required so a direct `kill -TERM <varlock-pid>` isn't lost.

## Out of scope

- Zombie reaping for PID 1 (no `waitpid(-1)` API in pure Node).
- `execve`-replacing the child when redaction is off (interactive TTY, no stdout piping needed) for perfect signal transparency — a separate follow-up.