### PR TITLE
fix(ci): gate Windows signing on an explicit `sign` input

### DIFF
--- a/.github/workflows/binary-preview.yaml
+++ b/.github/workflows/binary-preview.yaml
@@ -39,9 +39,10 @@ jobs:
   # Build Rust native binaries for Linux and Windows
   build-native-rust:
     needs: check-label
+    # Preview builds never sign, so no id-token is granted (signing is gated on
+    # the `sign` input, which only the release workflows pass).
     permissions:
       contents: read
-      id-token: write # Azure OIDC signing in the reusable workflow (release builds only)
     uses: ./.github/workflows/build-native-rust.yaml
     with:
       artifact-name: native-bin-rust-preview

--- a/.github/workflows/binary-preview.yaml
+++ b/.github/workflows/binary-preview.yaml
@@ -42,7 +42,6 @@ jobs:
     uses: ./.github/workflows/build-native-rust.yaml
     with:
       artifact-name: native-bin-rust-preview
-    secrets: inherit
 
   # Build SEA binaries for all platforms and upload as artifacts
   build-sea-binaries:

--- a/.github/workflows/binary-preview.yaml
+++ b/.github/workflows/binary-preview.yaml
@@ -39,6 +39,9 @@ jobs:
   # Build Rust native binaries for Linux and Windows
   build-native-rust:
     needs: check-label
+    permissions:
+      contents: read
+      id-token: write # Azure OIDC signing in the reusable workflow (release builds only)
     uses: ./.github/workflows/build-native-rust.yaml
     with:
       artifact-name: native-bin-rust-preview

--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -50,6 +50,9 @@ jobs:
 
   # Build Rust native binaries for Linux and Windows
   build-native-rust:
+    permissions:
+      contents: read
+      id-token: write # Azure OIDC signing in the reusable workflow
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'varlock@')
     uses: ./.github/workflows/build-native-rust.yaml
     with:

--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -55,7 +55,8 @@ jobs:
     with:
       artifact-name: native-bin-rust
       sign: true
-    secrets: inherit
+    secrets:
+      OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN }}
 
   release-binaries:
     needs: [notarize-native-macos, build-native-rust]

--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -54,6 +54,7 @@ jobs:
     uses: ./.github/workflows/build-native-rust.yaml
     with:
       artifact-name: native-bin-rust
+      sign: true
     secrets: inherit
 
   release-binaries:

--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -23,16 +23,16 @@ on:
         description: 'Pre-computed hash of Rust source files (from Ubuntu runner). When provided, used for the binary cache key instead of local hashFiles to ensure cross-OS consistency.'
         type: string
         default: ''
+      sign:
+        description: 'Code-sign the Windows binary via Azure Artifact Signing. Enabled only for release builds (callers pass secrets: inherit so OP_CI_TOKEN is available).'
+        type: boolean
+        default: false
 
 jobs:
   build:
     permissions:
       contents: read
       id-token: write # Azure Artifact Signing via OIDC (Windows job only)
-    # Map the secret into an env var so it can be referenced from step `if:`
-    # conditions — the `secrets` context is not available in `if:` expressions.
-    env:
-      OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN }}
     strategy:
       matrix:
         include:
@@ -90,32 +90,27 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       # --- Windows code signing (Azure Artifact Signing) ---
-      # Azure credentials are resolved from 1Password through varlock
-      # (see packages/encryption-binary-rust/.env.schema), mirroring the
-      # macOS Developer ID signing flow. Skipped when OP_CI_TOKEN is absent
-      # (e.g. fork PRs), leaving the Windows binary unsigned.
-      - name: Windows signing skipped (no OP_CI_TOKEN)
-        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN == ''
-        shell: bash
-        run: |
-          echo "Azure Artifact Signing skipped: OP_CI_TOKEN not available (fork PR?) — Windows binary will be unsigned"
-
+      # Only runs for release builds (inputs.sign), which pass secrets: inherit
+      # so OP_CI_TOKEN is available. Azure credentials are resolved from 1Password
+      # through varlock (see packages/encryption-binary-rust/.env.schema), mirroring
+      # the macOS Developer ID signing flow. PR/preview builds skip signing entirely,
+      # so no secrets are loaded there.
       - name: Setup Bun (for varlock secret loading)
-        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN != ''
+        if: inputs.sign && contains(matrix.os, 'windows')
         uses: oven-sh/setup-bun@v2
 
       - name: Install node deps (for varlock secret loading)
-        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN != ''
+        if: inputs.sign && contains(matrix.os, 'windows')
         run: bun install
 
       # Build varlock JS so we can use it to resolve secrets from 1Password
       - name: Build varlock libs
-        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN != ''
+        if: inputs.sign && contains(matrix.os, 'windows')
         run: bun run build:libs
 
       # Load Azure signing secrets from 1Password via varlock (scoped to the Rust package)
       - name: Load signing secrets
-        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN != ''
+        if: inputs.sign && contains(matrix.os, 'windows')
         uses: dmno-dev/varlock-action@v1.0.3
         with:
           working-directory: packages/encryption-binary-rust
@@ -123,7 +118,7 @@ jobs:
           OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN }}
 
       - name: Azure login (OIDC)
-        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN != ''
+        if: inputs.sign && contains(matrix.os, 'windows')
         uses: azure/login@v2
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
@@ -131,7 +126,7 @@ jobs:
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Sign Windows binary (Azure Artifact Signing)
-        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN != ''
+        if: inputs.sign && contains(matrix.os, 'windows')
         uses: azure/artifact-signing-action@v2
         with:
           endpoint: ${{ env.AZURE_ARTIFACT_SIGNING_ENDPOINT }}

--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -8,9 +8,13 @@ name: Build Rust native binaries
 #
 # Output: native binaries uploaded as artifacts, ready to be bundled
 # into the varlock npm package and CLI release archives.
-
-permissions:
-  contents: read
+#
+# Permissions are intentionally NOT declared here — this reusable workflow
+# inherits whatever the calling job passes. Callers grant `contents: read`,
+# and only the release callers (which set sign: true) additionally grant
+# `id-token: write` for the Azure OIDC signing step. Declaring id-token here
+# would force every caller — including PR/preview builds that never sign — to
+# grant it too.
 
 on:
   workflow_call:
@@ -34,9 +38,6 @@ on:
 
 jobs:
   build:
-    permissions:
-      contents: read
-      id-token: write # Azure Artifact Signing via OIDC (Windows job only)
     strategy:
       matrix:
         include:

--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -24,9 +24,13 @@ on:
         type: string
         default: ''
       sign:
-        description: 'Code-sign the Windows binary via Azure Artifact Signing. Enabled only for release builds (callers pass secrets: inherit so OP_CI_TOKEN is available).'
+        description: 'Code-sign the Windows binary via Azure Artifact Signing. Enabled only for release builds, which pass OP_CI_TOKEN.'
         type: boolean
         default: false
+    secrets:
+      OP_CI_TOKEN:
+        description: '1Password service-account token used to load Azure signing credentials. Required only when sign is true.'
+        required: false
 
 jobs:
   build:
@@ -90,8 +94,8 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       # --- Windows code signing (Azure Artifact Signing) ---
-      # Only runs for release builds (inputs.sign), which pass secrets: inherit
-      # so OP_CI_TOKEN is available. Azure credentials are resolved from 1Password
+      # Only runs for release builds (inputs.sign), which pass OP_CI_TOKEN
+      # so signing creds are available. Azure credentials are resolved from 1Password
       # through varlock (see packages/encryption-binary-rust/.env.schema), mirroring
       # the macOS Developer ID signing flow. PR/preview builds skip signing entirely,
       # so no secrets are loaded there.

--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -29,6 +29,10 @@ jobs:
     permissions:
       contents: read
       id-token: write # Azure Artifact Signing via OIDC (Windows job only)
+    # Map the secret into an env var so it can be referenced from step `if:`
+    # conditions — the `secrets` context is not available in `if:` expressions.
+    env:
+      OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN }}
     strategy:
       matrix:
         include:
@@ -91,27 +95,27 @@ jobs:
       # macOS Developer ID signing flow. Skipped when OP_CI_TOKEN is absent
       # (e.g. fork PRs), leaving the Windows binary unsigned.
       - name: Windows signing skipped (no OP_CI_TOKEN)
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN == ''
+        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN == ''
         shell: bash
         run: |
           echo "Azure Artifact Signing skipped: OP_CI_TOKEN not available (fork PR?) — Windows binary will be unsigned"
 
       - name: Setup Bun (for varlock secret loading)
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN != ''
         uses: oven-sh/setup-bun@v2
 
       - name: Install node deps (for varlock secret loading)
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN != ''
         run: bun install
 
       # Build varlock JS so we can use it to resolve secrets from 1Password
       - name: Build varlock libs
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN != ''
         run: bun run build:libs
 
       # Load Azure signing secrets from 1Password via varlock (scoped to the Rust package)
       - name: Load signing secrets
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN != ''
         uses: dmno-dev/varlock-action@v1.0.3
         with:
           working-directory: packages/encryption-binary-rust
@@ -119,7 +123,7 @@ jobs:
           OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN }}
 
       - name: Azure login (OIDC)
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN != ''
         uses: azure/login@v2
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
@@ -127,7 +131,7 @@ jobs:
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Sign Windows binary (Azure Artifact Signing)
-        if: contains(matrix.os, 'windows') && secrets.OP_CI_TOKEN != ''
+        if: contains(matrix.os, 'windows') && env.OP_CI_TOKEN != ''
         uses: azure/artifact-signing-action@v2
         with:
           endpoint: ${{ env.AZURE_ARTIFACT_SIGNING_ENDPOINT }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -186,6 +186,9 @@ jobs:
   # Build Rust native binaries for Linux and Windows. Skipped on a cache hit.
   build-native-rust:
     needs: plan
+    permissions:
+      contents: read
+      id-token: write # Azure OIDC signing in the reusable workflow
     if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true' && needs.plan.outputs.rust-cache-hit != 'true'
     uses: ./.github/workflows/build-native-rust.yaml
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -192,7 +192,8 @@ jobs:
       artifact-name: native-bin-rust
       source-hash: ${{ needs.plan.outputs.rust-source-hash }}
       sign: true
-    secrets: inherit
+    secrets:
+      OP_CI_TOKEN: ${{ secrets.OP_CI_TOKEN }}
 
   release:
     name: Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -191,6 +191,7 @@ jobs:
     with:
       artifact-name: native-bin-rust
       source-hash: ${{ needs.plan.outputs.rust-source-hash }}
+      sign: true
     secrets: inherit
 
   release:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -153,6 +153,12 @@ jobs:
   # Build Rust native binaries if varlock is being released AND (source changed or cache missing)
   build-native-rust:
     needs: build-and-test
+    # id-token granted for the reusable workflow's Azure OIDC signing step
+    # (only exercised on release builds; required here because the reusable
+    # workflow declares the permission statically).
+    permissions:
+      contents: read
+      id-token: write
     if: >-
       needs.build-and-test.outputs.includes-varlock == 'true'
       && (needs.build-and-test.outputs.rust-changed == 'true' || needs.build-and-test.outputs.rust-cache-hit != 'true')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -153,12 +153,10 @@ jobs:
   # Build Rust native binaries if varlock is being released AND (source changed or cache missing)
   build-native-rust:
     needs: build-and-test
-    # id-token granted for the reusable workflow's Azure OIDC signing step
-    # (only exercised on release builds; required here because the reusable
-    # workflow declares the permission statically).
+    # CI builds never sign, so no id-token is granted here (signing is gated on
+    # the `sign` input, which only the release workflows pass).
     permissions:
       contents: read
-      id-token: write
     if: >-
       needs.build-and-test.outputs.includes-varlock == 'true'
       && (needs.build-and-test.outputs.rust-changed == 'true' || needs.build-and-test.outputs.rust-cache-hit != 'true')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -160,7 +160,6 @@ jobs:
     with:
       artifact-name: native-bin-rust-ci
       source-hash: ${{ needs.build-and-test.outputs.rust-source-hash }}
-    secrets: inherit
 
   # Publish preview packages via pkg-pr-new
   release-preview-packages:

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,10 @@
     "packages/encryption-binary-rust": {
       "name": "@varlock/encryption-binary-rust",
       "version": "0.0.0",
+      "devDependencies": {
+        "@varlock/1password-plugin": "workspace:*",
+        "varlock": "workspace:*",
+      },
     },
     "packages/encryption-binary-swift": {
       "name": "@varlock/encryption-binary-swift",


### PR DESCRIPTION
## Problem

CI broke on main in #811. The new Azure Artifact Signing setup in the `build-native-rust` reusable workflow had three issues that made it (and every caller — `test.yaml`, `release.yaml`, `binary-preview`/`binary-release`) fail at startup with "This run likely failed because of a workflow file issue":

1. **`secrets` used in `if:`** — steps gated on `secrets.OP_CI_TOKEN`, but the `secrets` context isn't available in `if:` expressions.
2. **Secret not declared** — the reusable workflow referenced `secrets.OP_CI_TOKEN` without declaring it in `on.workflow_call.secrets`.
3. **`id-token: write` not granted by callers** — the reusable workflow's job statically requested `id-token: write` for Azure OIDC, but the calling jobs only granted `contents: read`. A reusable workflow requesting a permission the caller lacks fails at startup.

## Fix

- Gate Windows signing on an explicit `sign` input (default `false`) instead of probing whether the secret is set. Only `release.yaml` and `binary-release.yaml` pass `sign: true`; `test.yaml` and `binary-preview.yaml` never sign, so no signing secrets are loaded on PR/preview builds.
- Declare `OP_CI_TOKEN` (`required: false`) in `on.workflow_call.secrets` and pass it explicitly from the signing callers, matching the `build-native-macos` convention.
- **Scope `id-token: write` to release builds only.** The reusable workflow no longer declares its own permissions — it inherits the calling job's. Only the release callers grant `id-token: write`; CI/preview builds grant just `contents: read`, so OIDC is never available on non-prod builds.

Result: signing is explicit (release-only), OIDC is scoped to real release builds, and all callers start cleanly.