### PR TITLE
collect anonymous plugin, integration, and package manager data

### DIFF
--- a/.bumpy/1password-telemetry-attributes.md
+++ b/.bumpy/1password-telemetry-attributes.md
@@ -1,0 +1,5 @@
+---
+"@varlock/1password-plugin": patch
+---
+
+Report anonymous, non-sensitive usage attributes (auth mode, feature flags) through varlock's opt-out telemetry.

--- a/.bumpy/1password-telemetry-attributes.md
+++ b/.bumpy/1password-telemetry-attributes.md
@@ -1,5 +1,0 @@
----
-"@varlock/1password-plugin": patch
----
-
-Report anonymous, non-sensitive usage attributes (auth mode, feature flags) through varlock's opt-out telemetry.

--- a/.bumpy/integration-build-time-defines.md
+++ b/.bumpy/integration-build-time-defines.md
@@ -1,0 +1,9 @@
+---
+"@varlock/astro-integration": none
+"@varlock/cloudflare-integration": none
+"@varlock/expo-integration": none
+"@varlock/nextjs-integration": none
+"@varlock/vite-integration": none
+---
+
+

--- a/.bumpy/plugin-telemetry-attributes.md
+++ b/.bumpy/plugin-telemetry-attributes.md
@@ -1,4 +1,5 @@
 ---
+"@varlock/1password-plugin": patch
 "@varlock/akeyless-plugin": patch
 "@varlock/aws-secrets-plugin": patch
 "@varlock/azure-key-vault-plugin": patch

--- a/.bumpy/plugin-telemetry-attributes.md
+++ b/.bumpy/plugin-telemetry-attributes.md
@@ -1,0 +1,19 @@
+---
+"@varlock/akeyless-plugin": patch
+"@varlock/aws-secrets-plugin": patch
+"@varlock/azure-key-vault-plugin": patch
+"@varlock/bitwarden-plugin": patch
+"@varlock/dashlane-plugin": patch
+"@varlock/doppler-plugin": patch
+"@varlock/google-secret-manager-plugin": patch
+"@varlock/hashicorp-vault-plugin": patch
+"@varlock/infisical-plugin": patch
+"@varlock/keepass-plugin": patch
+"@varlock/keeper-plugin": patch
+"@varlock/kubernetes-plugin": patch
+"@varlock/pass-plugin": patch
+"@varlock/passbolt-plugin": patch
+"@varlock/proton-pass-plugin": patch
+---
+
+Report anonymous, non-sensitive usage attributes (auth mode, feature flags) through varlock's opt-out telemetry.

--- a/.bumpy/telemetry-usage-context.md
+++ b/.bumpy/telemetry-usage-context.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+Enrich CLI telemetry with plugin, integration, and schema feature context.

--- a/packages/integrations/astro/src/globals.d.ts
+++ b/packages/integrations/astro/src/globals.d.ts
@@ -1,0 +1,3 @@
+// injected as static defines at build time (see tsup.config.ts) — sourced from this package's package.json
+declare const __VARLOCK_INTEGRATION_NAME__: string;
+declare const __VARLOCK_INTEGRATION_VERSION__: string;

--- a/packages/integrations/astro/src/index.ts
+++ b/packages/integrations/astro/src/index.ts
@@ -4,7 +4,6 @@ import { createDebug } from 'varlock';
 import { scanForLeaks, varlockSettings } from 'varlock/env';
 import { varlockVitePlugin } from '@varlock/vite-integration';
 import type { AstroIntegration } from 'astro';
-import packageJson from '../package.json';
 
 const debug = createDebug('varlock:astro-integration');
 
@@ -82,8 +81,8 @@ function varlockAstroIntegration(
           varlockVitePlugin({
             ...vitePluginOptions,
             integrationTelemetry: integrationOptions?.integrationTelemetry ?? {
-              name: packageJson.name,
-              version: packageJson.version,
+              name: __VARLOCK_INTEGRATION_NAME__,
+              version: __VARLOCK_INTEGRATION_VERSION__,
             },
           }) as any,
         );

--- a/packages/integrations/astro/src/index.ts
+++ b/packages/integrations/astro/src/index.ts
@@ -4,6 +4,7 @@ import { createDebug } from 'varlock';
 import { scanForLeaks, varlockSettings } from 'varlock/env';
 import { varlockVitePlugin } from '@varlock/vite-integration';
 import type { AstroIntegration } from 'astro';
+import packageJson from '../package.json';
 
 const debug = createDebug('varlock:astro-integration');
 
@@ -78,7 +79,13 @@ function varlockAstroIntegration(
 
         opts.config.vite.plugins ||= [];
         opts.config.vite?.plugins?.push(
-          varlockVitePlugin(vitePluginOptions) as any,
+          varlockVitePlugin({
+            ...vitePluginOptions,
+            integrationTelemetry: integrationOptions?.integrationTelemetry ?? {
+              name: packageJson.name,
+              version: packageJson.version,
+            },
+          }) as any,
         );
       },
 

--- a/packages/integrations/astro/tsup.config.ts
+++ b/packages/integrations/astro/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'tsup';
+import pkg from './package.json';
 
 export default defineConfig({
   entry: [ // Entry point(s)
@@ -7,6 +8,13 @@ export default defineConfig({
   ],
 
   external: ['@varlock/cloudflare-integration/ssr-entry-code'],
+
+  // package name + version baked in as static defines so we don't import package.json into the bundle
+  esbuildOptions(options) {
+    options.define ||= {};
+    options.define.__VARLOCK_INTEGRATION_NAME__ = JSON.stringify(pkg.name);
+    options.define.__VARLOCK_INTEGRATION_VERSION__ = JSON.stringify(pkg.version);
+  },
 
   dts: true,
 

--- a/packages/integrations/cloudflare/src/globals.d.ts
+++ b/packages/integrations/cloudflare/src/globals.d.ts
@@ -1,0 +1,3 @@
+// injected as static defines at build time (see tsup.config.ts) — sourced from this package's package.json
+declare const __VARLOCK_INTEGRATION_NAME__: string;
+declare const __VARLOCK_INTEGRATION_VERSION__: string;

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -9,7 +9,6 @@ import {
 import { cloudflare, type PluginConfig, type WorkerConfig } from '@cloudflare/vite-plugin';
 import { CLOUDFLARE_SSR_ENTRY_CODE, disableWranglerDotEnvAutoload, logVarlockEnvInjectionNotice } from './shared-ssr-entry-code';
 import { encryptEnvBlobSync, generateEncryptionKeyHex } from 'varlock/encrypt-env';
-import packageJson from '../package.json';
 
 const isWindows = process.platform === 'win32';
 
@@ -310,8 +309,8 @@ export function varlockCloudflareVitePlugin(
     ssrEntryModuleIds: ['\0virtual:cloudflare/worker-entry'],
     ssrEntryCode: [CLOUDFLARE_SSR_ENTRY_CODE],
     integrationTelemetry: {
-      name: packageJson.name,
-      version: packageJson.version,
+      name: __VARLOCK_INTEGRATION_NAME__,
+      version: __VARLOCK_INTEGRATION_VERSION__,
     },
   });
 

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -9,6 +9,7 @@ import {
 import { cloudflare, type PluginConfig, type WorkerConfig } from '@cloudflare/vite-plugin';
 import { CLOUDFLARE_SSR_ENTRY_CODE, disableWranglerDotEnvAutoload, logVarlockEnvInjectionNotice } from './shared-ssr-entry-code';
 import { encryptEnvBlobSync, generateEncryptionKeyHex } from 'varlock/encrypt-env';
+import packageJson from '../package.json';
 
 const isWindows = process.platform === 'win32';
 
@@ -308,6 +309,10 @@ export function varlockCloudflareVitePlugin(
     ssrEdgeRuntime: true,
     ssrEntryModuleIds: ['\0virtual:cloudflare/worker-entry'],
     ssrEntryCode: [CLOUDFLARE_SSR_ENTRY_CODE],
+    integrationTelemetry: {
+      name: packageJson.name,
+      version: packageJson.version,
+    },
   });
 
   const cloudflarePlugin = cloudflare({

--- a/packages/integrations/cloudflare/src/varlock-wrangler.ts
+++ b/packages/integrations/cloudflare/src/varlock-wrangler.ts
@@ -10,7 +10,6 @@ import { spawn, execSync } from 'node:child_process';
 
 import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 import { encryptEnvBlobSync, generateEncryptionKeyHex } from 'varlock/encrypt-env';
-import packageJson from '../package.json';
 
 const isWindows = process.platform === 'win32';
 const debugEnabled = !!process.env.VARLOCK_DEBUG;
@@ -53,8 +52,8 @@ function loadSerializedGraph() {
   const { stdout } = execSyncVarlock('load --format json-full --compact', {
     fullResult: true,
     integrationTelemetry: {
-      name: packageJson.name,
-      version: packageJson.version,
+      name: __VARLOCK_INTEGRATION_NAME__,
+      version: __VARLOCK_INTEGRATION_VERSION__,
     },
   });
   return {

--- a/packages/integrations/cloudflare/src/varlock-wrangler.ts
+++ b/packages/integrations/cloudflare/src/varlock-wrangler.ts
@@ -10,6 +10,7 @@ import { spawn, execSync } from 'node:child_process';
 
 import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 import { encryptEnvBlobSync, generateEncryptionKeyHex } from 'varlock/encrypt-env';
+import packageJson from '../package.json';
 
 const isWindows = process.platform === 'win32';
 const debugEnabled = !!process.env.VARLOCK_DEBUG;
@@ -49,7 +50,13 @@ function spawnWrangler(args: Array<string>): Promise<number> {
 }
 
 function loadSerializedGraph() {
-  const { stdout } = execSyncVarlock('load --format json-full --compact', { fullResult: true });
+  const { stdout } = execSyncVarlock('load --format json-full --compact', {
+    fullResult: true,
+    integrationTelemetry: {
+      name: packageJson.name,
+      version: packageJson.version,
+    },
+  });
   return {
     json: stdout,
     graph: JSON.parse(stdout) as {

--- a/packages/integrations/cloudflare/tsup.config.ts
+++ b/packages/integrations/cloudflare/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'tsup';
+import pkg from './package.json';
 
 export default defineConfig({
   entry: [
@@ -8,6 +9,13 @@ export default defineConfig({
     'src/varlock-wrangler.ts',
     'src/shared-ssr-entry-code.ts',
   ],
+
+  // package name + version baked in as static defines so we don't import package.json into the bundle
+  esbuildOptions(options) {
+    options.define ||= {};
+    options.define.__VARLOCK_INTEGRATION_NAME__ = JSON.stringify(pkg.name);
+    options.define.__VARLOCK_INTEGRATION_VERSION__ = JSON.stringify(pkg.version);
+  },
 
   // cloudflare:workers is a runtime-only module (workerd/miniflare)
   // @cloudflare/vite-plugin is a peer dep, don't bundle it

--- a/packages/integrations/expo/src/babel-plugin.ts
+++ b/packages/integrations/expo/src/babel-plugin.ts
@@ -2,7 +2,6 @@ import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 import { initVarlockEnv } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
 import { createDebug, type SerializedEnvGraph } from 'varlock';
-import packageJson from '../package.json';
 
 const debug = createDebug('varlock:expo-integration');
 
@@ -19,8 +18,8 @@ function loadVarlockConfig() {
       fullResult: true,
       env: originalProcessEnv,
       integrationTelemetry: {
-        name: packageJson.name,
-        version: packageJson.version,
+        name: __VARLOCK_INTEGRATION_NAME__,
+        version: __VARLOCK_INTEGRATION_VERSION__,
       },
     });
     process.env.__VARLOCK_ENV = stdout;

--- a/packages/integrations/expo/src/babel-plugin.ts
+++ b/packages/integrations/expo/src/babel-plugin.ts
@@ -2,6 +2,7 @@ import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 import { initVarlockEnv } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
 import { createDebug, type SerializedEnvGraph } from 'varlock';
+import packageJson from '../package.json';
 
 const debug = createDebug('varlock:expo-integration');
 
@@ -17,6 +18,10 @@ function loadVarlockConfig() {
     const { stdout } = execSyncVarlock('load --format json-full', {
       fullResult: true,
       env: originalProcessEnv,
+      integrationTelemetry: {
+        name: packageJson.name,
+        version: packageJson.version,
+      },
     });
     process.env.__VARLOCK_ENV = stdout;
     varlockLoadedEnv = JSON.parse(stdout) as SerializedEnvGraph;

--- a/packages/integrations/expo/src/globals.d.ts
+++ b/packages/integrations/expo/src/globals.d.ts
@@ -1,0 +1,3 @@
+// injected as static defines at build time (see tsup.config.ts) — sourced from this package's package.json
+declare const __VARLOCK_INTEGRATION_NAME__: string;
+declare const __VARLOCK_INTEGRATION_VERSION__: string;

--- a/packages/integrations/expo/src/metro-config.ts
+++ b/packages/integrations/expo/src/metro-config.ts
@@ -3,7 +3,6 @@ import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 import { initVarlockEnv } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
 import type { SerializedEnvGraph } from 'varlock';
-import packageJson from '../package.json';
 
 const VARLOCK_SUBPATHS = [
   'varlock/env',
@@ -80,8 +79,8 @@ export function withVarlockMetroConfig<T extends Record<string, any>>(config: T)
     const { stdout } = execSyncVarlock('load --format json-full', {
       fullResult: true,
       integrationTelemetry: {
-        name: packageJson.name,
-        version: packageJson.version,
+        name: __VARLOCK_INTEGRATION_NAME__,
+        version: __VARLOCK_INTEGRATION_VERSION__,
       },
     });
     process.env.__VARLOCK_ENV = stdout;

--- a/packages/integrations/expo/src/metro-config.ts
+++ b/packages/integrations/expo/src/metro-config.ts
@@ -3,6 +3,7 @@ import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 import { initVarlockEnv } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
 import type { SerializedEnvGraph } from 'varlock';
+import packageJson from '../package.json';
 
 const VARLOCK_SUBPATHS = [
   'varlock/env',
@@ -76,7 +77,13 @@ export function withVarlockMetroConfig<T extends Record<string, any>>(config: T)
   if (process.env.__VARLOCK_ENV) return config;
 
   try {
-    const { stdout } = execSyncVarlock('load --format json-full', { fullResult: true });
+    const { stdout } = execSyncVarlock('load --format json-full', {
+      fullResult: true,
+      integrationTelemetry: {
+        name: packageJson.name,
+        version: packageJson.version,
+      },
+    });
     process.env.__VARLOCK_ENV = stdout;
 
     const parsed = JSON.parse(stdout) as SerializedEnvGraph;

--- a/packages/integrations/expo/test/metro-config.test.ts
+++ b/packages/integrations/expo/test/metro-config.test.ts
@@ -22,6 +22,7 @@ vi.mock('varlock/patch-console', () => ({
 }));
 
 import { withVarlockMetroConfig } from '../src/metro-config';
+import packageJson from '../package.json';
 
 const FAKE_ENV_GRAPH = {
   basePath: '/tmp',
@@ -61,7 +62,13 @@ describe('withVarlockMetroConfig', () => {
   it('calls execSyncVarlock to load config', () => {
     withVarlockMetroConfig({});
     expect(mockExecSyncVarlock).toHaveBeenCalledOnce();
-    expect(mockExecSyncVarlock).toHaveBeenCalledWith('load --format json-full', { fullResult: true });
+    expect(mockExecSyncVarlock).toHaveBeenCalledWith('load --format json-full', {
+      fullResult: true,
+      integrationTelemetry: {
+        name: packageJson.name,
+        version: packageJson.version,
+      },
+    });
   });
 
   it('sets process.env.__VARLOCK_ENV with the JSON result', () => {

--- a/packages/integrations/expo/tsup.config.ts
+++ b/packages/integrations/expo/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'tsup';
+import pkg from './package.json';
 
 export default defineConfig({
   entry: ['src/babel-plugin.ts', 'src/metro-config.ts'],
@@ -10,4 +11,11 @@ export default defineConfig({
   // Output both CJS (for older Babel/Metro setups) and ESM
   format: ['esm', 'cjs'],
   splitting: false,
+
+  // package name + version baked in as static defines so we don't import package.json into the bundle
+  esbuildOptions(options) {
+    options.define ||= {};
+    options.define.__VARLOCK_INTEGRATION_NAME__ = JSON.stringify(pkg.name);
+    options.define.__VARLOCK_INTEGRATION_VERSION__ = JSON.stringify(pkg.version);
+  },
 });

--- a/packages/integrations/expo/vitest.config.ts
+++ b/packages/integrations/expo/vitest.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import pkg from './package.json';
 
 export default defineConfig({
   test: {
     name: '@varlock/expo-integration',
+  },
+  define: {
+    __VARLOCK_INTEGRATION_NAME__: JSON.stringify(pkg.name),
+    __VARLOCK_INTEGRATION_VERSION__: JSON.stringify(pkg.version),
   },
 });

--- a/packages/integrations/nextjs/src/globals.d.ts
+++ b/packages/integrations/nextjs/src/globals.d.ts
@@ -1,0 +1,3 @@
+// injected as static defines at build time (see tsup.config.ts) — sourced from this package's package.json
+declare const __VARLOCK_INTEGRATION_NAME__: string;
+declare const __VARLOCK_INTEGRATION_VERSION__: string;

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -12,6 +12,7 @@ import { type SerializedEnvGraph } from 'varlock';
 import { initVarlockEnv, resetRedactionMap } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
 import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
+import packageJson from '../package.json';
 
 export type Env = { [key: string]: string | undefined };
 export type LoadedEnvFiles = Array<{
@@ -531,6 +532,10 @@ export function loadEnvConfig(
     const { stdout } = execSyncVarlock(`load --format json-full --env ${envFromNextCommand}`, {
       fullResult: true,
       env: cleanEnv as any,
+      integrationTelemetry: {
+        name: packageJson.name,
+        version: packageJson.version,
+      },
     });
     if (loadCount >= 2 && forceReload) {
       const envChanged = stdout !== previousSerializedEnv;

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -12,7 +12,6 @@ import { type SerializedEnvGraph } from 'varlock';
 import { initVarlockEnv, resetRedactionMap } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
 import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
-import packageJson from '../package.json';
 
 export type Env = { [key: string]: string | undefined };
 export type LoadedEnvFiles = Array<{
@@ -533,8 +532,8 @@ export function loadEnvConfig(
       fullResult: true,
       env: cleanEnv as any,
       integrationTelemetry: {
-        name: packageJson.name,
-        version: packageJson.version,
+        name: __VARLOCK_INTEGRATION_NAME__,
+        version: __VARLOCK_INTEGRATION_VERSION__,
       },
     });
     if (loadCount >= 2 && forceReload) {

--- a/packages/integrations/nextjs/tsup.config.ts
+++ b/packages/integrations/nextjs/tsup.config.ts
@@ -1,4 +1,12 @@
 import { defineConfig } from 'tsup';
+import pkg from './package.json';
+
+// package name + version baked in as static defines so we don't import package.json into the bundle
+function defineIntegrationIdentity(options: { define?: Record<string, string> }) {
+  options.define ||= {};
+  options.define.__VARLOCK_INTEGRATION_NAME__ = JSON.stringify(pkg.name);
+  options.define.__VARLOCK_INTEGRATION_VERSION__ = JSON.stringify(pkg.version);
+}
 
 export default defineConfig([
   // next-env-compat is the @next/env replacement and runs at both build time AND runtime.
@@ -21,6 +29,8 @@ export default defineConfig([
     // ! we are exporting cjs to match @next/env
     format: ['cjs'],
     splitting: false,
+
+    esbuildOptions: defineIntegrationIdentity,
   },
   // Other entry points only run at build time where varlock is always available.
   {

--- a/packages/integrations/vite/src/globals.d.ts
+++ b/packages/integrations/vite/src/globals.d.ts
@@ -1,0 +1,3 @@
+// injected as static defines at build time (see tsup.config.ts) — sourced from this package's package.json
+declare const __VARLOCK_INTEGRATION_NAME__: string;
+declare const __VARLOCK_INTEGRATION_VERSION__: string;

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -15,7 +15,6 @@ import { encryptEnvBlobSync, generateEncryptionKeyHex } from 'varlock/encrypt-en
 import { createReplacerTransformFn, SUPPORTED_FILES } from './transform';
 
 import { ansiToHtml } from './ansi-to-html';
-import packageJson from '../package.json';
 export { ansiToHtml };
 
 export function buildErrorPageHtml(ansiError?: string): string {
@@ -78,8 +77,8 @@ function resetStaticReplacements() {
 
 let loadCount = 0;
 let activeIntegrationTelemetry = {
-  name: packageJson.name,
-  version: packageJson.version,
+  name: __VARLOCK_INTEGRATION_NAME__,
+  version: __VARLOCK_INTEGRATION_VERSION__,
 };
 
 function reloadConfig(cwd?: string) {

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -15,6 +15,7 @@ import { encryptEnvBlobSync, generateEncryptionKeyHex } from 'varlock/encrypt-en
 import { createReplacerTransformFn, SUPPORTED_FILES } from './transform';
 
 import { ansiToHtml } from './ansi-to-html';
+import packageJson from '../package.json';
 export { ansiToHtml };
 
 export function buildErrorPageHtml(ansiError?: string): string {
@@ -76,12 +77,18 @@ function resetStaticReplacements() {
 
 
 let loadCount = 0;
+let activeIntegrationTelemetry = {
+  name: packageJson.name,
+  version: packageJson.version,
+};
+
 function reloadConfig(cwd?: string) {
   debug('loading config - count =', ++loadCount, cwd ? `(cwd: ${cwd})` : '');
   try {
     const { stdout } = execSyncVarlock('load --format json-full --compact', {
       fullResult: true,
       env: originalProcessEnv,
+      integrationTelemetry: activeIntegrationTelemetry,
       ...(cwd && { cwd }),
     });
     process.env.__VARLOCK_ENV = stdout;
@@ -143,6 +150,8 @@ export interface VarlockVitePluginOptions {
   ssrEdgeRuntime?: boolean,
   /** additional virtual module IDs to treat as entry points (e.g., '\0virtual:cloudflare/worker-entry') */
   ssrEntryModuleIds?: Array<string>,
+  /** override integration identity for CLI telemetry (used by composed integrations like Astro) */
+  integrationTelemetry?: { name: string, version: string },
 }
 
 // Return type is `any` instead of `Plugin` to avoid symlink type conflicts.
@@ -155,6 +164,14 @@ const VARLOCK_INIT_MODULE_ID = '\0varlock-ssr-init';
 export function varlockVitePlugin(
   vitePluginOptions?: VarlockVitePluginOptions,
 ): any {
+  if (vitePluginOptions?.integrationTelemetry) {
+    const prevName = activeIntegrationTelemetry.name;
+    activeIntegrationTelemetry = vitePluginOptions.integrationTelemetry;
+    if (prevName !== activeIntegrationTelemetry.name) {
+      reloadConfig();
+    }
+  }
+
   // Build the virtual init module content once. This module is imported
   // by SSR entry points and evaluates before any user code because it
   // has no transitive dependencies on user modules.

--- a/packages/integrations/vite/tsup.config.ts
+++ b/packages/integrations/vite/tsup.config.ts
@@ -1,9 +1,17 @@
 import { defineConfig } from 'tsup';
+import pkg from './package.json';
 
 export default defineConfig({
   entry: [ // Entry point(s)
     'src/index.ts',
   ],
+
+  // package name + version baked in as static defines so we don't import package.json into the bundle
+  esbuildOptions(options) {
+    options.define ||= {};
+    options.define.__VARLOCK_INTEGRATION_NAME__ = JSON.stringify(pkg.name);
+    options.define.__VARLOCK_INTEGRATION_VERSION__ = JSON.stringify(pkg.version);
+  },
 
   dts: true,
 

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -1061,12 +1061,14 @@ plugin.registerTelemetryAttributes(() => {
   const instances = Object.values(pluginInstances);
   const authModes = new Set(instances.map((i) => i.telemetryAuthMode));
   return {
+    // standard attributes
     instance_count: instances.length,
+    cache_enabled: instances.some((i) => i.telemetryUsesCache),
+    // custom attributes
     auth_app: authModes.has('app'),
     auth_service_account_sdk: authModes.has('service_account_sdk'),
     auth_service_account_cli: authModes.has('service_account_cli'),
     auth_connect: authModes.has('connect'),
     uses_environments: usedEnvironments,
-    uses_cache: instances.some((i) => i.telemetryUsesCache),
   };
 });

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -326,6 +326,17 @@ class OpPluginInstance {
   /** Whether this instance is configured for Connect server */
   get isConnect() { return !!(this.connectHost && this.connectToken); }
 
+  /** @internal telemetry: which auth path this instance is configured for */
+  get telemetryAuthMode(): 'connect' | 'service_account_cli' | 'service_account_sdk' | 'app' | 'none' {
+    if (this.isConnect) return 'connect';
+    if (this.token) return this.useCliWithServiceAccount ? 'service_account_cli' : 'service_account_sdk';
+    if (this.allowAppAuth) return 'app';
+    return 'none';
+  }
+
+  /** @internal telemetry: whether this instance has a cache TTL configured */
+  get telemetryUsesCache() { return this.cacheTtl != null; }
+
   opClientPromise: Promise<Client> | undefined;
   async initSdkClient() {
     if (!this.token) return;
@@ -749,6 +760,9 @@ class OpPluginInstance {
 }
 const pluginInstances: Record<string, OpPluginInstance> = {};
 
+/** @internal telemetry: set when the schema uses the opLoadEnvironment resolver */
+let usedEnvironments = false;
+
 /** Returns true if the error represents a missing 1Password item/field/vault */
 function isNotFoundError(err: any): boolean {
   const code = err?.code;
@@ -979,6 +993,7 @@ plugin.registerResolverFunction({
     arrayMaxLength: 2,
   },
   process() {
+    usedEnvironments = true;
     let instanceId = '_default';
     let environmentIdResolver: Resolver | undefined;
 
@@ -1038,4 +1053,20 @@ plugin.registerResolverFunction({
 
     return await selectedInstance.readEnvironment(environmentId);
   },
+});
+
+// Anonymous, non-sensitive usage signals — which auth path(s) and features are in use.
+// Strictly sanitized before send (booleans / counts only here); no item refs, accounts, or hosts.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  const authModes = new Set(instances.map((i) => i.telemetryAuthMode));
+  return {
+    instance_count: instances.length,
+    auth_app: authModes.has('app'),
+    auth_service_account_sdk: authModes.has('service_account_sdk'),
+    auth_service_account_cli: authModes.has('service_account_cli'),
+    auth_connect: authModes.has('connect'),
+    uses_environments: usedEnvironments,
+    uses_cache: instances.some((i) => i.telemetryUsesCache),
+  };
 });

--- a/packages/plugins/akeyless/src/plugin.ts
+++ b/packages/plugins/akeyless/src/plugin.ts
@@ -102,6 +102,16 @@ class AkeylessPluginInstance {
     );
   }
 
+  /** @internal telemetry: which auth method this instance is configured for (fixed enum, no user input) */
+  get telemetryAuthMethod(): 'api_key' | 'oidc' | 'none' {
+    if (this.accessId && this.accessKey) return 'api_key';
+    if (this.oidcAccessId) return 'oidc';
+    return 'none';
+  }
+
+  /** @internal telemetry: whether this instance targets a self-hosted gateway (non-default API URL) */
+  get telemetrySelfHosted() { return this.apiUrl !== DEFAULT_API_URL; }
+
   private _cacheKeyIdentity?: string;
   /** short hash identifying which Akeyless gateway/account is being read, used to namespace cache keys */
   get cacheKeyIdentity() {
@@ -363,6 +373,9 @@ class AkeylessPluginInstance {
 
 const pluginInstances: Record<string, AkeylessPluginInstance> = {};
 
+/** @internal telemetry: which secret types have been referenced by the schema (fixed enum keys) */
+const usedSecretTypes = { static: false, dynamic: false, rotated: false };
+
 plugin.registerRootDecorator({
   name: 'initAkeyless',
   description: 'Initialize an Akeyless plugin instance for akeyless() resolver',
@@ -547,6 +560,8 @@ plugin.registerResolverFunction({
       }
     }
 
+    usedSecretTypes[secretType] = true;
+
     return {
       instanceId, secretNameResolver, itemKey, keyResolver, secretType,
     };
@@ -620,4 +635,22 @@ plugin.registerResolverFunction({
 
     return await selectedInstance.getStaticSecret(finalSecretName, jsonKey);
   },
+});
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  const authMethods = new Set(instances.map((i) => i.telemetryAuthMethod));
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    cache_enabled: instances.some((i) => i.cacheTtl != null),
+    // custom attributes
+    auth_api_key: authMethods.has('api_key'),
+    auth_oidc: authMethods.has('oidc'),
+    self_hosted: instances.some((i) => i.telemetrySelfHosted),
+    uses_static_secrets: usedSecretTypes.static,
+    uses_dynamic_secrets: usedSecretTypes.dynamic,
+    uses_rotated_secrets: usedSecretTypes.rotated,
+  };
 });

--- a/packages/plugins/aws-secrets/src/plugin.ts
+++ b/packages/plugins/aws-secrets/src/plugin.ts
@@ -79,6 +79,17 @@ class AwsPluginInstance {
   ) {
   }
 
+  /**
+   * @internal telemetry: which credential source this instance is configured for (fixed enum, no user input).
+   * Mirrors the precedence in getCredentials(): explicit keys > OIDC role > named profile > default chain.
+   */
+  get telemetryAuthMethod(): 'access_key' | 'oidc' | 'profile' | 'default_chain' {
+    if (this.accessKeyId && this.secretAccessKey) return 'access_key';
+    if (this.oidcRoleArn) return 'oidc';
+    if (this.profile) return 'profile';
+    return 'default_chain';
+  }
+
   private _cacheKeyIdentity?: string;
   /** short hash identifying which AWS account/region is being read, used to namespace cache keys */
   get cacheKeyIdentity() {
@@ -493,6 +504,10 @@ class AwsPluginInstance {
 
 const pluginInstances: Record<string, AwsPluginInstance> = {};
 
+/** @internal telemetry: which AWS services the schema references */
+let usedSecretsManager = false;
+let usedParameterStore = false;
+
 plugin.registerRootDecorator({
   name: 'initAws',
   description: 'Initialize an AWS plugin instance for awsSecret() and awsParam() resolvers',
@@ -620,6 +635,7 @@ plugin.registerResolverFunction({
     arrayMinLength: 0,
   },
   process() {
+    usedSecretsManager = true;
     let instanceId: string;
     let secretIdResolver: Resolver | undefined;
     let inferredSecretName: string | undefined;
@@ -755,6 +771,7 @@ plugin.registerResolverFunction({
     arrayMinLength: 0,
   },
   process() {
+    usedParameterStore = true;
     let instanceId: string;
     let parameterNameResolver: Resolver | undefined;
     let inferredParamName: string | undefined;
@@ -879,4 +896,22 @@ plugin.registerResolverFunction({
     const parameterValue = await selectedInstance.getParameter(finalParameterName, jsonKey);
     return parameterValue;
   },
+});
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  const authMethods = new Set(instances.map((i) => i.telemetryAuthMethod));
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    cache_enabled: instances.some((i) => i.cacheTtl != null),
+    // custom attributes
+    auth_access_key: authMethods.has('access_key'),
+    auth_oidc: authMethods.has('oidc'),
+    auth_profile: authMethods.has('profile'),
+    auth_default_chain: authMethods.has('default_chain'),
+    uses_secrets_manager: usedSecretsManager,
+    uses_parameter_store: usedParameterStore,
+  };
 });

--- a/packages/plugins/azure-key-vault/src/plugin.ts
+++ b/packages/plugins/azure-key-vault/src/plugin.ts
@@ -88,6 +88,17 @@ class AzurePluginInstance {
     );
   }
 
+  /**
+   * @internal telemetry: which auth method this instance is *configured* for (fixed enum, no user input).
+   * 'ambient' means no explicit credentials were configured, so auth falls back to the runtime
+   * chain (Managed Identity / Azure CLI) determined at resolve time.
+   */
+  get telemetryAuthMethod(): 'service_principal' | 'oidc_federated' | 'ambient' {
+    if (this.tenantId && this.clientId && this.clientSecret) return 'service_principal';
+    if (this.tenantId && this.clientId) return 'oidc_federated';
+    return 'ambient';
+  }
+
   private _cacheKeyIdentity?: string;
   /** short hash identifying which Key Vault is being read, used to namespace cache keys */
   get cacheKeyIdentity() {
@@ -757,4 +768,19 @@ plugin.registerResolverFunction({
     const secretValue = await selectedInstance.getSecret(secretRef, jsonKey);
     return secretValue;
   },
+});
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  const authMethods = new Set(instances.map((i) => i.telemetryAuthMethod));
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    cache_enabled: instances.some((i) => i.cacheTtl != null),
+    // custom attributes
+    auth_service_principal: authMethods.has('service_principal'),
+    auth_oidc_federated: authMethods.has('oidc_federated'),
+    auth_ambient: authMethods.has('ambient'),
+  };
 });

--- a/packages/plugins/bitwarden/src/plugin.ts
+++ b/packages/plugins/bitwarden/src/plugin.ts
@@ -17,6 +17,9 @@ const { ValidationError, SchemaError, ResolutionError } = plugin.ERRORS;
 
 const BITWARDEN_ICON = 'simple-icons:bitwarden';
 
+const BITWARDEN_CLOUD_API_URL = 'https://api.bitwarden.com';
+const BITWARDEN_CLOUD_IDENTITY_URL = 'https://identity.bitwarden.com';
+
 plugin.name = 'bitwarden';
 const { debug } = plugin;
 debug('init - version =', plugin.version);
@@ -65,9 +68,9 @@ class BitwardenPluginInstance {
   /** Access token for Bitwarden Secrets Manager machine account */
   private accessToken?: string;
   /** API URL - defaults to https://api.bitwarden.com */
-  private apiUrl: string = 'https://api.bitwarden.com';
+  private apiUrl: string = BITWARDEN_CLOUD_API_URL;
   /** Identity URL - defaults to https://identity.bitwarden.com */
-  private identityUrl: string = 'https://identity.bitwarden.com';
+  private identityUrl: string = BITWARDEN_CLOUD_IDENTITY_URL;
   /** Cached authentication */
   private cachedAuth?: CachedAuth;
   /** In-flight auth promise - prevents parallel resolution from triggering multiple auth requests (rate limit fix) */
@@ -104,6 +107,11 @@ class BitwardenPluginInstance {
       this.identityUrl = identityUrl;
     }
     debug('bitwarden instance', this.id, 'set auth - apiUrl:', this.apiUrl);
+  }
+
+  /** @internal telemetry: whether a self-hosted server is configured (boolean only, never the URL) */
+  get telemetryUsesSelfHostedServer() {
+    return this.apiUrl !== BITWARDEN_CLOUD_API_URL || this.identityUrl !== BITWARDEN_CLOUD_IDENTITY_URL;
   }
 
   /**
@@ -949,4 +957,20 @@ plugin.registerResolverFunction({
 
     return await selectedInstance.getSecret(itemQuery, field);
   },
+});
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+plugin.registerTelemetryAttributes(() => {
+  const smInstances = Object.values(pluginInstances);
+  const pmInstances = Object.values(bwpPluginInstances);
+  const instances = [...smInstances, ...pmInstances];
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    cache_enabled: instances.some((i) => i.cacheTtl != null),
+    // custom attributes
+    uses_secrets_manager: smInstances.length > 0,
+    uses_password_manager: pmInstances.length > 0,
+    self_hosted_server: smInstances.some((i) => i.telemetryUsesSelfHostedServer),
+  };
 });

--- a/packages/plugins/dashlane/src/dashlane-instance.ts
+++ b/packages/plugins/dashlane/src/dashlane-instance.ts
@@ -30,6 +30,12 @@ export class DashlanePluginInstance {
     this.lockAfter = opts?.lockOnExit ?? !!serviceDeviceKeys;
   }
 
+  /** @internal telemetry: whether this instance auto-syncs the vault before reads */
+  get telemetryAutoSync() { return this.autoSync; }
+
+  /** @internal telemetry: whether this instance locks the vault on process exit */
+  get telemetryLockOnExit() { return this.lockAfter; }
+
   private get spawnEnv(): Record<string, string> | undefined {
     if (!this.serviceDeviceKeys) return undefined;
     return {

--- a/packages/plugins/dashlane/src/plugin.ts
+++ b/packages/plugins/dashlane/src/plugin.ts
@@ -91,3 +91,15 @@ plugin.registerDataType({
     if (error) throw new ValidationError(error);
   },
 });
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(manager.instances);
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    // custom attributes
+    auto_sync: instances.some((i) => i.telemetryAutoSync),
+    lock_on_exit: instances.some((i) => i.telemetryLockOnExit),
+  };
+});

--- a/packages/plugins/doppler/src/plugin.ts
+++ b/packages/plugins/doppler/src/plugin.ts
@@ -455,3 +455,13 @@ plugin.registerResolverFunction({
     return await selectedInstance.listSecrets();
   },
 });
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    cache_enabled: instances.some((i) => i.cacheTtl != null),
+  };
+});

--- a/packages/plugins/google-secret-manager/src/plugin.ts
+++ b/packages/plugins/google-secret-manager/src/plugin.ts
@@ -69,6 +69,13 @@ class GsmPluginInstance {
     );
   }
 
+  /** @internal telemetry: which auth path this instance is configured for (fixed enum, never raw config) */
+  get telemetryAuthMode(): 'service_account' | 'workload_identity' | 'adc' {
+    if (this.credentials) return 'service_account';
+    if (this.workloadIdentityProvider) return 'workload_identity';
+    return 'adc';
+  }
+
   private authClientPromise: Promise<GoogleAuth> | undefined;
   async initClient() {
     if (this.authClientPromise) return this.authClientPromise;
@@ -454,4 +461,19 @@ plugin.registerResolverFunction({
 
     return await selectedInstance.readSecret(secretRef);
   },
+});
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  const authModes = new Set(instances.map((i) => i.telemetryAuthMode));
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    cache_enabled: instances.some((i) => i.cacheTtl != null),
+    // custom attributes
+    auth_service_account: authModes.has('service_account'),
+    auth_workload_identity: authModes.has('workload_identity'),
+    auth_adc: authModes.has('adc'),
+  };
 });

--- a/packages/plugins/hashicorp-vault/src/plugin.ts
+++ b/packages/plugins/hashicorp-vault/src/plugin.ts
@@ -281,6 +281,17 @@ class VaultPluginInstance {
     }
   }
 
+  /** @internal telemetry: which auth method this instance is configured for (fixed enum, never raw values) */
+  get telemetryAuthMethod(): 'token' | 'approle' | 'jwt' | 'cli_file' {
+    if (this.token) return 'token';
+    if (this.roleId && this.secretId) return 'approle';
+    if (this.jwtRole) return 'jwt';
+    return 'cli_file';
+  }
+
+  /** @internal telemetry: whether a namespace is configured (HCP/enterprise vs OSS) — boolean only, never the namespace string */
+  get telemetryUsesNamespace() { return this.namespace != null; }
+
   buildPath(explicitPath?: string): string {
     let basePath: string;
     if (explicitPath) {
@@ -699,4 +710,21 @@ plugin.registerResolverFunction({
 
     return await selectedInstance.getSecret(fullPath, jsonKey);
   },
+});
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  const authMethods = new Set(instances.map((i) => i.telemetryAuthMethod));
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    cache_enabled: instances.some((i) => i.cacheTtl != null),
+    // custom attributes
+    auth_token: authMethods.has('token'),
+    auth_approle: authMethods.has('approle'),
+    auth_jwt: authMethods.has('jwt'),
+    auth_cli_file: authMethods.has('cli_file'),
+    uses_namespace: instances.some((i) => i.telemetryUsesNamespace),
+  };
 });

--- a/packages/plugins/infisical/src/plugin.ts
+++ b/packages/plugins/infisical/src/plugin.ts
@@ -83,6 +83,16 @@ class InfisicalPluginInstance {
     debug('infisical instance', this.id, 'set auth - projectId:', projectId, 'environment:', environment, 'hasIdentityId:', !!identityId);
   }
 
+  /** @internal telemetry: which auth method this instance is configured for (fixed enum, never raw values) */
+  get telemetryAuthMethod(): 'universal' | 'oidc' | 'none' {
+    if (this.clientId) return 'universal';
+    if (this.identityId) return 'oidc';
+    return 'none';
+  }
+
+  /** @internal telemetry: whether a custom site URL is set (self-hosted vs cloud) — boolean only, never the URL */
+  get telemetrySelfHosted() { return this.siteUrl != null; }
+
   private infisicalClientPromise?: Promise<InfisicalSDK>;
   private static readonly defaultSiteUrl = 'https://app.infisical.com';
 
@@ -652,4 +662,19 @@ plugin.registerResolverFunction({
 
     return await selectedInstance.listSecrets(secretPath, tagSlugs);
   },
+});
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  const authMethods = new Set(instances.map((i) => i.telemetryAuthMethod));
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    cache_enabled: instances.some((i) => i.cacheTtl != null),
+    // custom attributes
+    auth_universal: authMethods.has('universal'),
+    auth_oidc: authMethods.has('oidc'),
+    self_hosted: instances.some((i) => i.telemetrySelfHosted),
+  };
 });

--- a/packages/plugins/keepass/src/plugin.ts
+++ b/packages/plugins/keepass/src/plugin.ts
@@ -38,6 +38,11 @@ class KeePassPluginInstance {
     }
   }
 
+  /** Hardcoded enum: which reader backend is in use (never emits db path, key file, or password). */
+  get telemetryReaderMode(): 'file' | 'cli' | 'unknown' {
+    return this.readerMode ?? 'unknown';
+  }
+
   async readEntry(entryPath: string, attribute: string = 'Password'): Promise<string> {
     return await this.reader!.readEntry(entryPath, attribute);
   }
@@ -343,4 +348,18 @@ plugin.registerResolverFunction({
 
     return await selectedInstance.readAllEntries(groupPath);
   },
+});
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+// Booleans / counts / hardcoded enums only — never db paths, key files, passwords, or entry names.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  const readerModes = new Set(instances.map((i) => i.telemetryReaderMode));
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    // custom attributes
+    reader_file: readerModes.has('file'),
+    reader_cli: readerModes.has('cli'),
+  };
 });

--- a/packages/plugins/keeper/src/plugin.ts
+++ b/packages/plugins/keeper/src/plugin.ts
@@ -484,3 +484,13 @@ plugin.registerResolverFunction({
     return await fetchValue();
   },
 });
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    cache_enabled: instances.some((i) => i.cacheTtl != null),
+  };
+});

--- a/packages/plugins/kubernetes/src/plugin.ts
+++ b/packages/plugins/kubernetes/src/plugin.ts
@@ -149,6 +149,15 @@ class KubernetesPluginInstance {
     return kind === 'Secret' ? this.config.defaultSecret : this.config.defaultConfigMap;
   }
 
+  /** Hardcoded enum describing which connection path is configured (never emits server/context/path values). */
+  get telemetryAuthMode(): 'explicit_server' | 'kubeconfig' | 'default' {
+    if (this.config.clusterServer) return 'explicit_server';
+    if (this.config.kubeconfig) return 'kubeconfig';
+    return 'default';
+  }
+
+  get telemetryAllowMissing() { return !!this.config.allowMissing; }
+
   private async initKubeConfig(): Promise<k8s.KubeConfig> {
     const {
       namespace,
@@ -678,4 +687,20 @@ plugin.registerResolverFunction({
     const resourceName = await resolveResourceName(instanceId, resourceNameResolver, kind);
     return pluginInstances[instanceId].getConfigMapBulk(resourceName);
   },
+});
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+// Booleans / counts / hardcoded enums only — never server URLs, contexts, namespaces, tokens, or paths.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  const authModes = new Set(instances.map((i) => i.telemetryAuthMode));
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    // custom attributes
+    auth_explicit_server: authModes.has('explicit_server'),
+    auth_kubeconfig: authModes.has('kubeconfig'),
+    auth_default: authModes.has('default'),
+    allow_missing: instances.some((i) => i.telemetryAllowMissing),
+  };
 });

--- a/packages/plugins/pass/src/plugin.ts
+++ b/packages/plugins/pass/src/plugin.ts
@@ -540,3 +540,13 @@ plugin.registerResolverFunction({
     return await selectedInstance.getAllSecrets(pathPrefix);
   },
 });
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+// Only an instance count — store paths and name prefixes are user-controlled and never emitted.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  return {
+    // standard attributes
+    instance_count: instances.length,
+  };
+});

--- a/packages/plugins/passbolt/src/plugin.ts
+++ b/packages/plugins/passbolt/src/plugin.ts
@@ -430,3 +430,13 @@ plugin.registerResolverFunction({
     return await selectedInstance.getCustomFieldObj(resourceId);
   },
 });
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  return {
+    // standard attributes
+    instance_count: instances.length,
+    cache_enabled: instances.some((i) => i.cacheTtl != null),
+  };
+});

--- a/packages/plugins/proton-pass/src/plugin.ts
+++ b/packages/plugins/proton-pass/src/plugin.ts
@@ -653,3 +653,12 @@ plugin.registerResolverFunction({
     }
   },
 });
+
+// Anonymous, non-sensitive usage signals. Strictly sanitized before send.
+plugin.registerTelemetryAttributes(() => {
+  const instances = Object.values(pluginInstances);
+  return {
+    // standard attributes
+    instance_count: instances.length,
+  };
+});

--- a/packages/varlock-website/src/content/docs/guides/telemetry.mdx
+++ b/packages/varlock-website/src/content/docs/guides/telemetry.mdx
@@ -14,6 +14,7 @@ We track general usage information, and the environment in which `varlock` is be
 - Which framework integration invoked the CLI (if any), such as Vite, Next.js, or Astro — official `@varlock/*` package name and version only
 - Which plugins are installed in the project — `@varlock/*` plugin names and versions are sent as-is; third-party plugin names are hashed (SHA-256) and versions are omitted
 - Anonymous schema feature signals when a project is loaded — for example root settings like `@redactLogs`, cache mode, safe resolver/decorator identifiers in use, and data source type counts (not config keys, values, file paths, or error messages)
+- Whether the env graph was loaded (`graph_loaded`) and a coarse error category when the run failed (`error_code`: e.g. `parse_error`, `plugin_error`, `schema_error`, `validation_error`, `resolution_error`, `load_error`) — no error messages or file paths
 - Version information for varlock and Node.js
 - JavaScript package manager in use (if detectable from lockfiles or runtime env) — `npm`, `pnpm`, `yarn`, `bun`, or `deno` only
 - General system/machine information

--- a/packages/varlock-website/src/content/docs/guides/telemetry.mdx
+++ b/packages/varlock-website/src/content/docs/guides/telemetry.mdx
@@ -13,6 +13,7 @@ We track general usage information, and the environment in which `varlock` is be
 - Which varlock command is being invoked
 - Which framework integration invoked the CLI (if any), such as Vite, Next.js, or Astro — official `@varlock/*` package name and version only
 - Which plugins are installed in the project — `@varlock/*` plugin names and versions are sent as-is; third-party plugin names are hashed (SHA-256) and versions are omitted
+- Anonymous, non-sensitive usage attributes that official `@varlock/*` plugins report about how they are used (for example which authentication mode is active, or whether a feature is enabled) — booleans, short enum strings, and counts only; collected for official plugins only and strictly sanitized (never secret values, item references, hostnames, or paths)
 - Anonymous schema feature signals when a project is loaded — for example root settings like `@redactLogs`, cache mode, safe resolver/decorator identifiers in use, and data source type counts (not config keys, values, file paths, or error messages)
 - Whether the env graph was loaded (`graph_loaded`) and a coarse error category when the run failed (`error_code`: e.g. `parse_error`, `plugin_error`, `schema_error`, `validation_error`, `resolution_error`, `load_error`) — no error messages or file paths
 - Version information for varlock and Node.js

--- a/packages/varlock-website/src/content/docs/guides/telemetry.mdx
+++ b/packages/varlock-website/src/content/docs/guides/telemetry.mdx
@@ -11,7 +11,11 @@ The `varlock` CLI collects **anonymous telemetry data** about usage to help us u
 
 We track general usage information, and the environment in which `varlock` is being used. Specifically we collect _anonymous_ information about:
 - Which varlock command is being invoked
-- Version and settings for varlock, Node.js, and any plugins
+- Which framework integration invoked the CLI (if any), such as Vite, Next.js, or Astro — official `@varlock/*` package name and version only
+- Which plugins are installed in the project — `@varlock/*` plugin names and versions are sent as-is; third-party plugin names are hashed (SHA-256) and versions are omitted
+- Anonymous schema feature signals when a project is loaded — for example root settings like `@redactLogs`, cache mode, safe resolver/decorator identifiers in use, and data source type counts (not config keys, values, file paths, or error messages)
+- Version information for varlock and Node.js
+- JavaScript package manager in use (if detectable from lockfiles or runtime env) — `npm`, `pnpm`, `yarn`, `bun`, or `deno` only
 - General system/machine information
 - Anonymous user + project ID
 

--- a/packages/varlock/src/cli/cli-executable.ts
+++ b/packages/varlock/src/cli/cli-executable.ts
@@ -44,11 +44,12 @@ function buildLazyCommand(
   return {
     ...commandSpec,
     run: async (...args: Array<any>) => {
-      // Track command execution
-      await trackCommand(commandName, { command: commandName });
-      // load the command fn and run it
-      const commandSpecAndFn = await loadCommandFn();
-      return commandSpecAndFn.commandFn(...args);
+      try {
+        const commandSpecAndFn = await loadCommandFn();
+        return await commandSpecAndFn.commandFn(...args);
+      } finally {
+        await trackCommand(commandName, { command: commandName });
+      }
     },
   };
 }

--- a/packages/varlock/src/cli/helpers/telemetry-usage-context.ts
+++ b/packages/varlock/src/cli/helpers/telemetry-usage-context.ts
@@ -1,0 +1,190 @@
+import { createHash } from 'node:crypto';
+import type { EnvGraph, SerializedEnvGraph } from '../../env-graph/lib/env-graph';
+import type { Resolver } from '../../env-graph/lib/resolver';
+
+/** npm-style package name (scoped or unscoped), conservative length */
+const NPM_PACKAGE_NAME_RE = /^(@[a-z0-9][\w.-]*\/)?[a-z0-9][\w.-]*$/i;
+const NPM_VERSION_RE = /^[\d]+(?:\.[\d]+)*(?:-[\w.-]+)?$/;
+const TELEMETRY_IDENTIFIER_RE = /^[a-zA-Z][\w-]{0,63}$/;
+const KNOWN_SOURCE_TYPES = new Set(['schema', 'example', 'defaults', 'values', 'overrides']);
+
+export type TelemetryPluginInfo = {
+  /** Raw npm name for @varlock/* plugins; SHA-256 hex for all others */
+  name: string;
+  /** Semver for @varlock/* plugins; omitted (null) when name is hashed */
+  version: string | null;
+  type: 'single-file' | 'package';
+  is_official: boolean;
+  name_is_hashed: boolean;
+  has_loading_error: boolean;
+  warning_count: number;
+};
+
+export type TelemetryFeatureInfo = {
+  settings: SerializedEnvGraph['settings'];
+  cache_mode: 'auto' | 'memory' | 'disk' | 'disabled';
+  resolver_names: Array<string>;
+  root_decorator_names: Array<string>;
+  source_type_counts: Record<string, number>;
+  config_item_count: number;
+};
+
+export type TelemetryUsageContext = {
+  integration: { name: string; version: string } | null;
+  plugins: Array<TelemetryPluginInfo>;
+  features: TelemetryFeatureInfo | null;
+};
+
+let sessionUsageContext: Pick<TelemetryUsageContext, 'plugins' | 'features'> = {
+  plugins: [],
+  features: null,
+};
+
+let cachedIntegrationFromEnv: { name: string; version: string } | null | undefined;
+
+function hashTelemetryValue(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function isOfficialVarlockPackageName(name: string) {
+  return name.startsWith('@varlock/');
+}
+
+/** Only @varlock/* integration packages with npm-like name/version are accepted */
+export function sanitizeIntegrationIdentity(
+  integration: { name: string; version: string } | null,
+): { name: string; version: string } | null {
+  if (!integration) return null;
+  const { name, version } = integration;
+  if (
+    name.length > 128
+    || version.length > 32
+    || !isOfficialVarlockPackageName(name)
+    || !NPM_PACKAGE_NAME_RE.test(name)
+  ) {
+    return null;
+  }
+  if (version !== 'unknown' && !NPM_VERSION_RE.test(version)) return null;
+  return { name, version };
+}
+
+/** Resolver/decorator identifiers must match a strict safe pattern; internal names are dropped */
+export function sanitizeFeatureIdentifier(name: string): string | null {
+  if (name.startsWith('\0')) return null;
+  if (!TELEMETRY_IDENTIFIER_RE.test(name)) return null;
+  return name;
+}
+
+/** @internal exported for unit tests */
+export function sanitizePluginForTelemetry(plugin: {
+  name: string;
+  version: string;
+  type: 'single-file' | 'package';
+  loadingError?: unknown;
+  warnings: Array<unknown>;
+}): TelemetryPluginInfo {
+  const isOfficial = isOfficialVarlockPackageName(plugin.name);
+  const nameIsHashed = !isOfficial && plugin.name !== 'unnamed plugin';
+
+  return {
+    name: nameIsHashed ? hashTelemetryValue(plugin.name) : plugin.name,
+    version: isOfficial ? plugin.version : null,
+    type: plugin.type,
+    is_official: isOfficial,
+    name_is_hashed: nameIsHashed,
+    has_loading_error: !!plugin.loadingError,
+    warning_count: plugin.warnings.length,
+  };
+}
+
+/** @internal convention: integrations set `VARLOCK_INTEGRATION=name@version` before subprocess */
+export function parseIntegrationFromEnv(
+  envValue: string | undefined = process.env.VARLOCK_INTEGRATION,
+): { name: string; version: string } | null {
+  if (!envValue?.trim()) return null;
+  const trimmed = envValue.trim();
+  if (trimmed.length > 160) return null;
+
+  const at = trimmed.lastIndexOf('@');
+  const parsed = at <= 0
+    ? { name: trimmed, version: 'unknown' as const }
+    : {
+      name: trimmed.slice(0, at),
+      version: trimmed.slice(at + 1) || 'unknown',
+    };
+
+  return sanitizeIntegrationIdentity(parsed);
+}
+
+function collectResolverNames(resolver: Resolver | undefined, names: Set<string>) {
+  if (!resolver) return;
+  const sanitized = sanitizeFeatureIdentifier(resolver.fnName);
+  if (sanitized) names.add(sanitized);
+  for (const child of resolver.arrArgs ?? []) collectResolverNames(child, names);
+  for (const child of Object.values(resolver.objArgs ?? {})) collectResolverNames(child, names);
+}
+
+function countSourceTypes(sources: SerializedEnvGraph['sources']) {
+  const counts: Record<string, number> = {};
+  for (const source of sources) {
+    if (!KNOWN_SOURCE_TYPES.has(source.type)) continue;
+    counts[source.type] = (counts[source.type] ?? 0) + 1;
+  }
+  return counts;
+}
+
+export function captureUsageContextFromEnvGraph(graph: EnvGraph) {
+  const serialized = graph.getSerializedGraph();
+  const resolverNames = new Set<string>();
+  for (const itemKey of graph.sortedConfigKeys) {
+    collectResolverNames(graph.configSchema[itemKey].valueResolver, resolverNames);
+  }
+
+  const rootDecoratorNames = new Set<string>();
+  for (const source of graph.sortedDataSources) {
+    for (const dec of source.rootDecorators) {
+      const sanitized = sanitizeFeatureIdentifier(dec.name);
+      if (sanitized) rootDecoratorNames.add(sanitized);
+    }
+  }
+
+  sessionUsageContext = {
+    plugins: graph.plugins.map((p) => sanitizePluginForTelemetry(p)),
+    features: {
+      settings: serialized.settings,
+      cache_mode: graph._cacheMode,
+      resolver_names: [...resolverNames].sort(),
+      root_decorator_names: [...rootDecoratorNames].sort(),
+      source_type_counts: countSourceTypes(serialized.sources),
+      config_item_count: graph.sortedConfigKeys.length,
+    },
+  };
+}
+
+export function getTelemetryUsageContext(): TelemetryUsageContext {
+  if (cachedIntegrationFromEnv === undefined) {
+    cachedIntegrationFromEnv = parseIntegrationFromEnv();
+  }
+  return {
+    integration: cachedIntegrationFromEnv,
+    plugins: sessionUsageContext.plugins,
+    features: sessionUsageContext.features,
+  };
+}
+
+/** Flat PostHog properties derived from the session usage context */
+export function getTelemetryUsageContextPayload(): Record<string, unknown> {
+  const ctx = getTelemetryUsageContext();
+  return {
+    integration_name: ctx.integration?.name ?? null,
+    integration_version: ctx.integration?.version ?? null,
+    plugins: ctx.plugins,
+    features: ctx.features,
+  };
+}
+
+/** @internal test helper */
+export function resetTelemetryUsageContextForTests() {
+  sessionUsageContext = { plugins: [], features: null };
+  cachedIntegrationFromEnv = undefined;
+}

--- a/packages/varlock/src/cli/helpers/telemetry-usage-context.ts
+++ b/packages/varlock/src/cli/helpers/telemetry-usage-context.ts
@@ -1,12 +1,27 @@
 import { createHash } from 'node:crypto';
 import type { EnvGraph, SerializedEnvGraph } from '../../env-graph/lib/env-graph';
 import type { Resolver } from '../../env-graph/lib/resolver';
+import {
+  LoadingError,
+  ParseError,
+  ResolutionError,
+  SchemaError,
+  VarlockError,
+} from '../../env-graph/lib/errors';
 
 /** npm-style package name (scoped or unscoped), conservative length */
 const NPM_PACKAGE_NAME_RE = /^(@[a-z0-9][\w.-]*\/)?[a-z0-9][\w.-]*$/i;
 const NPM_VERSION_RE = /^[\d]+(?:\.[\d]+)*(?:-[\w.-]+)?$/;
 const TELEMETRY_IDENTIFIER_RE = /^[a-zA-Z][\w-]{0,63}$/;
 const KNOWN_SOURCE_TYPES = new Set(['schema', 'example', 'defaults', 'values', 'overrides']);
+
+/** Machine-friendly error category sent with telemetry (no messages or paths) */
+export type TelemetryErrorCode = | 'parse_error'
+  | 'plugin_error'
+  | 'load_error'
+  | 'schema_error'
+  | 'resolution_error'
+  | 'validation_error';
 
 export type TelemetryPluginInfo = {
   /** Raw npm name for @varlock/* plugins; SHA-256 hex for all others */
@@ -33,12 +48,19 @@ export type TelemetryUsageContext = {
   integration: { name: string; version: string } | null;
   plugins: Array<TelemetryPluginInfo>;
   features: TelemetryFeatureInfo | null;
+  graph_loaded: boolean;
+  error_code: TelemetryErrorCode | null;
 };
 
 let sessionUsageContext: Pick<TelemetryUsageContext, 'plugins' | 'features'> = {
   plugins: [],
   features: null,
 };
+
+let sessionGraph: EnvGraph | undefined;
+let sessionGraphLoaded = false;
+/** Set when graph load throws before a graph instance is available */
+let sessionLoadFailureErrorCode: TelemetryErrorCode | null = null;
 
 let cachedIntegrationFromEnv: { name: string; version: string } | null | undefined;
 
@@ -48,6 +70,56 @@ function hashTelemetryValue(value: string): string {
 
 function isOfficialVarlockPackageName(name: string) {
   return name.startsWith('@varlock/');
+}
+
+function isBlockingError(err: VarlockError) {
+  return !err.isWarning;
+}
+
+/** Classify a loaded graph's most significant blocking error (re-run at send time for post-resolve state) */
+export function classifyGraphTelemetryErrorCode(graph: EnvGraph): TelemetryErrorCode | null {
+  if (graph.plugins.some((p) => p.loadingError && isBlockingError(p.loadingError))) {
+    return 'plugin_error';
+  }
+
+  for (const source of graph.sortedDataSources) {
+    const loadingError = source.loadingError;
+    if (loadingError instanceof ParseError && isBlockingError(loadingError)) {
+      return 'parse_error';
+    }
+
+    for (const err of source.errors) {
+      if (!isBlockingError(err)) continue;
+      if (err instanceof ParseError) return 'parse_error';
+      if (err instanceof LoadingError) return 'load_error';
+      if (err instanceof SchemaError) return 'schema_error';
+    }
+
+    for (const err of source.resolutionErrors) {
+      if (isBlockingError(err)) return 'resolution_error';
+    }
+  }
+
+  for (const itemKey of graph.sortedConfigKeys) {
+    if (graph.configSchema[itemKey].validationState === 'error') {
+      return 'validation_error';
+    }
+  }
+
+  return null;
+}
+
+/** Map thrown load failures (before a graph is returned) to an error code */
+export function classifyThrownTelemetryErrorCode(err: unknown): TelemetryErrorCode {
+  let current: unknown = err;
+  while (current instanceof Error) {
+    if (current instanceof ParseError) return 'parse_error';
+    if (current instanceof SchemaError) return 'schema_error';
+    if (current instanceof ResolutionError) return 'resolution_error';
+    if (current instanceof LoadingError) return 'load_error';
+    current = current.cause;
+  }
+  return 'load_error';
 }
 
 /** Only @varlock/* integration packages with npm-like name/version are accepted */
@@ -134,6 +206,10 @@ function countSourceTypes(sources: SerializedEnvGraph['sources']) {
 }
 
 export function captureUsageContextFromEnvGraph(graph: EnvGraph) {
+  sessionGraph = graph;
+  sessionGraphLoaded = true;
+  sessionLoadFailureErrorCode = null;
+
   const serialized = graph.getSerializedGraph();
   const resolverNames = new Set<string>();
   for (const itemKey of graph.sortedConfigKeys) {
@@ -161,6 +237,21 @@ export function captureUsageContextFromEnvGraph(graph: EnvGraph) {
   };
 }
 
+/** Record a graph load failure before an EnvGraph instance is available */
+export function captureTelemetryGraphLoadFailure(err: unknown) {
+  sessionGraph = undefined;
+  sessionGraphLoaded = false;
+  sessionLoadFailureErrorCode = classifyThrownTelemetryErrorCode(err);
+  sessionUsageContext = { plugins: [], features: null };
+}
+
+function resolveTelemetryErrorCode(): TelemetryErrorCode | null {
+  if (sessionGraphLoaded && sessionGraph) {
+    return classifyGraphTelemetryErrorCode(sessionGraph);
+  }
+  return sessionLoadFailureErrorCode;
+}
+
 export function getTelemetryUsageContext(): TelemetryUsageContext {
   if (cachedIntegrationFromEnv === undefined) {
     cachedIntegrationFromEnv = parseIntegrationFromEnv();
@@ -169,6 +260,8 @@ export function getTelemetryUsageContext(): TelemetryUsageContext {
     integration: cachedIntegrationFromEnv,
     plugins: sessionUsageContext.plugins,
     features: sessionUsageContext.features,
+    graph_loaded: sessionGraphLoaded,
+    error_code: resolveTelemetryErrorCode(),
   };
 }
 
@@ -180,11 +273,16 @@ export function getTelemetryUsageContextPayload(): Record<string, unknown> {
     integration_version: ctx.integration?.version ?? null,
     plugins: ctx.plugins,
     features: ctx.features,
+    graph_loaded: ctx.graph_loaded,
+    error_code: ctx.error_code,
   };
 }
 
 /** @internal test helper */
 export function resetTelemetryUsageContextForTests() {
   sessionUsageContext = { plugins: [], features: null };
+  sessionGraph = undefined;
+  sessionGraphLoaded = false;
+  sessionLoadFailureErrorCode = null;
   cachedIntegrationFromEnv = undefined;
 }

--- a/packages/varlock/src/cli/helpers/telemetry-usage-context.ts
+++ b/packages/varlock/src/cli/helpers/telemetry-usage-context.ts
@@ -169,9 +169,9 @@ export function sanitizePluginForTelemetry(plugin: {
   };
 }
 
-/** @internal convention: integrations set `VARLOCK_INTEGRATION=name@version` before subprocess */
+/** @internal convention: integrations set `__VARLOCK_INTEGRATION=name@version` before subprocess */
 export function parseIntegrationFromEnv(
-  envValue: string | undefined = process.env.VARLOCK_INTEGRATION,
+  envValue: string | undefined = process.env.__VARLOCK_INTEGRATION,
 ): { name: string; version: string } | null {
   if (!envValue?.trim()) return null;
   const trimmed = envValue.trim();

--- a/packages/varlock/src/cli/helpers/telemetry-usage-context.ts
+++ b/packages/varlock/src/cli/helpers/telemetry-usage-context.ts
@@ -15,6 +15,12 @@ const NPM_VERSION_RE = /^[\d]+(?:\.[\d]+)*(?:-[\w.-]+)?$/;
 const TELEMETRY_IDENTIFIER_RE = /^[a-zA-Z][\w-]{0,63}$/;
 const KNOWN_SOURCE_TYPES = new Set(['schema', 'example', 'defaults', 'values', 'overrides']);
 
+/** Plugin telemetry attribute keys: short snake_case identifiers */
+const PLUGIN_ATTR_KEY_RE = /^[a-z][a-z0-9_]{0,39}$/;
+/** Plugin telemetry attribute enum string values: short, no free-form text (prevents leaking secrets/names/paths) */
+const PLUGIN_ATTR_ENUM_RE = /^[a-zA-Z][\w-]{0,31}$/;
+const MAX_PLUGIN_ATTR_KEYS = 24;
+
 /** Machine-friendly error category sent with telemetry (no messages or paths) */
 export type TelemetryErrorCode = | 'parse_error'
   | 'plugin_error'
@@ -22,6 +28,9 @@ export type TelemetryErrorCode = | 'parse_error'
   | 'schema_error'
   | 'resolution_error'
   | 'validation_error';
+
+/** Sanitized plugin-reported usage attributes (booleans, short enums, counts) */
+export type TelemetryPluginAttributes = Record<string, boolean | number | string | null>;
 
 export type TelemetryPluginInfo = {
   /** Raw npm name for @varlock/* plugins; SHA-256 hex for all others */
@@ -33,6 +42,8 @@ export type TelemetryPluginInfo = {
   name_is_hashed: boolean;
   has_loading_error: boolean;
   warning_count: number;
+  /** Plugin-defined usage attributes — collected for official plugins only, else null */
+  attributes: TelemetryPluginAttributes | null;
 };
 
 export type TelemetryFeatureInfo = {
@@ -147,6 +158,51 @@ export function sanitizeFeatureIdentifier(name: string): string | null {
   return name;
 }
 
+/** A single attribute value passes only if a primitive of an allowed, non-identifying shape */
+const DROP_ATTR = Symbol('drop-attr');
+function sanitizePluginAttributeValue(value: unknown): boolean | number | string | null | typeof DROP_ATTR {
+  if (value === null) return null;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : DROP_ATTR;
+  if (typeof value === 'string') return PLUGIN_ATTR_ENUM_RE.test(value) ? value : DROP_ATTR;
+  return DROP_ATTR; // objects, arrays, functions, symbols, undefined, bigint
+}
+
+/**
+ * Run a plugin's telemetry attributes provider and strictly sanitize the result.
+ * Only flat objects of booleans / finite numbers / short enum strings / null survive;
+ * keys must be short snake_case and the object is capped in size. A throwing provider
+ * or unexpected shape yields null. Prevents plugins from leaking secrets/names/paths.
+ *
+ * @internal exported for unit tests
+ */
+export function sanitizePluginAttributes(
+  provider: (() => unknown) | undefined,
+): TelemetryPluginAttributes | null {
+  if (typeof provider !== 'function') return null;
+
+  let raw: unknown;
+  try {
+    raw = provider();
+  } catch {
+    return null;
+  }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+
+  const out: TelemetryPluginAttributes = {};
+  let count = 0;
+  for (const [key, value] of Object.entries(raw)) {
+    if (count >= MAX_PLUGIN_ATTR_KEYS) break;
+    if (!PLUGIN_ATTR_KEY_RE.test(key)) continue;
+    const sanitized = sanitizePluginAttributeValue(value);
+    if (sanitized === DROP_ATTR) continue;
+    out[key] = sanitized;
+    count += 1;
+  }
+
+  return Object.keys(out).length ? out : null;
+}
+
 /** @internal exported for unit tests */
 export function sanitizePluginForTelemetry(plugin: {
   name: string;
@@ -154,6 +210,7 @@ export function sanitizePluginForTelemetry(plugin: {
   type: 'single-file' | 'package';
   loadingError?: unknown;
   warnings: Array<unknown>;
+  _getTelemetryAttributes?: () => unknown;
 }): TelemetryPluginInfo {
   const isOfficial = isOfficialVarlockPackageName(plugin.name);
   const nameIsHashed = !isOfficial && plugin.name !== 'unnamed plugin';
@@ -166,6 +223,8 @@ export function sanitizePluginForTelemetry(plugin: {
     name_is_hashed: nameIsHashed,
     has_loading_error: !!plugin.loadingError,
     warning_count: plugin.warnings.length,
+    // only official plugins' attribute providers are run (we author/review those)
+    attributes: isOfficial ? sanitizePluginAttributes(plugin._getTelemetryAttributes) : null,
   };
 }
 

--- a/packages/varlock/src/cli/helpers/telemetry-usage-context.ts
+++ b/packages/varlock/src/cli/helpers/telemetry-usage-context.ts
@@ -330,6 +330,11 @@ export function getTelemetryUsageContextPayload(): Record<string, unknown> {
   return {
     integration_name: ctx.integration?.name ?? null,
     integration_version: ctx.integration?.version ?? null,
+    // Flat, directly-breakdownable list of official plugin names in use (an
+    // array of strings can be sliced in PostHog's UI; the nested `plugins`
+    // detail below needs HogQL/SQL to query). Third-party (hashed) plugins are
+    // excluded here — see `plugins` for those.
+    official_plugins: ctx.plugins.filter((p) => p.is_official).map((p) => p.name).sort(),
     plugins: ctx.plugins,
     features: ctx.features,
     graph_loaded: ctx.graph_loaded,

--- a/packages/varlock/src/cli/helpers/telemetry.ts
+++ b/packages/varlock/src/cli/helpers/telemetry.ts
@@ -247,6 +247,26 @@ function getAnonymousProjectId() {
   return anonymizeValue(gitRemoteUrl);
 }
 
+/** Builds a canonical `host/owner/repo` slug (lowercased) from a host + path pair. */
+function buildProjectSlug(rawHost: string, rawPath: string): string | undefined {
+  // strip port from host, lowercase it
+  const host = rawHost.trim().replace(/:\d+$/, '').toLowerCase();
+  if (!host) return undefined;
+
+  // clean path: drop leading/trailing slashes, optional `.git` suffix, then lowercase.
+  // host paths are treated case-insensitively to maximize grouping (GitHub/GitLab/etc.
+  // treat owner/repo case-insensitively, and clones may differ only by case)
+  const path = rawPath
+    .trim()
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+    .replace(/\.git$/, '')
+    .toLowerCase();
+  if (!path) return undefined;
+
+  return `${host}/${path}`;
+}
+
 /**
  * Normalizes a git remote URL down to a canonical `host/owner/repo` (lowercased)
  * so that http(s), ssh, scp-style, and git:// clones of the same repo collapse to
@@ -290,49 +310,83 @@ export function normalizeGitRemoteUrl(rawUrl: string): string | undefined {
     path = scpMatch[2];
   }
 
-  // strip port from host, lowercase it
-  host = host.replace(/:\d+$/, '').toLowerCase();
-  if (!host) return undefined;
-
-  // clean path: drop leading/trailing slashes, optional `.git` suffix, then lowercase.
-  // host paths are treated case-insensitively to maximize grouping (GitHub/GitLab/etc.
-  // treat owner/repo case-insensitively, and clones may differ only by case)
-  path = path
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '')
-    .replace(/\.git$/, '')
-    .toLowerCase();
-  if (!path) return undefined;
-
-  return `${host}/${path}`;
+  return buildProjectSlug(host, path);
 }
 
 /**
- * Stable, anonymized project id derived from a normalized git remote.
+ * Resolves a canonical `host/owner/repo` slug from CI environment variables, when
+ * available. CI runners expose the repo slug directly and unambiguously — more
+ * reliable than parsing `.git/config`, and it works even when no remote is set.
+ * Output matches {@link normalizeGitRemoteUrl} so CI and local clones of the same
+ * repo collapse to the same id.
+ *
+ * @internal exported for unit tests
+ */
+export function getProjectSlugFromCi(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  // GitHub Actions (incl. GitHub Enterprise via GITHUB_SERVER_URL)
+  if (env.GITHUB_REPOSITORY) {
+    const host = (env.GITHUB_SERVER_URL || 'https://github.com').replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, '');
+    return buildProjectSlug(host, env.GITHUB_REPOSITORY);
+  }
+  // GitLab CI
+  if (env.CI_PROJECT_PATH && env.CI_SERVER_HOST) {
+    return buildProjectSlug(env.CI_SERVER_HOST, env.CI_PROJECT_PATH);
+  }
+  // Bitbucket Pipelines (no host env var — always bitbucket.org)
+  if (env.BITBUCKET_REPO_FULL_NAME) {
+    return buildProjectSlug('bitbucket.org', env.BITBUCKET_REPO_FULL_NAME);
+  }
+  return undefined;
+}
+
+let _cachedProjectSlug: string | undefined | null;
+/**
+ * Canonical `host/owner/repo` slug for the current project. Prefers CI env vars
+ * (deterministic, remote-independent), falling back to the parsed git remote.
+ * Cached; returns null if neither source yields a slug.
+ */
+function getNormalizedProjectSlug(): string | null {
+  if (_cachedProjectSlug !== undefined) return _cachedProjectSlug;
+  const ciSlug = getProjectSlugFromCi();
+  if (ciSlug) {
+    _cachedProjectSlug = ciSlug;
+    return _cachedProjectSlug;
+  }
+  const gitRemoteUrl = getProjectGitRemoteUrl();
+  _cachedProjectSlug = (gitRemoteUrl && normalizeGitRemoteUrl(gitRemoteUrl)) || null;
+  return _cachedProjectSlug;
+}
+
+/**
+ * Stable, anonymized project id derived from the normalized project slug.
  * Unlike {@link getAnonymousProjectId} (kept as-is for measurement continuity),
- * this collapses http/ssh/scp variants of the same repo to a single id.
+ * this collapses http/ssh/scp variants of the same repo to a single id and also
+ * resolves from CI env vars when available.
  */
 function getAnonymousProjectIdV2() {
-  const gitRemoteUrl = getProjectGitRemoteUrl();
-  if (!gitRemoteUrl) return null;
-  const normalized = normalizeGitRemoteUrl(gitRemoteUrl);
-  if (!normalized) return null;
-  return anonymizeValue(normalized);
+  const slug = getNormalizedProjectSlug();
+  if (!slug) return null;
+  return anonymizeValue(slug);
 }
 
 /**
- * Anonymized org-level id: hash of `host/owner` from the normalized remote.
+ * Anonymized org-level id: hash of `host/owner` from the normalized slug.
  * Lets us group activity across repos owned by the same org/user.
  */
 function getAnonymousOrgId() {
-  const gitRemoteUrl = getProjectGitRemoteUrl();
-  if (!gitRemoteUrl) return null;
-  const normalized = normalizeGitRemoteUrl(gitRemoteUrl);
-  if (!normalized) return null;
-  const segments = normalized.split('/');
+  const slug = getNormalizedProjectSlug();
+  if (!slug) return null;
+  const segments = slug.split('/');
   // host + first path segment (owner / top-level group)
   if (segments.length < 3) return null;
   return anonymizeValue(`${segments[0]}/${segments[1]}`);
+}
+
+/** Git host (e.g. `github.com`) for the current project. Not anonymized — host alone is not identifying. */
+function getGitHost(): string | null {
+  const slug = getNormalizedProjectSlug();
+  if (!slug) return null;
+  return slug.split('/')[0] || null;
 }
 
 
@@ -343,6 +397,8 @@ type TelemetryMeta = {
   anonymous_project_id_v2: string | null;
   // org-level id (host/owner) for grouping repos by org/user
   anonymous_org_id: string | null;
+  // git host (e.g. github.com) — not anonymized, host alone is not identifying
+  git_host: string | null;
   // version information
   node_version: string;
   varlock_version: string;
@@ -384,6 +440,7 @@ function getTelemetryMeta() {
     anonymous_project_id: getAnonymousProjectId(),
     anonymous_project_id_v2: getAnonymousProjectIdV2(),
     anonymous_org_id: getAnonymousOrgId(),
+    git_host: getGitHost(),
     node_version: process.version.replace(/^v?/, ''),
     varlock_version: versionIdentifier,
     system_platform: os.platform(),

--- a/packages/varlock/src/cli/helpers/telemetry.ts
+++ b/packages/varlock/src/cli/helpers/telemetry.ts
@@ -382,11 +382,36 @@ function getAnonymousOrgId() {
   return anonymizeValue(`${segments[0]}/${segments[1]}`);
 }
 
-/** Git host (e.g. `github.com`) for the current project. Not anonymized — host alone is not identifying. */
+/** Well-known public git hosts that are safe to report verbatim (not identifying). */
+const KNOWN_PUBLIC_GIT_HOSTS = new Set([
+  'github.com',
+  'gitlab.com',
+  'bitbucket.org',
+  'dev.azure.com',
+  'ssh.dev.azure.com',
+  'codeberg.org',
+  'gitea.com',
+  'git.sr.ht',
+  'sourceforge.net',
+]);
+
+/**
+ * Buckets a git host for telemetry. Sent unhashed, so we only ever emit a known
+ * public host verbatim; anything else (self-hosted GitLab, GitHub Enterprise,
+ * Bitbucket Server, internal Gitea, etc.) becomes `self-hosted` so we never leak
+ * a private/internal hostname.
+ *
+ * @internal exported for unit tests
+ */
+export function bucketGitHost(host: string | undefined | null): string | null {
+  if (!host) return null;
+  return KNOWN_PUBLIC_GIT_HOSTS.has(host) ? host : 'self-hosted';
+}
+
+/** Git host bucket for the current project (well-known public host name or `self-hosted`). */
 function getGitHost(): string | null {
   const slug = getNormalizedProjectSlug();
-  if (!slug) return null;
-  return slug.split('/')[0] || null;
+  return bucketGitHost(slug ? slug.split('/')[0] : null);
 }
 
 
@@ -467,49 +492,56 @@ const isOptedOut = checkIsOptedOut();
 let lastTelemetryReq: Promise<any> | undefined;
 
 async function posthogCapture(event: string, properties?: Record<string, any>) {
-  const telemetryMeta = getTelemetryMeta();
-  const usageContext = getTelemetryUsageContextPayload();
-  const payload = {
-    api_key: CONFIG.POSTHOG_API_KEY,
-    event,
-    properties: {
-      $process_person_profile: false,
-      ...telemetryMeta,
-      ...usageContext,
-      ...properties,
-    },
-    distinct_id: isOptedOut ? '---' : getAnonymousId(),
-  };
+  // Telemetry must never break the CLI. trackCommand() is awaited in a `finally`,
+  // and the payload (incl. project/git/plugin data) is built even when opted out,
+  // so any failure here is swallowed rather than surfaced to the caller.
+  try {
+    const telemetryMeta = getTelemetryMeta();
+    const usageContext = getTelemetryUsageContextPayload();
+    const payload = {
+      api_key: CONFIG.POSTHOG_API_KEY,
+      event,
+      properties: {
+        $process_person_profile: false,
+        ...telemetryMeta,
+        ...usageContext,
+        ...properties,
+      },
+      distinct_id: isOptedOut ? '---' : getAnonymousId(),
+    };
 
-  debug(`track${isOptedOut ? ' (disabled)' : ''}`, payload);
+    debug(`track${isOptedOut ? ' (disabled)' : ''}`, payload);
 
-  if (isOptedOut) return;
+    if (isOptedOut) return;
 
-  // add exit hook, so we can give the request a little time to finish
-  const removeExitHook = asyncExitHook(async () => {
-    // will still exit if the timeout is met, but will finish early if the request completes
-    await lastTelemetryReq;
-  }, { wait: 500 });
+    // add exit hook, so we can give the request a little time to finish
+    const removeExitHook = asyncExitHook(async () => {
+      // will still exit if the timeout is met, but will finish early if the request completes
+      await lastTelemetryReq;
+    }, { wait: 500 });
 
-  // Make the fetch call
-  lastTelemetryReq = fetch(`${CONFIG.POSTHOG_HOST}/i/v0/e/`, {
-    method: 'POST',
-    body: JSON.stringify(payload),
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  })
-    .then((res) => {
-      if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
-      return res.text();
+    // Make the fetch call
+    lastTelemetryReq = fetch(`${CONFIG.POSTHOG_HOST}/i/v0/e/`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: {
+        'Content-Type': 'application/json',
+      },
     })
-    .then((text) => debug('telemetry response:', text))
-    .catch((error) => {
-      debug('telemetry error:', error);
-    })
-    .finally(() => {
-      removeExitHook();
-    });
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
+        return res.text();
+      })
+      .then((text) => debug('telemetry response:', text))
+      .catch((error) => {
+        debug('telemetry error:', error);
+      })
+      .finally(() => {
+        removeExitHook();
+      });
+  } catch (err) {
+    debug('telemetry capture error:', err);
+  }
 }
 
 

--- a/packages/varlock/src/cli/helpers/telemetry.ts
+++ b/packages/varlock/src/cli/helpers/telemetry.ts
@@ -16,6 +16,11 @@ import packageJson from '../../../package.json';
 
 import { CONFIG } from '../../config';
 import { getUserVarlockDir } from '../../lib/user-config-dir';
+import { getTelemetryUsageContextPayload } from './telemetry-usage-context';
+import { detectJsPackageManager } from './js-package-manager-utils';
+import type { JsPackageManager } from '../../lib/workspace-utils';
+
+export { captureUsageContextFromEnvGraph } from './telemetry-usage-context';
 
 
 const debug = createDebug('varlock:telemetry');
@@ -265,7 +270,13 @@ type TelemetryMeta = {
   is_ci: boolean,
   ci_name: string | null,
   is_sea: boolean,
+  js_package_manager: JsPackageManager | null,
 };
+
+/** @internal exported for unit tests */
+export function getJsPackageManagerForTelemetry(): JsPackageManager | null {
+  return detectJsPackageManager()?.name ?? null;
+}
 
 let cachedTelemetryMetadata: TelemetryMeta | undefined;
 function getTelemetryMeta() {
@@ -281,7 +292,6 @@ function getTelemetryMeta() {
     anonymous_project_id: getAnonymousProjectId(),
     node_version: process.version.replace(/^v?/, ''),
     varlock_version: versionIdentifier,
-    // TODO: pass through version info for specific integrations/plugins?
     system_platform: os.platform(),
     system_release: os.release(),
     system_architecture: os.arch(),
@@ -295,6 +305,7 @@ function getTelemetryMeta() {
     is_ci: isCI,
     ci_name: ciName,
     is_sea: __VARLOCK_SEA_BUILD__,
+    js_package_manager: getJsPackageManagerForTelemetry(),
   };
   return cachedTelemetryMetadata;
 }
@@ -306,12 +317,14 @@ let lastTelemetryReq: Promise<any> | undefined;
 
 async function posthogCapture(event: string, properties?: Record<string, any>) {
   const telemetryMeta = getTelemetryMeta();
+  const usageContext = getTelemetryUsageContextPayload();
   const payload = {
     api_key: CONFIG.POSTHOG_API_KEY,
     event,
     properties: {
       $process_person_profile: false,
       ...telemetryMeta,
+      ...usageContext,
       ...properties,
     },
     distinct_id: isOptedOut ? '---' : getAnonymousId(),

--- a/packages/varlock/src/cli/helpers/telemetry.ts
+++ b/packages/varlock/src/cli/helpers/telemetry.ts
@@ -247,10 +247,102 @@ function getAnonymousProjectId() {
   return anonymizeValue(gitRemoteUrl);
 }
 
+/**
+ * Normalizes a git remote URL down to a canonical `host/owner/repo` (lowercased)
+ * so that http(s), ssh, scp-style, and git:// clones of the same repo collapse to
+ * the same value. Returns undefined if the URL can't be parsed.
+ *
+ * Examples (all -> `github.com/owner/repo`):
+ *   git@github.com:owner/repo.git
+ *   ssh://git@github.com/owner/repo.git
+ *   https://github.com/owner/repo.git
+ *   https://user:token@github.com/owner/repo
+ *   git://github.com/owner/repo.git
+ *
+ * @internal exported for unit tests
+ */
+export function normalizeGitRemoteUrl(rawUrl: string): string | undefined {
+  const url = rawUrl.trim();
+  if (!url) return undefined;
+
+  let host: string;
+  let path: string;
+
+  const schemeMatch = url.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/(.*)$/);
+  if (schemeMatch) {
+    // scheme-based URL (https://, http://, ssh://, git://, ftp://, ...)
+    let rest = schemeMatch[1];
+    // strip userinfo (user[:pass]@) if it appears before the first path slash
+    const atIdx = rest.indexOf('@');
+    const slashIdx = rest.indexOf('/');
+    if (atIdx !== -1 && (slashIdx === -1 || atIdx < slashIdx)) {
+      rest = rest.slice(atIdx + 1);
+    }
+    const firstSlash = rest.indexOf('/');
+    if (firstSlash === -1) return undefined;
+    host = rest.slice(0, firstSlash);
+    path = rest.slice(firstSlash + 1);
+  } else {
+    // scp-like syntax: [user@]host:path
+    const scpMatch = url.match(/^(?:[^@/]+@)?([^/]+?):(.+)$/);
+    if (!scpMatch) return undefined;
+    host = scpMatch[1];
+    path = scpMatch[2];
+  }
+
+  // strip port from host, lowercase it
+  host = host.replace(/:\d+$/, '').toLowerCase();
+  if (!host) return undefined;
+
+  // clean path: drop leading/trailing slashes, optional `.git` suffix, then lowercase.
+  // host paths are treated case-insensitively to maximize grouping (GitHub/GitLab/etc.
+  // treat owner/repo case-insensitively, and clones may differ only by case)
+  path = path
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+    .replace(/\.git$/, '')
+    .toLowerCase();
+  if (!path) return undefined;
+
+  return `${host}/${path}`;
+}
+
+/**
+ * Stable, anonymized project id derived from a normalized git remote.
+ * Unlike {@link getAnonymousProjectId} (kept as-is for measurement continuity),
+ * this collapses http/ssh/scp variants of the same repo to a single id.
+ */
+function getAnonymousProjectIdV2() {
+  const gitRemoteUrl = getProjectGitRemoteUrl();
+  if (!gitRemoteUrl) return null;
+  const normalized = normalizeGitRemoteUrl(gitRemoteUrl);
+  if (!normalized) return null;
+  return anonymizeValue(normalized);
+}
+
+/**
+ * Anonymized org-level id: hash of `host/owner` from the normalized remote.
+ * Lets us group activity across repos owned by the same org/user.
+ */
+function getAnonymousOrgId() {
+  const gitRemoteUrl = getProjectGitRemoteUrl();
+  if (!gitRemoteUrl) return null;
+  const normalized = normalizeGitRemoteUrl(gitRemoteUrl);
+  if (!normalized) return null;
+  const segments = normalized.split('/');
+  // host + first path segment (owner / top-level group)
+  if (segments.length < 3) return null;
+  return anonymizeValue(`${segments[0]}/${segments[1]}`);
+}
+
 
 type TelemetryMeta = {
   // project info
   anonymous_project_id: string | null;
+  // normalized variant (host/owner/repo) that collapses http/ssh/scp clone variants
+  anonymous_project_id_v2: string | null;
+  // org-level id (host/owner) for grouping repos by org/user
+  anonymous_org_id: string | null;
   // version information
   node_version: string;
   varlock_version: string;
@@ -290,6 +382,8 @@ function getTelemetryMeta() {
 
   cachedTelemetryMetadata = {
     anonymous_project_id: getAnonymousProjectId(),
+    anonymous_project_id_v2: getAnonymousProjectIdV2(),
+    anonymous_org_id: getAnonymousOrgId(),
     node_version: process.version.replace(/^v?/, ''),
     varlock_version: versionIdentifier,
     system_platform: os.platform(),

--- a/packages/varlock/src/cli/helpers/test/telemetry-usage-context.test.ts
+++ b/packages/varlock/src/cli/helpers/test/telemetry-usage-context.test.ts
@@ -111,12 +111,12 @@ describe('sanitizePluginForTelemetry', () => {
 describe('captureUsageContextFromEnvGraph', () => {
   beforeEach(() => {
     resetTelemetryUsageContextForTests();
-    delete process.env.VARLOCK_INTEGRATION;
+    delete process.env.__VARLOCK_INTEGRATION;
   });
 
   afterEach(() => {
     resetTelemetryUsageContextForTests();
-    delete process.env.VARLOCK_INTEGRATION;
+    delete process.env.__VARLOCK_INTEGRATION;
   });
 
   it('extracts plugins, resolver names, and settings from a loaded graph', async () => {
@@ -156,7 +156,7 @@ describe('captureUsageContextFromEnvGraph', () => {
   });
 
   it('includes integration env in telemetry payload when valid', () => {
-    process.env.VARLOCK_INTEGRATION = '@varlock/astro-integration@1.0.4';
+    process.env.__VARLOCK_INTEGRATION = '@varlock/astro-integration@1.0.4';
 
     const payload = getTelemetryUsageContextPayload();
     expect(payload.integration_name).toBe('@varlock/astro-integration');
@@ -248,11 +248,11 @@ describe('classifyThrownTelemetryErrorCode', () => {
 describe('integration env sanitization in payload', () => {
   beforeEach(() => {
     resetTelemetryUsageContextForTests();
-    delete process.env.VARLOCK_INTEGRATION;
+    delete process.env.__VARLOCK_INTEGRATION;
   });
 
   it('ignores invalid integration env values in telemetry payload', () => {
-    process.env.VARLOCK_INTEGRATION = 'not-a-valid-integration@secret-data';
+    process.env.__VARLOCK_INTEGRATION = 'not-a-valid-integration@secret-data';
 
     const payload = getTelemetryUsageContextPayload();
     expect(payload.integration_name).toBeNull();

--- a/packages/varlock/src/cli/helpers/test/telemetry-usage-context.test.ts
+++ b/packages/varlock/src/cli/helpers/test/telemetry-usage-context.test.ts
@@ -8,6 +8,7 @@ import {
   sanitizeIntegrationIdentity,
   sanitizeFeatureIdentifier,
   sanitizePluginForTelemetry,
+  sanitizePluginAttributes,
   classifyGraphTelemetryErrorCode,
   classifyThrownTelemetryErrorCode,
   captureUsageContextFromEnvGraph,
@@ -105,6 +106,96 @@ describe('sanitizePluginForTelemetry', () => {
     expect(result.name_is_hashed).toBe(false);
     expect(result.name).toBe('@varlock/pass-plugin');
     expect(result.version).toBe('0.4.0');
+  });
+
+  it('collects sanitized attributes for official plugins', () => {
+    const result = sanitizePluginForTelemetry({
+      name: '@varlock/1password-plugin',
+      version: '1.0.0',
+      type: 'package',
+      warnings: [],
+      _getTelemetryAttributes: () => ({ auth_connect: true, instance_count: 2 }),
+    });
+    expect(result.attributes).toEqual({ auth_connect: true, instance_count: 2 });
+  });
+
+  it('never collects attributes for third-party plugins (provider is not even called)', () => {
+    let called = false;
+    const result = sanitizePluginForTelemetry({
+      name: '@acme/secrets-plugin',
+      version: '9.9.9',
+      type: 'package',
+      warnings: [],
+      _getTelemetryAttributes: () => {
+        called = true;
+        return { leaked: true };
+      },
+    });
+    expect(result.attributes).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  it('attributes is null when an official plugin has no provider', () => {
+    const result = sanitizePluginForTelemetry({
+      name: '@varlock/pass-plugin',
+      version: '0.4.0',
+      type: 'package',
+      warnings: [],
+    });
+    expect(result.attributes).toBeNull();
+  });
+});
+
+describe('sanitizePluginAttributes', () => {
+  it('keeps booleans, finite numbers, short enum strings, and null', () => {
+    expect(sanitizePluginAttributes(() => ({
+      a: true, b: false, n: 3, mode: 'service-account', empty: null,
+    }))).toEqual({
+      a: true, b: false, n: 3, mode: 'service-account', empty: null,
+    });
+  });
+
+  it('drops non-primitive, non-finite, and free-form/long string values', () => {
+    expect(sanitizePluginAttributes(() => ({
+      ok: true,
+      obj: { nested: 1 },
+      arr: [1, 2],
+      inf: Infinity,
+      nan: NaN,
+      secret: 'op://vault/item/field', // contains "/" and ":" — not an enum
+      long: 'x'.repeat(40),
+      fn: () => 1,
+    }))).toEqual({ ok: true });
+  });
+
+  it('drops invalid keys (non snake_case, too long) and caps the number of keys', () => {
+    const many: Record<string, boolean> = {};
+    for (let i = 0; i < 50; i++) {
+      many[`k${i}`] = true;
+    }
+    const result = sanitizePluginAttributes(() => ({
+      'Bad-Key': true,
+      UPPER: true,
+      '1leading': true,
+      good: true,
+      ...many,
+    }))!;
+    expect(result['Bad-Key']).toBeUndefined();
+    expect(result.UPPER).toBeUndefined();
+    expect(result['1leading']).toBeUndefined();
+    expect(result.good).toBe(true);
+    expect(Object.keys(result).length).toBeLessThanOrEqual(24);
+  });
+
+  it('returns null for a throwing provider, non-object return, or no provider', () => {
+    const throwing = () => {
+      throw new Error('boom');
+    };
+    expect(sanitizePluginAttributes(throwing)).toBeNull();
+    expect(sanitizePluginAttributes(() => 'nope' as unknown as object)).toBeNull();
+    expect(sanitizePluginAttributes(() => [1, 2] as unknown as object)).toBeNull();
+    expect(sanitizePluginAttributes(() => ({}))).toBeNull();
+    expect(sanitizePluginAttributes(undefined)).toBeNull();
   });
 });
 

--- a/packages/varlock/src/cli/helpers/test/telemetry-usage-context.test.ts
+++ b/packages/varlock/src/cli/helpers/test/telemetry-usage-context.test.ts
@@ -244,6 +244,9 @@ describe('captureUsageContextFromEnvGraph', () => {
     expect(ctx.features?.source_type_counts.schema).toBeGreaterThan(0);
     expect(ctx.graph_loaded).toBe(true);
     expect(ctx.error_code).toBeNull();
+
+    // flat, breakdownable list of official plugin names
+    expect(getTelemetryUsageContextPayload().official_plugins).toEqual(['@varlock/test-plugin']);
   });
 
   it('includes integration env in telemetry payload when valid', () => {
@@ -253,6 +256,7 @@ describe('captureUsageContextFromEnvGraph', () => {
     expect(payload.integration_name).toBe('@varlock/astro-integration');
     expect(payload.integration_version).toBe('1.0.4');
     expect(payload.plugins).toEqual([]);
+    expect(payload.official_plugins).toEqual([]);
     expect(payload.features).toBeNull();
     expect(payload.graph_loaded).toBe(false);
     expect(payload.error_code).toBeNull();

--- a/packages/varlock/src/cli/helpers/test/telemetry-usage-context.test.ts
+++ b/packages/varlock/src/cli/helpers/test/telemetry-usage-context.test.ts
@@ -1,0 +1,167 @@
+import {
+  describe, it, expect, beforeEach, afterEach, vi,
+} from 'vitest';
+import outdent from 'outdent';
+import path from 'node:path';
+import {
+  parseIntegrationFromEnv,
+  sanitizeIntegrationIdentity,
+  sanitizeFeatureIdentifier,
+  sanitizePluginForTelemetry,
+  captureUsageContextFromEnvGraph,
+  getTelemetryUsageContext,
+  getTelemetryUsageContextPayload,
+  resetTelemetryUsageContextForTests,
+} from '../telemetry-usage-context';
+import { EnvGraph, DotEnvFileDataSource } from '../../../env-graph';
+
+describe('parseIntegrationFromEnv', () => {
+  it('returns null for empty values', () => {
+    expect(parseIntegrationFromEnv(undefined)).toBeNull();
+    expect(parseIntegrationFromEnv('')).toBeNull();
+    expect(parseIntegrationFromEnv('   ')).toBeNull();
+  });
+
+  it('parses scoped @varlock integration package name and version', () => {
+    expect(parseIntegrationFromEnv('@varlock/vite-integration@1.1.3')).toEqual({
+      name: '@varlock/vite-integration',
+      version: '1.1.3',
+    });
+  });
+
+  it('rejects unscoped or non-@varlock integration strings', () => {
+    expect(parseIntegrationFromEnv('custom-integration')).toBeNull();
+    expect(parseIntegrationFromEnv('@acme/custom-integration@1.0.0')).toBeNull();
+    expect(parseIntegrationFromEnv('user@example.com@1.0.0')).toBeNull();
+  });
+
+  it('rejects oversized integration env values', () => {
+    expect(parseIntegrationFromEnv(`@varlock/vite-integration@${'1'.repeat(200)}`)).toBeNull();
+  });
+});
+
+describe('sanitizeIntegrationIdentity', () => {
+  it('accepts official integration packages only', () => {
+    expect(sanitizeIntegrationIdentity({
+      name: '@varlock/nextjs-integration',
+      version: '1.1.3',
+    })).toEqual({
+      name: '@varlock/nextjs-integration',
+      version: '1.1.3',
+    });
+  });
+
+  it('rejects third-party package names', () => {
+    expect(sanitizeIntegrationIdentity({
+      name: '@acme/internal-vite-plugin',
+      version: '2.0.0',
+    })).toBeNull();
+  });
+});
+
+describe('sanitizeFeatureIdentifier', () => {
+  it('drops internal resolver names', () => {
+    expect(sanitizeFeatureIdentifier('\0static')).toBeNull();
+  });
+
+  it('drops identifiers with unsafe characters', () => {
+    expect(sanitizeFeatureIdentifier('pass(user-email)')).toBeNull();
+    expect(sanitizeFeatureIdentifier('../path')).toBeNull();
+  });
+
+  it('keeps safe builtin-style identifiers', () => {
+    expect(sanitizeFeatureIdentifier('forEnv')).toBe('forEnv');
+    expect(sanitizeFeatureIdentifier('redactLogs')).toBe('redactLogs');
+  });
+});
+
+describe('sanitizePluginForTelemetry', () => {
+  it('hashes third-party plugin names and omits version', () => {
+    const result = sanitizePluginForTelemetry({
+      name: '@acme/internal-secrets-plugin',
+      version: '9.9.9',
+      type: 'package',
+      warnings: [],
+    });
+    expect(result.name_is_hashed).toBe(true);
+    expect(result.name).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.version).toBeNull();
+    expect(result.is_official).toBe(false);
+  });
+
+  it('preserves @varlock plugin name and version', () => {
+    const result = sanitizePluginForTelemetry({
+      name: '@varlock/pass-plugin',
+      version: '0.4.0',
+      type: 'package',
+      warnings: [],
+    });
+    expect(result.name_is_hashed).toBe(false);
+    expect(result.name).toBe('@varlock/pass-plugin');
+    expect(result.version).toBe('0.4.0');
+  });
+});
+
+describe('captureUsageContextFromEnvGraph', () => {
+  beforeEach(() => {
+    resetTelemetryUsageContextForTests();
+    delete process.env.VARLOCK_INTEGRATION;
+  });
+
+  afterEach(() => {
+    resetTelemetryUsageContextForTests();
+    delete process.env.VARLOCK_INTEGRATION;
+  });
+
+  it('extracts plugins, resolver names, and settings from a loaded graph', async () => {
+    const testDir = path.join(
+      path.dirname(expect.getState().testPath!),
+      '../../../env-graph/test',
+    );
+    vi.spyOn(process, 'cwd').mockReturnValue(testDir);
+
+    const graph = new EnvGraph();
+    const source = new DotEnvFileDataSource('.env.schema', {
+      overrideContents: outdent`
+        # @plugin(./plugins/test-plugin/)
+        # @redactLogs
+        # ---
+        PLUGIN_RESOLVER_TEST=test(foo)
+      `,
+    });
+    await graph.setRootDataSource(source);
+    await graph.finishLoad();
+
+    captureUsageContextFromEnvGraph(graph);
+
+    const ctx = getTelemetryUsageContext();
+    expect(ctx.plugins.length).toBeGreaterThan(0);
+    expect(ctx.plugins[0].is_official).toBe(true);
+    expect(ctx.plugins[0].name).toBe('@varlock/test-plugin');
+    expect(ctx.plugins[0].version).toBe('1.2.3');
+    expect(ctx.plugins[0].name_is_hashed).toBe(false);
+    expect(ctx.features?.resolver_names).toContain('test');
+    expect(ctx.features?.root_decorator_names).toContain('plugin');
+    expect(ctx.features?.settings.redactLogs).toBe(true);
+    expect(ctx.features?.config_item_count).toBeGreaterThan(0);
+    expect(ctx.features?.source_type_counts.schema).toBeGreaterThan(0);
+  });
+
+  it('includes integration env in telemetry payload when valid', () => {
+    process.env.VARLOCK_INTEGRATION = '@varlock/astro-integration@1.0.4';
+
+    const payload = getTelemetryUsageContextPayload();
+    expect(payload.integration_name).toBe('@varlock/astro-integration');
+    expect(payload.integration_version).toBe('1.0.4');
+    expect(payload.plugins).toEqual([]);
+    expect(payload.features).toBeNull();
+  });
+
+  it('ignores invalid integration env values in telemetry payload', () => {
+    process.env.VARLOCK_INTEGRATION = 'not-a-valid-integration@secret-data';
+
+    const payload = getTelemetryUsageContextPayload();
+    expect(payload.integration_name).toBeNull();
+    expect(payload.integration_version).toBeNull();
+  });
+});

--- a/packages/varlock/src/cli/helpers/test/telemetry-usage-context.test.ts
+++ b/packages/varlock/src/cli/helpers/test/telemetry-usage-context.test.ts
@@ -8,12 +8,18 @@ import {
   sanitizeIntegrationIdentity,
   sanitizeFeatureIdentifier,
   sanitizePluginForTelemetry,
+  classifyGraphTelemetryErrorCode,
+  classifyThrownTelemetryErrorCode,
   captureUsageContextFromEnvGraph,
+  captureTelemetryGraphLoadFailure,
   getTelemetryUsageContext,
   getTelemetryUsageContextPayload,
   resetTelemetryUsageContextForTests,
 } from '../telemetry-usage-context';
 import { EnvGraph, DotEnvFileDataSource } from '../../../env-graph';
+import {
+  ParseError, SchemaError, LoadingError,
+} from '../../../env-graph/lib/errors';
 
 describe('parseIntegrationFromEnv', () => {
   it('returns null for empty values', () => {
@@ -145,6 +151,8 @@ describe('captureUsageContextFromEnvGraph', () => {
     expect(ctx.features?.settings.redactLogs).toBe(true);
     expect(ctx.features?.config_item_count).toBeGreaterThan(0);
     expect(ctx.features?.source_type_counts.schema).toBeGreaterThan(0);
+    expect(ctx.graph_loaded).toBe(true);
+    expect(ctx.error_code).toBeNull();
   });
 
   it('includes integration env in telemetry payload when valid', () => {
@@ -155,6 +163,92 @@ describe('captureUsageContextFromEnvGraph', () => {
     expect(payload.integration_version).toBe('1.0.4');
     expect(payload.plugins).toEqual([]);
     expect(payload.features).toBeNull();
+    expect(payload.graph_loaded).toBe(false);
+    expect(payload.error_code).toBeNull();
+  });
+
+  it('re-classifies error_code from live graph state at send time', async () => {
+    const testDir = path.join(
+      path.dirname(expect.getState().testPath!),
+      '../../../env-graph/test',
+    );
+    vi.spyOn(process, 'cwd').mockReturnValue(testDir);
+
+    const graph = new EnvGraph();
+    await graph.setRootDataSource(new DotEnvFileDataSource('.env.schema', {
+      overrideContents: outdent`
+        # ---
+        FOO=bar
+      `,
+    }));
+    await graph.finishLoad();
+
+    captureUsageContextFromEnvGraph(graph);
+    expect(getTelemetryUsageContextPayload().error_code).toBeNull();
+
+    graph.sortedDataSources[0]._errors.push(new SchemaError('bad schema'));
+    const payload = getTelemetryUsageContextPayload();
+    expect(payload.graph_loaded).toBe(true);
+    expect(payload.error_code).toBe('schema_error');
+  });
+
+  it('records load failures before a graph is returned', () => {
+    captureTelemetryGraphLoadFailure(new ParseError('bad syntax'));
+    const payload = getTelemetryUsageContextPayload();
+    expect(payload.graph_loaded).toBe(false);
+    expect(payload.error_code).toBe('parse_error');
+    expect(payload.features).toBeNull();
+  });
+});
+
+describe('classifyGraphTelemetryErrorCode', () => {
+  it('returns null for a graph with no blocking errors', () => {
+    const graph = {
+      plugins: [],
+      sortedDataSources: [{ loadingError: undefined, errors: [], resolutionErrors: [] }],
+      sortedConfigKeys: ['FOO'],
+      configSchema: { FOO: { validationState: 'valid' } },
+    } as unknown as EnvGraph;
+    expect(classifyGraphTelemetryErrorCode(graph)).toBeNull();
+  });
+
+  it('prioritizes plugin_error over schema_error', () => {
+    const graph = {
+      plugins: [{ loadingError: new LoadingError('plugin failed') }],
+      sortedDataSources: [{ errors: [new SchemaError('bad')], resolutionErrors: [] }],
+      sortedConfigKeys: [],
+      configSchema: {},
+    } as unknown as EnvGraph;
+    expect(classifyGraphTelemetryErrorCode(graph)).toBe('plugin_error');
+  });
+
+  it('returns validation_error when items fail validation', () => {
+    const graph = {
+      plugins: [],
+      sortedDataSources: [{ errors: [], resolutionErrors: [] }],
+      sortedConfigKeys: ['API_KEY'],
+      configSchema: { API_KEY: { validationState: 'error' } },
+    } as unknown as EnvGraph;
+    expect(classifyGraphTelemetryErrorCode(graph)).toBe('validation_error');
+  });
+});
+
+describe('classifyThrownTelemetryErrorCode', () => {
+  it('maps Varlock error types', () => {
+    expect(classifyThrownTelemetryErrorCode(new ParseError('x'))).toBe('parse_error');
+    expect(classifyThrownTelemetryErrorCode(new SchemaError('x'))).toBe('schema_error');
+    expect(classifyThrownTelemetryErrorCode(new LoadingError('x'))).toBe('load_error');
+  });
+
+  it('defaults unknown errors to load_error', () => {
+    expect(classifyThrownTelemetryErrorCode(new Error('boom'))).toBe('load_error');
+  });
+});
+
+describe('integration env sanitization in payload', () => {
+  beforeEach(() => {
+    resetTelemetryUsageContextForTests();
+    delete process.env.VARLOCK_INTEGRATION;
   });
 
   it('ignores invalid integration env values in telemetry payload', () => {

--- a/packages/varlock/src/cli/helpers/test/telemetry.test.ts
+++ b/packages/varlock/src/cli/helpers/test/telemetry.test.ts
@@ -7,7 +7,7 @@ vi.mock('../js-package-manager-utils', () => ({
 }));
 
 import { detectJsPackageManager } from '../js-package-manager-utils';
-import { getJsPackageManagerForTelemetry, normalizeGitRemoteUrl } from '../telemetry';
+import { getJsPackageManagerForTelemetry, normalizeGitRemoteUrl, getProjectSlugFromCi } from '../telemetry';
 
 describe('getJsPackageManagerForTelemetry', () => {
   beforeEach(() => {
@@ -69,5 +69,39 @@ describe('normalizeGitRemoteUrl', () => {
     expect(normalizeGitRemoteUrl('   ')).toBeUndefined();
     expect(normalizeGitRemoteUrl('not-a-url')).toBeUndefined();
     expect(normalizeGitRemoteUrl('https://github.com')).toBeUndefined();
+  });
+});
+
+describe('getProjectSlugFromCi', () => {
+  it('resolves GitHub Actions repo slug', () => {
+    expect(getProjectSlugFromCi({ GITHUB_REPOSITORY: 'Owner/Repo' })).toBe('github.com/owner/repo');
+  });
+
+  it('honors GITHUB_SERVER_URL for GitHub Enterprise', () => {
+    expect(getProjectSlugFromCi({
+      GITHUB_REPOSITORY: 'owner/repo',
+      GITHUB_SERVER_URL: 'https://github.acme.com',
+    })).toBe('github.acme.com/owner/repo');
+  });
+
+  it('resolves GitLab CI slug incl. subgroups', () => {
+    expect(getProjectSlugFromCi({
+      CI_SERVER_HOST: 'gitlab.com',
+      CI_PROJECT_PATH: 'group/subgroup/repo',
+    })).toBe('gitlab.com/group/subgroup/repo');
+  });
+
+  it('resolves Bitbucket Pipelines slug', () => {
+    expect(getProjectSlugFromCi({ BITBUCKET_REPO_FULL_NAME: 'workspace/repo' }))
+      .toBe('bitbucket.org/workspace/repo');
+  });
+
+  it('matches normalizeGitRemoteUrl output for the same repo (CI vs local clone)', () => {
+    expect(getProjectSlugFromCi({ GITHUB_REPOSITORY: 'owner/repo' }))
+      .toBe(normalizeGitRemoteUrl('git@github.com:owner/repo.git'));
+  });
+
+  it('returns undefined when no CI repo vars are present', () => {
+    expect(getProjectSlugFromCi({})).toBeUndefined();
   });
 });

--- a/packages/varlock/src/cli/helpers/test/telemetry.test.ts
+++ b/packages/varlock/src/cli/helpers/test/telemetry.test.ts
@@ -1,0 +1,33 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+
+vi.mock('../js-package-manager-utils', () => ({
+  detectJsPackageManager: vi.fn(),
+}));
+
+import { detectJsPackageManager } from '../js-package-manager-utils';
+import { getJsPackageManagerForTelemetry } from '../telemetry';
+
+describe('getJsPackageManagerForTelemetry', () => {
+  beforeEach(() => {
+    vi.mocked(detectJsPackageManager).mockReset();
+  });
+
+  it('returns the detected package manager name', () => {
+    vi.mocked(detectJsPackageManager).mockReturnValue({
+      name: 'pnpm',
+      lockfiles: ['pnpm-lock.yaml'],
+      add: 'pnpm add',
+      exec: 'pnpm exec',
+      dlx: 'pnpm dlx',
+    });
+
+    expect(getJsPackageManagerForTelemetry()).toBe('pnpm');
+  });
+
+  it('returns null when no package manager is detected', () => {
+    vi.mocked(detectJsPackageManager).mockReturnValue(undefined);
+    expect(getJsPackageManagerForTelemetry()).toBeNull();
+  });
+});

--- a/packages/varlock/src/cli/helpers/test/telemetry.test.ts
+++ b/packages/varlock/src/cli/helpers/test/telemetry.test.ts
@@ -7,7 +7,7 @@ vi.mock('../js-package-manager-utils', () => ({
 }));
 
 import { detectJsPackageManager } from '../js-package-manager-utils';
-import { getJsPackageManagerForTelemetry } from '../telemetry';
+import { getJsPackageManagerForTelemetry, normalizeGitRemoteUrl } from '../telemetry';
 
 describe('getJsPackageManagerForTelemetry', () => {
   beforeEach(() => {
@@ -29,5 +29,45 @@ describe('getJsPackageManagerForTelemetry', () => {
   it('returns null when no package manager is detected', () => {
     vi.mocked(detectJsPackageManager).mockReturnValue(undefined);
     expect(getJsPackageManagerForTelemetry()).toBeNull();
+  });
+});
+
+describe('normalizeGitRemoteUrl', () => {
+  it('collapses http/ssh/scp/git clone variants to the same canonical value', () => {
+    const variants = [
+      'git@github.com:owner/repo.git',
+      'git@github.com:owner/repo',
+      'ssh://git@github.com/owner/repo.git',
+      'ssh://git@github.com:22/owner/repo.git',
+      'https://github.com/owner/repo.git',
+      'https://github.com/owner/repo',
+      'http://github.com/owner/repo.git',
+      'https://user:token@github.com/owner/repo.git',
+      'git://github.com/owner/repo.git',
+      'https://github.com/owner/repo/',
+      'https://GitHub.com/Owner/Repo.git',
+    ];
+    for (const v of variants) {
+      expect(normalizeGitRemoteUrl(v), v).toBe('github.com/owner/repo');
+    }
+  });
+
+  it('keeps host distinct so same owner/repo on different hosts do not collide', () => {
+    expect(normalizeGitRemoteUrl('git@gitlab.com:owner/repo.git')).toBe('gitlab.com/owner/repo');
+    expect(normalizeGitRemoteUrl('https://bitbucket.org/owner/repo.git')).toBe('bitbucket.org/owner/repo');
+  });
+
+  it('preserves nested groups (e.g. gitlab subgroups)', () => {
+    expect(normalizeGitRemoteUrl('git@gitlab.com:group/subgroup/repo.git'))
+      .toBe('gitlab.com/group/subgroup/repo');
+    expect(normalizeGitRemoteUrl('https://gitlab.com/group/subgroup/repo.git'))
+      .toBe('gitlab.com/group/subgroup/repo');
+  });
+
+  it('returns undefined for unparseable or empty input', () => {
+    expect(normalizeGitRemoteUrl('')).toBeUndefined();
+    expect(normalizeGitRemoteUrl('   ')).toBeUndefined();
+    expect(normalizeGitRemoteUrl('not-a-url')).toBeUndefined();
+    expect(normalizeGitRemoteUrl('https://github.com')).toBeUndefined();
   });
 });

--- a/packages/varlock/src/cli/helpers/test/telemetry.test.ts
+++ b/packages/varlock/src/cli/helpers/test/telemetry.test.ts
@@ -7,7 +7,9 @@ vi.mock('../js-package-manager-utils', () => ({
 }));
 
 import { detectJsPackageManager } from '../js-package-manager-utils';
-import { getJsPackageManagerForTelemetry, normalizeGitRemoteUrl, getProjectSlugFromCi } from '../telemetry';
+import {
+  getJsPackageManagerForTelemetry, normalizeGitRemoteUrl, getProjectSlugFromCi, bucketGitHost,
+} from '../telemetry';
 
 describe('getJsPackageManagerForTelemetry', () => {
   beforeEach(() => {
@@ -69,6 +71,26 @@ describe('normalizeGitRemoteUrl', () => {
     expect(normalizeGitRemoteUrl('   ')).toBeUndefined();
     expect(normalizeGitRemoteUrl('not-a-url')).toBeUndefined();
     expect(normalizeGitRemoteUrl('https://github.com')).toBeUndefined();
+  });
+});
+
+describe('bucketGitHost', () => {
+  it('emits well-known public hosts verbatim', () => {
+    expect(bucketGitHost('github.com')).toBe('github.com');
+    expect(bucketGitHost('gitlab.com')).toBe('gitlab.com');
+    expect(bucketGitHost('bitbucket.org')).toBe('bitbucket.org');
+  });
+
+  it('buckets self-hosted / internal hosts so a private hostname is never emitted', () => {
+    expect(bucketGitHost('github.acme-corp.com')).toBe('self-hosted'); // GitHub Enterprise
+    expect(bucketGitHost('gitlab.internal.example')).toBe('self-hosted');
+    expect(bucketGitHost('git.acme.io')).toBe('self-hosted');
+  });
+
+  it('returns null for empty input', () => {
+    expect(bucketGitHost(null)).toBeNull();
+    expect(bucketGitHost(undefined)).toBeNull();
+    expect(bucketGitHost('')).toBeNull();
   });
 });
 

--- a/packages/varlock/src/env-graph/lib/plugins.ts
+++ b/packages/varlock/src/env-graph/lib/plugins.ts
@@ -158,6 +158,11 @@ async function loadPluginModuleESM(filePath: string): Promise<void> {
 }
 
 
+/** Allowed value types for plugin telemetry attributes (strictly sanitized before send) */
+export type PluginTelemetryAttributeValue = boolean | number | string | null;
+/** Flat object of anonymous, non-sensitive usage attributes a plugin reports for telemetry */
+export type PluginTelemetryAttributes = Record<string, PluginTelemetryAttributeValue>;
+
 export class VarlockPlugin {
   // helper so end user code can get same error classes
   readonly ERRORS = {
@@ -254,6 +259,21 @@ export class VarlockPlugin {
   registerResolverFunction<T>(resolverDef: ResolverDef<T>) {
     this.debug('registerResolverFunction', resolverDef.name);
     this.resolverFunctions!.push(resolverDef);
+  }
+
+  /** @internal telemetry attributes provider registered by the plugin (collected for official plugins only) */
+  _getTelemetryAttributes?: () => PluginTelemetryAttributes;
+  /**
+   * Register a function returning a flat object of anonymous, non-sensitive usage
+   * attributes for this plugin (booleans, short enum strings, counts) — e.g. which
+   * auth mode is in use, whether a feature is enabled. Called when telemetry is
+   * captured. Values are strictly sanitized and only collected for official
+   * `@varlock/*` plugins. Throwing or returning unexpected shapes is safe —
+   * offending entries are dropped. Never include secret values, names, or paths.
+   */
+  registerTelemetryAttributes(fn: () => PluginTelemetryAttributes) {
+    this.debug('registerTelemetryAttributes');
+    this._getTelemetryAttributes = fn;
   }
 
   /**

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -56,6 +56,29 @@ export class VarlockExecError extends Error {
 
 export type ExecVarlockResult = { stdout: string, stderr: string };
 
+export function integrationTelemetryEnv(name: string, version: string) {
+  return { VARLOCK_INTEGRATION: `${name}@${version}` };
+}
+
+function mergeExecEnv(
+  opts?: ExecSyncVarlockOpts,
+): NodeJS.ProcessEnv | undefined {
+  const baseEnv = opts?.env ?? process.env;
+  if (!opts?.integrationTelemetry && !opts?.env) return undefined;
+
+  const merged = { ...baseEnv } as NodeJS.ProcessEnv;
+  if (
+    opts.integrationTelemetry
+    && !merged.VARLOCK_INTEGRATION
+  ) {
+    Object.assign(
+      merged,
+      integrationTelemetryEnv(opts.integrationTelemetry.name, opts.integrationTelemetry.version),
+    );
+  }
+  return merged;
+}
+
 type ExecSyncVarlockOpts = Parameters<typeof execSyncType>[1] & {
   exitOnError?: boolean,
   showLogsOnError?: boolean,
@@ -72,6 +95,8 @@ type ExecSyncVarlockOpts = Parameters<typeof execSyncType>[1] & {
    * instead of the raw execSync error.
    */
   fullResult?: boolean,
+  /** Identifies the framework integration invoking varlock (passed as VARLOCK_INTEGRATION) */
+  integrationTelemetry?: { name: string, version: string },
 };
 
 /**
@@ -88,13 +113,22 @@ export function execSyncVarlock(
   command: string,
   opts?: ExecSyncVarlockOpts,
 ): string | ExecVarlockResult {
+  const execEnv = mergeExecEnv(opts);
+  const {
+    exitOnError: _exitOnError,
+    showLogsOnError: _showLogsOnError,
+    callerDir: _callerDir,
+    fullResult: _fullResult,
+    integrationTelemetry: _integrationTelemetry,
+    ...childProcessOpts
+  } = opts ?? {};
   try {
     // in most cases, user will be running via their package manager
     // and a package.json script (ie `pnpm run start`)
     // which will inject node_modules/.bin into PATH
     try {
       const result = execSync(`varlock ${command}`, {
-        ...opts?.env && { env: opts.env },
+        ...(execEnv && { env: execEnv }),
         ...opts?.cwd && { cwd: opts.cwd },
         stdio: 'pipe',
       });
@@ -127,7 +161,8 @@ export function execSyncVarlock(
         // .cmd files are batch scripts that must be run through cmd.exe
         const needsShell = varlockPath.endsWith('.cmd');
         const result = execFileSync(varlockPath, command.split(' '), {
-          ...opts,
+          ...childProcessOpts,
+          ...(execEnv && { env: execEnv }),
           stdio: 'pipe',
           ...(needsShell && { shell: true }),
         });

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -57,7 +57,7 @@ export class VarlockExecError extends Error {
 export type ExecVarlockResult = { stdout: string, stderr: string };
 
 export function integrationTelemetryEnv(name: string, version: string) {
-  return { VARLOCK_INTEGRATION: `${name}@${version}` };
+  return { __VARLOCK_INTEGRATION: `${name}@${version}` };
 }
 
 function mergeExecEnv(
@@ -69,7 +69,7 @@ function mergeExecEnv(
   const merged = { ...baseEnv } as NodeJS.ProcessEnv;
   if (
     opts.integrationTelemetry
-    && !merged.VARLOCK_INTEGRATION
+    && !merged.__VARLOCK_INTEGRATION
   ) {
     Object.assign(
       merged,
@@ -95,7 +95,7 @@ type ExecSyncVarlockOpts = Parameters<typeof execSyncType>[1] & {
    * instead of the raw execSync error.
    */
   fullResult?: boolean,
-  /** Identifies the framework integration invoking varlock (passed as VARLOCK_INTEGRATION) */
+  /** Identifies the framework integration invoking varlock (passed as __VARLOCK_INTEGRATION) */
   integrationTelemetry?: { name: string, version: string },
 };
 

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -67,10 +67,9 @@ function mergeExecEnv(
   if (!opts?.integrationTelemetry && !opts?.env) return undefined;
 
   const merged = { ...baseEnv } as NodeJS.ProcessEnv;
-  if (
-    opts.integrationTelemetry
-    && !merged.__VARLOCK_INTEGRATION
-  ) {
+  if (opts.integrationTelemetry) {
+    // __VARLOCK_INTEGRATION is for our internal use only — the integration-provided
+    // identity is authoritative and always wins over any inherited/user-set value.
     Object.assign(
       merged,
       integrationTelemetryEnv(opts.integrationTelemetry.name, opts.integrationTelemetry.version),

--- a/packages/varlock/src/lib/load-graph.ts
+++ b/packages/varlock/src/lib/load-graph.ts
@@ -1,9 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { loadEnvGraph } from '../env-graph';
+import { loadEnvGraph, type EnvGraph } from '../env-graph';
 import { VarlockResolver } from './local-encrypt/builtin-resolver';
 import { KeychainResolver } from './local-encrypt/keychain-resolver';
 import { CliExitError } from '../cli/helpers/exit-error';
+import { captureUsageContextFromEnvGraph } from '../cli/helpers/telemetry-usage-context';
 import { runWithWorkspaceInfo } from './workspace-utils';
 import { readVarlockPackageJsonConfig } from './package-json-config';
 import { createDebug } from './debug';
@@ -20,6 +21,13 @@ function getGraphEnvOverridesFromRuntimeEnv() {
 function normalizePkgLoadPath(pkgLoadPath: string | Array<string>): Array<string> {
   if (Array.isArray(pkgLoadPath)) return pkgLoadPath;
   return [pkgLoadPath];
+}
+
+function captureUsageAfterLoad(promise: Promise<EnvGraph>) {
+  return promise.then((graph) => {
+    captureUsageContextFromEnvGraph(graph);
+    return graph;
+  });
 }
 
 function loadFromPaths(
@@ -50,7 +58,7 @@ function loadFromPaths(
     }
   }
 
-  return runWithWorkspaceInfo(() => loadEnvGraph({
+  return captureUsageAfterLoad(runWithWorkspaceInfo(() => loadEnvGraph({
     currentEnvFallback: config.currentEnvFallback,
     entryFilePaths: resolvedPaths,
     overrideValues: config.overrideValues,
@@ -61,7 +69,7 @@ function loadFromPaths(
       g.registerResolver(VarlockResolver);
       g.registerResolver(KeychainResolver);
     },
-  }));
+  })));
 }
 
 export function loadVarlockEnvGraph(opts?: {
@@ -108,7 +116,7 @@ export function loadVarlockEnvGraph(opts?: {
 
   debug('no path configured, using cwd: %s', process.cwd());
 
-  return runWithWorkspaceInfo(() => loadEnvGraph({
+  return captureUsageAfterLoad(runWithWorkspaceInfo(() => loadEnvGraph({
     currentEnvFallback: opts?.currentEnvFallback,
     overrideValues: runtimeOverrideValues,
     processEnvOverride: runtimeOverrideValues,
@@ -118,5 +126,5 @@ export function loadVarlockEnvGraph(opts?: {
       g.registerResolver(VarlockResolver);
       g.registerResolver(KeychainResolver);
     },
-  }));
+  })));
 }

--- a/packages/varlock/src/lib/load-graph.ts
+++ b/packages/varlock/src/lib/load-graph.ts
@@ -4,7 +4,7 @@ import { loadEnvGraph, type EnvGraph } from '../env-graph';
 import { VarlockResolver } from './local-encrypt/builtin-resolver';
 import { KeychainResolver } from './local-encrypt/keychain-resolver';
 import { CliExitError } from '../cli/helpers/exit-error';
-import { captureUsageContextFromEnvGraph } from '../cli/helpers/telemetry-usage-context';
+import { captureUsageContextFromEnvGraph, captureTelemetryGraphLoadFailure } from '../cli/helpers/telemetry-usage-context';
 import { runWithWorkspaceInfo } from './workspace-utils';
 import { readVarlockPackageJsonConfig } from './package-json-config';
 import { createDebug } from './debug';
@@ -24,10 +24,15 @@ function normalizePkgLoadPath(pkgLoadPath: string | Array<string>): Array<string
 }
 
 function captureUsageAfterLoad(promise: Promise<EnvGraph>) {
-  return promise.then((graph) => {
-    captureUsageContextFromEnvGraph(graph);
-    return graph;
-  });
+  return promise
+    .then((graph) => {
+      captureUsageContextFromEnvGraph(graph);
+      return graph;
+    })
+    .catch((err) => {
+      captureTelemetryGraphLoadFailure(err);
+      throw err;
+    });
 }
 
 function loadFromPaths(
@@ -52,9 +57,11 @@ function loadFromPaths(
 
   for (const resolvedPath of resolvedPaths) {
     if (!fs.existsSync(resolvedPath)) {
-      throw new CliExitError(`${config.errorPrefix}: ${resolvedPath}`, {
+      const err = new CliExitError(`${config.errorPrefix}: ${resolvedPath}`, {
         suggestion: config.errorSuggestion,
       });
+      captureTelemetryGraphLoadFailure(err);
+      throw err;
     }
   }
 

--- a/packages/varlock/src/lib/load-graph.ts
+++ b/packages/varlock/src/lib/load-graph.ts
@@ -26,11 +26,16 @@ function normalizePkgLoadPath(pkgLoadPath: string | Array<string>): Array<string
 function captureUsageAfterLoad(promise: Promise<EnvGraph>) {
   return promise
     .then((graph) => {
-      captureUsageContextFromEnvGraph(graph);
+      // telemetry capture must never turn a successful load into a failure
+      try {
+        captureUsageContextFromEnvGraph(graph);
+      } catch { /* swallow - telemetry is best-effort */ }
       return graph;
     })
     .catch((err) => {
-      captureTelemetryGraphLoadFailure(err);
+      try {
+        captureTelemetryGraphLoadFailure(err);
+      } catch { /* swallow - telemetry is best-effort */ }
       throw err;
     });
 }

--- a/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
+++ b/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
@@ -25,7 +25,7 @@ describe('execSyncVarlock integration telemetry', () => {
     });
   });
 
-  it('passes integrationTelemetry into subprocess env without overwriting explicit values', () => {
+  it('integration-provided identity overrides any inherited __VARLOCK_INTEGRATION (internal use only)', () => {
     execSyncVarlock('load', {
       env: {
         ...process.env,
@@ -41,7 +41,7 @@ describe('execSyncVarlock integration telemetry', () => {
       'varlock load',
       expect.objectContaining({
         env: expect.objectContaining({
-          __VARLOCK_INTEGRATION: '@custom/explicit@9.9.9',
+          __VARLOCK_INTEGRATION: '@varlock/vite-integration@1.1.3',
         }),
       }),
     );

--- a/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
+++ b/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
@@ -1,0 +1,67 @@
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+import { execSync, execFileSync } from 'node:child_process';
+import { integrationTelemetryEnv, execSyncVarlock } from '../exec-sync-varlock';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(() => Buffer.from('ok')),
+  execFileSync: vi.fn(() => Buffer.from('ok')),
+}));
+
+describe('execSyncVarlock integration telemetry', () => {
+  beforeEach(() => {
+    vi.mocked(execSync).mockClear();
+    vi.mocked(execFileSync).mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.VARLOCK_INTEGRATION;
+  });
+
+  it('integrationTelemetryEnv formats VARLOCK_INTEGRATION', () => {
+    expect(integrationTelemetryEnv('@varlock/vite-integration', '1.1.3')).toEqual({
+      VARLOCK_INTEGRATION: '@varlock/vite-integration@1.1.3',
+    });
+  });
+
+  it('passes integrationTelemetry into subprocess env without overwriting explicit values', () => {
+    execSyncVarlock('load', {
+      env: {
+        ...process.env,
+        VARLOCK_INTEGRATION: '@custom/explicit@9.9.9',
+      },
+      integrationTelemetry: {
+        name: '@varlock/vite-integration',
+        version: '1.1.3',
+      },
+    });
+
+    expect(execSync).toHaveBeenCalledWith(
+      'varlock load',
+      expect.objectContaining({
+        env: expect.objectContaining({
+          VARLOCK_INTEGRATION: '@custom/explicit@9.9.9',
+        }),
+      }),
+    );
+  });
+
+  it('sets VARLOCK_INTEGRATION when integrationTelemetry is provided', () => {
+    execSyncVarlock('load', {
+      integrationTelemetry: {
+        name: '@varlock/nextjs-integration',
+        version: '1.1.3',
+      },
+    });
+
+    expect(execSync).toHaveBeenCalledWith(
+      'varlock load',
+      expect.objectContaining({
+        env: expect.objectContaining({
+          VARLOCK_INTEGRATION: '@varlock/nextjs-integration@1.1.3',
+        }),
+      }),
+    );
+  });
+});

--- a/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
+++ b/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
@@ -16,12 +16,12 @@ describe('execSyncVarlock integration telemetry', () => {
   });
 
   afterEach(() => {
-    delete process.env.VARLOCK_INTEGRATION;
+    delete process.env.__VARLOCK_INTEGRATION;
   });
 
-  it('integrationTelemetryEnv formats VARLOCK_INTEGRATION', () => {
+  it('integrationTelemetryEnv formats __VARLOCK_INTEGRATION', () => {
     expect(integrationTelemetryEnv('@varlock/vite-integration', '1.1.3')).toEqual({
-      VARLOCK_INTEGRATION: '@varlock/vite-integration@1.1.3',
+      __VARLOCK_INTEGRATION: '@varlock/vite-integration@1.1.3',
     });
   });
 
@@ -29,7 +29,7 @@ describe('execSyncVarlock integration telemetry', () => {
     execSyncVarlock('load', {
       env: {
         ...process.env,
-        VARLOCK_INTEGRATION: '@custom/explicit@9.9.9',
+        __VARLOCK_INTEGRATION: '@custom/explicit@9.9.9',
       },
       integrationTelemetry: {
         name: '@varlock/vite-integration',
@@ -41,13 +41,13 @@ describe('execSyncVarlock integration telemetry', () => {
       'varlock load',
       expect.objectContaining({
         env: expect.objectContaining({
-          VARLOCK_INTEGRATION: '@custom/explicit@9.9.9',
+          __VARLOCK_INTEGRATION: '@custom/explicit@9.9.9',
         }),
       }),
     );
   });
 
-  it('sets VARLOCK_INTEGRATION when integrationTelemetry is provided', () => {
+  it('sets __VARLOCK_INTEGRATION when integrationTelemetry is provided', () => {
     execSyncVarlock('load', {
       integrationTelemetry: {
         name: '@varlock/nextjs-integration',
@@ -59,7 +59,7 @@ describe('execSyncVarlock integration telemetry', () => {
       'varlock load',
       expect.objectContaining({
         env: expect.objectContaining({
-          VARLOCK_INTEGRATION: '@varlock/nextjs-integration@1.1.3',
+          __VARLOCK_INTEGRATION: '@varlock/nextjs-integration@1.1.3',
         }),
       }),
     );

--- a/packages/varlock/src/plugin-lib.ts
+++ b/packages/varlock/src/plugin-lib.ts
@@ -2,6 +2,7 @@ import type { VarlockPlugin } from './env-graph/lib/plugins';
 import { pluginProxy } from './plugin-context';
 
 export type { Resolver } from './env-graph/lib/resolver';
+export type { PluginTelemetryAttributes, PluginTelemetryAttributeValue } from './env-graph/lib/plugins';
 export type { PluginCacheAccessor } from './lib/cache/plugin-cache-accessor';
 export { parseTtl } from './lib/cache/ttl-parser';
 export { resolveCacheTtl } from './lib/cache/resolve-cache-ttl';


### PR DESCRIPTION
Enriches anonymous CLI telemetry so we can understand how varlock is used in the wild — which commands run, which framework integrations invoke the CLI, which plugins and schema features are active, how each plugin is configured, and the JS package manager — without collecting config values, env vars, secrets, or file paths.

### Usage context (populated when the env graph loads)
- Plugins in use (`@varlock/*` names + versions as-is; third-party names SHA-256 hashed, versions omitted), integration identity, and schema feature signals (settings flags, cache mode, allowlisted resolver/decorator names, source-type counts, config item count)
- `graph_loaded` plus a coarse `error_code` enum on failure (no messages or paths)
- Defers `trackCommand()` until after command handlers finish so graph-loading commands include this data

### Per-plugin usage attributes (new)
- Adds `plugin.registerTelemetryAttributes()` so a plugin can report anonymous, non-sensitive usage signals (auth mode, feature flags, counts)
- Collected for **official `@varlock/*` plugins only**; values are strictly sanitized (booleans / short enums / finite numbers / null; key count capped) so secrets, hostnames, IDs, and paths can't leak. A throwing hook is ignored.
- Implemented across all official plugins — e.g. 1Password (app vs service-account vs Connect, environments), AWS/Azure/GCP/Vault/Akeyless/Infisical auth methods, self-hosted vs cloud, Bitwarden Secrets Manager vs Password Manager (`bw` CLI), Kubernetes connection mode, etc. Local/single-auth plugins report standard attributes only.

### Project grouping
- Keeps the original `anonymous_project_id` (raw-remote hash) for measurement continuity
- Adds `anonymous_project_id_v2` (hash of canonical `host/owner/repo`, collapsing http/ssh/scp/git clone variants), `anonymous_org_id` (hash of `host/owner`), and `git_host`
- The normalized slug resolves from CI env vars first (GitHub Actions incl. GHE, GitLab CI, Bitbucket), falling back to the parsed remote
- `git_host` is sent unhashed but allowlisted to well-known public hosts; self-hosted / GitHub Enterprise hosts bucket to `self-hosted` so no private hostname is ever emitted

### Integrations
- Pass identity to the CLI via the internal `__VARLOCK_INTEGRATION` env var (`integrationTelemetry` option through `execSyncVarlock`); the integration-provided value is authoritative
- Bake each integration's package name/version in as build-time defines instead of importing `package.json` into the shipped bundle
- Adds `js_package_manager` (npm / pnpm / yarn / bun / deno / null) via existing lockfile detection

### Safety
- Telemetry is fully failure-isolated: usage capture can never fail an otherwise-successful load, and the send path can never throw into / mask a CLI command (even when opted out)
- All fields flow through the existing opt-out gate — no network requests when telemetry is disabled
- Updates the [telemetry guide](/packages/varlock-website/src/content/docs/guides/telemetry.mdx)