### PR TITLE
fix(ci): work around bun Windows segfault from Socket security scanner

### DIFF
--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -104,6 +104,20 @@ jobs:
         if: inputs.sign && contains(matrix.os, 'windows')
         uses: oven-sh/setup-bun@v2
 
+      # `bun install` segfaults on Windows when the Socket security scanner runs
+      # (bun crashes with "Segmentation fault" right after "Security scanner
+      # installed successfully"). Drop the [install.security] section for this
+      # native-build install only — supply-chain scanning still runs in the
+      # dedicated Socket workflows. Remove once the upstream bun bug is fixed.
+      - name: Disable bun security scanner (Windows bun crash workaround)
+        if: inputs.sign && contains(matrix.os, 'windows')
+        shell: bash
+        run: |
+          awk '/^\[install\.security\]/{skip=1; next} /^\[/{skip=0} !skip' bunfig.toml > bunfig.toml.tmp
+          mv bunfig.toml.tmp bunfig.toml
+          echo "=== bunfig.toml after workaround ==="
+          cat bunfig.toml
+
       - name: Install node deps (for varlock secret loading)
         if: inputs.sign && contains(matrix.os, 'windows')
         run: bun install


### PR DESCRIPTION
## What

With the `varlock-action@v1.0.5` bump, the Windows binary signing job gets past secret loading but now fails earlier, at `bun install`:

```
bun install v1.3.14
Resolving dependencies
Security scanner installed successfully.
panic(main thread): Segmentation fault at address 0x55C00000C87
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

bun segfaults on **Windows** runners when the Socket security scanner (`[install.security]` in `bunfig.toml`) runs during install. macOS/Linux installs are unaffected — it's a Windows-specific bun bug.

## Fix

This job's `bun install` exists only to build varlock locally so it can resolve the Azure signing secrets from 1Password. Supply-chain scanning is enforced separately (the dedicated Socket workflows + PR installs), so we strip the `[install.security]` section from `bunfig.toml` for this Windows native-build install only. Scoped to `inputs.sign && windows`; nothing else changes. Remove once the upstream bun bug is fixed.