### PR TITLE
Add @internal decorator to exclude items from app injection

### DIFF
--- a/.bumpy/cloud-cred-internal-docs.md
+++ b/.bumpy/cloud-cred-internal-docs.md
@@ -1,0 +1,7 @@
+---
+"@varlock/aws-secrets-plugin": patch
+"@varlock/azure-key-vault-plugin": patch
+"@varlock/google-secret-manager-plugin": patch
+---
+
+Docs: recommend marking cloud-provider credentials @internal when varlock is the only consumer (use @internal=false to opt out if your app reads them directly).

--- a/.bumpy/internal-decorator.md
+++ b/.bumpy/internal-decorator.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+Add @internal decorator to mark items used only by varlock (e.g. a secret-zero token) so they are resolved but not injected into your app

--- a/.bumpy/plugin-tokens-internal.md
+++ b/.bumpy/plugin-tokens-internal.md
@@ -1,0 +1,16 @@
+---
+"@varlock/1password-plugin": major
+"@varlock/akeyless-plugin": major
+"@varlock/bitwarden-plugin": major
+"@varlock/dashlane-plugin": major
+"@varlock/doppler-plugin": major
+"@varlock/hashicorp-vault-plugin": major
+"@varlock/infisical-plugin": major
+"@varlock/keepass-plugin": major
+"@varlock/keeper-plugin": major
+"@varlock/passbolt-plugin": major
+"@varlock/proton-pass-plugin": major
+"@varlock/kubernetes-plugin": major
+---
+
+**Breaking:** the service-account / auth token data types are now `@internal` by default — varlock still uses them to fetch your other secrets, but they are no longer injected into your application. If your app reads one of these credentials directly (e.g. to write secrets back or fetch more at runtime), set `@internal=false` to keep it injected.

--- a/packages/plugins/1password/README.md
+++ b/packages/plugins/1password/README.md
@@ -47,7 +47,7 @@ For deployed environments (CI/CD, production, etc), you'll need a service accoun
 # @initOp(token=$OP_TOKEN)
 # ---
 
-# @type=opServiceAccountToken @sensitive
+# @type=opServiceAccountToken @sensitive @internal
 OP_TOKEN=
 ```
 
@@ -74,7 +74,7 @@ Set `useCliWithServiceAccount=true` to use the `op` CLI binary instead of the SD
 # @initOp(token=$OP_TOKEN, useCliWithServiceAccount=true)
 # ---
 
-# @type=opServiceAccountToken @sensitive
+# @type=opServiceAccountToken @sensitive @internal
 OP_TOKEN=
 ```
 
@@ -94,7 +94,7 @@ During local development, you can use the 1Password desktop app instead of a ser
 # @initOp(token=$OP_TOKEN, allowAppAuth=true, account=acmeco)
 # ---
 
-# @type=opServiceAccountToken @sensitive
+# @type=opServiceAccountToken @sensitive @internal
 OP_TOKEN=
 ```
 
@@ -121,7 +121,7 @@ If you are running a self-hosted [1Password Connect server](https://www.1passwor
 # @initOp(connectHost="http://connect-server:8080", connectToken=$OP_CONNECT_TOKEN)
 # ---
 
-# @type=opConnectToken @sensitive
+# @type=opConnectToken @sensitive @internal
 OP_CONNECT_TOKEN=
 ```
 
@@ -155,7 +155,7 @@ This plugin introduces the `op()` function to fetch secret values using 1Passwor
 # @initOp(token=$OP_TOKEN, allowAppAuth=forEnv(dev), account=acmeco)
 # ---
 
-# @type=opServiceAccountToken @sensitive
+# @type=opServiceAccountToken @sensitive @internal
 OP_TOKEN=
 
 # Fetch secrets using 1Password secret references
@@ -209,7 +209,7 @@ Use `opLoadEnvironment()` with `@setValuesBulk` to load all variables from a [1P
 # @setValuesBulk(opLoadEnvironment(your-environment-id))
 # ---
 
-# @type=opServiceAccountToken @sensitive
+# @type=opServiceAccountToken @sensitive @internal
 OP_TOKEN=
 
 API_KEY=

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -850,6 +850,7 @@ plugin.registerRootDecorator({
 plugin.registerDataType({
   name: 'opServiceAccountToken',
   sensitive: true,
+  internal: true,
   typeDescription: 'Service account token used to authenticate with the [1Password CLI](https://developer.1password.com/docs/cli/get-started/) and [SDKs](https://developer.1password.com/docs/sdks/)',
   icon: OP_ICON,
   docs: [
@@ -868,6 +869,7 @@ plugin.registerDataType({
 plugin.registerDataType({
   name: 'opConnectToken',
   sensitive: true,
+  internal: true,
   typeDescription: 'API token used to authenticate with a self-hosted [1Password Connect server](https://developer.1password.com/docs/connect/)',
   icon: OP_ICON,
   docs: [

--- a/packages/plugins/akeyless/README.md
+++ b/packages/plugins/akeyless/README.md
@@ -53,7 +53,7 @@ The simplest auth method uses an API Key (Access ID + Access Key):
 
 # @type=akeylessAccessId
 AKEYLESS_ACCESS_ID=
-# @type=akeylessAccessKey @sensitive
+# @type=akeylessAccessKey @sensitive @internal
 AKEYLESS_ACCESS_KEY=
 ```
 

--- a/packages/plugins/akeyless/src/plugin.ts
+++ b/packages/plugins/akeyless/src/plugin.ts
@@ -453,6 +453,7 @@ plugin.registerDataType({
 plugin.registerDataType({
   name: 'akeylessAccessKey',
   sensitive: true,
+  internal: true,
   typeDescription: 'Akeyless Access Key for API Key authentication',
   docs: [
     {

--- a/packages/plugins/aws-secrets/README.md
+++ b/packages/plugins/aws-secrets/README.md
@@ -72,11 +72,13 @@ If you're deploying outside of AWS (e.g., Azure, GCP, on-premises), wire up IAM 
 # @type=awsAccessKey
 AWS_ACCESS_KEY_ID=
 
-# @type=awsSecretKey @sensitive
+# @type=awsSecretKey @sensitive @internal
 AWS_SECRET_ACCESS_KEY=
 ```
 
 You would then need to inject these env vars using your CI/CD system.
+
+> `@internal` keeps this credential out of your app's environment — varlock only uses it to fetch your secrets. If you need the credential at runtime for other purposes (e.g. via the AWS SDK), set `@internal=false` to keep it injected.
 
 ### OIDC workload identity (For Vercel, GitHub Actions, etc.)
 

--- a/packages/plugins/azure-key-vault/README.md
+++ b/packages/plugins/azure-key-vault/README.md
@@ -74,11 +74,13 @@ AZURE_TENANT_ID=
 # @type=azureClientId
 AZURE_CLIENT_ID=
 
-# @type=azureClientSecret @sensitive
+# @type=azureClientSecret @sensitive @internal
 AZURE_CLIENT_SECRET=
 ```
 
 You would then need to inject these env vars using your CI/CD system.
+
+> `@internal` keeps this credential out of your app's environment — varlock only uses it to fetch your secrets. If you need the credential at runtime for other purposes (e.g. via the Azure SDK), set `@internal=false` to keep it injected.
 
 ### OIDC workload identity (For Vercel, GitHub Actions, etc.)
 

--- a/packages/plugins/bitwarden/README.md
+++ b/packages/plugins/bitwarden/README.md
@@ -46,7 +46,7 @@ For most use cases, you only need to provide the access token:
 # @initBitwarden(accessToken=$BITWARDEN_ACCESS_TOKEN)
 # ---
 
-# @type=bitwardenAccessToken @sensitive
+# @type=bitwardenAccessToken @sensitive @internal
 BITWARDEN_ACCESS_TOKEN=
 ```
 
@@ -90,7 +90,7 @@ This plugin introduces the `bitwarden()` function to fetch secret values.
 # @initBitwarden(accessToken=$BITWARDEN_ACCESS_TOKEN)
 # ---
 
-# @type=bitwardenAccessToken @sensitive
+# @type=bitwardenAccessToken @sensitive @internal
 BITWARDEN_ACCESS_TOKEN=
 
 # Fetch secrets by UUID

--- a/packages/plugins/bitwarden/src/plugin.ts
+++ b/packages/plugins/bitwarden/src/plugin.ts
@@ -396,6 +396,7 @@ plugin.registerRootDecorator({
 plugin.registerDataType({
   name: 'bitwardenAccessToken',
   sensitive: true,
+  internal: true,
   typeDescription: 'Access token for a Bitwarden Secrets Manager machine account',
   icon: BITWARDEN_ICON,
   docs: [
@@ -850,6 +851,7 @@ plugin.registerRootDecorator({
 plugin.registerDataType({
   name: 'bwSessionToken',
   sensitive: true,
+  internal: true,
   typeDescription: 'Bitwarden CLI session token (output of `bw unlock`)',
   icon: BITWARDEN_ICON,
   docs: [

--- a/packages/plugins/dashlane/src/plugin.ts
+++ b/packages/plugins/dashlane/src/plugin.ts
@@ -77,6 +77,7 @@ plugin.registerResolverFunction({
 plugin.registerDataType({
   name: 'dashlaneDeviceKeys',
   sensitive: true,
+  internal: true,
   typeDescription: 'Service device keys for non-interactive Dashlane CLI authentication',
   icon: DASHLANE_ICON,
   docs: [

--- a/packages/plugins/doppler/README.md
+++ b/packages/plugins/doppler/README.md
@@ -44,7 +44,7 @@ Navigate to your project config in the Doppler dashboard → **Access** → **Se
 # )
 # ---
 
-# @type=dopplerServiceToken @sensitive
+# @type=dopplerServiceToken @sensitive @internal
 DOPPLER_TOKEN=
 ```
 
@@ -80,7 +80,7 @@ PROD_DATABASE=doppler(prod, "DATABASE_URL")
 # @setValuesBulk(dopplerBulk())
 # ---
 
-# @type=dopplerServiceToken @sensitive
+# @type=dopplerServiceToken @sensitive @internal
 DOPPLER_TOKEN=
 
 DATABASE_URL=

--- a/packages/plugins/doppler/src/plugin.ts
+++ b/packages/plugins/doppler/src/plugin.ts
@@ -269,6 +269,7 @@ plugin.registerRootDecorator({
 plugin.registerDataType({
   name: 'dopplerServiceToken',
   sensitive: true,
+  internal: true,
   typeDescription: 'Doppler service token for API access',
   icon: DOPPLER_ICON,
   docs: [

--- a/packages/plugins/google-secret-manager/README.md
+++ b/packages/plugins/google-secret-manager/README.md
@@ -65,9 +65,11 @@ For explicit service account authentication:
 # @initGsm(projectId=my-gcp-project, credentials=$GCP_SA_KEY)
 # ---
 
-# @type=gcpServiceAccountJson @sensitive
+# @type=gcpServiceAccountJson @sensitive @internal
 GCP_SA_KEY=
 ```
+
+> `@internal` keeps this credential out of your app's environment — varlock only uses it to fetch your secrets. If you need the credential at runtime for other purposes (e.g. via the Google Cloud SDK), set `@internal=false` to keep it injected.
 
 The `credentials` parameter accepts:
 - JSON string containing the service account key

--- a/packages/plugins/hashicorp-vault/README.md
+++ b/packages/plugins/hashicorp-vault/README.md
@@ -87,7 +87,7 @@ You can also provide a token directly:
 # )
 # ---
 
-# @type=vaultToken @sensitive
+# @type=vaultToken @sensitive @internal
 VAULT_TOKEN=
 ```
 

--- a/packages/plugins/hashicorp-vault/src/plugin.ts
+++ b/packages/plugins/hashicorp-vault/src/plugin.ts
@@ -529,6 +529,7 @@ plugin.registerRootDecorator({
 plugin.registerDataType({
   name: 'vaultToken',
   sensitive: true,
+  internal: true,
   typeDescription: 'HashiCorp Vault authentication token',
   icon: VAULT_ICON,
   docs: [

--- a/packages/plugins/infisical/README.md
+++ b/packages/plugins/infisical/README.md
@@ -61,7 +61,7 @@ Add the plugin to your `.env.schema` file:
 # ---
 # @type=infisicalClientId
 INFISICAL_CLIENT_ID=
-# @type=infisicalClientSecret @sensitive
+# @type=infisicalClientSecret @sensitive @internal
 INFISICAL_CLIENT_SECRET=
 ```
 
@@ -143,11 +143,11 @@ Use multiple Infisical projects or environments:
 # ---
 # @type=infisicalClientId
 DEV_CLIENT_ID=
-# @type=infisicalClientSecret @sensitive
+# @type=infisicalClientSecret @sensitive @internal
 DEV_CLIENT_SECRET=
 # @type=infisicalClientId
 PROD_CLIENT_ID=
-# @type=infisicalClientSecret @sensitive
+# @type=infisicalClientSecret @sensitive @internal
 PROD_CLIENT_SECRET=
 
 DEV_DATABASE=infisical(dev, "DATABASE_URL")
@@ -165,7 +165,7 @@ Use `infisicalBulk()` with `@setValuesBulk` to load all secrets from a project e
 # ---
 # @type=infisicalClientId
 INFISICAL_CLIENT_ID=
-# @type=infisicalClientSecret @sensitive
+# @type=infisicalClientSecret @sensitive @internal
 INFISICAL_CLIENT_SECRET=
 
 # These will be populated from Infisical
@@ -280,7 +280,7 @@ The plugin provides helpful error messages:
 # ---
 # @type=infisicalClientId
 INFISICAL_CLIENT_ID=
-# @type=infisicalClientSecret @sensitive
+# @type=infisicalClientSecret @sensitive @internal
 INFISICAL_CLIENT_SECRET=
 
 # Secret names automatically match config keys
@@ -319,7 +319,7 @@ SENDGRID_KEY=infisical("SENDGRID_KEY", "/api")
 # ---
 # @type=infisicalClientId
 INFISICAL_CLIENT_ID=
-# @type=infisicalClientSecret @sensitive
+# @type=infisicalClientSecret @sensitive @internal
 INFISICAL_CLIENT_SECRET=
 
 DATABASE_URL=

--- a/packages/plugins/infisical/src/plugin.ts
+++ b/packages/plugins/infisical/src/plugin.ts
@@ -430,6 +430,7 @@ plugin.registerDataType({
 plugin.registerDataType({
   name: 'infisicalClientSecret',
   sensitive: true,
+  internal: true,
   typeDescription: 'Client Secret for Infisical Universal Auth (machine identity)',
   icon: INFISICAL_ICON,
   docs: [

--- a/packages/plugins/keepass/README.md
+++ b/packages/plugins/keepass/README.md
@@ -87,7 +87,7 @@ After registering the plugin, initialize it with the `@initKeePass` root decorat
 # @initKeePass(dbPath="./secrets.kdbx", password=$KP_PASSWORD)
 # ---
 
-# @type=kdbxPassword @sensitive
+# @type=kdbxPassword @sensitive @internal
 KP_PASSWORD=
 ```
 

--- a/packages/plugins/keepass/src/plugin.ts
+++ b/packages/plugins/keepass/src/plugin.ts
@@ -168,6 +168,7 @@ plugin.registerRootDecorator({
 plugin.registerDataType({
   name: 'kdbxPassword',
   sensitive: true,
+  internal: true,
   typeDescription: 'Master password for a KeePass KDBX database file',
   icon: KP_ICON,
   docs: [

--- a/packages/plugins/keeper/README.md
+++ b/packages/plugins/keeper/README.md
@@ -54,7 +54,7 @@ ksm profile export --format json | base64
 # @initKeeper(token=$KSM_CONFIG)
 # ---
 
-# @type=keeperSmToken @sensitive
+# @type=keeperSmToken @sensitive @internal
 KSM_CONFIG=
 ```
 
@@ -66,10 +66,10 @@ KSM_CONFIG=
 # @initKeeper(token=$KSM_CONFIG_DEV, id=dev)
 # ---
 
-# @type=keeperSmToken @sensitive
+# @type=keeperSmToken @sensitive @internal
 KSM_CONFIG_PROD=
 
-# @type=keeperSmToken @sensitive
+# @type=keeperSmToken @sensitive @internal
 KSM_CONFIG_DEV=
 ```
 
@@ -210,7 +210,7 @@ ksm profile export --format json | base64
 # @initKeeper(token=$KSM_CONFIG)
 # ---
 
-# @type=keeperSmToken @sensitive
+# @type=keeperSmToken @sensitive @internal
 KSM_CONFIG=
 
 # Your secrets

--- a/packages/plugins/keeper/src/plugin.ts
+++ b/packages/plugins/keeper/src/plugin.ts
@@ -366,6 +366,7 @@ plugin.registerRootDecorator({
 plugin.registerDataType({
   name: 'keeperSmToken',
   sensitive: true,
+  internal: true,
   typeDescription: 'Base64-encoded configuration token for the [Keeper Secrets Manager](https://docs.keeper.io/secrets-manager/) SDK',
   icon: KEEPER_ICON,
   docs: [

--- a/packages/plugins/kubernetes/README.md
+++ b/packages/plugins/kubernetes/README.md
@@ -62,7 +62,7 @@ For deployments without a kubeconfig, provide the API server URL and a bearer to
 # )
 # ---
 
-# @type=kubernetesBearerToken @sensitive
+# @type=kubernetesBearerToken @sensitive @internal
 KUBERNETES_TOKEN=
 ```
 

--- a/packages/plugins/kubernetes/src/plugin.ts
+++ b/packages/plugins/kubernetes/src/plugin.ts
@@ -583,6 +583,7 @@ plugin.registerRootDecorator({
 plugin.registerDataType({
   name: 'kubernetesBearerToken',
   sensitive: true,
+  internal: true,
   typeDescription: 'Kubernetes bearer token for API authentication',
   icon: KUBERNETES_ICON,
   docs: [

--- a/packages/plugins/passbolt/README.md
+++ b/packages/plugins/passbolt/README.md
@@ -44,7 +44,7 @@ You will need to provide your Passbolt account kit and its passphrase:
 # @plugin(@varlock/passbolt-plugin)
 # @initPassbolt(accountKit=$PB_ACCOUNT_KIT, passphrase=$PB_PASSPHRASE)
 # ---
-# @type=passboltAccountKit @sensitive
+# @type=passboltAccountKit @sensitive @internal
 PB_ACCOUNT_KIT=
 # @type=string @sensitive
 PB_PASSPHRASE=
@@ -67,7 +67,7 @@ This plugin introduces the `passbolt()` function to fetch secret values.
 # @plugin(@varlock/passbolt-plugin)
 # @initPassbolt(accountKit=$PB_ACCOUNT_KIT, passphrase=$PB_PASSPHRASE)
 # ---
-# @type=passboltAccountKit @sensitive
+# @type=passboltAccountKit @sensitive @internal
 PB_ACCOUNT_KIT=
 # @type=string @sensitive
 PB_PASSPHRASE=
@@ -105,7 +105,7 @@ Use `passboltBulk()` with `@setValuesBulk` to load all secrets (passwords) from 
 # @initPassbolt(accountKit=$PB_ACCOUNT_KIT, passphrase=$PB_PASSPHRASE)
 # @setValuesBulk(passboltBulk(folderPath="Database/Dev"))
 # ---
-# @type=passboltAccountKit @sensitive
+# @type=passboltAccountKit @sensitive @internal
 PB_ACCOUNT_KIT=
 # @type=string @sensitive
 PB_PASSPHRASE=
@@ -122,7 +122,7 @@ Or use `passboltCustomFieldsObj()` with `@setValuesBulk` to load all custom fiel
 # @initPassbolt(accountKit=$PB_ACCOUNT_KIT, passphrase=$PB_PASSPHRASE)
 # @setValuesBulk(passboltCustomFieldsObj("01234567-0123-4567-890a-bcdef0123456"))
 # ---
-# @type=passboltAccountKit @sensitive
+# @type=passboltAccountKit @sensitive @internal
 PB_ACCOUNT_KIT=
 # @type=string @sensitive
 PB_PASSPHRASE=

--- a/packages/plugins/passbolt/src/plugin.ts
+++ b/packages/plugins/passbolt/src/plugin.ts
@@ -295,6 +295,7 @@ plugin.registerRootDecorator({
 plugin.registerDataType({
   name: 'passboltAccountKit',
   sensitive: true,
+  internal: true,
   typeDescription: 'Passbolt accountKit for authentication',
   icon: PASSBOLT_ICON,
   async validate(val: any): Promise<true> {

--- a/packages/plugins/proton-pass/src/plugin.ts
+++ b/packages/plugins/proton-pass/src/plugin.ts
@@ -430,6 +430,7 @@ plugin.registerDataType({
 plugin.registerDataType({
   name: 'protonPassPassword',
   sensitive: true,
+  internal: true,
   typeDescription: 'Proton Pass account password used by `pass-cli login --interactive`',
   icon: PROTON_PASS_ICON,
   docs: [
@@ -447,6 +448,7 @@ plugin.registerDataType({
 plugin.registerDataType({
   name: 'protonPassTotp',
   sensitive: true,
+  internal: true,
   typeDescription: 'Proton Pass TOTP code used by `pass-cli login --interactive` (if 2FA is enabled)',
   icon: PROTON_PASS_ICON,
   async validate(val): Promise<true> {
@@ -459,6 +461,7 @@ plugin.registerDataType({
 plugin.registerDataType({
   name: 'protonPassExtraPassword',
   sensitive: true,
+  internal: true,
   typeDescription: 'Proton Pass extra password used by `pass-cli login --interactive` (if required by your account)',
   icon: PROTON_PASS_ICON,
   async validate(val): Promise<true> {
@@ -470,6 +473,7 @@ plugin.registerDataType({
 plugin.registerDataType({
   name: 'protonPassPersonalAccessToken',
   sensitive: true,
+  internal: true,
   typeDescription: 'Proton Pass personal access token used by `pass-cli login` (non-interactive, recommended for CI)',
   icon: PROTON_PASS_ICON,
   docs: [

--- a/packages/varlock-website/src/content/docs/plugins/1password.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/1password.mdx
@@ -31,7 +31,7 @@ See the [plugins guide](/guides/plugins/#installation) for more instructions on 
 # ---
 
 # 3. Add a service account token config item (if applicable)
-# @type=opServiceAccountToken @sensitive
+# @type=opServiceAccountToken @sensitive @internal
 OP_TOKEN=
 ```
 
@@ -65,9 +65,12 @@ This service account token will now serve as your _secret-zero_ - which grants a
     # @plugin(@varlock/1password-plugin)
     # @initOp(token=$OP_TOKEN)
     # ---
-    +# @type=opServiceAccountToken @sensitive
+    +# @type=opServiceAccountToken @sensitive @internal
     +OP_TOKEN=
     ```
+    :::note[Service account tokens are `@internal` by default]
+    The `opServiceAccountToken` type is marked [`@internal`](/reference/item-decorators/#internal), so the token is used by varlock to fetch your other secrets but is **not** injected into your application — keeping this secret-zero out of your app's environment. It still shows (redacted) in `varlock load` output so you can debug it. If your app genuinely needs the token directly, opt out with `@internal=false`.
+    :::
 3. **Set your service account token in deployed environments**. Copy the token value from where you saved it earlier, and set it in deployed environments using your platform's env var management UI. Be sure to use the same name as you defined in your schema (e.g. `OP_TOKEN`).
 </Steps>
 
@@ -87,7 +90,7 @@ Set `useCliWithServiceAccount=true` to use the `op` CLI binary instead of the SD
 # @initOp(token=$OP_TOKEN, useCliWithServiceAccount=true)
 # ---
 
-# @type=opServiceAccountToken @sensitive
+# @type=opServiceAccountToken @sensitive @internal
 OP_TOKEN=
 ```
 
@@ -175,7 +178,7 @@ Use `opLoadEnvironment()` with `@setValuesBulk` to load all variables from a [1P
 # @setValuesBulk(opLoadEnvironment(your-environment-id))
 # ---
 
-# @type=opServiceAccountToken @sensitive
+# @type=opServiceAccountToken @sensitive @internal
 OP_TOKEN=
 
 API_KEY=

--- a/packages/varlock-website/src/content/docs/plugins/akeyless.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/akeyless.mdx
@@ -61,7 +61,7 @@ The plugin authenticates using an API Key consisting of an Access ID and Access 
 
     # @type=akeylessAccessId
     AKEYLESS_ACCESS_ID=
-    # @type=akeylessAccessKey @sensitive
+    # @type=akeylessAccessKey @sensitive @internal
     AKEYLESS_ACCESS_KEY=
     ```
 
@@ -253,6 +253,9 @@ AKEYLESS_ACCESS_ID=
 </div>
 <div>
 #### `akeylessAccessKey`
+
+This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+
 
 Represents an Akeyless Access Key for API Key authentication. This type is marked as `@sensitive`.
 

--- a/packages/varlock-website/src/content/docs/plugins/aws-secrets.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/aws-secrets.mdx
@@ -85,7 +85,7 @@ If you're deploying outside of AWS (e.g., Azure, GCP, on-premises), wire up IAM 
     # @type=awsAccessKey
     AWS_ACCESS_KEY_ID=
 
-    # @type=awsSecretKey @sensitive
+    # @type=awsSecretKey @sensitive @internal
     AWS_SECRET_ACCESS_KEY=
     ```
 
@@ -392,6 +392,15 @@ Represents an AWS secret access key (40-character string). This type is marked a
 # @type=awsSecretKey
 AWS_SECRET_ACCESS_KEY=
 ```
+
+:::tip[Does your app use these credentials too?]
+The examples here mark the credential [`@internal`](/reference/item-decorators/#internal) so it's used by varlock to fetch your secrets but **not** injected into your app — the recommended posture when varlock is the only consumer. Unlike the dedicated secrets-manager tokens, AWS credentials are **not** `@internal` by default (they're commonly read directly by the AWS SDK), so if you need the credential at runtime for other purposes, opt out with `@internal=false` to keep it injected:
+
+```env-spec
+# @type=awsSecretKey @internal=false
+AWS_SECRET_ACCESS_KEY=
+```
+:::
 </div>
 </div>
 

--- a/packages/varlock-website/src/content/docs/plugins/azure-key-vault.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/azure-key-vault.mdx
@@ -94,7 +94,7 @@ If you're deploying outside of Azure (e.g., AWS, GCP, on-premises), wire up serv
     # @type=azureClientId @sensitive
     AZURE_CLIENT_ID=
 
-    # @type=azureClientSecret @sensitive
+    # @type=azureClientSecret @sensitive @internal
     AZURE_CLIENT_SECRET=
     ```
 
@@ -354,6 +354,15 @@ Represents a service principal client secret (password). This type is marked as 
 # @type=azureClientSecret
 AZURE_CLIENT_SECRET=
 ```
+
+:::tip[Does your app use these credentials too?]
+The examples here mark the credential [`@internal`](/reference/item-decorators/#internal) so it's used by varlock to fetch your secrets but **not** injected into your app — the recommended posture when varlock is the only consumer. Unlike the dedicated secrets-manager tokens, Azure credentials are **not** `@internal` by default (they're commonly read directly by the Azure SDK), so if you need the credential at runtime for other purposes, opt out with `@internal=false` to keep it injected:
+
+```env-spec
+# @type=azureClientSecret @internal=false
+AZURE_CLIENT_SECRET=
+```
+:::
 </div>
 </div>
 

--- a/packages/varlock-website/src/content/docs/plugins/bitwarden.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/bitwarden.mdx
@@ -39,7 +39,7 @@ See the [plugins guide](/guides/plugins/#installation) for more instructions on 
 # ---
 
 # 3. Add a machine account access token config item
-# @type=bitwardenAccessToken @sensitive
+# @type=bitwardenAccessToken @sensitive @internal
 BITWARDEN_ACCESS_TOKEN=
 ```
 
@@ -81,7 +81,7 @@ BITWARDEN_ACCESS_TOKEN=
     # @initBitwarden(accessToken=$BITWARDEN_ACCESS_TOKEN)
     # ---
 
-    # @type=bitwardenAccessToken @sensitive
+    # @type=bitwardenAccessToken @sensitive @internal
     BITWARDEN_ACCESS_TOKEN=
     ```
 
@@ -305,7 +305,7 @@ Interactive unlock needs a TTY, so a non-interactive load (a dev server started 
 # Option B: let varlock unlock non-interactively with a master password
 # @initBwp(masterPassword=$BW_MASTER_PASSWORD)
 # ---
-# @type=bwSessionToken @sensitive
+# @type=bwSessionToken @sensitive @internal
 BWP_SESSION=
 ```
 
@@ -356,7 +356,7 @@ Initialize a Bitwarden Secrets Manager plugin instance for accessing secrets.
 ```env-spec "@initBitwarden"
 # @initBitwarden(accessToken=$BITWARDEN_ACCESS_TOKEN)
 # ---
-# @type=bitwardenAccessToken @sensitive
+# @type=bitwardenAccessToken @sensitive @internal
 BITWARDEN_ACCESS_TOKEN=
 ```
 </div>
@@ -386,6 +386,9 @@ DB_PASSWORD=bwp("Production DB")
 <div class="reference-docs">
 <div>
 #### `bitwardenAccessToken`
+
+This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+
 
 Represents a Bitwarden Secrets Manager machine account access token. Validation ensures the token is in the correct format (`0.<client_id>.<client_secret>:<encryption_key>`).
 Note that the type itself is marked as `@sensitive`, so adding an explicit `@sensitive` decorator is optional.
@@ -420,6 +423,8 @@ BITWARDEN_ORG_ID=87654321-4321-4321-4321-cba987654321
 
 <div>
 #### `bwSessionToken`
+
+This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
 
 Represents a Bitwarden CLI session token (the output of `bw unlock`). Only needed when supplying a token manually for non-interactive use. Marked `@sensitive`.
 

--- a/packages/varlock-website/src/content/docs/plugins/dashlane.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/dashlane.mdx
@@ -152,6 +152,9 @@ Initialize a Dashlane plugin instance for `dashlane()` resolver.
 <div>
 #### `dashlaneDeviceKeys`
 
+This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+
+
 Service device keys for non-interactive Dashlane CLI authentication. Must start with `dls_`.
 
 See: [Dashlane CLI device registration](https://cli.dashlane.com/personal/devices)

--- a/packages/varlock-website/src/content/docs/plugins/doppler.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/doppler.mdx
@@ -43,7 +43,7 @@ See the [plugins guide](/guides/plugins/#installation) for more instructions on 
 # ---
 
 # 3. Add your service token
-# @type=dopplerServiceToken @sensitive
+# @type=dopplerServiceToken @sensitive @internal
 DOPPLER_TOKEN=
 ```
 
@@ -77,7 +77,7 @@ DOPPLER_TOKEN=
     # )
     # ---
 
-    # @type=dopplerServiceToken @sensitive
+    # @type=dopplerServiceToken @sensitive @internal
     DOPPLER_TOKEN=
     ```
 
@@ -139,7 +139,7 @@ Use `dopplerBulk()` with `@setValuesBulk` to load all secrets from a Doppler con
 # @initDoppler(project=my-project, config=dev, serviceToken=$DOPPLER_TOKEN)
 # @setValuesBulk(dopplerBulk())
 # ---
-# @type=dopplerServiceToken @sensitive
+# @type=dopplerServiceToken @sensitive @internal
 DOPPLER_TOKEN=
 
 API_KEY=
@@ -179,7 +179,7 @@ Initialize a Doppler plugin instance for accessing secrets.
 #   cacheTtl="1h"
 # )
 # ---
-# @type=dopplerServiceToken @sensitive
+# @type=dopplerServiceToken @sensitive @internal
 DOPPLER_TOKEN=
 ```
 
@@ -191,10 +191,13 @@ DOPPLER_TOKEN=
 <div>
 #### `dopplerServiceToken`
 
+This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+
+
 Represents a Doppler service token. This type is marked as `@sensitive`.
 
 ```env-spec "dopplerServiceToken"
-# @type=dopplerServiceToken @sensitive
+# @type=dopplerServiceToken @sensitive @internal
 DOPPLER_TOKEN=
 ```
 </div>
@@ -251,7 +254,7 @@ Bulk-load all secrets from a Doppler config. Intended for use with `@setValuesBu
 # @plugin(@varlock/doppler-plugin)
 # @initDoppler(project=my-app, config=dev, serviceToken=$DOPPLER_TOKEN)
 # ---
-# @type=dopplerServiceToken @sensitive
+# @type=dopplerServiceToken @sensitive @internal
 DOPPLER_TOKEN=
 
 # Secret names automatically match config keys
@@ -281,7 +284,7 @@ PROD_DATABASE=doppler(prod, "DATABASE_URL")
 # @initDoppler(project=my-app, config=dev, serviceToken=$DOPPLER_TOKEN)
 # @setValuesBulk(dopplerBulk())
 # ---
-# @type=dopplerServiceToken @sensitive
+# @type=dopplerServiceToken @sensitive @internal
 DOPPLER_TOKEN=
 
 # These will be populated from Doppler secrets with matching names

--- a/packages/varlock-website/src/content/docs/plugins/google-secret-manager.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/google-secret-manager.mdx
@@ -68,7 +68,7 @@ In rare cases, it may be useful to pass in a service account key explicitly. Thi
     # @plugin(@varlock/google-secret-manager-plugin)
     # @initGsm(projectId=my-gcp-project, credentials=$GCP_SA_KEY)
     # ---
-    +# @type=gcpServiceAccountJson @sensitive
+    +# @type=gcpServiceAccountJson @sensitive @internal
     +GCP_SA_KEY=
     ```
 
@@ -245,7 +245,7 @@ Initializes an instance of the Google Secret Manager plugin - setting up options
 ```env-spec "@initGsm"
 # @initGsm(id=prod, projectId=my-gcp-project, credentials=$GCP_SA_KEY)
 # ---
-# @type=gcpServiceAccountJson @sensitive
+# @type=gcpServiceAccountJson @sensitive @internal
 GCP_SA_KEY=
 ```
 </div>
@@ -263,6 +263,15 @@ Represents a [Google Cloud service account JSON key](https://cloud.google.com/ia
 # @type=gcpServiceAccountJson
 GCP_SA_KEY=
 ```
+
+:::tip[Does your app use these credentials too?]
+The examples here mark the credential [`@internal`](/reference/item-decorators/#internal) so it's used by varlock to fetch your secrets but **not** injected into your app — the recommended posture when varlock is the only consumer. Unlike the dedicated secrets-manager tokens, GCP service account keys are **not** `@internal` by default (they're commonly read directly by the Google Cloud SDK), so if you need the credential at runtime for other purposes, opt out with `@internal=false` to keep it injected:
+
+```env-spec
+# @type=gcpServiceAccountJson @internal=false
+GCP_SA_KEY=
+```
+:::
 </div>
 </div>
 

--- a/packages/varlock-website/src/content/docs/plugins/hashicorp-vault.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/hashicorp-vault.mdx
@@ -136,7 +136,7 @@ You can also provide a token directly:
 # )
 # ---
 
-# @type=vaultToken @sensitive
+# @type=vaultToken @sensitive @internal
 VAULT_TOKEN=
 ```
 
@@ -370,6 +370,9 @@ Initialize a HashiCorp Vault / OpenBao plugin instance.
 <div class="reference-docs">
 <div>
 #### `vaultToken`
+
+This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+
 
 Represents a HashiCorp Vault authentication token. This type is marked as `@sensitive`.
 

--- a/packages/varlock-website/src/content/docs/plugins/infisical.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/infisical.mdx
@@ -50,7 +50,7 @@ See the [plugins guide](/guides/plugins/#installation) for more instructions on 
 # @type=infisicalClientId
 INFISICAL_CLIENT_ID=
 
-# @type=infisicalClientSecret @sensitive
+# @type=infisicalClientSecret @sensitive @internal
 INFISICAL_CLIENT_SECRET=
 ```
 :::caution[Note for EU users]
@@ -97,7 +97,7 @@ If you are using the Infisical EU Cloud, you must set `@initFisical(siteUrl=http
     # @type=infisicalClientId
     INFISICAL_CLIENT_ID=
 
-    # @type=infisicalClientSecret @sensitive
+    # @type=infisicalClientSecret @sensitive @internal
     INFISICAL_CLIENT_SECRET=
     ```
 
@@ -211,7 +211,7 @@ Use `infisicalBulk()` with `@setValuesBulk` to load all secrets from a project e
 # ---
 # @type=infisicalClientId
 INFISICAL_CLIENT_ID=
-# @type=infisicalClientSecret @sensitive
+# @type=infisicalClientSecret @sensitive @internal
 INFISICAL_CLIENT_SECRET=
 
 API_KEY=
@@ -268,7 +268,7 @@ Initialize an Infisical plugin instance for accessing secrets.
 # ---
 # @type=infisicalClientId
 INFISICAL_CLIENT_ID=
-# @type=infisicalClientSecret @sensitive
+# @type=infisicalClientSecret @sensitive @internal
 INFISICAL_CLIENT_SECRET=
 ```
 
@@ -290,6 +290,9 @@ INFISICAL_CLIENT_ID=
 
 <div>
 #### `infisicalClientSecret`
+
+This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+
 
 Represents an Infisical Universal Auth Client Secret. This type is marked as `@sensitive`.
 
@@ -370,7 +373,7 @@ Bulk-load all secrets from an Infisical project environment. Intended for use wi
 # ---
 # @type=infisicalClientId
 INFISICAL_CLIENT_ID=
-# @type=infisicalClientSecret @sensitive
+# @type=infisicalClientSecret @sensitive @internal
 INFISICAL_CLIENT_SECRET=
 
 # Secret names automatically match config keys

--- a/packages/varlock-website/src/content/docs/plugins/keepass.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/keepass.mdx
@@ -223,10 +223,13 @@ Initialize a KeePass plugin instance for accessing secrets from a KDBX database.
 <div>
 #### `kdbxPassword`
 
+This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+
+
 A sensitive string type for KeePass database master passwords. Validates that the value is a non-empty string and is automatically marked as sensitive.
 
 ```env-spec "kdbxPassword"
-# @type=kdbxPassword @sensitive
+# @type=kdbxPassword @sensitive @internal
 KP_PASSWORD=
 ```
 </div>
@@ -303,7 +306,7 @@ Entry paths are sanitized to valid env var names (uppercased, non-alphanumeric r
 # @initKeePass(dbPath="./secrets.kdbx", password=$KP_PASSWORD)
 # ---
 
-# @type=kdbxPassword @sensitive
+# @type=kdbxPassword @sensitive @internal
 KP_PASSWORD=
 
 DB_PASSWORD=kp("Database/production")
@@ -319,7 +322,7 @@ SMTP_USER=kp("Email/smtp#UserName")
 # @setValuesBulk(kpBulk(Production), createMissing=true)
 # ---
 
-# @type=kdbxPassword @sensitive
+# @type=kdbxPassword @sensitive @internal
 KP_PASSWORD=
 
 # These are auto-populated from entries in the "Production" group
@@ -336,7 +339,7 @@ REDIS_URL=
 # @setValuesBulk(kp("Database/production", customAttributesObj=true), createMissing=true)
 # ---
 
-# @type=kdbxPassword @sensitive
+# @type=kdbxPassword @sensitive @internal
 KP_PASSWORD=
 
 # Custom fields from the "Database/production" entry
@@ -352,7 +355,7 @@ DB_NAME=
 # @initKeePass(dbPath="./secrets.kdbx", password=$KP_PASSWORD, useCli=forEnv(dev))
 # ---
 
-# @type=kdbxPassword @sensitive
+# @type=kdbxPassword @sensitive @internal
 KP_PASSWORD=
 
 # In dev: reads via keepassxc-cli (YubiKey, etc.)

--- a/packages/varlock-website/src/content/docs/plugins/keeper.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/keeper.mdx
@@ -38,7 +38,7 @@ See the [plugins guide](/guides/plugins/#installation) for more instructions on 
 # ---
 
 # 3. Add a config item for the Secrets Manager config token
-# @type=keeperSmToken @sensitive
+# @type=keeperSmToken @sensitive @internal
 KSM_CONFIG=
 ```
 
@@ -78,7 +78,7 @@ KSM_CONFIG=
     # @initKeeper(token=$KSM_CONFIG)
     # ---
 
-    # @type=keeperSmToken @sensitive
+    # @type=keeperSmToken @sensitive @internal
     KSM_CONFIG=
     ```
 
@@ -97,9 +97,9 @@ If you need to connect to different Keeper applications or vaults, register mult
 # @initKeeper(token=$KSM_DEV, id=dev)
 # ---
 
-# @type=keeperSmToken @sensitive
+# @type=keeperSmToken @sensitive @internal
 KSM_PROD=
-# @type=keeperSmToken @sensitive
+# @type=keeperSmToken @sensitive @internal
 KSM_DEV=
 
 PROD_SECRET=keeper(prod, "XXXXXXXXXXXXXXXXXXXX")
@@ -188,7 +188,7 @@ Initialize a Keeper Secrets Manager plugin instance for accessing secrets.
 ```env-spec "@initKeeper"
 # @initKeeper(token=$KSM_CONFIG)
 # ---
-# @type=keeperSmToken @sensitive
+# @type=keeperSmToken @sensitive @internal
 KSM_CONFIG=
 ```
 </div>
@@ -198,6 +198,9 @@ KSM_CONFIG=
 <div class="reference-docs">
 <div>
 #### `keeperSmToken`
+
+This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+
 
 Represents a base64-encoded configuration token for the Keeper Secrets Manager SDK. Validation ensures the value is a valid base64-encoded JSON string.
 Note that the type itself is marked as `@sensitive`, so adding an explicit `@sensitive` decorator is optional.

--- a/packages/varlock-website/src/content/docs/plugins/kubernetes.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/kubernetes.mdx
@@ -99,7 +99,7 @@ If you don't want to rely on a kubeconfig file — for example, in CI/CD or othe
     # )
     # ---
 
-    # @type=kubernetesBearerToken @sensitive
+    # @type=kubernetesBearerToken @sensitive @internal
     KUBERNETES_TOKEN=
     ```
 
@@ -400,6 +400,9 @@ Initialize a Kubernetes plugin instance for `k8sSecret()`, `k8sConfigMap()`, `k8
 <div class="reference-docs">
 <div>
 #### `kubernetesBearerToken`
+
+This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+
 
 Represents a Kubernetes bearer token used for API server authentication (typically a service account token). This type is marked as `@sensitive`.
 

--- a/packages/varlock-website/src/content/docs/plugins/passbolt.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/passbolt.mdx
@@ -39,7 +39,7 @@ See the [plugins guide](/guides/plugins/#installation) for more instructions on 
 # ---
 
 # 3. Add config items for your credentials
-# @type=passboltAccountKit @sensitive
+# @type=passboltAccountKit @sensitive @internal
 PB_ACCOUNT_KIT=
 # @sensitive
 PB_PASSPHRASE=
@@ -61,7 +61,7 @@ The plugin authenticates using your Passbolt **account kit** (a base64-encoded b
     # @plugin(@varlock/passbolt-plugin)
     # @initPassbolt(accountKit=$PB_ACCOUNT_KIT, passphrase=$PB_PASSPHRASE)
     # ---
-    # @type=passboltAccountKit @sensitive
+    # @type=passboltAccountKit @sensitive @internal
     PB_ACCOUNT_KIT=
     # @sensitive
     PB_PASSPHRASE=
@@ -136,7 +136,7 @@ Use `passboltBulk()` with `@setValuesBulk` to load all passwords from a Passbolt
 # @initPassbolt(accountKit=$PB_ACCOUNT_KIT, passphrase=$PB_PASSPHRASE)
 # @setValuesBulk(passboltBulk(folderPath="Database/Dev"))
 # ---
-# @type=passboltAccountKit @sensitive
+# @type=passboltAccountKit @sensitive @internal
 PB_ACCOUNT_KIT=
 # @sensitive
 PB_PASSPHRASE=
@@ -187,7 +187,7 @@ Initializes an instance of the Passbolt plugin — setting up authentication and
 ```env-spec "@initPassbolt"
 # @initPassbolt(accountKit=$PB_ACCOUNT_KIT, passphrase=$PB_PASSPHRASE, cacheTtl="1h")
 # ---
-# @type=passboltAccountKit @sensitive
+# @type=passboltAccountKit @sensitive @internal
 PB_ACCOUNT_KIT=
 # @sensitive
 PB_PASSPHRASE=
@@ -202,10 +202,13 @@ PB_PASSPHRASE=
 <div>
 #### `passboltAccountKit`
 
+This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+
+
 Represents a Passbolt account kit (base64-encoded). Validation ensures the value is valid base64. The type is marked as `@sensitive`, so adding an explicit `@sensitive` decorator is optional.
 
 ```env-spec "passboltAccountKit"
-# @type=passboltAccountKit @sensitive
+# @type=passboltAccountKit @sensitive @internal
 PB_ACCOUNT_KIT=
 ```
 </div>

--- a/packages/varlock-website/src/content/docs/plugins/proton-pass.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/proton-pass.mdx
@@ -44,6 +44,10 @@ See: [Proton Pass CLI overview](https://protonpass.github.io/pass-cli/).
 In production/CI you typically want a fully non-interactive login. The plugin supports two
 authentication methods — a **personal access token** (recommended) or a **username + password**.
 
+:::note[Login credentials are `@internal` by default]
+The login credential types (`protonPassPersonalAccessToken`, `protonPassPassword`, `protonPassTotp`, `protonPassExtraPassword`) are marked [`@internal`](/reference/item-decorators/#internal) — varlock uses them to authenticate but does **not** inject them into your application. Override with `@internal=false` if needed.
+:::
+
 #### Personal access token (recommended)
 
 A [personal access token](https://protonpass.github.io/pass-cli/commands/login/#personal-access-token-login)
@@ -72,7 +76,7 @@ pass-cli pat access grant ...
 # )
 # ---
 
-# @type=protonPassPersonalAccessToken @sensitive
+# @type=protonPassPersonalAccessToken @sensitive @internal
 PROTON_PASS_PERSONAL_ACCESS_TOKEN=
 ```
 
@@ -97,13 +101,13 @@ the value in your config — there is nothing for the plugin to refresh or cache
 # )
 # ---
 
-# @type=protonPassPassword @sensitive
+# @type=protonPassPassword @sensitive @internal
 PROTON_PASS_PASSWORD=
 
-# @type=protonPassTotp @sensitive
+# @type=protonPassTotp @sensitive @internal
 PROTON_PASS_TOTP=
 
-# @type=protonPassExtraPassword @sensitive
+# @type=protonPassExtraPassword @sensitive @internal
 PROTON_PASS_EXTRA_PASSWORD=
 ```
 

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -151,6 +151,7 @@ varlock run -- <command>
 **Options:**
 - `--redact-stdout` / `--no-redact-stdout`: Override automatic stdout/stderr redaction. `--redact-stdout` forces redaction of piped/redirected output (e.g., to override `@redactLogs=false`) and errors if output is attached to an interactive terminal, where redaction is not possible without breaking TTY behavior. `--no-redact-stdout` disables redaction entirely.
 - `--no-inject-graph`: Disable injection of `__VARLOCK_ENV` serialized config graph into the child process environment
+- `--include-internal`: Pass [`@internal`](/reference/item-decorators/#internal) items through to the child process. By default they are stripped from the child env — even if set in the ambient environment — so a secret-zero token never reaches your app. Use this for a _nested_ `varlock run` whose own resolution needs the internal value.
 - `--path` / `-p`: Path to a specific `.env` file or directory to use as the entry point. Can be specified multiple times to load from multiple paths — later paths take higher precedence.
 - `--clear-cache`: Clear the active cache store before resolving values, then re-resolve all values (when combined with `--skip-cache`, the cache is cleared first, then reads and writes are skipped for the run)
 - `--skip-cache`: Skip cache entirely for this invocation (no reads or writes). This overrides `@cache=disk`/`@cache=memory`.

--- a/packages/varlock-website/src/content/docs/reference/item-decorators.mdx
+++ b/packages/varlock-website/src/content/docs/reference/item-decorators.mdx
@@ -68,6 +68,8 @@ Sets whether the item should be considered _sensitive_ - meaning it cannot be ex
 
 Default behavior for all items can be set using the [`@defaultSensitive` root decorator](/reference/root-decorators/#defaultsensitive)
 
+Sensitivity may also be implied by the item's [data type](/reference/data-types) — for example plugin "secret-zero" credential types (like a [1Password `opServiceAccountToken`](/plugins/1password/)) are sensitive by default, so you don't need to add `@sensitive` explicitly (use `@public` or `@sensitive=false` to override). An explicit `@sensitive` on the item always wins.
+
 📖 See the [secrets management guide](/guides/secrets/) for best practices on handling sensitive values, and how to use plugins to fetch them from secret management platforms.
 
 ```env-spec
@@ -108,6 +110,42 @@ Opposite of [`@sensitive`](#sensitive). Equivalent to writing `@sensitive=false`
 # @public
 PUBLIC_API_URL=https://api.example.com
 ```
+</div>
+
+<div>
+### `@internal`
+**Value type:** `boolean`
+
+Marks an item as used **only internally by varlock** — not by your application. Internal items are still resolved and can be referenced by other items (e.g. via [`ref()`](/reference/functions/#ref) or string expansion), but they are **excluded** from everything that reaches your app: the injected env vars, the [serialized graph](/reference/root-decorators/#generatetypes) blob, and generated types.
+
+The most common use is a "secret zero" — a credential used only to fetch _other_ secrets (for example a vault/secrets-manager token). Your application never needs it, and keeping it out of the process environment reduces your attack surface.
+
+```env-spec
+# the token below is only used to resolve the secrets that follow it
+# @internal @sensitive
+OP_TOKEN=
+
+# resolved using OP_TOKEN, but only DATABASE_URL is injected into the app
+# @sensitive
+DATABASE_URL=exec(`op read "op://app/db/url"`)
+```
+
+Some plugin data types are **internal by default** — for example a [1Password `opServiceAccountToken`](/plugins/1password/) or other secrets-manager credential, which authenticates varlock but is rarely needed in app code. You can opt back in with `@internal=false`:
+
+```env-spec
+# @type=opServiceAccountToken @internal=false
+OP_TOKEN=
+```
+
+:::caution[Marking something internal stops injecting it]
+Because internal items still resolve and validate, marking a variable internal does **not** produce an error if your application actually reads it — the value simply won't be in the environment at runtime. If your app uses one of these credentials directly (e.g. to write secrets back, renew Vault leases, or fetch more secrets at runtime), set `@internal=false` so it keeps being injected.
+:::
+
+:::note
+`@internal` controls what varlock _injects_, not what it shows. Internal items still appear (redacted) in inspection output — the `varlock load` summary and `varlock load --agent` — so they can be set and debugged.
+:::
+
+`varlock run` strips internal items from the child process environment **even if they were set in the ambient environment** (e.g. `OP_TOKEN=xxx varlock run ...`), so a secret-zero token never leaks into your app. If a _nested_ `varlock run` needs the internal value for its own resolution, pass [`--include-internal`](/reference/cli-commands/#run) to keep it in the child env.
 </div>
 
 <div>

--- a/packages/varlock/src/cli/commands/explain.command.ts
+++ b/packages/varlock/src/cli/commands/explain.command.ts
@@ -11,7 +11,27 @@ import {
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { CliExitError } from '../helpers/exit-error';
 import { StaticValueResolver } from '../../env-graph/lib/resolver';
+import type { ConfigItem } from '../../env-graph/lib/config-item';
 import _ from '@env-spec/utils/my-dash';
+
+/** Human-readable explanation of how an item's sensitivity was determined */
+function describeSensitiveSource(item: ConfigItem): string {
+  switch (item.sensitiveSource) {
+    case 'explicit': return 'set explicitly';
+    case 'data-type': return `from the \`${item.dataType?.name}\` data type`;
+    case 'resolver': return `inferred from the ${item.valueResolver?.fnName}() resolver`;
+    case 'default-decorator': return 'from @defaultSensitive';
+    case 'prefix': return 'from a @defaultSensitive prefix rule';
+    default: return 'default — items are sensitive unless marked @public';
+  }
+}
+
+/** Human-readable explanation of how an item became @internal */
+function describeInternalSource(item: ConfigItem): string {
+  return item.internalSource === 'explicit'
+    ? 'set explicitly via @internal'
+    : `set by the \`${item.dataType?.name}\` data type`;
+}
 
 export const commandSpec = define({
   name: 'explain',
@@ -97,7 +117,16 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   else props.push('optional');
   if (isSensitive) props.push('sensitive');
   else props.push('public');
+  if (item.isInternal) props.push('internal');
   console.log(`  ${ansis.gray('Properties:')} ${props.join(', ')}`);
+
+  // Show *how* sensitivity / internal-ness were determined (explicit vs implied by data type/resolver)
+  if (isSensitive) {
+    console.log(`  ${ansis.gray('Sensitive:')} yes ${ansis.gray.italic(`(${describeSensitiveSource(item)})`)}`);
+  }
+  if (item.isInternal) {
+    console.log(`  ${ansis.gray('Internal:')} ${ansis.yellow('yes')} ${ansis.gray.italic(`(${describeInternalSource(item)} — not injected into your app; set @internal=false to inject)`)}`);
+  }
 
   // Resolved value
   console.log('');

--- a/packages/varlock/src/cli/commands/load.command.ts
+++ b/packages/varlock/src/cli/commands/load.command.ts
@@ -157,7 +157,9 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   /** When --agent is set, return a copy of the resolved env with sensitive values redacted */
   function getRedactedEnvObject() {
     const redactedEnv: Record<string, unknown> = {};
-    const resolvedEnv = envGraph.getResolvedEnvObject();
+    // include @internal items here: they aren't injected, but an agent inspecting the env
+    // still needs to see they exist (redacted) to help set/debug them
+    const resolvedEnv = envGraph.getResolvedEnvObject({ includeInternal: true });
     for (const itemKey of envGraph.sortedConfigKeys) {
       const item = envGraph.configSchema[itemKey];
       const value = resolvedEnv[itemKey];
@@ -187,7 +189,9 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     console.log(JSON.stringify(env, null, 2));
   } else if (outputFormat === 'json-full') {
     const indent = compact ? 0 : 2;
-    const serialized = envGraph.getSerializedGraph();
+    // this is an inspection dump (not the injected blob), so include @internal items —
+    // they're flagged with isInternal and redacted below like any other sensitive value
+    const serialized = envGraph.getSerializedGraph({ includeInternal: true });
     if (agent) {
       for (const key in serialized.config) {
         const item = serialized.config[key];

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -31,6 +31,10 @@ export const commandSpec = define({
       type: 'boolean',
       description: 'Deprecated: use --inject vars instead',
     },
+    'include-internal': {
+      type: 'boolean',
+      description: 'Pass @internal items through to the child process (by default they are stripped, even when set in the ambient env). Use this for a nested `varlock run` whose own resolution needs the internal value (e.g. a secret-zero token).',
+    },
     path: {
       type: 'string',
       short: 'p',
@@ -194,7 +198,10 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
 
   // will fail above if there are any errors
 
-  const resolvedEnv = envGraph.getResolvedEnvObject();
+  // by default @internal items are never handed to the child; --include-internal opts out
+  // (e.g. a nested `varlock run` whose own resolution needs a secret-zero token)
+  const includeInternal = !!ctx.values['include-internal'];
+  const resolvedEnv = envGraph.getResolvedEnvObject({ includeInternal });
   const serializedGraph = envGraph.getSerializedGraph();
   const { resetRedactionMap } = await import('../../runtime/env');
   const { createRedactedStreamWriter } = await import('../../runtime/lib/redact-stream');
@@ -220,6 +227,15 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     __VARLOCK_RUN: '1', // flag for a child process to detect it is running via `varlock run`
     ...(injectBlob ? { __VARLOCK_ENV: JSON.stringify(serializedGraph) } : {}),
   };
+
+  // @internal items must not reach the application. The spread of process.env above can carry
+  // an ambiently-set value (e.g. `OP_TOKEN=xxx varlock run ...`), so strip those keys here —
+  // unless --include-internal was passed, in which case they were intentionally injected above.
+  if (!includeInternal) {
+    for (const itemKey of envGraph.sortedConfigKeys) {
+      if (envGraph.configSchema[itemKey].isInternal) delete fullInjectedEnv[itemKey];
+    }
+  }
 
   // when only injecting the blob, also inject the encryption key so the
   // child process can decrypt it (if encrypted)

--- a/packages/varlock/src/cli/helpers/error-checks.ts
+++ b/packages/varlock/src/cli/helpers/error-checks.ts
@@ -191,9 +191,10 @@ export function checkForConfigErrors(envGraph: EnvGraph, opts?: {
         'Valid items:',
         ansis.italic.gray('(remove `--show-all` flag to hide)'),
       ]));
+      // strictly-clean items only — warn-state items are already listed above
       const validItems = envGraph.sortedConfigKeys
         .map((k) => envGraph.configSchema[k])
-        .filter((i) => !!i.isValid);
+        .filter((i) => i.validationState === 'valid');
       for (const item of validItems) {
         console.error(getItemSummary(item));
       }

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -138,6 +138,23 @@ export class ConfigItem {
     const val = deprecatedDec.parsedDecorator.simplifiedValue;
     return typeof val === 'string' ? val : undefined;
   }
+
+  /**
+   * Whether this item is used only internally by varlock (e.g. a "secret zero" used to
+   * resolve _other_ items) and must NOT be injected into the running application.
+   * Internal items are still resolved and can be referenced by other items via ref(),
+   * but are excluded from the injected env vars, the serialized graph blob, and generated types.
+   */
+  get isInternal(): boolean {
+    const internalDec = this.getDec('internal');
+    // an explicit `@internal` / `@internal=false` always wins over a data-type default
+    if (internalDec) {
+      // bare `@internal` === `@internal=true`; `@internal=false` explicitly opts out
+      return internalDec.parsedDecorator.simplifiedValue === true;
+    }
+    // otherwise fall back to the data type's default (e.g. a service-account token type)
+    return this.dataType?.isInternal ?? false;
+  }
   get docsLinks() {
     // matching { url, description } from OpenAPI
     const links: Array<{ url: string, description?: string }> = [];
@@ -440,8 +457,21 @@ export class ConfigItem {
 
   _isSensitive: boolean = true;
   _sensitiveExplicitlySet = false;
+  /** how sensitivity was determined (undefined = the global default that items are sensitive) */
+  _sensitiveSource?: 'explicit' | 'data-type' | 'resolver' | 'default-decorator' | 'prefix';
   get isSensitive(): boolean {
     return this._isSensitive;
+  }
+
+  /** how this item's sensitivity was determined — used by `varlock explain` */
+  get sensitiveSource(): 'explicit' | 'data-type' | 'resolver' | 'default-decorator' | 'prefix' | 'default' {
+    return this._sensitiveSource ?? 'default';
+  }
+
+  /** how this item's @internal status was determined, or undefined if not internal */
+  get internalSource(): 'explicit' | 'data-type' | undefined {
+    if (!this.isInternal) return undefined;
+    return this.getDec('internal') ? 'explicit' : 'data-type';
   }
 
   /**
@@ -478,6 +508,7 @@ export class ConfigItem {
         if (sensitiveDec.schemaErrors.some((e) => !e.isWarning)) return;
         this._isSensitive = this.applySensitiveOptions(resolved ?? {});
         this._sensitiveExplicitlySet = true;
+        this._sensitiveSource = 'explicit';
         return;
       }
       // an array literal is never valid here — guide toward the object form
@@ -495,6 +526,7 @@ export class ConfigItem {
       if (sensitiveDecValue !== undefined) {
         this._isSensitive = usingPublic ? !sensitiveDecValue : sensitiveDecValue;
         this._sensitiveExplicitlySet = true;
+        this._sensitiveSource = 'explicit';
         return;
       }
     }
@@ -513,6 +545,7 @@ export class ConfigItem {
             return;
           }
           this._isSensitive = !this.key.startsWith(prefix);
+          this._sensitiveSource = 'prefix';
           return;
         } else {
           const defaultSensitiveVal = await defaultSensitiveDec.resolve();
@@ -520,13 +553,17 @@ export class ConfigItem {
             this._schemaErrors.push(new SchemaError('@defaultSensitive must resolve to a boolean value'));
           } else {
             this._isSensitive = defaultSensitiveVal;
+            this._sensitiveSource = 'default-decorator';
             return;
           }
         }
       }
     }
 
-    if (sensitiveFromDataType !== undefined) this._isSensitive = sensitiveFromDataType;
+    if (sensitiveFromDataType !== undefined) {
+      this._isSensitive = sensitiveFromDataType;
+      this._sensitiveSource = 'data-type';
+    }
   }
 
   /**
@@ -619,6 +656,8 @@ export class ConfigItem {
       const wasSensitive = this._isSensitive;
       this._isSensitive = true;
       if (!wasSensitive) {
+        // the resolver is what actually made this sensitive (it wasn't otherwise)
+        this._sensitiveSource = 'resolver';
         const hasSchemaSource = this.defs.some((d) => d.source && d.source.type !== 'overrides');
         if (hasSchemaSource) {
           this._schemaErrors.push(new SchemaError(
@@ -717,7 +756,9 @@ export class ConfigItem {
   }
 
   get isValid() {
-    return this.validationState === 'valid';
+    // a warning is advisory — only a real error makes an item invalid (and e.g. unsafe to
+    // reference from another item). `validationState === 'valid'` would wrongly exclude warn-state.
+    return this.validationState !== 'error';
   }
 
   /**

--- a/packages/varlock/src/env-graph/lib/data-types.ts
+++ b/packages/varlock/src/env-graph/lib/data-types.ts
@@ -39,6 +39,14 @@ type EnvGraphDataTypeDef<CoerceReturnType, ValidateInputType = FallbackIfUnknown
   /** will make items of this type sensitive, unless overridden specifically on that item */
   sensitive?: boolean,
 
+  /**
+   * will make items of this type internal (used only by varlock, not injected into the app),
+   * unless overridden specifically on that item via `@internal=false`.
+   * Useful for credentials like a service-account token that fetch other secrets but
+   * are very rarely needed in application code.
+   */
+  internal?: boolean,
+
   /** adds docs info for these  */
   docs?: Array<string | { url: string, description: string }>;
   // do we want to allow adding settings that usually come from other decorators?
@@ -60,6 +68,7 @@ export class EnvGraphDataType {
   get name() { return this.def.name; }
   get icon() { return this.def.icon; }
   get isSensitive() { return this.def.sensitive; }
+  get isInternal() { return this.def.internal; }
   get docsEntries() { return this.def.docs; }
 
   /** @internal */

--- a/packages/varlock/src/env-graph/lib/decorators.ts
+++ b/packages/varlock/src/env-graph/lib/decorators.ts
@@ -522,6 +522,9 @@ export const builtInItemDecorators: Array<ItemDecoratorDef<any>> = [
     incompatibleWith: ['sensitive'],
   },
   {
+    name: 'internal',
+  },
+  {
     name: 'type',
     useFnArgsResolver: true,
   },

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -61,6 +61,8 @@ export type SerializedEnvGraph = {
     isSensitive: boolean;
     /** false = opted out of runtime leak detection (still redacted in logs). Omitted when true (the default). */
     preventLeaks?: boolean;
+    /** true = used only by varlock, not injected into the app. Only present in inspection output (never in the blob). */
+    isInternal?: boolean;
   }>;
   /** provenance metadata for process.env overrides across nested invocations */
   __varlockOverrideMeta?: OverrideProvenanceMetadata;
@@ -689,16 +691,19 @@ export class EnvGraph {
     return keys;
   }
 
-  getResolvedEnvObject() {
+  getResolvedEnvObject(opts?: { includeInternal?: boolean }) {
     const envObject: Record<string, any> = {};
     for (const itemKey of this.sortedConfigKeys) {
       const item = this.configSchema[itemKey];
+      // @internal items are used only by varlock (e.g. to resolve other items) and are
+      // never injected into the application — exclude them from the resolved env output
+      if (item.isInternal && !opts?.includeInternal) continue;
       envObject[itemKey] = item.resolvedValue;
     }
     return envObject;
   }
 
-  getSerializedGraph(): SerializedEnvGraph {
+  getSerializedGraph(opts?: { includeInternal?: boolean }): SerializedEnvGraph {
     const serializedGraph: SerializedEnvGraph = {
       basePath: this.basePath,
       sources: [],
@@ -720,9 +725,14 @@ export class EnvGraph {
       // reserved prefix so any current/future infra var is excluded automatically.
       if (isVarlockReservedKey(itemKey)) continue;
       const item = this.configSchema[itemKey];
+      // @internal items are never injected into the app, so the blob (delivered to the app
+      // process via __VARLOCK_ENV) must exclude them entirely. Inspection callers
+      // (e.g. `load --format json-full`) opt in via includeInternal to show them, flagged.
+      if (item.isInternal && !opts?.includeInternal) continue;
       serializedGraph.config[itemKey] = {
         value: item.resolvedValue,
         isSensitive: item.isSensitive,
+        ...item.isInternal ? { isInternal: true } : {},
         // only emit when opted out — keeps the common-case blob smaller
         ...item.isSensitive && !item.preventLeaks ? { preventLeaks: false } : {},
       };

--- a/packages/varlock/src/env-graph/lib/type-generation.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation.ts
@@ -251,6 +251,8 @@ export async function generateTypes(graph: EnvGraph, lang: string, typesPath: st
     if (isVarlockReservedKey(itemKey)) continue;
     const configItem = graph.configSchema[itemKey];
     if (!configItem.defsForTypeGeneration.length) continue;
+    // @internal items are not injected into the app, so they shouldn't appear in the typed ENV
+    if (configItem.isInternal) continue;
     items.push(await configItem.getTypeGenInfo());
   }
 

--- a/packages/varlock/src/env-graph/test/internal-decorator.test.ts
+++ b/packages/varlock/src/env-graph/test/internal-decorator.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import outdent from 'outdent';
+import { EnvGraph } from '../index';
+import { DotEnvFileDataSource } from '../lib/data-source';
+import { createEnvGraphDataType } from '../lib/data-types';
+
+async function loadSchema(contents: string) {
+  const g = new EnvGraph();
+  await g.setRootDataSource(new DotEnvFileDataSource('.env.schema', { overrideContents: contents }));
+  await g.finishLoad();
+  await g.resolveEnvValues();
+  return g;
+}
+
+async function loadSchemaWithInternalType(contents: string) {
+  const g = new EnvGraph();
+  // mirrors a plugin data type (e.g. a service-account token) that defaults to @internal
+  g.registerDataType(createEnvGraphDataType({ name: 'svc-token', sensitive: true, internal: true }));
+  await g.setRootDataSource(new DotEnvFileDataSource('.env.schema', { overrideContents: contents }));
+  await g.finishLoad();
+  await g.resolveEnvValues();
+  return g;
+}
+
+describe('@internal item decorator', () => {
+  it('marks an item internal and still resolves its value', async () => {
+    const g = await loadSchema(outdent`
+      # @internal @sensitive
+      OP_TOKEN=abc123
+    `);
+    const item = g.configSchema.OP_TOKEN;
+    expect(item.isInternal).toBe(true);
+    expect(item.resolvedValue).toBe('abc123');
+    expect(item.errors.length).toBe(0);
+  });
+
+  it('can be referenced by other items via ref(), but is excluded from injected output', async () => {
+    const g = await loadSchema(outdent`
+      # @internal
+      OP_TOKEN=abc123
+      DB_URL=concat("postgres://", ref(OP_TOKEN), "@host")
+      PUBLIC_VAR=hello
+    `);
+
+    // the internal "secret zero" still resolves and is usable by other items
+    expect(g.configSchema.DB_URL.resolvedValue).toBe('postgres://abc123@host');
+
+    // ...but is not part of the resolved env handed to the application
+    const env = g.getResolvedEnvObject();
+    expect(env).not.toHaveProperty('OP_TOKEN');
+    expect(env.DB_URL).toBe('postgres://abc123@host');
+    expect(env.PUBLIC_VAR).toBe('hello');
+  });
+
+  it('is excluded from the serialized graph blob', async () => {
+    const g = await loadSchema(outdent`
+      # @internal
+      OP_TOKEN=abc123
+      DB_URL=concat("x-", ref(OP_TOKEN))
+    `);
+    const blob = g.getSerializedGraph();
+    expect(blob.config).not.toHaveProperty('OP_TOKEN');
+    expect(blob.config).toHaveProperty('DB_URL');
+  });
+
+  it('is included (flagged) in the serialized graph when includeInternal is set', async () => {
+    const g = await loadSchema(outdent`
+      # @internal
+      OP_TOKEN=abc123
+      DB_URL=concat("x-", ref(OP_TOKEN))
+    `);
+    // inspection output (e.g. `load --format json-full`) opts in and tags the item
+    const inspect = g.getSerializedGraph({ includeInternal: true });
+    expect(inspect.config.OP_TOKEN).toMatchObject({ value: 'abc123', isInternal: true });
+    // non-internal items are not tagged
+    expect(inspect.config.DB_URL.isInternal).toBeUndefined();
+  });
+
+  it('can be opted back into resolved output via includeInternal', async () => {
+    const g = await loadSchema(outdent`
+      # @internal
+      OP_TOKEN=abc123
+    `);
+    expect(g.getResolvedEnvObject()).not.toHaveProperty('OP_TOKEN');
+    expect(g.getResolvedEnvObject({ includeInternal: true })).toHaveProperty('OP_TOKEN', 'abc123');
+  });
+
+  it('a data type with internal:true makes items internal by default', async () => {
+    const g = await loadSchemaWithInternalType(outdent`
+      # @type=svc-token
+      OP_TOKEN=abc123
+      PUBLIC_VAR=hello
+    `);
+    expect(g.configSchema.OP_TOKEN.isInternal).toBe(true);
+    expect(g.configSchema.PUBLIC_VAR.isInternal).toBe(false);
+    const env = g.getResolvedEnvObject();
+    expect(env).not.toHaveProperty('OP_TOKEN');
+    expect(env.PUBLIC_VAR).toBe('hello');
+  });
+
+  it('@internal=false overrides a data type internal default', async () => {
+    const g = await loadSchemaWithInternalType(outdent`
+      # @type=svc-token @internal=false
+      OP_TOKEN=abc123
+    `);
+    expect(g.configSchema.OP_TOKEN.isInternal).toBe(false);
+    expect(g.getResolvedEnvObject()).toHaveProperty('OP_TOKEN', 'abc123');
+  });
+
+  it('@internal=false does not mark the item as internal', async () => {
+    const g = await loadSchema(outdent`
+      # @internal=false
+      FOO=bar
+    `);
+    expect(g.configSchema.FOO.isInternal).toBe(false);
+    expect(g.getResolvedEnvObject()).toHaveProperty('FOO', 'bar');
+  });
+
+  it('is excluded from generated types', async () => {
+    const g = new EnvGraph();
+    await g.setRootDataSource(new DotEnvFileDataSource('.env.schema', {
+      overrideContents: outdent`
+        # @internal
+        OP_TOKEN=abc123
+        PUBLIC_VAR=hello
+      `,
+    }));
+    await g.finishLoad();
+
+    const { generateTsTypesSrc } = await import('../lib/type-generation');
+    const items = [];
+    for (const key of g.sortedConfigKeys) {
+      const item = g.configSchema[key];
+      if (item.isInternal) continue;
+      if (!item.defsForTypeGeneration.length) continue;
+      items.push(await item.getTypeGenInfo());
+    }
+    const src = await generateTsTypesSrc(items);
+    expect(src).not.toContain('OP_TOKEN');
+    expect(src).toContain('PUBLIC_VAR');
+  });
+});

--- a/packages/varlock/src/env-graph/test/sensitivity-source.test.ts
+++ b/packages/varlock/src/env-graph/test/sensitivity-source.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import outdent from 'outdent';
+import { EnvGraph } from '../index';
+import { DotEnvFileDataSource } from '../lib/data-source';
+import { createEnvGraphDataType } from '../lib/data-types';
+import { createResolver } from '../lib/resolver';
+
+// a fake resolver that implies sensitivity (like varlock()/keychain() do)
+const SecretResolver = createResolver({
+  name: 'mysecret',
+  impliesSensitive: true,
+  resolve() { return 'shhh'; },
+});
+
+async function load(contents: string, opts?: { withTypeAndResolver?: boolean }) {
+  const g = new EnvGraph();
+  if (opts?.withTypeAndResolver) {
+    g.registerDataType(createEnvGraphDataType({ name: 'svc-token', sensitive: true, internal: true }));
+    g.registerResolver(SecretResolver);
+  }
+  await g.setRootDataSource(new DotEnvFileDataSource('.env.schema', { overrideContents: contents }));
+  await g.finishLoad();
+  await g.resolveEnvValues();
+  return g;
+}
+
+describe('sensitivity / internal provenance (for `varlock explain`)', () => {
+  it('reports an explicit @sensitive / @internal as "explicit"', async () => {
+    const g = await load(outdent`
+      # @sensitive @internal
+      TOKEN=abc
+    `);
+    expect(g.configSchema.TOKEN.sensitiveSource).toBe('explicit');
+    expect(g.configSchema.TOKEN.internalSource).toBe('explicit');
+  });
+
+  it('reports sensitivity / internal implied by the data type as "data-type"', async () => {
+    const g = await load(outdent`
+      # @type=svc-token
+      TOKEN=abc
+    `, { withTypeAndResolver: true });
+    expect(g.configSchema.TOKEN.sensitiveSource).toBe('data-type');
+    expect(g.configSchema.TOKEN.internalSource).toBe('data-type');
+  });
+
+  it('reports sensitivity inferred from the resolver as "resolver"', async () => {
+    const g = await load(outdent`
+      # @defaultSensitive=false
+      # ---
+      SECRET=mysecret()
+    `, { withTypeAndResolver: true });
+    expect(g.configSchema.SECRET.isSensitive).toBe(true);
+    expect(g.configSchema.SECRET.sensitiveSource).toBe('resolver');
+  });
+
+  it('falls back to "default" sensitivity and undefined internal source', async () => {
+    const g = await load(outdent`
+      PLAIN=hello
+    `);
+    expect(g.configSchema.PLAIN.sensitiveSource).toBe('default');
+    expect(g.configSchema.PLAIN.internalSource).toBeUndefined();
+  });
+});

--- a/packages/varlock/src/env-graph/test/warning-validity.test.ts
+++ b/packages/varlock/src/env-graph/test/warning-validity.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import outdent from 'outdent';
+import { EnvGraph } from '../index';
+import { DotEnvFileDataSource } from '../lib/data-source';
+
+async function loadSchema(contents: string) {
+  const g = new EnvGraph();
+  await g.setRootDataSource(new DotEnvFileDataSource('.env.schema', { overrideContents: contents }));
+  await g.finishLoad();
+  await g.resolveEnvValues();
+  return g;
+}
+
+// A warning is advisory — it must not invalidate an item or prevent other items from
+// referencing it. `@warn` is a test-only decorator that attaches a warning to an item.
+describe('warnings do not invalidate items', () => {
+  it('a warn-state item is still valid', async () => {
+    const g = await loadSchema(outdent`
+      # @warn
+      WARNED=hello
+    `);
+    const item = g.configSchema.WARNED;
+    expect(item.validationState).toBe('warn');
+    expect(item.isValid).toBe(true);
+    expect(item.resolvedValue).toBe('hello');
+  });
+
+  it('a warn-state item can still be referenced by another item', async () => {
+    const g = await loadSchema(outdent`
+      # @warn
+      WARNED=hello
+      DEPENDENT=concat("x-", ref(WARNED))
+    `);
+    expect(g.configSchema.DEPENDENT.validationState).not.toBe('error');
+    expect(g.configSchema.DEPENDENT.resolvedValue).toBe('x-hello');
+  });
+
+  it('a real error still invalidates an item and blocks referencing', async () => {
+    const g = await loadSchema(outdent`
+      # @required
+      BROKEN=
+      DEPENDENT=concat("x-", ref(BROKEN))
+    `);
+    expect(g.configSchema.BROKEN.isValid).toBe(false);
+    expect(g.configSchema.DEPENDENT.validationState).toBe('error');
+  });
+});

--- a/packages/varlock/src/lib/formatting.ts
+++ b/packages/varlock/src/lib/formatting.ts
@@ -128,6 +128,7 @@ export function getItemSummary(item: ConfigItem) {
 
     // ansis.gray(`[type = ${item.type.typeLabel}]`),
     isSensitive && ` 🔐${ansis.gray.italic('sensitive')}`,
+    item.isInternal && ` 🔩${ansis.gray.italic('internal')}`,
     item.isDeprecated && ` 😵${ansis.yellow.dim.italic('deprecated')}`,
 
     // item.useAt ? ansis.gray.italic(`(${item.useAt?.join(', ')})`) : undefined,

--- a/smoke-tests/smoke-test-internal/.env.schema
+++ b/smoke-tests/smoke-test-internal/.env.schema
@@ -1,0 +1,5 @@
+# @defaultRequired=false
+# ---
+# @internal
+OP_TOKEN=
+PUBLIC_VAR=visible

--- a/smoke-tests/tests/cli.test.ts
+++ b/smoke-tests/tests/cli.test.ts
@@ -261,6 +261,24 @@ describe('CLI Commands', () => {
       const vars = JSON.parse(result.stdout);
       expect(vars.SHARED_VAR).toBe('from-shell-inner');
     });
+
+    test('strips @internal vars from the child env even when set ambiently', () => {
+      // child exits 0 only if OP_TOKEN is ABSENT (exit code can't be redacted, unlike stdout)
+      const result = runVarlock(['run', '--', 'node', '-e', 'process.exit(process.env.OP_TOKEN ? 1 : 0)'], {
+        cwd: 'smoke-test-internal',
+        env: { OP_TOKEN: 'secret-zero' },
+      });
+      expect(result.exitCode).toBe(0);
+    });
+
+    test('--include-internal passes @internal vars through to the child', () => {
+      // child exits 0 only if OP_TOKEN is PRESENT
+      const result = runVarlock(['run', '--include-internal', '--', 'node', '-e', 'process.exit(process.env.OP_TOKEN ? 0 : 1)'], {
+        cwd: 'smoke-test-internal',
+        env: { OP_TOKEN: 'secret-zero' },
+      });
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe('type generation', () => {


### PR DESCRIPTION
## What

Adds a new `@internal` item decorator that marks a config item as **used only by varlock — not by the application**. Internal items are still resolved and can be referenced by other items via `ref()` / `${...}`, but are excluded from everything that is **injected into the app**. `@internal` controls **injection, not visibility**:

| Surface | Internal var? |
|---|---|
| injected env vars (`run`, `load --format env`/`shell`/`json`) | excluded |
| `varlock run` child env (incl. ambiently-set value) | **stripped** (unless `--include-internal`) |
| serialized graph **blob** (`__VARLOCK_ENV`) | excluded (no name or value reaches the app) |
| generated types | excluded |
| `load` pretty summary | shown, redacted, `🔩 internal` marker |
| `load --agent` (json) | shown, redacted |
| `load --format json-full` | shown, flagged `isInternal: true` (redacted under `--agent`) |
| `varlock explain <VAR>` | shown — plus how `@internal`/`@sensitive` were determined (explicit decorator, data type, or inferred from resolver) and a "not injected" note |

`@internal` (bare) = `@internal=true`; `@internal=false` opts out. An explicit decorator always wins over a data-type default.

## Why

The motivating case is a **"secret zero"** — a credential used only to fetch _other_ secrets (e.g. a 1Password / vault token). The app never needs it, so injecting it is unnecessary attack surface.

```sh
# only used to resolve the secrets below — never injected into the app
# @internal @sensitive
OP_TOKEN=

# @sensitive
DATABASE_URL=exec(`op read "op://app/db/url"`)
```

## `varlock run --include-internal` (nested resolution)

By default `varlock run` strips internal items from the child environment — even when set ambiently (`OP_TOKEN=xxx varlock run ...`), so a secret-zero token never leaks into the app. For the **nested case** — an app/agent inside `varlock run` that itself runs varlock and needs the internal value for its own resolution — pass `--include-internal` to forward them:

```sh
OP_TOKEN=xxx varlock run --include-internal -- some-agent-that-runs-varlock
```

## Plugin data types are internal by default

Data types can now default to `@internal` via an `internal` flag (mirroring the existing `sensitive` flag). The **dedicated secrets-manager auth tokens** across plugins now set it — they authenticate varlock to fetch other secrets but are rarely needed in app code:

`opServiceAccountToken`, `opConnectToken` (1Password), `vaultToken` (HashiCorp Vault), `dopplerServiceToken`, `bitwardenAccessToken`, `bwSessionToken` (Bitwarden PM), `akeylessAccessKey`, `infisicalClientSecret`, `keeperSmToken`, `passboltAccountKit`, `dashlaneDeviceKeys`, `kdbxPassword` (KeePass), `kubernetesBearerToken`, and the Proton Pass login credentials.

**Cloud-provider credentials are intentionally _not_ internal by default** — `awsSecretKey`, `azureClientSecret`, `gcpServiceAccountJson` are commonly used directly by application SDKs, so they stay injected (still `@sensitive`). Their docs and examples still show `@internal` (the recommended posture — varlock fetches with them, the app doesn't), with `@internal=false` to opt out if your app reads them directly.

## `varlock explain` provenance

`varlock explain <VAR>` now shows whether an item is `@internal`/`@sensitive` **and how that was determined** — set explicitly, implied by the data type, inferred from the resolver (e.g. `varlock()`), from `@defaultSensitive`/a prefix rule, or the global default — plus an explicit "not injected into your app" line for internal items.

## Versioning & the breaking change

This changes injection behavior for existing plugin users: after upgrade, the now-internal tokens are no longer injected (and are stripped from the child env even if set ambiently). It's a **silent runtime change** — load/validate still succeed; an app that reads one of these credentials *directly* (writing secrets back, renewing Vault leases, fetching more at runtime) only fails when that path runs. Mitigations: it's scoped to dedicated fetch tokens (direct app use is uncommon), the high-risk cloud creds are carved out, `varlock explain` surfaces the status, and docs spell out `@internal=false` for those cases.

The break lives entirely in the plugins, so:
- **core `varlock` → minor** (purely additive — only affects items explicitly/by-type marked `@internal`)
- **the 12 affected plugin packages → major**, with a `**Breaking:**` changeset that names the `@internal=false` escape hatch

## Also fixed: warnings no longer invalidate items

A latent bug: a warn-state item (`validationState: 'warn'`) was treated as `!isValid`, so `getDepValue` rejected it — any item *referencing* a warned item failed with "Referenced item X is not valid". A warning is advisory; only a real error should invalidate. `isValid` now means `validationState !== 'error'`. The resolution scheduler already used the correct check, so this only loosens `getDepValue` + the `--show-all` "valid items" display.

## Docs

- `@internal` reference section + a caution that marking something internal silently stops injecting it (set `@internal=false` if your app reads it)
- `@sensitive` and `@internal` reference both note the property can be implied by the data type
- secret-zero examples across all plugin docs pages and READMEs show `@sensitive @internal` explicitly
- cloud-cred pages show how to opt in; `--include-internal` documented in the CLI reference

## Tests

- `internal-decorator.test.ts` — decorator, data-type default, `@internal=false` override, serialized-graph include/exclude
- `sensitivity-source.test.ts` — explain provenance (explicit / data-type / resolver-inferred / default)
- `warning-validity.test.ts` — warn-state items are valid + referenceable; real errors still invalidate
- `cli.test.ts` smoke tests — `varlock run` strips an ambiently-set internal var; `--include-internal` forwards it

Env-graph suite (505) + varlock CLI tests + all plugin typechecks green.

## Deferred follow-ups

- **Forwarding an already-resolved internal value** to a nested layer without exposing it to the app (out-of-band channel) — `getResolvedEnvObject({ includeInternal })` is the seam.
- **`varlock run` parent-side redaction** of internal values — they're excluded from the blob the redaction map builds from. Low risk (the value isn't in the child to leak).