### PR TITLE
fix(website): prevent docs TOC from being clipped by wide content

### DIFF
--- a/packages/varlock-website/src/styles/global.css
+++ b/packages/varlock-website/src/styles/global.css
@@ -586,6 +586,15 @@ html[data-theme='light'] .starlight-aside .starlight-aside__title {
   .right-sidebar-container {
     width: var(--sl-sidebar-width);
   }
+
+  /* Allow the main content column to shrink to its computed width instead of
+     being stretched by wide, non-wrapping content (code blocks, tables). The
+     default flex `min-width: auto` lets such content expand the pane, which
+     pushes the right TOC sidebar off the right edge of the viewport (the TOC
+     heading gets clipped). `min-width: 0` lets the content scroll internally. */
+  .main-pane {
+    min-width: 0;
+  }
 }
 
 #starlight__mobile-toc .toggle {


### PR DESCRIPTION
## Problem

On some docs pages the right-hand "On this page" TOC was clipped at the right edge of the viewport (e.g. `/guides/schema/`), while others rendered fine (e.g. `/getting-started/introduction/`).

## Cause

Starlight lays out the main content column (`.main-pane`) and the TOC column (`.right-sidebar-container`) as flex siblings, sizing them from `--sl-content-width` (set to `75rem` here). Flex items default to `min-width: auto`, so they won't shrink below their content's intrinsic width. Pages with wide, non-wrapping content (code blocks, tables) have a large min-content width, so `.main-pane` stretched past its computed width and pushed the TOC column partly off-screen. Plain-text pages wrap freely and stay at the computed width, which is why only some pages were affected.

## Fix

Add `min-width: 0` to `.main-pane` (within the existing `@media (min-width: 72rem)` block). The content column now shrinks to its computed width and wide code blocks/tables scroll internally instead of blowing out the layout.

Verified in the browser across 1160–1280px: the TOC now fits on the affected pages (schema, reference pages with tables), matching the previously-working pages, with no horizontal page scroll.