### PR TITLE
feat: add keychain CLI commands

### DIFF
--- a/.bumpy/keychain-import-require-schema.md
+++ b/.bumpy/keychain-import-require-schema.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Require an explicit schema before importing plaintext Keychain secrets

--- a/.bumpy/varlock-keychain-cli.md
+++ b/.bumpy/varlock-keychain-cli.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+Add macOS Keychain management commands.

--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -50,6 +50,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.native-bin-subdir }}
+    env:
+      HAS_OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN != '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -91,27 +93,27 @@ jobs:
       # macOS Developer ID signing flow. Skipped when OP_CI_TOKEN is absent
       # (e.g. fork PRs), leaving the Windows binary unsigned.
       - name: Windows signing skipped (no OP_CI_TOKEN)
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN == ''
+        if: contains(matrix.os, 'windows') && env.HAS_OP_CI_TOKEN != 'true'
         shell: bash
         run: |
           echo "Azure Artifact Signing skipped: OP_CI_TOKEN not available (fork PR?) — Windows binary will be unsigned"
 
       - name: Setup Bun (for varlock secret loading)
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        if: contains(matrix.os, 'windows') && env.HAS_OP_CI_TOKEN == 'true'
         uses: oven-sh/setup-bun@v2
 
       - name: Install node deps (for varlock secret loading)
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        if: contains(matrix.os, 'windows') && env.HAS_OP_CI_TOKEN == 'true'
         run: bun install
 
       # Build varlock JS so we can use it to resolve secrets from 1Password
       - name: Build varlock libs
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        if: contains(matrix.os, 'windows') && env.HAS_OP_CI_TOKEN == 'true'
         run: bun run build:libs
 
       # Load Azure signing secrets from 1Password via varlock (scoped to the Rust package)
       - name: Load signing secrets
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        if: contains(matrix.os, 'windows') && env.HAS_OP_CI_TOKEN == 'true'
         uses: dmno-dev/varlock-action@v1.0.3
         with:
           working-directory: packages/encryption-binary-rust
@@ -119,7 +121,7 @@ jobs:
           OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN }}
 
       - name: Azure login (OIDC)
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        if: contains(matrix.os, 'windows') && env.HAS_OP_CI_TOKEN == 'true'
         uses: azure/login@v2
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
@@ -127,7 +129,7 @@ jobs:
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Sign Windows binary (Azure Artifact Signing)
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        if: contains(matrix.os, 'windows') && env.HAS_OP_CI_TOKEN == 'true'
         uses: azure/artifact-signing-action@v2
         with:
           endpoint: ${{ env.AZURE_ARTIFACT_SIGNING_ENDPOINT }}

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
@@ -12,6 +12,25 @@ enum KeychainError: LocalizedError {
     case keychainNotFound(String)
     case ambiguousMatch(service: String, accounts: [String])
 
+    var code: String {
+        switch self {
+        case .itemNotFound:
+            return "itemNotFound"
+        case .accessDenied:
+            return "accessDenied"
+        case .duplicateItem:
+            return "duplicateItem"
+        case .unexpectedData:
+            return "unexpectedData"
+        case .unhandledError:
+            return "unhandledError"
+        case .keychainNotFound:
+            return "keychainNotFound"
+        case .ambiguousMatch:
+            return "ambiguousMatch"
+        }
+    }
+
     var errorDescription: String? {
         switch self {
         case .itemNotFound:

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
@@ -301,6 +301,50 @@ final class KeychainManager {
 
     // MARK: - Add Item
 
+    /// Create or update a generic password item.
+    /// Returns true when an existing item was updated, false when a new item was created.
+    static func setGenericPassword(service: String, account: String, value: String, update: Bool = false) throws -> Bool {
+        guard let valueData = value.data(using: .utf8) else {
+            throw KeychainError.unexpectedData
+        }
+
+        let lookup: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+        ]
+
+        if update {
+            let attrs: [CFString: Any] = [
+                kSecValueData: valueData,
+                kSecAttrLabel: account.isEmpty ? service : account,
+            ]
+            let status = SecItemUpdate(lookup as CFDictionary, attrs as CFDictionary)
+            switch status {
+            case errSecSuccess:
+                return true
+            case errSecItemNotFound:
+                break
+            default:
+                throw KeychainError.unhandledError(status)
+            }
+        }
+
+        var addQuery = lookup
+        addQuery[kSecAttrLabel] = account.isEmpty ? service : account
+        addQuery[kSecValueData] = valueData
+
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        switch status {
+        case errSecSuccess:
+            return false
+        case errSecDuplicateItem:
+            throw KeychainError.duplicateItem
+        default:
+            throw KeychainError.unhandledError(status)
+        }
+    }
+
     /// Create a new keychain item as a secure note.
     /// The label is the only user-visible identifier in Keychain Access.
     /// The value is stored as RTF for Keychain Access compatibility.

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
@@ -483,6 +483,16 @@ final class KeychainManager {
     /// Get a SecKeychainItem reference for ACL operations.
     /// Searches generic passwords first, then internet passwords.
     private static func getItemRef(service: String, account: String?, keychainName: String?) throws -> SecKeychainItem {
+        let searchList: [SecKeychain]?
+        if let keychainName = keychainName {
+            guard let keychainRef = resolveKeychain(named: keychainName) else {
+                throw KeychainError.keychainNotFound(keychainName)
+            }
+            searchList = [keychainRef]
+        } else {
+            searchList = nil
+        }
+
         for itemClass in [kSecClassGenericPassword, kSecClassInternetPassword] {
             let serviceAttribute = itemClass == kSecClassGenericPassword ? kSecAttrService : kSecAttrServer
 
@@ -494,8 +504,8 @@ final class KeychainManager {
                     serviceAttribute: service,
                 ]
 
-                if let keychainName = keychainName, let keychainRef = resolveKeychain(named: keychainName) {
-                    countQuery[kSecMatchSearchList] = [keychainRef]
+                if let searchList = searchList {
+                    countQuery[kSecMatchSearchList] = searchList
                 }
 
                 var countResult: AnyObject?
@@ -520,8 +530,8 @@ final class KeychainManager {
                 query[kSecAttrAccount] = account
             }
 
-            if let keychainName = keychainName, let keychainRef = resolveKeychain(named: keychainName) {
-                query[kSecMatchSearchList] = [keychainRef]
+            if let searchList = searchList {
+                query[kSecMatchSearchList] = searchList
             }
 
             var result: AnyObject?

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
@@ -484,17 +484,37 @@ final class KeychainManager {
     /// Searches generic passwords first, then internet passwords.
     private static func getItemRef(service: String, account: String?, keychainName: String?) throws -> SecKeychainItem {
         for itemClass in [kSecClassGenericPassword, kSecClassInternetPassword] {
+            let serviceAttribute = itemClass == kSecClassGenericPassword ? kSecAttrService : kSecAttrServer
+
+            if account == nil {
+                var countQuery: [CFString: Any] = [
+                    kSecClass: itemClass,
+                    kSecReturnAttributes: true,
+                    kSecMatchLimit: kSecMatchLimitAll,
+                    serviceAttribute: service,
+                ]
+
+                if let keychainName = keychainName, let keychainRef = resolveKeychain(named: keychainName) {
+                    countQuery[kSecMatchSearchList] = [keychainRef]
+                }
+
+                var countResult: AnyObject?
+                let countStatus = SecItemCopyMatching(countQuery as CFDictionary, &countResult)
+                if countStatus == errSecSuccess, let items = countResult as? [[String: Any]], items.count > 1 {
+                    let accounts = items.compactMap { $0[kSecAttrAccount as String] as? String }
+                    throw KeychainError.ambiguousMatch(
+                        service: service,
+                        accounts: accounts
+                    )
+                }
+            }
+
             var query: [CFString: Any] = [
                 kSecClass: itemClass,
                 kSecReturnRef: true,
                 kSecMatchLimit: kSecMatchLimitOne,
+                serviceAttribute: service,
             ]
-
-            if itemClass == kSecClassGenericPassword {
-                query[kSecAttrService] = service
-            } else {
-                query[kSecAttrServer] = service
-            }
 
             if let account = account {
                 query[kSecAttrAccount] = account

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/main.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/main.swift
@@ -364,6 +364,54 @@ case "daemon":
             }
             return ["result": selected]
 
+        case "keychain-fix-access":
+            guard let payload = message["payload"] as? [String: Any] else {
+                return ["error": "Missing payload"]
+            }
+            guard let service = payload["service"] as? String else {
+                return ["error": "Missing service"]
+            }
+            let account = payload["account"] as? String
+            let keychainName = payload["keychain"] as? String
+            let appPath = Bundle.main.executablePath ?? ProcessInfo.processInfo.arguments[0]
+
+            do {
+                let modified = try KeychainManager.addToACL(
+                    service: service,
+                    account: account,
+                    keychainName: keychainName,
+                    appPath: appPath
+                )
+                return ["result": ["modified": modified]]
+            } catch {
+                return ["error": error.localizedDescription]
+            }
+
+        case "keychain-set":
+            guard let payload = message["payload"] as? [String: Any] else {
+                return ["error": "Missing payload"]
+            }
+            guard let service = payload["service"] as? String else {
+                return ["error": "Missing service"]
+            }
+            guard let value = payload["value"] as? String else {
+                return ["error": "Missing value"]
+            }
+            let account = payload["account"] as? String ?? ""
+            let update = payload["update"] as? Bool ?? false
+
+            do {
+                let updated = try KeychainManager.setGenericPassword(
+                    service: service,
+                    account: account,
+                    value: value,
+                    update: update
+                )
+                return ["result": ["updated": updated]]
+            } catch {
+                return ["error": error.localizedDescription]
+            }
+
         default:
             return ["error": "Unknown action: \(action)"]
         }

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/main.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/main.swift
@@ -27,6 +27,16 @@ func jsonSuccess(_ result: [String: Any]) -> Never {
     _exit(0)
 }
 
+func keychainErrorResponse(_ error: Error) -> [String: Any] {
+    if let keychainError = error as? KeychainError {
+        return [
+            "error": keychainError.localizedDescription,
+            "errorCode": keychainError.code,
+        ]
+    }
+    return ["error": error.localizedDescription]
+}
+
 // MARK: - CLI Parsing
 
 let args = CommandLine.arguments
@@ -324,7 +334,7 @@ case "daemon":
                     )
                     return ["result": value]
                 } catch {
-                    return ["error": error.localizedDescription]
+                    return keychainErrorResponse(error)
                 }
             }
 
@@ -344,7 +354,7 @@ case "daemon":
                 statusBarMenu?.refresh()
                 return ["result": value]
             } catch {
-                return ["error": error.localizedDescription]
+                return keychainErrorResponse(error)
             }
 
         case "keychain-search":
@@ -384,7 +394,7 @@ case "daemon":
                 )
                 return ["result": ["modified": modified]]
             } catch {
-                return ["error": error.localizedDescription]
+                return keychainErrorResponse(error)
             }
 
         case "keychain-set":
@@ -409,7 +419,7 @@ case "daemon":
                 )
                 return ["result": ["updated": updated]]
             } catch {
-                return ["error": error.localizedDescription]
+                return keychainErrorResponse(error)
             }
 
         default:

--- a/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
@@ -47,7 +47,7 @@ If you already have sensitive plaintext values in a local `.env` file, import th
 varlock keychain import --from .env --profile jb --write .env.jb
 ```
 
-Import only includes variables marked `@sensitive` in your schema. It never prints secret values. By default, Varlock refuses to overwrite existing Keychain items or existing refs in the target env file; pass `--force` to overwrite both.
+Import requires an existing `.env.schema` file for the input env file so Varlock knows which input variables are secrets and which are not. It only includes variables marked `@sensitive` in that schema and never prints secret values. By default, Varlock refuses to overwrite existing Keychain items or existing refs in the target env file; pass `--force` to overwrite both.
 
 Generated refs use `service="varlock"` and account names like `<project>:<profile>:<ENV_VAR>`. The project defaults to the current directory name and can be overridden:
 

--- a/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
@@ -39,6 +39,58 @@ Rather than wiring up items individually, the easiest way to get started is by u
 ITEM=keychain(prompt) # Opens a native picker dialog
 ```
 
+## Import plaintext env files
+
+If you already have sensitive plaintext values in a local `.env` file, import them into macOS Keychain and write stable `keychain(...)` references to a profile env file:
+
+```sh
+varlock keychain import --from .env --profile jb --write .env.jb
+```
+
+Import only includes variables marked `@sensitive` in your schema. It never prints secret values. By default, Varlock refuses to overwrite existing Keychain items or existing refs in the target env file; pass `--force` to overwrite both.
+
+Generated refs use `service="varlock"` and account names like `<project>:<profile>:<ENV_VAR>`. The project defaults to the current directory name and can be overridden:
+
+```sh
+varlock keychain import --from .env --profile jb --project my-app --write .env.jb
+```
+
+## Set one secret manually
+
+To store one secret without putting the value in shell history, run `set` and enter the value at the masked prompt:
+
+```sh
+varlock keychain set API_KEY --profile jb --write .env.jb
+```
+
+This stores the item under `service="varlock"` with account `<project>:<profile>:API_KEY`, then writes the matching `keychain(...)` ref when `--write` is provided. If you need to paste a multi-line secret, pipe it through stdin instead of passing it as a command-line argument:
+
+```sh
+cat secret.txt | varlock keychain set PRIVATE_KEY --profile jb --write .env.jb
+```
+
+By default, `set` refuses to overwrite an existing Keychain item or env ref. Pass `--force` to replace both.
+
+## Access management
+
+If VarlockEnclave cannot read an existing Keychain item, grant access without using `/usr/bin/security` directly:
+
+```sh
+varlock keychain fix-access --account "my-app:jb:API_KEY"
+```
+
+`--service` defaults to `varlock`, but can be overridden for legacy or manually-created Keychain items:
+
+```sh
+varlock keychain fix-access --service "com.company.api" --account "admin"
+```
+
+You can also fix every explicit `keychain(...)` ref in an env file:
+
+```sh
+varlock keychain fix-access --path .env.jb
+```
+
 ## Reference
 
 <div class="reference-docs">

--- a/packages/varlock/src/cli/cli-executable.ts
+++ b/packages/varlock/src/cli/cli-executable.ts
@@ -29,6 +29,7 @@ import { commandSpec as installPluginCommandSpec } from './commands/install-plug
 import { commandSpec as auditCommandSpec } from './commands/audit.command';
 import { commandSpec as generateKeyCommandSpec } from './commands/generate-key.command';
 import { commandSpec as cacheCommandSpec } from './commands/cache.command';
+import { commandSpec as keychainCommandSpec } from './commands/keychain.command';
 // import { commandSpec as loginCommandSpec } from './commands/login.command';
 // import { commandSpec as pluginCommandSpec } from './commands/plugin.command';
 
@@ -71,6 +72,7 @@ subCommands.set('typegen', buildLazyCommand(typegenCommandSpec, async () => awai
 subCommands.set('install-plugin', buildLazyCommand(installPluginCommandSpec, async () => await import('./commands/install-plugin.command')));
 subCommands.set('generate-key', buildLazyCommand(generateKeyCommandSpec, async () => await import('./commands/generate-key.command')));
 subCommands.set('cache', buildLazyCommand(cacheCommandSpec, async () => await import('./commands/cache.command')));
+subCommands.set('keychain', buildLazyCommand(keychainCommandSpec, async () => await import('./commands/keychain.command')));
 // subCommands.set('login', buildLazyCommand(loginCommandSpec, async () => await import('./commands/login.command')));
 // subCommands.set('plugin', buildLazyCommand(pluginCommandSpec, async () => await import('./commands/plugin.command')));
 

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -1,0 +1,469 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import ansis from 'ansis';
+import { define } from 'gunshi';
+import { isCancel } from '@clack/prompts';
+import {
+  parseEnvSpecDotEnvFile,
+  ParsedEnvSpecFunctionCall,
+  ParsedEnvSpecKeyValuePair,
+  ParsedEnvSpecStaticValue,
+} from '@env-spec/parser';
+
+import { loadVarlockEnvGraph } from '../../lib/load-graph';
+import { writeBackValue } from '../../lib/local-encrypt/write-back';
+import { getDaemonClient } from '../../lib/local-encrypt';
+import { CliExitError } from '../helpers/exit-error';
+import { password } from '../helpers/prompts';
+import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
+
+type KeychainRef = {
+  key?: string;
+  service: string;
+  account?: string;
+  keychain?: string;
+};
+
+export const commandSpec = define({
+  name: 'keychain',
+  description: 'Manage macOS Keychain items used by keychain()',
+  args: {
+    service: {
+      type: 'string',
+      description: 'Keychain service name (default: varlock)',
+      default: 'varlock',
+    },
+    account: {
+      type: 'string',
+      description: 'Keychain account name',
+    },
+    keychain: {
+      type: 'string',
+      description: 'Keychain name to search, such as Login or System',
+    },
+    path: {
+      type: 'string',
+      description: 'Path to an env file containing keychain() refs',
+    },
+    from: {
+      type: 'string',
+      description: 'Plaintext env file to import from',
+    },
+    write: {
+      type: 'string',
+      description: 'Env file to write keychain() refs to',
+    },
+    profile: {
+      type: 'string',
+      description: 'Profile name used in generated account names',
+      default: 'local',
+    },
+    project: {
+      type: 'string',
+      description: 'Project slug used in generated account names (default: current directory name)',
+    },
+    force: {
+      type: 'boolean',
+      description: 'Overwrite existing Keychain items and env refs',
+    },
+  },
+  examples: `
+Examples:
+  varlock keychain list
+  varlock keychain fix-access --account "my-project:jb:API_KEY"
+  varlock keychain fix-access --path .env.jb
+  varlock keychain import --from .env --profile jb --write .env.jb
+  varlock keychain set API_KEY --profile jb --write .env.jb
+`.trim(),
+});
+
+function assertMacOS() {
+  if (process.platform !== 'darwin') {
+    throw new CliExitError('varlock keychain is only supported on macOS');
+  }
+}
+
+function quoteEnvString(value: string): string {
+  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+}
+
+function formatKeychainRef(ref: KeychainRef): string {
+  const parts = [`service=${quoteEnvString(ref.service)}`];
+  if (ref.account) parts.push(`account=${quoteEnvString(ref.account)}`);
+  if (ref.keychain) parts.push(`keychain=${quoteEnvString(ref.keychain)}`);
+  return `keychain(${parts.join(', ')})`;
+}
+
+function getGeneratedAccount(project: string, profile: string, key: string): string {
+  return `${project}:${profile}:${key}`;
+}
+
+function getStaticString(value: unknown): string | undefined {
+  if (value instanceof ParsedEnvSpecStaticValue && typeof value.value === 'string') {
+    return value.value;
+  }
+  return undefined;
+}
+
+export function extractKeychainRefFromCall(key: string, call: ParsedEnvSpecFunctionCall): KeychainRef | undefined {
+  if (call.name !== 'keychain') return undefined;
+
+  let service: string | undefined;
+  let account: string | undefined;
+  let keychain: string | undefined;
+
+  for (const arg of call.data.args.values) {
+    if (arg instanceof ParsedEnvSpecStaticValue) {
+      const value = getStaticString(arg);
+      if (value && value !== 'prompt' && !service) service = value;
+      continue;
+    }
+
+    if (!(arg instanceof ParsedEnvSpecKeyValuePair)) continue;
+
+    const value = getStaticString(arg.value);
+    if (typeof value !== 'string') continue;
+
+    if (arg.key === 'service') service = value;
+    if (arg.key === 'account') account = value;
+    if (arg.key === 'keychain') keychain = value;
+  }
+
+  if (!service) return undefined;
+  return {
+    key, service, account, keychain,
+  };
+}
+
+export function extractKeychainRefsFromFile(filePath: string): Array<KeychainRef> {
+  const contents = fs.readFileSync(filePath, 'utf-8');
+  const parsed = parseEnvSpecDotEnvFile(contents);
+  const refs: Array<KeychainRef> = [];
+
+  for (const item of parsed.configItems) {
+    if (item.value instanceof ParsedEnvSpecFunctionCall) {
+      const ref = extractKeychainRefFromCall(item.key, item.value);
+      if (ref) refs.push(ref);
+    }
+  }
+
+  return refs;
+}
+
+function appendEnvRef(filePath: string, key: string, ref: string) {
+  let current = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  if (current.length > 0 && !current.endsWith('\n')) current += '\n';
+  current += `${key}=${ref}\n`;
+  fs.writeFileSync(filePath, current);
+}
+
+function getExistingEnvKeys(filePath: string): Set<string> {
+  if (!fs.existsSync(filePath)) return new Set();
+  const parsed = parseEnvSpecDotEnvFile(fs.readFileSync(filePath, 'utf-8'));
+  return new Set(parsed.configItems.map((item) => item.key));
+}
+
+function writeEnvRef(filePath: string, key: string, ref: string, force: boolean) {
+  const existingKeys = getExistingEnvKeys(filePath);
+  if (!existingKeys.has(key)) {
+    appendEnvRef(filePath, key, ref);
+    return;
+  }
+
+  if (!force) {
+    throw new CliExitError(`Refusing to overwrite ${key} in ${filePath}`, {
+      suggestion: 'Re-run with --force to overwrite existing env refs.',
+    });
+  }
+
+  const result = writeBackValue(key, ref, filePath);
+  if (!result.updated) {
+    throw new CliExitError(`Failed to update ${key} in ${filePath}`);
+  }
+}
+
+async function listKeychainItems(query?: string, keychain?: string) {
+  const client = getDaemonClient();
+  const items = await client.keychainSearch({ query, keychain });
+  if (items.length === 0) {
+    console.log(ansis.gray('No matching Keychain items found.'));
+    return;
+  }
+
+  for (const item of items) {
+    const account = item.account ? ` ${ansis.gray(item.account)}` : '';
+    const kc = item.keychain ? ` ${ansis.gray(`[${item.keychain}]`)}` : '';
+    console.log(`${item.service}${account}${kc}`);
+  }
+}
+
+async function fixAccessForRefs(refs: Array<KeychainRef>) {
+  const client = getDaemonClient();
+  let updated = 0;
+  let unchanged = 0;
+  let failed = 0;
+
+  for (const ref of refs) {
+    try {
+      const result = await client.keychainFixAccess(ref);
+      if (result.modified) updated++;
+      else unchanged++;
+      const label = ref.key ? `${ref.key} ` : '';
+      console.log(`  ${label}${result.modified ? 'updated' : 'already allowed'}`);
+    } catch (err) {
+      failed++;
+      const label = ref.key ? `${ref.key}: ` : '';
+      console.error(ansis.red(`  ${label}${err instanceof Error ? err.message : err}`));
+    }
+  }
+
+  console.log(`\nChecked ${refs.length} item${refs.length === 1 ? '' : 's'}: ${updated} updated, ${unchanged} already allowed, ${failed} failed.`);
+  if (failed > 0) process.exitCode = 1;
+}
+
+async function readSecretForSet(label: string): Promise<string | undefined> {
+  if (!process.stdin.isTTY) {
+    const chunks: Array<Buffer> = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as Buffer);
+    }
+    const rawValue = Buffer.concat(chunks).toString('utf-8').replace(/\r?\n$/, '');
+    if (!rawValue) throw new CliExitError('No value received on stdin');
+    return rawValue;
+  }
+
+  const prompted = await password({
+    message: `Enter secret value for ${label}`,
+    hint: 'for multi-line values, pipe via stdin',
+  });
+  if (isCancel(prompted)) return undefined;
+  if (!prompted) throw new CliExitError('Secret value cannot be empty');
+  return prompted;
+}
+
+async function setKeychainSecret(opts: {
+  key?: string;
+  service: string;
+  account: string;
+  write?: string;
+  force: boolean;
+}) {
+  if (opts.write && !opts.key) {
+    throw new CliExitError('Cannot write an env ref without an env var key', {
+      suggestion: 'Use `varlock keychain set API_KEY --write .env.profile`, or omit --write.',
+    });
+  }
+
+  const label = opts.key ?? opts.account;
+  const value = await readSecretForSet(label);
+  if (value === undefined) return;
+
+  const client = getDaemonClient();
+  if (!opts.force) {
+    try {
+      await client.keychainGet({
+        service: opts.service,
+        account: opts.account,
+        field: 'account',
+      });
+      throw new CliExitError(`Refusing to overwrite existing Keychain item for ${label}`, {
+        suggestion: 'Re-run with --force to overwrite the existing Keychain item.',
+      });
+    } catch (err) {
+      if (err instanceof CliExitError) throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      if (!message.includes('not found')) throw err;
+    }
+  }
+
+  await client.keychainSet({
+    service: opts.service,
+    account: opts.account,
+    value,
+    update: opts.force,
+  });
+
+  const ref = formatKeychainRef({ service: opts.service, account: opts.account });
+  if (opts.write && opts.key) {
+    writeEnvRef(path.resolve(opts.write), opts.key, ref, opts.force);
+  }
+
+  console.log(`Stored ${label} in macOS Keychain.`);
+  if (opts.write) {
+    console.log(`Wrote ref to ${opts.write}.`);
+  } else {
+    console.log(`Ref: ${ref}`);
+  }
+}
+
+async function importPlaintextEnv(opts: {
+  from: string;
+  write: string;
+  service: string;
+  profile: string;
+  project: string;
+  force: boolean;
+}) {
+  const fromPath = path.resolve(opts.from);
+  const writePath = path.resolve(opts.write);
+  if (!fs.existsSync(fromPath)) throw new CliExitError(`File not found: ${fromPath}`);
+
+  const envGraph = await loadVarlockEnvGraph();
+  const sourceFile = parseEnvSpecDotEnvFile(fs.readFileSync(fromPath, 'utf-8'));
+  const itemsToImport: Array<{ key: string; value: string; ref: KeychainRef }> = [];
+
+  for (const item of sourceFile.configItems) {
+    const schemaItem = envGraph.configSchema[item.key];
+    const markedSensitive = schemaItem?.defs.some((def) => (
+      def.itemDef.decorators?.some((decorator) => decorator.name === 'sensitive')
+    ));
+    if (!schemaItem?.isSensitive || !markedSensitive) continue;
+    if (!(item.value instanceof ParsedEnvSpecStaticValue)) continue;
+    const value = item.value.unescapedValue;
+    if (typeof value !== 'string' || value === '') continue;
+
+    itemsToImport.push({
+      key: item.key,
+      value,
+      ref: {
+        service: opts.service,
+        account: getGeneratedAccount(opts.project, opts.profile, item.key),
+      },
+    });
+  }
+
+  if (itemsToImport.length === 0) {
+    console.log('No sensitive plaintext values found to import.');
+    return;
+  }
+
+  const existingEnvKeys = getExistingEnvKeys(writePath);
+  if (!opts.force) {
+    const existingKey = itemsToImport.find((item) => existingEnvKeys.has(item.key));
+    if (existingKey) {
+      throw new CliExitError(`Refusing to overwrite ${existingKey.key} in ${writePath}`, {
+        suggestion: 'Re-run with --force to overwrite existing env refs and Keychain items.',
+      });
+    }
+  }
+
+  const client = getDaemonClient();
+  if (!opts.force) {
+    for (const item of itemsToImport) {
+      try {
+        await client.keychainGet({
+          service: item.ref.service,
+          account: item.ref.account,
+          field: 'account',
+        });
+        throw new CliExitError(`Refusing to overwrite existing Keychain item for ${item.key}`, {
+          suggestion: 'Re-run with --force to overwrite existing env refs and Keychain items.',
+        });
+      } catch (err) {
+        if (err instanceof CliExitError) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        if (!message.includes('not found')) throw err;
+      }
+    }
+  }
+
+  let imported = 0;
+  for (const item of itemsToImport) {
+    await client.keychainSet({
+      service: item.ref.service,
+      account: item.ref.account,
+      value: item.value,
+      update: opts.force,
+    });
+    writeEnvRef(writePath, item.key, formatKeychainRef(item.ref), opts.force);
+    imported++;
+    console.log(`  Imported ${item.key}`);
+  }
+
+  console.log(`\nImported ${imported} sensitive value${imported === 1 ? '' : 's'} into macOS Keychain.`);
+  console.log(`Wrote refs to ${path.relative(process.cwd(), writePath) || writePath}.`);
+}
+
+export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
+  assertMacOS();
+
+  const positionals = (ctx.positionals ?? []).slice(ctx.commandPath?.length ?? 0);
+  const action = positionals[0] ?? 'list';
+  const service = String(ctx.values.service || 'varlock');
+  const account = ctx.values.account ? String(ctx.values.account) : undefined;
+  const keychain = ctx.values.keychain ? String(ctx.values.keychain) : undefined;
+
+  if (action === 'list') {
+    await listKeychainItems(positionals[1], keychain);
+    return;
+  }
+
+  if (action === 'fix-access') {
+    if (ctx.values.path) {
+      const filePath = path.resolve(String(ctx.values.path));
+      const refs = extractKeychainRefsFromFile(filePath);
+      if (refs.length === 0) {
+        console.log(ansis.gray('No explicit keychain() refs found.'));
+        return;
+      }
+      await fixAccessForRefs(refs);
+      return;
+    }
+
+    if (!account) {
+      throw new CliExitError('Missing --account for keychain fix-access', {
+        suggestion: 'Use --account "project:profile:KEY" or --path .env.profile',
+      });
+    }
+
+    await fixAccessForRefs([{ service, account, keychain }]);
+    return;
+  }
+
+  if (action === 'set') {
+    if (keychain) {
+      throw new CliExitError('keychain set does not support --keychain yet', {
+        suggestion: 'Omit --keychain to store the item in the default login keychain.',
+      });
+    }
+
+    const key = positionals[1];
+    const profile = String(ctx.values.profile || 'local');
+    const project = String(ctx.values.project || path.basename(process.cwd()));
+    const targetAccount = account ?? (key ? getGeneratedAccount(project, profile, key) : undefined);
+    if (!targetAccount) {
+      throw new CliExitError('Missing env var key or --account for keychain set', {
+        suggestion: 'Use `varlock keychain set API_KEY --profile local` or `varlock keychain set --account name`.',
+      });
+    }
+
+    await setKeychainSecret({
+      key,
+      service,
+      account: targetAccount,
+      write: ctx.values.write ? String(ctx.values.write) : undefined,
+      force: Boolean(ctx.values.force),
+    });
+    return;
+  }
+
+  if (action === 'import') {
+    if (!ctx.values.from) throw new CliExitError('Missing --from for keychain import');
+    const profile = String(ctx.values.profile || 'local');
+    const project = String(ctx.values.project || path.basename(process.cwd()));
+    const write = ctx.values.write ? String(ctx.values.write) : `.env.${profile}`;
+    await importPlaintextEnv({
+      from: String(ctx.values.from),
+      write,
+      service,
+      profile,
+      project,
+      force: Boolean(ctx.values.force),
+    });
+    return;
+  }
+
+  throw new CliExitError(`Unknown keychain action: ${action}`, {
+    suggestion: 'Use list, fix-access, import, or set.',
+  });
+};

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -13,6 +13,7 @@ import {
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
 import { writeBackValue } from '../../lib/local-encrypt/write-back';
 import { getDaemonClient } from '../../lib/local-encrypt';
+import { DaemonError } from '../../lib/local-encrypt/daemon-client';
 import { CliExitError } from '../helpers/exit-error';
 import { password } from '../helpers/prompts';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
@@ -105,6 +106,10 @@ function getStaticString(value: unknown): string | undefined {
   return undefined;
 }
 
+export function isKeychainItemNotFoundError(error: unknown): boolean {
+  return error instanceof DaemonError && error.code === 'itemNotFound';
+}
+
 export function extractKeychainRefFromCall(key: string, call: ParsedEnvSpecFunctionCall): KeychainRef | undefined {
   if (call.name !== 'keychain') return undefined;
 
@@ -163,6 +168,18 @@ function getExistingEnvKeys(filePath: string): Set<string> {
   return new Set(parsed.configItems.map((item) => item.key));
 }
 
+export function getSensitivePlaintextImportValue(
+  schemaItem: { isSensitive?: boolean; defs?: Array<{ source?: { type?: string } }> } | undefined,
+  value: unknown,
+): string | undefined {
+  const hasSchemaDefinition = schemaItem?.defs?.some((def) => def.source?.type === 'schema');
+  if (!schemaItem?.isSensitive || !hasSchemaDefinition) return undefined;
+  if (!(value instanceof ParsedEnvSpecStaticValue)) return undefined;
+  const unescapedValue = value.unescapedValue;
+  if (typeof unescapedValue !== 'string' || unescapedValue === '') return undefined;
+  return unescapedValue;
+}
+
 function writeEnvRef(filePath: string, key: string, ref: string, force: boolean) {
   const existingKeys = getExistingEnvKeys(filePath);
   if (!existingKeys.has(key)) {
@@ -179,6 +196,20 @@ function writeEnvRef(filePath: string, key: string, ref: string, force: boolean)
   const result = writeBackValue(key, ref, filePath);
   if (!result.updated) {
     throw new CliExitError(`Failed to update ${key} in ${filePath}`);
+  }
+}
+
+export function assertKeychainImportSchemaPresent(envGraph: {
+  sortedDataSources?: Array<{ type?: string; fullPath?: string }>;
+}) {
+  const hasExplicitSchemaFile = envGraph.sortedDataSources?.some((source) => (
+    source.type === 'schema' && source.fullPath
+  ));
+
+  if (!hasExplicitSchemaFile) {
+    throw new CliExitError('Cannot import plaintext secrets without .env.schema for the input file', {
+      suggestion: 'Create .env.schema so Varlock knows which variables in the input env file are secrets, then mark them with @sensitive before running `varlock keychain import`.',
+    });
   }
 }
 
@@ -271,8 +302,7 @@ async function setKeychainSecret(opts: {
       });
     } catch (err) {
       if (err instanceof CliExitError) throw err;
-      const message = err instanceof Error ? err.message : String(err);
-      if (!message.includes('not found')) throw err;
+      if (!isKeychainItemNotFoundError(err)) throw err;
     }
   }
 
@@ -309,18 +339,14 @@ async function importPlaintextEnv(opts: {
   if (!fs.existsSync(fromPath)) throw new CliExitError(`File not found: ${fromPath}`);
 
   const envGraph = await loadVarlockEnvGraph();
+  assertKeychainImportSchemaPresent(envGraph);
   const sourceFile = parseEnvSpecDotEnvFile(fs.readFileSync(fromPath, 'utf-8'));
   const itemsToImport: Array<{ key: string; value: string; ref: KeychainRef }> = [];
 
   for (const item of sourceFile.configItems) {
     const schemaItem = envGraph.configSchema[item.key];
-    const markedSensitive = schemaItem?.defs.some((def) => (
-      def.itemDef.decorators?.some((decorator) => decorator.name === 'sensitive')
-    ));
-    if (!schemaItem?.isSensitive || !markedSensitive) continue;
-    if (!(item.value instanceof ParsedEnvSpecStaticValue)) continue;
-    const value = item.value.unescapedValue;
-    if (typeof value !== 'string' || value === '') continue;
+    const value = getSensitivePlaintextImportValue(schemaItem, item.value);
+    if (value === undefined) continue;
 
     itemsToImport.push({
       key: item.key,
@@ -361,8 +387,7 @@ async function importPlaintextEnv(opts: {
         });
       } catch (err) {
         if (err instanceof CliExitError) throw err;
-        const message = err instanceof Error ? err.message : String(err);
-        if (!message.includes('not found')) throw err;
+        if (!isKeychainItemNotFoundError(err)) throw err;
       }
     }
   }

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -85,10 +85,10 @@ function assertMacOS() {
 }
 
 function quoteEnvString(value: string): string {
-  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('$', '\\$')}"`;
 }
 
-function formatKeychainRef(ref: KeychainRef): string {
+export function formatKeychainRef(ref: KeychainRef): string {
   const parts = [`service=${quoteEnvString(ref.service)}`];
   if (ref.account) parts.push(`account=${quoteEnvString(ref.account)}`);
   if (ref.keychain) parts.push(`keychain=${quoteEnvString(ref.keychain)}`);
@@ -134,7 +134,14 @@ export function extractKeychainRefFromCall(key: string, call: ParsedEnvSpecFunct
     if (arg.key === 'keychain') keychain = value;
   }
 
-  if (!service) return undefined;
+  if (!service) {
+    if (account) {
+      throw new CliExitError(`Cannot fix access for ${key}: account-only keychain() refs are not supported`, {
+        suggestion: 'Add an explicit service to the ref, for example keychain(service="varlock", account="...").',
+      });
+    }
+    return undefined;
+  }
   return {
     key, service, account, keychain,
   };
@@ -286,6 +293,15 @@ async function setKeychainSecret(opts: {
   }
 
   const label = opts.key ?? opts.account;
+  if (opts.write && opts.key && !opts.force) {
+    const writePath = path.resolve(opts.write);
+    if (getExistingEnvKeys(writePath).has(opts.key)) {
+      throw new CliExitError(`Refusing to overwrite ${opts.key} in ${writePath}`, {
+        suggestion: 'Re-run with --force to overwrite the existing env ref and Keychain item.',
+      });
+    }
+  }
+
   const value = await readSecretForSet(label);
   if (value === undefined) return;
 
@@ -338,7 +354,7 @@ async function importPlaintextEnv(opts: {
   const writePath = path.resolve(opts.write);
   if (!fs.existsSync(fromPath)) throw new CliExitError(`File not found: ${fromPath}`);
 
-  const envGraph = await loadVarlockEnvGraph();
+  const envGraph = await loadVarlockEnvGraph({ entryFilePaths: [fromPath] });
   assertKeychainImportSchemaPresent(envGraph);
   const sourceFile = parseEnvSpecDotEnvFile(fs.readFileSync(fromPath, 'utf-8'));
   const itemsToImport: Array<{ key: string; value: string; ref: KeychainRef }> = [];

--- a/packages/varlock/src/cli/commands/test/keychain.command.test.ts
+++ b/packages/varlock/src/cli/commands/test/keychain.command.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { parseEnvSpecDotEnvFile, ParsedEnvSpecFunctionCall } from '@env-spec/parser';
+
+import { extractKeychainRefFromCall } from '../keychain.command.js';
+
+function parseValue(source: string) {
+  const file = parseEnvSpecDotEnvFile(source);
+  const value = file.configItems[0]?.value;
+  if (!(value instanceof ParsedEnvSpecFunctionCall)) throw new Error('Expected function call');
+  return value;
+}
+
+describe('extractKeychainRefFromCall', () => {
+  test('extracts named service and account refs', () => {
+    const ref = extractKeychainRefFromCall(
+      'API_KEY',
+      parseValue('API_KEY=keychain(service="varlock", account="project:jb:API_KEY")'),
+    );
+
+    expect(ref).toEqual({
+      key: 'API_KEY',
+      service: 'varlock',
+      account: 'project:jb:API_KEY',
+      keychain: undefined,
+    });
+  });
+
+  test('extracts positional service shorthand', () => {
+    const ref = extractKeychainRefFromCall(
+      'DATABASE_PASSWORD',
+      parseValue('DATABASE_PASSWORD=keychain("com.company.database")'),
+    );
+
+    expect(ref).toEqual({
+      key: 'DATABASE_PASSWORD',
+      service: 'com.company.database',
+      account: undefined,
+      keychain: undefined,
+    });
+  });
+
+  test('ignores prompt mode refs', () => {
+    const ref = extractKeychainRefFromCall('API_KEY', parseValue('API_KEY=keychain(prompt)'));
+    expect(ref).toBeUndefined();
+  });
+});

--- a/packages/varlock/src/cli/commands/test/keychain.command.test.ts
+++ b/packages/varlock/src/cli/commands/test/keychain.command.test.ts
@@ -1,11 +1,24 @@
 import { describe, expect, test } from 'vitest';
 import { parseEnvSpecDotEnvFile, ParsedEnvSpecFunctionCall } from '@env-spec/parser';
 
-import { extractKeychainRefFromCall } from '../keychain.command.js';
+import {
+  assertKeychainImportSchemaPresent,
+  extractKeychainRefFromCall,
+  getSensitivePlaintextImportValue,
+  isKeychainItemNotFoundError,
+} from '../keychain.command.js';
+import { CliExitError } from '../../helpers/exit-error.js';
+import { DaemonError } from '../../../lib/local-encrypt/daemon-client.js';
+
+function parseConfigItem(source: string) {
+  const file = parseEnvSpecDotEnvFile(source);
+  const item = file.configItems[0];
+  if (!item) throw new Error('Expected config item');
+  return item;
+}
 
 function parseValue(source: string) {
-  const file = parseEnvSpecDotEnvFile(source);
-  const value = file.configItems[0]?.value;
+  const value = parseConfigItem(source).value;
   if (!(value instanceof ParsedEnvSpecFunctionCall)) throw new Error('Expected function call');
   return value;
 }
@@ -42,5 +55,55 @@ describe('extractKeychainRefFromCall', () => {
   test('ignores prompt mode refs', () => {
     const ref = extractKeychainRefFromCall('API_KEY', parseValue('API_KEY=keychain(prompt)'));
     expect(ref).toBeUndefined();
+  });
+});
+
+describe('assertKeychainImportSchemaPresent', () => {
+  test('allows import when an explicit schema file was loaded', () => {
+    expect(() => assertKeychainImportSchemaPresent({
+      sortedDataSources: [{ type: 'container' }, { type: 'schema', fullPath: '/project/.env.schema' }],
+    })).not.toThrow();
+  });
+
+  test('rejects import when only value env files were loaded', () => {
+    expect(() => assertKeychainImportSchemaPresent({
+      sortedDataSources: [{ type: 'container' }, { type: 'values', fullPath: '/project/.env' }],
+    })).toThrow(CliExitError);
+  });
+});
+
+describe('getSensitivePlaintextImportValue', () => {
+  test('imports schema-sensitive plaintext even without an explicit @sensitive decorator', () => {
+    const item = parseConfigItem('API_KEY=secret-value');
+
+    expect(getSensitivePlaintextImportValue({
+      isSensitive: true,
+      defs: [{ source: { type: 'schema' } }],
+    }, item.value)).toBe('secret-value');
+  });
+
+  test('skips non-sensitive plaintext values', () => {
+    const item = parseConfigItem('PUBLIC_VALUE=hello');
+
+    expect(getSensitivePlaintextImportValue({
+      isSensitive: false,
+      defs: [{ source: { type: 'schema' } }],
+    }, item.value)).toBeUndefined();
+  });
+
+  test('skips values that were not defined by the schema file', () => {
+    const item = parseConfigItem('UNSCHEMAED_SECRET=secret-value');
+
+    expect(getSensitivePlaintextImportValue({
+      isSensitive: true,
+      defs: [{ source: { type: 'values' } }],
+    }, item.value)).toBeUndefined();
+  });
+});
+
+describe('isKeychainItemNotFoundError', () => {
+  test('uses stable daemon error codes instead of localized text', () => {
+    expect(isKeychainItemNotFoundError(new DaemonError('localized message', 'itemNotFound'))).toBe(true);
+    expect(isKeychainItemNotFoundError(new DaemonError('Keychain item not found'))).toBe(false);
   });
 });

--- a/packages/varlock/src/cli/commands/test/keychain.command.test.ts
+++ b/packages/varlock/src/cli/commands/test/keychain.command.test.ts
@@ -4,6 +4,7 @@ import { parseEnvSpecDotEnvFile, ParsedEnvSpecFunctionCall } from '@env-spec/par
 import {
   assertKeychainImportSchemaPresent,
   extractKeychainRefFromCall,
+  formatKeychainRef,
   getSensitivePlaintextImportValue,
   isKeychainItemNotFoundError,
 } from '../keychain.command.js';
@@ -55,6 +56,22 @@ describe('extractKeychainRefFromCall', () => {
   test('ignores prompt mode refs', () => {
     const ref = extractKeychainRefFromCall('API_KEY', parseValue('API_KEY=keychain(prompt)'));
     expect(ref).toBeUndefined();
+  });
+
+  test('rejects account-only refs because fix-access requires a service', () => {
+    expect(() => extractKeychainRefFromCall(
+      'API_KEY',
+      parseValue('API_KEY=keychain(account="project:jb:API_KEY")'),
+    )).toThrow(CliExitError);
+  });
+});
+
+describe('formatKeychainRef', () => {
+  test('escapes env-spec expansion syntax in generated refs', () => {
+    expect(formatKeychainRef({
+      service: 'var$lock',
+      account: 'project:$(whoami):API_KEY',
+    })).toBe('keychain(service="var\\$lock", account="project:\\$(whoami):API_KEY")');
   });
 });
 

--- a/packages/varlock/src/lib/local-encrypt/daemon-client.ts
+++ b/packages/varlock/src/lib/local-encrypt/daemon-client.ts
@@ -23,7 +23,9 @@ import { spawn } from 'node:child_process';
 import { getUserVarlockDir } from '../user-config-dir';
 import { resolveNativeBinary } from './binary-resolver';
 import { isWSL } from './wsl-detect';
-import type { KeychainItemMeta, KeychainItemRef } from './types';
+import type {
+  KeychainFixAccessResult, KeychainItemMeta, KeychainItemRef, KeychainSetResult,
+} from './types';
 
 /** Timeout for daemon IPC messages that don't involve user interaction */
 const SEND_TIMEOUT_MS = 30_000;
@@ -375,6 +377,37 @@ export class DaemonClient {
         if (err instanceof Error && err.message === 'cancelled') return undefined;
         throw err;
       }
+    });
+  }
+
+  async keychainFixAccess(opts: {
+    service: string;
+    account?: string;
+    keychain?: string;
+  }): Promise<KeychainFixAccessResult> {
+    return this.withRetry(async () => {
+      await this.ensureConnected();
+      const result = await this.sendMessage({
+        action: 'keychain-fix-access',
+        payload: opts,
+      }, INTERACTIVE_TIMEOUT_MS);
+      return result as KeychainFixAccessResult;
+    });
+  }
+
+  async keychainSet(opts: {
+    service: string;
+    account?: string;
+    value: string;
+    update?: boolean;
+  }): Promise<KeychainSetResult> {
+    return this.withRetry(async () => {
+      await this.ensureConnected();
+      const result = await this.sendMessage({
+        action: 'keychain-set',
+        payload: opts,
+      }, BIOMETRIC_TIMEOUT_MS);
+      return result as KeychainSetResult;
     });
   }
 

--- a/packages/varlock/src/lib/local-encrypt/daemon-client.ts
+++ b/packages/varlock/src/lib/local-encrypt/daemon-client.ts
@@ -41,6 +41,13 @@ const INTERACTIVE_TIMEOUT_MS = 5 * 60_000;
 /** How long to wait for SIGTERM before escalating to SIGKILL */
 const KILL_GRACE_MS = 2_000;
 
+export class DaemonError extends Error {
+  constructor(message: string, readonly code?: string) {
+    super(message);
+    this.name = 'DaemonError';
+  }
+}
+
 function debug(msg: string) {
   if (process.env.VARLOCK_DEBUG) {
     process.stderr.write(`[varlock:daemon-client] ${msg}\n`);
@@ -520,7 +527,7 @@ export class DaemonClient {
           const { resolve: res, reject: rej } = this.messageQueue.get(message.id)!;
           this.messageQueue.delete(message.id);
           if (message.error) {
-            rej(new Error(message.error));
+            rej(new DaemonError(String(message.error), message.errorCode));
           } else {
             res(message.result);
           }

--- a/packages/varlock/src/lib/local-encrypt/types.ts
+++ b/packages/varlock/src/lib/local-encrypt/types.ts
@@ -25,7 +25,7 @@ export interface BackendInfo {
 export interface DaemonMessage {
   id: string;
   action: 'decrypt' | 'encrypt' | 'prompt-secret' | 'ping' | 'invalidate-session'
-    | 'keychain-get' | 'keychain-search' | 'keychain-pick';
+    | 'keychain-get' | 'keychain-search' | 'keychain-pick' | 'keychain-fix-access' | 'keychain-set';
   payload?: Record<string, unknown>;
 }
 
@@ -51,6 +51,16 @@ export interface KeychainItemRef {
   account?: string;
   keychain?: string;
   label?: string;
+}
+
+/** Result from adding VarlockEnclave to a keychain item's access list */
+export interface KeychainFixAccessResult {
+  modified: boolean;
+}
+
+/** Result from creating or updating a keychain item */
+export interface KeychainSetResult {
+  updated: boolean;
 }
 
 /** Result from the status command of a native binary */

--- a/packages/varlock/src/lib/local-encrypt/types.ts
+++ b/packages/varlock/src/lib/local-encrypt/types.ts
@@ -34,6 +34,7 @@ export interface DaemonResponse {
   id: string;
   result?: unknown;
   error?: string;
+  errorCode?: string;
 }
 
 /** Metadata about a keychain item (no secret values) */


### PR DESCRIPTION
Fixes https://github.com/dmno-dev/varlock/issues/819

Adds a native `varlock keychain` CLI namespace for managing macOS Keychain-backed secrets:

- `keychain set` stores secrets through Varlock's own daemon/helper and can write matching `keychain(...)` refs back to env files.
- `keychain import` migrates sensitive plaintext values from an env file into Keychain using the file's schema to decide what should be imported.
- `keychain fix-access` grants Varlock's helper access to existing explicit `keychain(...)` refs, for cases where items were created by another tool.
- `keychain list` provides a metadata-only view of matching Keychain items.

Also updates docs and release workflows for the native Keychain/Rust signing changes, and adds tests for the new CLI parsing/import behavior.
