### PR TITLE
fix(smoke-tests): make SIGINT/SIGTERM signal tests robust on macOS bash 3.2

### DIFF
--- a/smoke-tests/tests/signals.test.ts
+++ b/smoke-tests/tests/signals.test.ts
@@ -47,9 +47,17 @@ function runAndSignal(command: Array<string>, signal: NodeJS.Signals, env?: Reco
 
 // signals / process groups are POSIX concepts
 describe.skipIf(process.platform === 'win32')('Signal handling', () => {
+  // We background the sleep and `wait` rather than sleeping in the foreground so the
+  // child's trap fires the instant the signal arrives, consistently across bash versions.
+  // A foreground `sleep` makes bash defer the trap until the command returns, and bash's
+  // handling of that case differs for SIGINT (the interactive-interrupt signal): macOS
+  // still ships bash 3.2, which — unlike Linux's bash 5.x — does not run the INT trap
+  // promptly when a foreground child is interrupted, so the test would hang until the
+  // sleep's full duration elapsed. `sleep & wait` sidesteps that and is the canonical
+  // signal-handling idiom anyway.
   test('forwards SIGTERM to the child so its handler runs and the exit code is preserved', async () => {
     const result = await runAndSignal(
-      ['bash', '-c', 'trap "echo bye; exit 0" TERM; echo ready; sleep 60'],
+      ['bash', '-c', 'trap "echo bye; exit 0" TERM; echo ready; sleep 60 & wait'],
       'SIGTERM',
     );
 
@@ -61,7 +69,7 @@ describe.skipIf(process.platform === 'win32')('Signal handling', () => {
 
   test('forwards SIGINT to the child', async () => {
     const result = await runAndSignal(
-      ['bash', '-c', 'trap "echo interrupted; exit 0" INT; echo ready; sleep 60'],
+      ['bash', '-c', 'trap "echo interrupted; exit 0" INT; echo ready; sleep 60 & wait'],
       'SIGINT',
     );
 


### PR DESCRIPTION
## Problem

`Smoke Test (macos-latest) > Signal handling > forwards SIGINT to the child` hangs and times out (15s), printing only `ready`. Ubuntu and Windows pass. Seen on the release PR #815.

## Cause

The failure is in the test's bash child, not varlock's forwarding (Ubuntu exercises the identical POSIX path and passes).

The child slept in the **foreground** (`trap … INT; echo ready; sleep 60`). bash defers a trap until the foreground command returns, and **special-cases SIGINT** (the interactive-interrupt signal). macOS still ships **bash 3.2**; Linux has 5.x — and 3.2 does not run the `INT` trap promptly when a foreground child is interrupted. So `sleep` ran its full duration and the test timed out. The adjacent SIGTERM test passed because SIGTERM has no such special-casing.

## Fix

Use the canonical `sleep 60 & wait` idiom for the SIGTERM/SIGINT tests. With the sleep backgrounded, bash's own trapped-signal handling interrupts `wait` immediately and runs the trap consistently across bash versions. The trap fires the instant the signal arrives — no 60s wait.

The SIGHUP and SIGKILL-escalation tests don't depend on this behavior and are untouched.