### PR TITLE
feat(varlock): honor _VARLOCK_* config vars set in .env/.env.local

### DIFF
--- a/.bumpy/honor-varlock-config-vars-in-dotenv.md
+++ b/.bumpy/honor-varlock-config-vars-in-dotenv.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+Honor `_VARLOCK_*` config vars set as static values in `.env` / `.env.local`. Setting `_VARLOCK_ENV_KEY`, `_VARLOCK_CACHE_KEY`, or `_VARLOCK_REDACT_STDOUT` in a (gitignored) `.env.local` now configures varlock — handy for local development. A real environment variable still takes precedence. These keys configure varlock itself, so they never appear as app config (excluded from the resolved env, `varlock load` output, and the injected blob). Only `.env`/`.env.local` are honored — a `_VARLOCK_*` key in another file warns it has no effect, an unrecognized key warns (likely a typo), and a non-static value is an error.

--- a/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
+++ b/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
@@ -12,12 +12,20 @@ varlock reserves a couple of environment variable namespaces for its own use. Kn
 | `__VARLOCK_*` (double underscore) | `__VARLOCK_ENV` | varlock internals — injected automatically, never set these yourself |
 
 :::caution[The `_VARLOCK_` prefix is reserved]
-Config items whose key starts with `_VARLOCK_` are reserved for varlock. They are **excluded** from the injected env blob, generated types, and override provenance — even if you define one in your `.env.schema`. varlock emits a warning if you do, since such an item won't behave like a normal config value. Don't name your own variables with this prefix.
+Keys starting with `_VARLOCK_` configure varlock itself, not your app. They never become config items — they're excluded from the injected env blob, the resolved env, `varlock load` output, generated types, and override provenance, and **can't be referenced from other items** (`FOO=$_VARLOCK_ENV_KEY` won't resolve). Don't name your own variables with this prefix; varlock warns if you use it on a key it doesn't recognize (most likely a typo).
 :::
 
 ## Configuration variables (`_VARLOCK_*`)
 
 Set these in your shell, CI, or deploy environment to configure varlock's behavior.
+
+You can also set a recognized config var (other than the internal ones) as a **static value in `.env` or `.env.local`** — e.g. `_VARLOCK_ENV_KEY` in a gitignored `.env.local` for local development. A few rules:
+
+- **Only `.env` and `.env.local` are honored** — not the committed `.env.schema` or env-specific files like `.env.production`. A `_VARLOCK_*` key elsewhere warns that it has no effect.
+- **Must be a plain literal** — references or functions can't be resolved before the config they configure, so a non-static value is an error.
+- **A real environment variable always takes precedence**, and these values are not passed through to `varlock run` child processes (a child re-reads `.env.local` itself).
+
+At runtime in a deployed app there are no `.env` files, so anything needed there (like `_VARLOCK_ENV_KEY` to decrypt the injected blob) must still be a real environment variable.
 
 ### `_VARLOCK_ENV_KEY`
 

--- a/packages/varlock/src/auto-load.ts
+++ b/packages/varlock/src/auto-load.ts
@@ -21,20 +21,33 @@ try {
   });
 
   const parsed = JSON.parse(stdout);
+
+  // The `load` CLI read the .env files; any `_VARLOCK_*` config vars it found there (e.g.
+  // _VARLOCK_ENV_KEY in .env.local) come back on this side-channel field, not as real config.
+  // Strip it out so it never leaks into the injected blob, then re-serialize for the blob
+  // (only when present, so the common path is unchanged).
+  const fileConfigVars = parsed.__varlockConfigVars as Record<string, string> | undefined;
+  let blobJson = stdout;
+  if (fileConfigVars) {
+    delete parsed.__varlockConfigVars;
+    blobJson = JSON.stringify(parsed);
+  }
+
   // set parsed object on globalThis so initVarlockEnv() picks it up directly
   (globalThis as any).__varlockLoadedEnv = parsed;
 
-  // encrypt the blob in process.env so sensitive values aren't sitting
-  // in plaintext in process.env.__VARLOCK_ENV
-  let encryptionKey = process.env._VARLOCK_ENV_KEY;
+  // encrypt the blob in process.env so sensitive values aren't sitting in plaintext in
+  // process.env.__VARLOCK_ENV. A real _VARLOCK_ENV_KEY wins over one set in a .env file.
+  let encryptionKey = process.env._VARLOCK_ENV_KEY ?? fileConfigVars?._VARLOCK_ENV_KEY;
   if (parsed.settings?.encryptInjectedEnv && !encryptionKey) {
     encryptionKey = generateEncryptionKeyHex();
-    process.env._VARLOCK_ENV_KEY = encryptionKey;
   }
   if (encryptionKey) {
-    process.env.__VARLOCK_ENV = encryptEnvBlobSync(stdout, encryptionKey);
+    // ensure the key is in process.env so spawned children / runtime init can decrypt the blob
+    process.env._VARLOCK_ENV_KEY ||= encryptionKey;
+    process.env.__VARLOCK_ENV = encryptEnvBlobSync(blobJson, encryptionKey);
   } else {
-    process.env.__VARLOCK_ENV = stdout;
+    process.env.__VARLOCK_ENV = blobJson;
   }
 } catch (err) {
   if (err instanceof VarlockExecError && err.stderr) {

--- a/packages/varlock/src/cli/commands/cache.command.ts
+++ b/packages/varlock/src/cli/commands/cache.command.ts
@@ -6,6 +6,8 @@ import { isCancel } from '@clack/prompts';
 
 import { CacheStore, createEnvKeyCacheStore, getCacheEnvKey } from '../../lib/cache';
 import { groupKeyPrefix } from '../../lib/cache/cache-store';
+import { loadVarlockConfigVarsFromFiles } from '../../env-graph/lib/loader';
+import { mergeVarlockConfigEnv } from '../../env-graph/lib/reserved-vars';
 import { formatTimeAgo, formatDuration } from '../../lib/formatting';
 import * as localEncrypt from '../../lib/local-encrypt';
 import { select, confirm } from '../helpers/prompts';
@@ -107,9 +109,11 @@ const isInteractive = () => process.stdout.isTTY && process.stdin.isTTY;
  * Resolve the cache store to operate on. Returns `null` (after logging) when no
  * cache is active — e.g. an invalid `_VARLOCK_CACHE_KEY` or no local key present.
  */
-function resolveStore(): CacheStore | null {
-  // when an env-provided key is active (e.g. CI), manage that key's cache file
-  const envKey = getCacheEnvKey();
+async function resolveStore(): Promise<CacheStore | null> {
+  // honor a _VARLOCK_CACHE_KEY set in the real env or in a .env file (env wins), so this
+  // manages the same cache `varlock run` does — parse-only, so a broken schema can't block it
+  const fileVars = await loadVarlockConfigVarsFromFiles(process.cwd());
+  const envKey = getCacheEnvKey(mergeVarlockConfigEnv(fileVars));
   if (envKey) {
     try {
       return createEnvKeyCacheStore(envKey);
@@ -134,7 +138,7 @@ const statusCommand = define({
   description: 'Print a cache status summary (non-interactive)',
   run: async () => {
     await trackCommand('cache status', { command: 'cache status' });
-    const store = resolveStore();
+    const store = await resolveStore();
     if (!store) return;
     printStatus(store);
   },
@@ -163,7 +167,7 @@ const clearCommand = define({
   run: async (ctx) => {
     await trackCommand('cache clear', { command: 'cache clear' });
 
-    const store = resolveStore();
+    const store = await resolveStore();
     if (!store) return;
 
     const pluginName = ctx.values.plugin;
@@ -227,7 +231,7 @@ Examples:
  * otherwise a non-interactive status summary (safe for CI).
  */
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async () => {
-  const store = resolveStore();
+  const store = await resolveStore();
   if (!store) return;
 
   if (!isInteractive()) {

--- a/packages/varlock/src/cli/commands/load.command.ts
+++ b/packages/varlock/src/cli/commands/load.command.ts
@@ -202,7 +202,14 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
         }
       }
     }
-    console.log(JSON.stringify(serialized, null, indent));
+    // Side-channel: `_VARLOCK_*` config vars picked up from .env files (e.g. _VARLOCK_ENV_KEY
+    // in .env.local). Kept OUT of getSerializedGraph (so it never lands in the run/auto-load
+    // blob); the auto-load parent reads it to configure itself and strips it before injecting.
+    const output: typeof serialized & { __varlockConfigVars?: Record<string, string> } = serialized;
+    if (Object.keys(envGraph.varlockConfigVarsFromFiles).length) {
+      output.__varlockConfigVars = envGraph.varlockConfigVarsFromFiles;
+    }
+    console.log(JSON.stringify(output, null, indent));
     // Output JSON to stdout even on failure (so consumers can parse err.stdout),
     // but still exit non-zero so execSync callers know something is wrong
     if (serialized.errors) {

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -238,8 +238,9 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     }
   }
 
-  // when only injecting the blob, also inject the encryption key so the
-  // child process can decrypt it (if encrypted)
+  // when only injecting the blob, also inject the encryption key so the child process can
+  // decrypt it (if encrypted). Only a real env var is forwarded — a `.env.local`-sourced key
+  // stays local (a child that runs varlock re-reads .env.local itself).
   if (injectBlob && !injectVars && process.env._VARLOCK_ENV_KEY) {
     fullInjectedEnv._VARLOCK_ENV_KEY = process.env._VARLOCK_ENV_KEY;
   }
@@ -247,8 +248,9 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   const redactLogs = serializedGraph.settings?.redactLogs ?? true;
   // tri-state override (true = force on, false = force off, undefined = auto-detect):
   // the --redact-stdout / --no-redact-stdout flag takes precedence, falling back to the
-  // _VARLOCK_REDACT_STDOUT env var, otherwise we auto-detect per stream below
-  const redactOverride = ctx.values['redact-stdout'] ?? parseEnvToggle(process.env._VARLOCK_REDACT_STDOUT);
+  // _VARLOCK_REDACT_STDOUT env var (which may come from a .env file), otherwise we
+  // auto-detect per stream below
+  const redactOverride = ctx.values['redact-stdout'] ?? parseEnvToggle(envGraph.varlockConfigEnv._VARLOCK_REDACT_STDOUT);
   const forceRedact = redactOverride === true;
   const forceNoRedact = redactOverride === false;
 

--- a/packages/varlock/src/env-graph/lib/data-source.ts
+++ b/packages/varlock/src/env-graph/lib/data-source.ts
@@ -18,6 +18,7 @@ import { pathExists } from '@env-spec/utils/fs-utils';
 import { processPluginInstallDecorators } from './plugins';
 import { RootDecoratorInstance } from './decorators';
 import { isBuiltinVar } from './builtin-vars';
+import { isVarlockReservedKey } from './reserved-vars';
 import { type KeyFilter, keyMatchesFilter, parseKeyFilterArgs } from './key-filter';
 
 /**
@@ -269,6 +270,10 @@ export abstract class EnvGraphDataSource {
       if (!this.isKeyImported(itemKey)) continue;
       const itemDef = this.configItemDefs[itemKey];
       if (!itemDef) continue;
+      // _VARLOCK_* keys configure varlock itself, not the app — never register them as config
+      // items (so they aren't resolved, validated, shown, or injected). They're picked up
+      // separately from the parsed defs via EnvGraph.processVarlockConfigVarsFromFiles().
+      if (isVarlockReservedKey(itemKey)) continue;
 
       // check if this item was already early-resolved (used by @currentEnv, @import enabled, or @disable)
       // a later file setting a conflicting value would silently contradict the decision already made

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -1,4 +1,5 @@
 import _ from '@env-spec/utils/my-dash';
+import { ParsedEnvSpecStaticValue } from '@env-spec/parser';
 import path from 'node:path';
 import { ConfigItem } from './config-item';
 import {
@@ -21,7 +22,10 @@ import type { VarlockPlugin } from './plugins';
 import { runWithResolutionContext, getResolutionContext } from './resolution-context';
 import { getCiEnv, type CiEnvInfo } from '@varlock/ci-env-info';
 import { BUILTIN_VARS, isBuiltinVar } from './builtin-vars';
-import { isVarlockReservedKey } from './reserved-vars';
+import {
+  isVarlockReservedKey, isKnownVarlockConfigVar, isFileHonorableVarlockConfigVar,
+  mergeVarlockConfigEnv, VARLOCK_CONFIG_VAR_FILENAMES,
+} from './reserved-vars';
 import { buildOverrideProvenanceMetadata, type OverrideProvenanceMetadata } from '../../lib/injected-env-provenance';
 
 const processExists = !!globalThis.process;
@@ -301,6 +305,113 @@ export class EnvGraph {
   }
 
   /**
+   * Static-literal `_VARLOCK_*` config vars picked up from `.env` files (e.g. an
+   * `_VARLOCK_ENV_KEY` set in `.env.local`). These configure varlock itself and are kept
+   * out of the resolved graph/blob. A real environment variable always takes precedence —
+   * see `varlockConfigEnv` and the consumers in the CLI / auto-load.
+   */
+  varlockConfigVarsFromFiles: Record<string, string> = {};
+
+  /** guards against re-running the `.env` config-var extraction within a single load */
+  private _varlockConfigVarsProcessed = false;
+
+  /**
+   * The environment varlock reads its OWN config (`_VARLOCK_*`) from: the real process env
+   * (or its override) layered over any static values picked up from `.env` files, with the
+   * real env winning. Used for things like the cache encryption key.
+   */
+  get varlockConfigEnv(): Record<string, string | undefined> {
+    return mergeVarlockConfigEnv(this.varlockConfigVarsFromFiles, this.processEnvOverride ?? process.env);
+  }
+
+  /**
+   * Scan the `.env` / `.env.local` data sources for `_VARLOCK_*` keys defined as static values
+   * and record the honorable ones (highest precedence wins, real env still overrides later).
+   * Only those two files are honored — config doesn't belong in the committed `.env.schema` or
+   * env-specific files. When `emitDiagnostics` is set, also surface mistakes: a hard error for a
+   * recognized config var given a non-static value (it can never resolve before the graph it
+   * configures), and warnings for unrecognized keys (likely typos), internal vars (env-only),
+   * and `_VARLOCK_*` keys placed in a file where they won't take effect. Runs at most once per
+   * load (cached after the first call).
+   */
+  processVarlockConfigVarsFromFiles({ emitDiagnostics = false }: { emitDiagnostics?: boolean } = {}) {
+    if (this._varlockConfigVarsProcessed) return this.varlockConfigVarsFromFiles;
+    this._varlockConfigVarsProcessed = true;
+    const values: Record<string, string> = {};
+    const decided = new Set<string>();
+    for (const { source, filterNode } of this.sortedDefinitionSources) {
+      if (source.disabled) continue;
+      if (!(source instanceof FileBasedDataSource)) continue;
+      const isConfigFile = VARLOCK_CONFIG_VAR_FILENAMES.has(source.fileName);
+      for (const itemKey of Object.keys(source.configItemDefs)) {
+        if (!isVarlockReservedKey(itemKey)) continue;
+        if (filterNode && !filterNode.isKeyImported(itemKey)) continue;
+
+        // varlock's own config is only honored from .env / .env.local. Anywhere else it has no
+        // effect — flag it so a misplaced key isn't silently ignored.
+        if (!isConfigFile) {
+          if (emitDiagnostics) {
+            source._errors.push(new SchemaError(
+              `"${itemKey}" has no effect in ${source.fileName}`,
+              {
+                isWarning: true,
+                tip: '_VARLOCK_* vars configure varlock itself and are only read from .env / .env.local (or the real environment) — not the committed schema or env-specific files.',
+              },
+            ));
+          }
+          continue;
+        }
+
+        // only the highest-precedence definition in a config file decides a key's fate
+        if (decided.has(itemKey)) continue;
+        decided.add(itemKey);
+
+        const def = source.configItemDefs[itemKey];
+        const isStatic = def?.parsedValue instanceof ParsedEnvSpecStaticValue;
+
+        if (!isKnownVarlockConfigVar(itemKey)) {
+          if (emitDiagnostics) {
+            source._errors.push(new SchemaError(
+              `"${itemKey}" is not a recognized varlock config var`,
+              {
+                isWarning: true,
+                tip: '_VARLOCK_* keys are reserved for configuring varlock itself. This looks like a typo — check the spelling, or rename this item.',
+              },
+            ));
+          }
+        } else if (!isFileHonorableVarlockConfigVar(itemKey)) {
+          if (emitDiagnostics) {
+            source._errors.push(new SchemaError(
+              `"${itemKey}" is read from the environment only and has no effect when defined here`,
+              {
+                isWarning: true,
+                tip: `${itemKey} is an internal varlock config var resolved before your .env files load. Set it as a real environment variable instead.`,
+              },
+            ));
+          }
+        } else if (!isStatic) {
+          // a non-static value can never be honored (it's read before the graph resolves), and
+          // silently falling back to a different/auto key would be a footgun — fail loudly
+          if (emitDiagnostics) {
+            source._errors.push(new SchemaError(
+              `"${itemKey}" must be a static value`,
+              {
+                tip: `${itemKey} configures varlock itself and is read before the graph resolves, so it can't use references or functions. Use a literal value, or set it as a real environment variable.`,
+              },
+            ));
+          }
+        } else {
+          // config vars are env-var-like strings; the parser may type a bare `true`/number,
+          // so coerce (matches how a real env var would arrive)
+          values[itemKey] = String((def!.parsedValue as ParsedEnvSpecStaticValue).unescapedValue);
+        }
+      }
+    }
+    this.varlockConfigVarsFromFiles = values;
+    return values;
+  }
+
+  /**
    * Register a builtin VARLOCK_* variable.
    * Attaches an internal def with the builtin resolver so it flows through the normal pipeline.
    * If the item already exists (user-defined), the internal def is added as a fallback.
@@ -391,23 +502,10 @@ export class EnvGraph {
       if (isBuiltinVar(key)) this.registerBuiltinVar(key);
     }
 
-    // Warn about items defined with varlock's reserved _VARLOCK_ prefix. These keys are
-    // excluded from the injected env blob and generated types, so a user-defined one is
-    // almost certainly a mistake (or a typo'd internal var that won't behave as expected).
-    for (const source of this.sortedDataSources) {
-      if (source.disabled) continue;
-      for (const itemKey of Object.keys(source.configItemDefs)) {
-        if (isVarlockReservedKey(itemKey)) {
-          source._errors.push(new SchemaError(
-            `"${itemKey}" uses varlock's reserved _VARLOCK_ prefix`,
-            {
-              isWarning: true,
-              tip: 'Keys starting with _VARLOCK_ are reserved for configuring varlock itself and are excluded from the injected env and generated types. Rename this item unless that exclusion is intended.',
-            },
-          ));
-        }
-      }
-    }
+    // Extract any `_VARLOCK_*` config vars set as static values in .env files (so they can
+    // configure varlock itself) and warn about ones that can't be honored. A no-op when the
+    // loader already ran this before cache init; needed for callers that finishLoad directly.
+    this.processVarlockConfigVarsFromFiles({ emitDiagnostics: true });
 
     // process root decorators
     let hasErrors = false;
@@ -447,7 +545,7 @@ export class EnvGraph {
           // explicit disk mode overrides the auto policy's safety fallback — allowed, but warn
           const localEncrypt = await import('../../lib/local-encrypt');
           const { createEnvKeyCacheStore, getCacheEnvKey } = await import('../../lib/cache');
-          const envKey = getCacheEnvKey(this.processEnvOverride ?? process.env);
+          const envKey = getCacheEnvKey(this.varlockConfigEnv);
           const backendIsFile = localEncrypt.getBackendInfo().type === 'file';
 
           let diskStore: import('../../lib/cache/cache-store').CacheStoreLike | undefined;

--- a/packages/varlock/src/env-graph/lib/loader.ts
+++ b/packages/varlock/src/env-graph/lib/loader.ts
@@ -35,49 +35,6 @@ export async function loadEnvGraph(opts?: {
   if (opts?.clearCache) graph._clearCacheMode = true;
   if (opts?.skipCache) graph._skipCacheMode = true;
 
-  const envKey = getCacheEnvKey(opts?.processEnvOverride ?? process.env);
-
-  // --clear-cache always clears the persistent disk cache(s), even when combined
-  // with --skip-cache or when the active store for this run is memory-backed
-  if (opts?.clearCache) {
-    const diskStores = [new CacheStore()];
-    if (envKey) {
-      try {
-        diskStores.push(createEnvKeyCacheStore(envKey));
-      } catch {
-        // invalid env key — nothing to clear for it
-      }
-    }
-    for (const store of diskStores) {
-      if (fs.existsSync(store.getFilePath())) await store.clearAll();
-    }
-  }
-
-  // initialize cache store (encryption key is ensured lazily on first write)
-  // auto policy: native-backend disk > env-key disk > in-process memory
-  if (!opts?.skipCache) {
-    const backend = localEncrypt.getBackendInfo();
-    const isCi = graph.ciEnvInfo.isCI;
-    if (backend.type !== 'file' && !isCi) {
-      graph._cacheMode = 'disk';
-      graph._cacheStore = new CacheStore();
-    } else if (envKey) {
-      // _VARLOCK_CACHE_KEY (e.g. provided as a CI secret) enables disk caching
-      // without the encryption key ever touching disk
-      try {
-        graph._cacheStore = createEnvKeyCacheStore(envKey);
-        graph._cacheMode = 'disk';
-      } catch (err) {
-        debug('invalid %s — falling back to memory cache: %O', '_VARLOCK_CACHE_KEY', err);
-        graph._cacheMode = 'memory';
-        graph._cacheStore = new InMemoryCacheStore();
-      }
-    } else {
-      graph._cacheMode = 'memory';
-      graph._cacheStore = new InMemoryCacheStore();
-    }
-  }
-
   let rawPaths: Array<string> | undefined;
   if (opts?.entryFilePaths) {
     rawPaths = Array.isArray(opts.entryFilePaths) ? opts.entryFilePaths : [opts.entryFilePaths];
@@ -112,7 +69,75 @@ export async function loadEnvGraph(opts?: {
     await graph.setRootDataSource(new DirectoryDataSource(graph.basePath));
   }
 
+  // Pick up any `_VARLOCK_*` config vars set as static values in the now-parsed .env files
+  // (e.g. an `_VARLOCK_CACHE_KEY` in `.env.local`) so they can configure varlock itself. A
+  // real env var still wins — see `graph.varlockConfigEnv`. Runs once (finishLoad's call is a
+  // no-op after this); disabled/env flags are already settled here.
+  graph.processVarlockConfigVarsFromFiles({ emitDiagnostics: true });
+
+  // initialize cache store (encryption key is ensured lazily on first write)
+  // auto policy: native-backend disk > env-key disk > in-process memory
+  // NOTE: runs after parsing so the cache key can come from a .env file; this means values
+  // resolved during early init (envFlag/@disable/@import) are not disk-cached, which is fine.
+  const envKey = getCacheEnvKey(graph.varlockConfigEnv);
+
+  // --clear-cache always clears the persistent disk cache(s), even when combined
+  // with --skip-cache or when the active store for this run is memory-backed
+  if (opts?.clearCache) {
+    const diskStores = [new CacheStore()];
+    if (envKey) {
+      try {
+        diskStores.push(createEnvKeyCacheStore(envKey));
+      } catch {
+        // invalid env key — nothing to clear for it
+      }
+    }
+    for (const store of diskStores) {
+      if (fs.existsSync(store.getFilePath())) await store.clearAll();
+    }
+  }
+
+  if (!opts?.skipCache) {
+    const backend = localEncrypt.getBackendInfo();
+    const isCi = graph.ciEnvInfo.isCI;
+    if (backend.type !== 'file' && !isCi) {
+      graph._cacheMode = 'disk';
+      graph._cacheStore = new CacheStore();
+    } else if (envKey) {
+      // _VARLOCK_CACHE_KEY (e.g. provided as a CI secret) enables disk caching
+      // without the encryption key ever touching disk
+      try {
+        graph._cacheStore = createEnvKeyCacheStore(envKey);
+        graph._cacheMode = 'disk';
+      } catch (err) {
+        debug('invalid %s — falling back to memory cache: %O', '_VARLOCK_CACHE_KEY', err);
+        graph._cacheMode = 'memory';
+        graph._cacheStore = new InMemoryCacheStore();
+      }
+    } else {
+      graph._cacheMode = 'memory';
+      graph._cacheStore = new InMemoryCacheStore();
+    }
+  }
+
   await graph.finishLoad();
 
   return graph;
+}
+
+/**
+ * Lightweight, parse-only extraction of `_VARLOCK_*` config vars set as static values in a
+ * directory's `.env` files. Skips full resolution (and the cache), so callers that only need
+ * varlock's own config — e.g. the `cache` command — can read it without the cost or potential
+ * recursion of a full graph load. Returns `{}` if the files can't be parsed.
+ */
+export async function loadVarlockConfigVarsFromFiles(basePath: string): Promise<Record<string, string>> {
+  const graph = new EnvGraph();
+  graph.basePath = basePath;
+  try {
+    await graph.setRootDataSource(new DirectoryDataSource(basePath));
+  } catch {
+    return {};
+  }
+  return graph.processVarlockConfigVarsFromFiles();
 }

--- a/packages/varlock/src/env-graph/lib/reserved-vars.ts
+++ b/packages/varlock/src/env-graph/lib/reserved-vars.ts
@@ -16,6 +16,13 @@
  */
 export const VARLOCK_RESERVED_KEY_PREFIX = '_VARLOCK_';
 
+/**
+ * The `.env` files varlock reads its own `_VARLOCK_*` config from. Only these are scanned —
+ * not the committed `.env.schema`, nor env-specific files like `.env.production` — so this
+ * config stays in the local/value files where it belongs.
+ */
+export const VARLOCK_CONFIG_VAR_FILENAMES = new Set(['.env', '.env.local']);
+
 export type ReservedVarInfo = {
   name: string;
   description: string;
@@ -65,4 +72,37 @@ export const VARLOCK_INTERNAL_ENV_VARS: Array<ReservedVarInfo> = [
  */
 export function isVarlockReservedKey(key: string): boolean {
   return key.startsWith(VARLOCK_RESERVED_KEY_PREFIX);
+}
+
+const VARLOCK_CONFIG_VARS_BY_NAME = new Map(VARLOCK_CONFIG_ENV_VARS.map((v) => [v.name, v]));
+
+/**
+ * Check if a key is a recognized `_VARLOCK_*` config var (e.g. `_VARLOCK_ENV_KEY`). An
+ * unrecognized `_VARLOCK_*` key is almost certainly a typo.
+ */
+export function isKnownVarlockConfigVar(key: string): boolean {
+  return VARLOCK_CONFIG_VARS_BY_NAME.has(key);
+}
+
+/**
+ * Whether a `_VARLOCK_*` config var can be honored when set as a static value in a `.env`
+ * file (extracted before/around graph resolution and used to configure varlock itself).
+ * Internal vars (e.g. `_VARLOCK_FORCE_FILE_ENCRYPTION_FALLBACK`) are read from the real
+ * environment at module load, too early to source from a file, so they're excluded.
+ */
+export function isFileHonorableVarlockConfigVar(key: string): boolean {
+  const info = VARLOCK_CONFIG_VARS_BY_NAME.get(key);
+  return !!info && !info.internal;
+}
+
+/**
+ * The single precedence rule for varlock's own config: a real environment variable wins
+ * over a value picked up from a `.env` file. Returns a merged env record (env layered over
+ * file values) — use this anywhere a `_VARLOCK_*` setting is read.
+ */
+export function mergeVarlockConfigEnv(
+  fileVars: Record<string, string | undefined> = {},
+  env: Record<string, string | undefined> = process.env,
+): Record<string, string | undefined> {
+  return { ...fileVars, ...env };
 }

--- a/packages/varlock/src/env-graph/test/loader-cache-policy.test.ts
+++ b/packages/varlock/src/env-graph/test/loader-cache-policy.test.ts
@@ -5,7 +5,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import crypto from 'node:crypto';
-import { loadEnvGraph } from '../lib/loader';
+import { loadEnvGraph, loadVarlockConfigVarsFromFiles } from '../lib/loader';
 import { CacheStore, InMemoryCacheStore } from '../../lib/cache';
 
 // switchable local-encrypt backend so tests can simulate native vs file-fallback
@@ -92,10 +92,52 @@ describe('loadEnvGraph cache auto-policy', () => {
     expect((graph._cacheStore as CacheStore).getFilePath().endsWith('varlock-default.json')).toBe(true);
   });
 
+  it('honors a _VARLOCK_CACHE_KEY set in a .env.local file', async () => {
+    fs.writeFileSync(path.join(tempProjectDir, '.env.local'), `_VARLOCK_CACHE_KEY=${VALID_CACHE_KEY}\n`);
+    const graph = await loadEnvGraph({
+      entryFilePaths: tempProjectDir,
+      processEnvOverride: { CI: 'true' },
+    });
+    expect(graph.varlockConfigVarsFromFiles._VARLOCK_CACHE_KEY).toBe(VALID_CACHE_KEY);
+    expect(graph._cacheMode).toBe('disk');
+    expect((graph._cacheStore as CacheStore).getFilePath().endsWith(`env-key-${keyFingerprint}.json`)).toBe(true);
+  });
+
+  it('lets a real _VARLOCK_CACHE_KEY env var override the .env.local value', async () => {
+    const realKey = crypto.randomBytes(32).toString('hex');
+    const realFingerprint = crypto.createHash('sha256').update(realKey).digest('hex').slice(0, 12);
+    fs.writeFileSync(path.join(tempProjectDir, '.env.local'), `_VARLOCK_CACHE_KEY=${VALID_CACHE_KEY}\n`);
+    const graph = await loadEnvGraph({
+      entryFilePaths: tempProjectDir,
+      processEnvOverride: { CI: 'true', _VARLOCK_CACHE_KEY: realKey },
+    });
+    expect((graph._cacheStore as CacheStore).getFilePath().endsWith(`env-key-${realFingerprint}.json`)).toBe(true);
+  });
+
   it('falls back to memory when _VARLOCK_CACHE_KEY is invalid', async () => {
     const graph = await load({ processEnvOverride: { CI: 'true', _VARLOCK_CACHE_KEY: 'not-a-valid-key' } });
     expect(graph._cacheMode).toBe('memory');
     expect(graph._cacheStore).toBeInstanceOf(InMemoryCacheStore);
+  });
+
+  it('loadVarlockConfigVarsFromFiles does a parse-only extraction of file config vars', async () => {
+    fs.writeFileSync(path.join(tempProjectDir, '.env.local'), [
+      `_VARLOCK_CACHE_KEY=${VALID_CACHE_KEY}`,
+      '_VARLOCK_REDACT_STDOUT=true',
+      '',
+    ].join('\n'));
+    const fileVars = await loadVarlockConfigVarsFromFiles(tempProjectDir);
+    expect(fileVars._VARLOCK_CACHE_KEY).toBe(VALID_CACHE_KEY);
+    expect(fileVars._VARLOCK_REDACT_STDOUT).toBe('true');
+  });
+
+  it('loadVarlockConfigVarsFromFiles returns {} for a directory with no .env files', async () => {
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'varlock-empty-'));
+    try {
+      expect(await loadVarlockConfigVarsFromFiles(emptyDir)).toEqual({});
+    } finally {
+      fs.rmSync(emptyDir, { recursive: true, force: true });
+    }
   });
 
   it('creates no store with --skip-cache', async () => {

--- a/packages/varlock/src/env-graph/test/varlock-reserved-keys.test.ts
+++ b/packages/varlock/src/env-graph/test/varlock-reserved-keys.test.ts
@@ -3,6 +3,7 @@ import outdent from 'outdent';
 import { EnvGraph, DotEnvFileDataSource } from '../index';
 import {
   isVarlockReservedKey,
+  mergeVarlockConfigEnv,
   VARLOCK_RESERVED_KEY_PREFIX,
   VARLOCK_CONFIG_ENV_VARS,
   VARLOCK_INTERNAL_ENV_VARS,
@@ -89,20 +90,6 @@ describe('serialized graph excludes reserved _VARLOCK_ keys', () => {
     expect(overrideKeys.some((k) => k.startsWith('_VARLOCK_'))).toBe(false);
   });
 
-  it('warns (non-fatally) when a user defines a reserved _VARLOCK_ key', async () => {
-    const g = await buildGraph(outdent`
-      # @defaultSensitive=false
-      # ---
-      FOO=bar
-      _VARLOCK_REDACT_STDOUT=true
-    `);
-
-    const warnings = g.sortedDataSources.flatMap((s) => s.errors).filter((e) => e.isWarning);
-    expect(warnings.some((w) => w.message.includes('_VARLOCK_REDACT_STDOUT'))).toBe(true);
-    // a warning must not invalidate the source
-    expect(g.sortedDataSources.every((s) => s.isValid)).toBe(true);
-  });
-
   it('does not warn for normal keys', async () => {
     const g = await buildGraph(outdent`
       # @defaultSensitive=false
@@ -110,6 +97,132 @@ describe('serialized graph excludes reserved _VARLOCK_ keys', () => {
       FOO=bar
     `);
     const warnings = g.sortedDataSources.flatMap((s) => s.errors).filter((e) => e.isWarning);
-    expect(warnings.some((w) => w.message.includes('reserved'))).toBe(false);
+    expect(warnings.some((w) => w.message.includes('varlock config var'))).toBe(false);
+  });
+});
+
+describe('mergeVarlockConfigEnv (single precedence rule)', () => {
+  it('merges with env taking precedence over files', () => {
+    const merged = mergeVarlockConfigEnv({ A: 'file-a', B: 'file-b' }, { B: 'env-b', C: 'env-c' });
+    expect(merged).toEqual({ A: 'file-a', B: 'env-b', C: 'env-c' });
+  });
+});
+
+describe('honoring _VARLOCK_* config vars set in .env files', () => {
+  function onlyWarnings(g: EnvGraph) {
+    return g.sortedDataSources.flatMap((s) => s.errors).filter((e) => e.isWarning);
+  }
+
+  // _VARLOCK_* config is only honored from .env / .env.local, so the source must be one of those
+  async function buildGraph(envFile: string) {
+    const g = new EnvGraph();
+    await g.setRootDataSource(new DotEnvFileDataSource('.env', { overrideContents: envFile }));
+    await g.finishLoad();
+    await g.resolveEnvValues();
+    return g;
+  }
+
+  it('extracts a recognized static config var without warning, but keeps it out of the config', async () => {
+    const g = await buildGraph(outdent`
+      # @defaultSensitive=false
+      # ---
+      FOO=bar
+      _VARLOCK_ENV_KEY=abc123
+      _VARLOCK_REDACT_STDOUT=true
+    `);
+    expect(g.varlockConfigVarsFromFiles._VARLOCK_ENV_KEY).toBe('abc123');
+    expect(g.varlockConfigVarsFromFiles._VARLOCK_REDACT_STDOUT).toBe('true');
+    expect(onlyWarnings(g).some((w) => w.message.includes('_VARLOCK_'))).toBe(false);
+    // still excluded from the resolved/serialized config
+    expect(Object.keys(g.getSerializedGraph().config)).not.toContain('_VARLOCK_ENV_KEY');
+  });
+
+  it('lets a real env var take precedence over the .env file value', async () => {
+    const g = new EnvGraph();
+    g.processEnvOverride = { _VARLOCK_ENV_KEY: 'from-env' };
+    await g.setRootDataSource(new DotEnvFileDataSource('.env.local', {
+      overrideContents: outdent`
+        # @defaultSensitive=false
+        # ---
+        _VARLOCK_ENV_KEY=from-file
+      `,
+    }));
+    await g.finishLoad();
+    expect(g.varlockConfigVarsFromFiles._VARLOCK_ENV_KEY).toBe('from-file');
+    expect(g.varlockConfigEnv._VARLOCK_ENV_KEY).toBe('from-env');
+  });
+
+  it('errors (not just warns) and does not honor a recognized config var with a non-static value', async () => {
+    // classify straight off the parsed defs — a non-static reserved value is never honored.
+    // (full resolution isn't needed and isn't exercised here.)
+    const g = new EnvGraph();
+    await g.setRootDataSource(new DotEnvFileDataSource('.env.local', {
+      overrideContents: outdent`
+        # @defaultSensitive=false
+        # ---
+        _VARLOCK_ENV_KEY=concat("a","b")
+      `,
+    }));
+    g.processVarlockConfigVarsFromFiles({ emitDiagnostics: true });
+    const allErrors = g.sortedDataSources.flatMap((s) => s.errors);
+    const err = allErrors.find((x) => x.message.includes('_VARLOCK_ENV_KEY'));
+    expect(err?.message).toContain('must be a static value');
+    expect(err?.isWarning).toBeFalsy(); // a hard error, not a warning
+    expect(g.varlockConfigVarsFromFiles._VARLOCK_ENV_KEY).toBeUndefined();
+  });
+
+  it('warns that an internal config var is environment-only and does not honor it', async () => {
+    const g = await buildGraph(outdent`
+      # @defaultSensitive=false
+      # ---
+      _VARLOCK_FORCE_FILE_ENCRYPTION_FALLBACK=true
+    `);
+    const w = onlyWarnings(g).find((x) => x.message.includes('_VARLOCK_FORCE_FILE_ENCRYPTION_FALLBACK'));
+    expect(w?.message).toContain('environment only');
+    expect(g.varlockConfigVarsFromFiles._VARLOCK_FORCE_FILE_ENCRYPTION_FALLBACK).toBeUndefined();
+  });
+
+  it('does not honor _VARLOCK_* keys outside .env / .env.local, but warns they have no effect', async () => {
+    const g = new EnvGraph();
+    await g.setRootDataSource(new DotEnvFileDataSource('.env.schema', {
+      overrideContents: outdent`
+        # @defaultSensitive=false
+        # ---
+        _VARLOCK_ENV_KEY=abc123
+      `,
+    }));
+    await g.finishLoad();
+    // not honored, and excluded from config (never a config item)
+    expect(g.varlockConfigVarsFromFiles._VARLOCK_ENV_KEY).toBeUndefined();
+    expect(Object.keys(g.getSerializedGraph().config)).not.toContain('_VARLOCK_ENV_KEY');
+    // but the user gets a heads-up that it's in the wrong place
+    const w = onlyWarnings(g).find((x) => x.message.includes('_VARLOCK_ENV_KEY'));
+    expect(w?.message).toContain('has no effect in .env.schema');
+  });
+
+  it('keeps _VARLOCK_* out of the resolved env object (varlock config, not app config)', async () => {
+    const g = await buildGraph(outdent`
+      # @defaultSensitive=false
+      # ---
+      FOO=bar
+      _VARLOCK_ENV_KEY=abc123
+    `);
+    const resolved = g.getResolvedEnvObject();
+    expect(resolved).toHaveProperty('FOO');
+    expect(resolved).not.toHaveProperty('_VARLOCK_ENV_KEY');
+    // and it's not even a config item
+    expect(g.configSchema._VARLOCK_ENV_KEY).toBeUndefined();
+  });
+
+  it('warns (non-fatally) for an unrecognized _VARLOCK_ key (likely a typo)', async () => {
+    const g = await buildGraph(outdent`
+      # @defaultSensitive=false
+      # ---
+      FOO=bar
+      _VARLOCK_ENV_KYE=oops
+    `);
+    const w = onlyWarnings(g).find((x) => x.message.includes('_VARLOCK_ENV_KYE'));
+    expect(w?.message).toContain('not a recognized varlock config var');
+    expect(g.sortedDataSources.every((s) => s.isValid)).toBe(true);
   });
 });

--- a/packages/varlock/src/runtime/init-edge.ts
+++ b/packages/varlock/src/runtime/init-edge.ts
@@ -11,6 +11,7 @@ import { isEncryptedBlob, decryptEnvBlobSync } from '../runtime/crypto';
 // Decrypt the env blob if it was encrypted at build time.
 // Modern edge runtimes (Vercel Edge, Cloudflare with nodejs_compat) support node:crypto,
 // so we use the sync version here. Pure Web Crypto async path is available in env.ts as fallback.
+// At runtime there are no .env files, so _VARLOCK_ENV_KEY must already be a real env var.
 if (process.env.__VARLOCK_ENV && isEncryptedBlob(process.env.__VARLOCK_ENV)) {
   const key = process.env._VARLOCK_ENV_KEY;
   if (!key) throw new Error('[varlock] __VARLOCK_ENV is encrypted but _VARLOCK_ENV_KEY is not set');

--- a/packages/varlock/src/runtime/init-server.ts
+++ b/packages/varlock/src/runtime/init-server.ts
@@ -8,7 +8,8 @@ import { patchGlobalServerResponse } from '../runtime/patch-server-response';
 import { patchGlobalResponse } from '../runtime/patch-response';
 import { isEncryptedBlob, decryptEnvBlobSync } from '../runtime/crypto';
 
-// Decrypt the env blob if it was encrypted at build time
+// Decrypt the env blob if it was encrypted at build time. At runtime there are no .env files,
+// so _VARLOCK_ENV_KEY must already be a real environment variable.
 if (process.env.__VARLOCK_ENV && isEncryptedBlob(process.env.__VARLOCK_ENV)) {
   const key = process.env._VARLOCK_ENV_KEY;
   if (!key) throw new Error('[varlock] __VARLOCK_ENV is encrypted but _VARLOCK_ENV_KEY is not set');


### PR DESCRIPTION
## What

Lets you set varlock's own config vars (`_VARLOCK_ENV_KEY`, `_VARLOCK_CACHE_KEY`, `_VARLOCK_REDACT_STDOUT`) as static literals in `.env` / `.env.local`, so they configure varlock during local development instead of being silently ignored. A real environment variable always takes precedence.

## Why

Setting `_VARLOCK_ENV_KEY` in a gitignored `.env.local` is a natural thing to want for local dev, but it previously had no effect (and the warning didn't explain why).

## Behavior

- **Honored only from `.env` / `.env.local`** — not the committed `.env.schema` or env-specific files. A `_VARLOCK_*` key elsewhere warns it has no effect.
- **Must be a plain literal** — these are read before the graph resolves, so a non-static value (`$ref`/`fn()`) is a hard error rather than a silent fallback.
- **Unrecognized `_VARLOCK_*` keys warn** (likely a typo).
- **They are varlock config, never app config** — excluded from the resolved env, `varlock load` output, the injected blob, generated types, and override provenance; not referenceable from other items; not forwarded to `varlock run` children (a real env var still is, via inheritance).
- `varlock cache` honors a file-set `_VARLOCK_CACHE_KEY` too.

## Notes

- Single read path for varlock's own config (`mergeVarlockConfigEnv` / `getVarlockConfigVar`), with `.env`-file values layered under the real environment.
- Reserved `_VARLOCK_*` keys are no longer registered as config items, which also fixes a prior inconsistency where they showed up in `load` output despite being excluded from the blob.