### PR TITLE
fix(ci): load Windows signing secrets with standalone varlock

### DIFF
--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -100,18 +100,24 @@ jobs:
       # through varlock (see packages/encryption-binary-rust/.env.schema), mirroring
       # the macOS Developer ID signing flow. PR/preview builds skip signing entirely,
       # so no secrets are loaded there.
-      - name: Setup Bun (for varlock secret loading)
+      # Standalone varlock (installed by varlock-action via `npm install -g varlock`,
+      # which has zero runtime deps) resolves the 1Password plugin by downloading it
+      # from npm, which requires a fixed version. We keep the committed schema
+      # unversioned so local/workspace runs resolve the in-repo plugin; inject the
+      # published version here, in CI only.
+      - name: Pin 1Password plugin version for standalone varlock (CI only)
         if: inputs.sign && contains(matrix.os, 'windows')
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install node deps (for varlock secret loading)
-        if: inputs.sign && contains(matrix.os, 'windows')
-        run: bun install
-
-      # Build varlock JS so we can use it to resolve secrets from 1Password
-      - name: Build varlock libs
-        if: inputs.sign && contains(matrix.os, 'windows')
-        run: bun run build:libs
+        shell: bash
+        env:
+          # Published @varlock/1password-plugin version — must already be on npm; bump as needed.
+          OP_PLUGIN_VERSION: '1.2.0'
+        run: |
+          schema=packages/encryption-binary-rust/.env.schema
+          sed -i "s|@plugin(@varlock/1password-plugin)|@plugin(@varlock/1password-plugin@${OP_PLUGIN_VERSION})|" "$schema"
+          grep -q "@plugin(@varlock/1password-plugin@${OP_PLUGIN_VERSION})" "$schema" \
+            || { echo "::error::failed to inject 1Password plugin version into $schema"; exit 1; }
+          echo "=== schema @plugin line ==="
+          grep '@plugin' "$schema"
 
       # Load Azure signing secrets from 1Password via varlock (scoped to the Rust package)
       - name: Load signing secrets


### PR DESCRIPTION
## What

The Windows binary signing job built varlock from source (`bun install` + `build:libs`) just to load Azure signing secrets — and that `bun install` segfaults on Windows when the Socket security scanner runs.

This drops the local build entirely. `varlock-action` (v1.0.5) installs varlock globally via npm; since varlock has **zero runtime dependencies**, that pulls in nothing else. varlock then resolves the 1Password plugin by downloading it from npm (the plugin is also a self-contained, zero-dep bundle), and reads `op://` refs via the bundled `@1password/sdk` using the service-account token — so no `op` CLI is needed either.

## The version injection

Downloading an official `@varlock/*` plugin from npm requires a **fixed version**. We keep the committed schema unversioned (`@plugin(@varlock/1password-plugin)`) so local/workspace runs resolve the in-repo plugin via `node_modules`, and inject the published version in CI only:

```yaml
env:
  OP_PLUGIN_VERSION: '1.2.0'   # published version; bump as needed
run: |
  sed -i "s|@plugin(@varlock/1password-plugin)|@plugin(@varlock/1password-plugin@${OP_PLUGIN_VERSION})|" "$schema"
```

## Net effect on the Windows signing job

- No `bun install` → no Socket-scanner segfault
- No third-party packages installed (only zero-dep, first-party varlock + plugin) → no supply-chain hole
- No `op` CLI needed
- Still dogfoods varlock for secret loading

Supersedes #829 (the scanner-disable workaround is no longer needed).