### PR TITLE
fix(ci): bump varlock-action to v1.0.5 for Windows signing

### DIFF
--- a/.github/workflows/build-native-macos.yaml
+++ b/.github/workflows/build-native-macos.yaml
@@ -65,7 +65,7 @@ jobs:
 
       # Load secrets from 1Password via varlock (scoped to the Swift package)
       - name: Load signing secrets
-        uses: dmno-dev/varlock-action@v1.0.3
+        uses: dmno-dev/varlock-action@v1.0.5
         with:
           working-directory: packages/encryption-binary-swift
         env:

--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -113,6 +113,20 @@ jobs:
         if: inputs.sign && contains(matrix.os, 'windows')
         run: bun run build:libs
 
+      # varlock-action locates varlock on Windows by looking for a
+      # node_modules/.bin/varlock.cmd shim, which `bun install` does not create
+      # (bun emits .exe/.bunx shims instead). Without it the action falls back to
+      # `npm install -g varlock`, whose post-install check can't resolve a .cmd via
+      # PATHEXT under spawnSync({shell:false}), so it fails with "Failed to install
+      # varlock". Drop a .cmd shim pointing at the workspace varlock so the action's
+      # local-binary path finds it — mirroring how macOS finds node_modules/.bin/varlock.
+      - name: Shim varlock for varlock-action (Windows)
+        if: inputs.sign && contains(matrix.os, 'windows')
+        shell: bash
+        run: |
+          mkdir -p node_modules/.bin
+          printf '@node "%%~dp0..\\varlock\\bin\\cli.js" %%*\r\n' > node_modules/.bin/varlock.cmd
+
       # Load Azure signing secrets from 1Password via varlock (scoped to the Rust package)
       - name: Load signing secrets
         if: inputs.sign && contains(matrix.os, 'windows')

--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -113,24 +113,10 @@ jobs:
         if: inputs.sign && contains(matrix.os, 'windows')
         run: bun run build:libs
 
-      # varlock-action locates varlock on Windows by looking for a
-      # node_modules/.bin/varlock.cmd shim, which `bun install` does not create
-      # (bun emits .exe/.bunx shims instead). Without it the action falls back to
-      # `npm install -g varlock`, whose post-install check can't resolve a .cmd via
-      # PATHEXT under spawnSync({shell:false}), so it fails with "Failed to install
-      # varlock". Drop a .cmd shim pointing at the workspace varlock so the action's
-      # local-binary path finds it — mirroring how macOS finds node_modules/.bin/varlock.
-      - name: Shim varlock for varlock-action (Windows)
-        if: inputs.sign && contains(matrix.os, 'windows')
-        shell: bash
-        run: |
-          mkdir -p node_modules/.bin
-          printf '@node "%%~dp0..\\varlock\\bin\\cli.js" %%*\r\n' > node_modules/.bin/varlock.cmd
-
       # Load Azure signing secrets from 1Password via varlock (scoped to the Rust package)
       - name: Load signing secrets
         if: inputs.sign && contains(matrix.os, 'windows')
-        uses: dmno-dev/varlock-action@v1.0.3
+        uses: dmno-dev/varlock-action@v1.0.5
         with:
           working-directory: packages/encryption-binary-rust
         env:

--- a/.github/workflows/notarize-native-macos.yaml
+++ b/.github/workflows/notarize-native-macos.yaml
@@ -54,7 +54,7 @@ jobs:
 
       # Load secrets from 1Password via varlock (scoped to the Swift package)
       - name: Load signing secrets
-        uses: dmno-dev/varlock-action@v1.0.3
+        uses: dmno-dev/varlock-action@v1.0.5
         with:
           working-directory: packages/encryption-binary-swift
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -345,7 +345,7 @@ jobs:
       # varlock the action uses.)
       - name: Load extension publishing secrets from 1Password
         if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-vscode == 'true'
-        uses: dmno-dev/varlock-action@v1.0.3
+        uses: dmno-dev/varlock-action@v1.0.5
         with:
           working-directory: packages/vscode-plugin
         env:

--- a/.github/workflows/vscode-release.yaml
+++ b/.github/workflows/vscode-release.yaml
@@ -29,7 +29,7 @@ jobs:
       # Resolve publishing secrets from 1Password via varlock: AZURE_CLIENT_ID /
       # AZURE_TENANT_ID (for Marketplace OIDC) and OVSX_PAT (for Open VSX).
       - name: Load extension publishing secrets from 1Password
-        uses: dmno-dev/varlock-action@v1.0.3
+        uses: dmno-dev/varlock-action@v1.0.5
         with:
           working-directory: packages/vscode-plugin
         env:


### PR DESCRIPTION
## What

The Windows native-binary signing job (`build-native-rust`) failed at **Load signing secrets** with `Failed to install varlock` — `varlock-action` couldn't resolve varlock on Windows runners.

Rather than work around it in this repo, the fix lives upstream in the action ([dmno-dev/varlock-action#18](https://github.com/dmno-dev/varlock-action/pull/18), released as **v1.0.5**), which fixes two Windows bugs:
- local detection now probes bun's `varlock.exe` shim, not just npm's `varlock.cmd`
- the global-install fallback resolves bare commands via `where` (Node's `spawnSync({shell:false})` doesn't apply PATHEXT)

This PR bumps every `varlock-action` pin in the repo from `v1.0.3` → `v1.0.5`.

## ⚠️ Merge order

Merge **after** [varlock-action#18](https://github.com/dmno-dev/varlock-action/pull/18) is merged and the `v1.0.5` tag is published — otherwise the `@v1.0.5` ref won't resolve.