### PR TITLE
fix(ci): gitignore generated SHA256SUMS.txt so release publish isn't blocked

### DIFF
--- a/packages/varlock/.gitignore
+++ b/packages/varlock/.gitignore
@@ -2,3 +2,8 @@ dist
 dist-sea
 native-bins
 skills
+
+# Generated during the release job (native binary checksums, uploaded as a
+# workflow artifact, not part of the npm package). Ignored so it does not
+# leave the working tree dirty before bumpy publishes.
+SHA256SUMS.txt


### PR DESCRIPTION
## What

The release reached the publish step for the first time (now that Windows signing works), and bumpy aborted:

```
info No pending bump files — checking for unpublished packages...
warn You have uncommitted changes. Commit or stash them before publishing.
```

The Release job generates `packages/varlock/SHA256SUMS.txt` (native-binary checksums, uploaded as a workflow artifact) right before `bunx @varlock/bumpy ci release`. That file is **neither tracked nor gitignored**, so it leaves the working tree dirty and bumpy's clean-tree guard fails.

(Introduced in #811 alongside the Windows signing + checksums; never surfaced before because every release since then died at the broken signing step, so the publish job was skipped.)

## Fix

Add `SHA256SUMS.txt` to `packages/varlock/.gitignore`. It's a release artifact — varlock's `files` allowlist doesn't include it, so it's never part of the npm package — so ignoring it is safe and keeps the tree clean for bumpy.

The staged native binaries themselves are already gitignored (`native-bins`), so they don't dirty the tree.