### PR TITLE
feat: add keychain CLI commands

### DIFF
--- a/.bumpy/keychain-import-require-schema.md
+++ b/.bumpy/keychain-import-require-schema.md
@@ -1,5 +1,0 @@
----
-varlock: patch
----
-
-Require an explicit schema before importing plaintext Keychain secrets

--- a/.bumpy/keychain-import-require-schema.md
+++ b/.bumpy/keychain-import-require-schema.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Require an explicit schema before importing plaintext Keychain secrets

--- a/.bumpy/varlock-keychain-cli.md
+++ b/.bumpy/varlock-keychain-cli.md
@@ -2,4 +2,4 @@
 varlock: minor
 ---
 
-Add macOS Keychain management commands.
+Add `varlock keychain` commands to manage macOS Keychain-backed secrets.

--- a/.bumpy/varlock-keychain-cli.md
+++ b/.bumpy/varlock-keychain-cli.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+Add macOS Keychain management commands.

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
@@ -12,6 +12,25 @@ enum KeychainError: LocalizedError {
     case keychainNotFound(String)
     case ambiguousMatch(service: String, accounts: [String])
 
+    var code: String {
+        switch self {
+        case .itemNotFound:
+            return "itemNotFound"
+        case .accessDenied:
+            return "accessDenied"
+        case .duplicateItem:
+            return "duplicateItem"
+        case .unexpectedData:
+            return "unexpectedData"
+        case .unhandledError:
+            return "unhandledError"
+        case .keychainNotFound:
+            return "keychainNotFound"
+        case .ambiguousMatch:
+            return "ambiguousMatch"
+        }
+    }
+
     var errorDescription: String? {
         switch self {
         case .itemNotFound:

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
@@ -301,6 +301,50 @@ final class KeychainManager {
 
     // MARK: - Add Item
 
+    /// Create or update a generic password item.
+    /// Returns true when an existing item was updated, false when a new item was created.
+    static func setGenericPassword(service: String, account: String, value: String, update: Bool = false) throws -> Bool {
+        guard let valueData = value.data(using: .utf8) else {
+            throw KeychainError.unexpectedData
+        }
+
+        let lookup: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+        ]
+
+        if update {
+            let attrs: [CFString: Any] = [
+                kSecValueData: valueData,
+                kSecAttrLabel: account.isEmpty ? service : account,
+            ]
+            let status = SecItemUpdate(lookup as CFDictionary, attrs as CFDictionary)
+            switch status {
+            case errSecSuccess:
+                return true
+            case errSecItemNotFound:
+                break
+            default:
+                throw KeychainError.unhandledError(status)
+            }
+        }
+
+        var addQuery = lookup
+        addQuery[kSecAttrLabel] = account.isEmpty ? service : account
+        addQuery[kSecValueData] = valueData
+
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        switch status {
+        case errSecSuccess:
+            return false
+        case errSecDuplicateItem:
+            throw KeychainError.duplicateItem
+        default:
+            throw KeychainError.unhandledError(status)
+        }
+    }
+
     /// Create a new keychain item as a secure note.
     /// The label is the only user-visible identifier in Keychain Access.
     /// The value is stored as RTF for Keychain Access compatibility.

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
@@ -483,6 +483,16 @@ final class KeychainManager {
     /// Get a SecKeychainItem reference for ACL operations.
     /// Searches generic passwords first, then internet passwords.
     private static func getItemRef(service: String, account: String?, keychainName: String?) throws -> SecKeychainItem {
+        let searchList: [SecKeychain]?
+        if let keychainName = keychainName {
+            guard let keychainRef = resolveKeychain(named: keychainName) else {
+                throw KeychainError.keychainNotFound(keychainName)
+            }
+            searchList = [keychainRef]
+        } else {
+            searchList = nil
+        }
+
         for itemClass in [kSecClassGenericPassword, kSecClassInternetPassword] {
             let serviceAttribute = itemClass == kSecClassGenericPassword ? kSecAttrService : kSecAttrServer
 
@@ -494,8 +504,8 @@ final class KeychainManager {
                     serviceAttribute: service,
                 ]
 
-                if let keychainName = keychainName, let keychainRef = resolveKeychain(named: keychainName) {
-                    countQuery[kSecMatchSearchList] = [keychainRef]
+                if let searchList = searchList {
+                    countQuery[kSecMatchSearchList] = searchList
                 }
 
                 var countResult: AnyObject?
@@ -520,8 +530,8 @@ final class KeychainManager {
                 query[kSecAttrAccount] = account
             }
 
-            if let keychainName = keychainName, let keychainRef = resolveKeychain(named: keychainName) {
-                query[kSecMatchSearchList] = [keychainRef]
+            if let searchList = searchList {
+                query[kSecMatchSearchList] = searchList
             }
 
             var result: AnyObject?

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/KeychainManager.swift
@@ -484,17 +484,37 @@ final class KeychainManager {
     /// Searches generic passwords first, then internet passwords.
     private static func getItemRef(service: String, account: String?, keychainName: String?) throws -> SecKeychainItem {
         for itemClass in [kSecClassGenericPassword, kSecClassInternetPassword] {
+            let serviceAttribute = itemClass == kSecClassGenericPassword ? kSecAttrService : kSecAttrServer
+
+            if account == nil {
+                var countQuery: [CFString: Any] = [
+                    kSecClass: itemClass,
+                    kSecReturnAttributes: true,
+                    kSecMatchLimit: kSecMatchLimitAll,
+                    serviceAttribute: service,
+                ]
+
+                if let keychainName = keychainName, let keychainRef = resolveKeychain(named: keychainName) {
+                    countQuery[kSecMatchSearchList] = [keychainRef]
+                }
+
+                var countResult: AnyObject?
+                let countStatus = SecItemCopyMatching(countQuery as CFDictionary, &countResult)
+                if countStatus == errSecSuccess, let items = countResult as? [[String: Any]], items.count > 1 {
+                    let accounts = items.compactMap { $0[kSecAttrAccount as String] as? String }
+                    throw KeychainError.ambiguousMatch(
+                        service: service,
+                        accounts: accounts
+                    )
+                }
+            }
+
             var query: [CFString: Any] = [
                 kSecClass: itemClass,
                 kSecReturnRef: true,
                 kSecMatchLimit: kSecMatchLimitOne,
+                serviceAttribute: service,
             ]
-
-            if itemClass == kSecClassGenericPassword {
-                query[kSecAttrService] = service
-            } else {
-                query[kSecAttrServer] = service
-            }
 
             if let account = account {
                 query[kSecAttrAccount] = account

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/main.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/main.swift
@@ -364,6 +364,54 @@ case "daemon":
             }
             return ["result": selected]
 
+        case "keychain-fix-access":
+            guard let payload = message["payload"] as? [String: Any] else {
+                return ["error": "Missing payload"]
+            }
+            guard let service = payload["service"] as? String else {
+                return ["error": "Missing service"]
+            }
+            let account = payload["account"] as? String
+            let keychainName = payload["keychain"] as? String
+            let appPath = Bundle.main.executablePath ?? ProcessInfo.processInfo.arguments[0]
+
+            do {
+                let modified = try KeychainManager.addToACL(
+                    service: service,
+                    account: account,
+                    keychainName: keychainName,
+                    appPath: appPath
+                )
+                return ["result": ["modified": modified]]
+            } catch {
+                return ["error": error.localizedDescription]
+            }
+
+        case "keychain-set":
+            guard let payload = message["payload"] as? [String: Any] else {
+                return ["error": "Missing payload"]
+            }
+            guard let service = payload["service"] as? String else {
+                return ["error": "Missing service"]
+            }
+            guard let value = payload["value"] as? String else {
+                return ["error": "Missing value"]
+            }
+            let account = payload["account"] as? String ?? ""
+            let update = payload["update"] as? Bool ?? false
+
+            do {
+                let updated = try KeychainManager.setGenericPassword(
+                    service: service,
+                    account: account,
+                    value: value,
+                    update: update
+                )
+                return ["result": ["updated": updated]]
+            } catch {
+                return ["error": error.localizedDescription]
+            }
+
         default:
             return ["error": "Unknown action: \(action)"]
         }

--- a/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/main.swift
+++ b/packages/encryption-binary-swift/swift/Sources/VarlockEnclave/main.swift
@@ -27,6 +27,16 @@ func jsonSuccess(_ result: [String: Any]) -> Never {
     _exit(0)
 }
 
+func keychainErrorResponse(_ error: Error) -> [String: Any] {
+    if let keychainError = error as? KeychainError {
+        return [
+            "error": keychainError.localizedDescription,
+            "errorCode": keychainError.code,
+        ]
+    }
+    return ["error": error.localizedDescription]
+}
+
 // MARK: - CLI Parsing
 
 let args = CommandLine.arguments
@@ -324,7 +334,7 @@ case "daemon":
                     )
                     return ["result": value]
                 } catch {
-                    return ["error": error.localizedDescription]
+                    return keychainErrorResponse(error)
                 }
             }
 
@@ -344,7 +354,7 @@ case "daemon":
                 statusBarMenu?.refresh()
                 return ["result": value]
             } catch {
-                return ["error": error.localizedDescription]
+                return keychainErrorResponse(error)
             }
 
         case "keychain-search":
@@ -384,7 +394,7 @@ case "daemon":
                 )
                 return ["result": ["modified": modified]]
             } catch {
-                return ["error": error.localizedDescription]
+                return keychainErrorResponse(error)
             }
 
         case "keychain-set":
@@ -409,7 +419,7 @@ case "daemon":
                 )
                 return ["result": ["updated": updated]]
             } catch {
-                return ["error": error.localizedDescription]
+                return keychainErrorResponse(error)
             }
 
         default:

--- a/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
@@ -41,18 +41,24 @@ ITEM=keychain(prompt) # Opens a native picker dialog
 
 ## Import plaintext env files
 
-If you already have sensitive plaintext values in a local `.env` file, import them into macOS Keychain and write stable `keychain(...)` references to a profile env file:
+If you already have sensitive plaintext values in a local `.env` file, import them into macOS Keychain and replace the plaintext with stable `keychain(...)` references. The file to import is the first argument:
 
 ```sh
-varlock keychain import --from .env --profile jb --write .env.jb
+varlock keychain import .env --profile jb
 ```
 
-Import requires an existing `.env.schema` file for the input env file so Varlock knows which input variables are secrets and which are not. It only includes variables marked `@sensitive` in that schema and never prints secret values. By default, Varlock refuses to overwrite existing Keychain items or existing refs in the target env file; pass `--force` to overwrite both.
+By default this **edits the file in place** — each sensitive plaintext value is replaced by its `keychain(...)` ref, so the secret no longer lives on disk. Comments and non-sensitive values are left untouched. To write the refs to a *different* file instead and leave the source as-is, pass `--write`:
+
+```sh
+varlock keychain import .env --profile jb --write .env.jb
+```
+
+Import requires an existing `.env.schema` file for the input env file so Varlock knows which input variables are secrets and which are not. It only imports variables marked `@sensitive` in that schema and never prints secret values. Re-running is safe: values already converted to `keychain(...)` refs are skipped. By default, Varlock refuses to overwrite an existing Keychain item (or, with `--write`, an existing ref in the target file); pass `--force` to overwrite.
 
 Generated refs use `service="varlock"` and account names like `<project>:<profile>:<ENV_VAR>`. The project defaults to the current directory name and can be overridden:
 
 ```sh
-varlock keychain import --from .env --profile jb --project my-app --write .env.jb
+varlock keychain import .env --profile jb --project my-app
 ```
 
 ## Set one secret manually

--- a/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
@@ -55,6 +55,8 @@ varlock keychain import .env --profile jb --write-to .env.jb
 
 Import requires an existing `.env.schema` file for the input env file so Varlock knows which input variables are secrets and which are not. It only imports variables marked `@sensitive` in that schema and never prints secret values. Re-running is safe: values already converted to `keychain(...)` refs are skipped. By default, Varlock refuses to overwrite an existing Keychain item (or, with `--write-to`, an existing ref in the target file); pass `--force` to overwrite.
 
+The file you name must be one Varlock loads as part of your env setup — it resolves your normal env graph (from `package.json` `varlock.loadPath`, or the files in the current directory) to read sensitivity from your schema, the same way `varlock encrypt --file` works. An arbitrary file outside that setup can't be imported. The value stored in Keychain is taken from the file you named specifically; an override of the same variable in another file (such as `.env.local`) does not change what gets imported.
+
 Generated refs use `service="varlock"` and account names like `<project>:<profile>:<ENV_VAR>`. The project defaults to the current directory name and can be overridden:
 
 ```sh

--- a/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
@@ -97,6 +97,21 @@ You can also fix every explicit `keychain(...)` ref in an env file:
 varlock keychain fix-access --path .env.jb
 ```
 
+## List Keychain items
+
+To see which Keychain items are available, list them by service name. This shows metadata only (service, account, and keychain) and never reads secret values:
+
+```sh
+varlock keychain list           # same as bare `varlock keychain`
+varlock keychain list API_KEY   # filter (matches service, account, or label)
+```
+
+Pass `--keychain` to search a specific keychain, such as `System`:
+
+```sh
+varlock keychain list --keychain System
+```
+
 ## Reference
 
 <div class="reference-docs">

--- a/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
@@ -47,7 +47,7 @@ If you already have sensitive plaintext values in a local `.env` file, import th
 varlock keychain import --from .env --profile jb --write .env.jb
 ```
 
-Import only includes variables marked `@sensitive` in your schema. It never prints secret values. By default, Varlock refuses to overwrite existing Keychain items or existing refs in the target env file; pass `--force` to overwrite both.
+Import requires an existing `.env.schema` file for the input env file so Varlock knows which input variables are secrets and which are not. It only includes variables marked `@sensitive` in that schema and never prints secret values. By default, Varlock refuses to overwrite existing Keychain items or existing refs in the target env file; pass `--force` to overwrite both.
 
 Generated refs use `service="varlock"` and account names like `<project>:<profile>:<ENV_VAR>`. The project defaults to the current directory name and can be overridden:
 

--- a/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
@@ -47,13 +47,13 @@ If you already have sensitive plaintext values in a local `.env` file, import th
 varlock keychain import .env --profile jb
 ```
 
-By default this **edits the file in place** — each sensitive plaintext value is replaced by its `keychain(...)` ref, so the secret no longer lives on disk. Comments and non-sensitive values are left untouched. To write the refs to a *different* file instead and leave the source as-is, pass `--write`:
+By default this **edits the file in place** — each sensitive plaintext value is replaced by its `keychain(...)` ref, so the secret no longer lives on disk. Comments and non-sensitive values are left untouched. To write the refs to a *different* file instead and leave the source as-is, pass `--write-to`:
 
 ```sh
-varlock keychain import .env --profile jb --write .env.jb
+varlock keychain import .env --profile jb --write-to .env.jb
 ```
 
-Import requires an existing `.env.schema` file for the input env file so Varlock knows which input variables are secrets and which are not. It only imports variables marked `@sensitive` in that schema and never prints secret values. Re-running is safe: values already converted to `keychain(...)` refs are skipped. By default, Varlock refuses to overwrite an existing Keychain item (or, with `--write`, an existing ref in the target file); pass `--force` to overwrite.
+Import requires an existing `.env.schema` file for the input env file so Varlock knows which input variables are secrets and which are not. It only imports variables marked `@sensitive` in that schema and never prints secret values. Re-running is safe: values already converted to `keychain(...)` refs are skipped. By default, Varlock refuses to overwrite an existing Keychain item (or, with `--write-to`, an existing ref in the target file); pass `--force` to overwrite.
 
 Generated refs use `service="varlock"` and account names like `<project>:<profile>:<ENV_VAR>`. The project defaults to the current directory name and can be overridden:
 
@@ -66,13 +66,13 @@ varlock keychain import .env --profile jb --project my-app
 To store one secret without putting the value in shell history, run `set` and enter the value at the masked prompt:
 
 ```sh
-varlock keychain set API_KEY --profile jb --write .env.jb
+varlock keychain set API_KEY --profile jb --write-to .env.jb
 ```
 
-This stores the item under `service="varlock"` with account `<project>:<profile>:API_KEY`, then writes the matching `keychain(...)` ref when `--write` is provided. If you need to paste a multi-line secret, pipe it through stdin instead of passing it as a command-line argument:
+This stores the item under `service="varlock"` with account `<project>:<profile>:API_KEY`, then writes the matching `keychain(...)` ref when `--write-to` is provided. If you need to paste a multi-line secret, pipe it through stdin instead of passing it as a command-line argument:
 
 ```sh
-cat secret.txt | varlock keychain set PRIVATE_KEY --profile jb --write .env.jb
+cat secret.txt | varlock keychain set PRIVATE_KEY --profile jb --write-to .env.jb
 ```
 
 By default, `set` refuses to overwrite an existing Keychain item or env ref. Pass `--force` to replace both.

--- a/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
@@ -39,6 +39,58 @@ Rather than wiring up items individually, the easiest way to get started is by u
 ITEM=keychain(prompt) # Opens a native picker dialog
 ```
 
+## Import plaintext env files
+
+If you already have sensitive plaintext values in a local `.env` file, import them into macOS Keychain and write stable `keychain(...)` references to a profile env file:
+
+```sh
+varlock keychain import --from .env --profile jb --write .env.jb
+```
+
+Import only includes variables marked `@sensitive` in your schema. It never prints secret values. By default, Varlock refuses to overwrite existing Keychain items or existing refs in the target env file; pass `--force` to overwrite both.
+
+Generated refs use `service="varlock"` and account names like `<project>:<profile>:<ENV_VAR>`. The project defaults to the current directory name and can be overridden:
+
+```sh
+varlock keychain import --from .env --profile jb --project my-app --write .env.jb
+```
+
+## Set one secret manually
+
+To store one secret without putting the value in shell history, run `set` and enter the value at the masked prompt:
+
+```sh
+varlock keychain set API_KEY --profile jb --write .env.jb
+```
+
+This stores the item under `service="varlock"` with account `<project>:<profile>:API_KEY`, then writes the matching `keychain(...)` ref when `--write` is provided. If you need to paste a multi-line secret, pipe it through stdin instead of passing it as a command-line argument:
+
+```sh
+cat secret.txt | varlock keychain set PRIVATE_KEY --profile jb --write .env.jb
+```
+
+By default, `set` refuses to overwrite an existing Keychain item or env ref. Pass `--force` to replace both.
+
+## Access management
+
+If VarlockEnclave cannot read an existing Keychain item, grant access without using `/usr/bin/security` directly:
+
+```sh
+varlock keychain fix-access --account "my-app:jb:API_KEY"
+```
+
+`--service` defaults to `varlock`, but can be overridden for legacy or manually-created Keychain items:
+
+```sh
+varlock keychain fix-access --service "com.company.api" --account "admin"
+```
+
+You can also fix every explicit `keychain(...)` ref in an env file:
+
+```sh
+varlock keychain fix-access --path .env.jb
+```
+
 ## Reference
 
 <div class="reference-docs">

--- a/packages/varlock/src/cli/cli-executable.ts
+++ b/packages/varlock/src/cli/cli-executable.ts
@@ -29,6 +29,7 @@ import { commandSpec as installPluginCommandSpec } from './commands/install-plug
 import { commandSpec as auditCommandSpec } from './commands/audit.command';
 import { commandSpec as generateKeyCommandSpec } from './commands/generate-key.command';
 import { commandSpec as cacheCommandSpec } from './commands/cache.command';
+import { commandSpec as keychainCommandSpec } from './commands/keychain.command';
 // import { commandSpec as loginCommandSpec } from './commands/login.command';
 // import { commandSpec as pluginCommandSpec } from './commands/plugin.command';
 
@@ -72,6 +73,7 @@ subCommands.set('typegen', buildLazyCommand(typegenCommandSpec, async () => awai
 subCommands.set('install-plugin', buildLazyCommand(installPluginCommandSpec, async () => await import('./commands/install-plugin.command')));
 subCommands.set('generate-key', buildLazyCommand(generateKeyCommandSpec, async () => await import('./commands/generate-key.command')));
 subCommands.set('cache', buildLazyCommand(cacheCommandSpec, async () => await import('./commands/cache.command')));
+subCommands.set('keychain', buildLazyCommand(keychainCommandSpec, async () => await import('./commands/keychain.command')));
 // subCommands.set('login', buildLazyCommand(loginCommandSpec, async () => await import('./commands/login.command')));
 // subCommands.set('plugin', buildLazyCommand(pluginCommandSpec, async () => await import('./commands/plugin.command')));
 

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -16,6 +16,7 @@ import { getDaemonClient } from '../../lib/local-encrypt';
 import { DaemonError } from '../../lib/local-encrypt/daemon-client';
 import { CliExitError } from '../helpers/exit-error';
 import { password } from '../helpers/prompts';
+import { trackCommand } from '../helpers/telemetry';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 
 type KeychainRef = {
@@ -24,59 +25,6 @@ type KeychainRef = {
   account?: string;
   keychain?: string;
 };
-
-export const commandSpec = define({
-  name: 'keychain',
-  description: 'Manage macOS Keychain items used by keychain()',
-  args: {
-    service: {
-      type: 'string',
-      description: 'Keychain service name (default: varlock)',
-      default: 'varlock',
-    },
-    account: {
-      type: 'string',
-      description: 'Keychain account name',
-    },
-    keychain: {
-      type: 'string',
-      description: 'Keychain name to search, such as Login or System',
-    },
-    path: {
-      type: 'string',
-      description: 'Path to an env file containing keychain() refs',
-    },
-    from: {
-      type: 'string',
-      description: 'Plaintext env file to import from',
-    },
-    write: {
-      type: 'string',
-      description: 'Env file to write keychain() refs to',
-    },
-    profile: {
-      type: 'string',
-      description: 'Profile name used in generated account names',
-      default: 'local',
-    },
-    project: {
-      type: 'string',
-      description: 'Project slug used in generated account names (default: current directory name)',
-    },
-    force: {
-      type: 'boolean',
-      description: 'Overwrite existing Keychain items and env refs',
-    },
-  },
-  examples: `
-Examples:
-  varlock keychain list
-  varlock keychain fix-access --account "my-project:jb:API_KEY"
-  varlock keychain fix-access --path .env.jb
-  varlock keychain import --from .env --profile jb --write .env.jb
-  varlock keychain set API_KEY --profile jb --write .env.jb
-`.trim(),
-});
 
 function assertMacOS() {
   if (process.platform !== 'darwin') {
@@ -279,6 +227,22 @@ async function readSecretForSet(label: string): Promise<string | undefined> {
   return prompted;
 }
 
+/** Throw a refusal error if a matching Keychain item already exists (the non-force guard). */
+async function assertKeychainItemAbsent(
+  client: ReturnType<typeof getDaemonClient>,
+  ref: { service: string; account?: string },
+  label: string,
+  suggestion: string,
+) {
+  try {
+    await client.keychainGet({ service: ref.service, account: ref.account, field: 'account' });
+  } catch (err) {
+    if (isKeychainItemNotFoundError(err)) return;
+    throw err;
+  }
+  throw new CliExitError(`Refusing to overwrite existing Keychain item for ${label}`, { suggestion });
+}
+
 async function setKeychainSecret(opts: {
   key?: string;
   service: string;
@@ -307,19 +271,12 @@ async function setKeychainSecret(opts: {
 
   const client = getDaemonClient();
   if (!opts.force) {
-    try {
-      await client.keychainGet({
-        service: opts.service,
-        account: opts.account,
-        field: 'account',
-      });
-      throw new CliExitError(`Refusing to overwrite existing Keychain item for ${label}`, {
-        suggestion: 'Re-run with --force to overwrite the existing Keychain item.',
-      });
-    } catch (err) {
-      if (err instanceof CliExitError) throw err;
-      if (!isKeychainItemNotFoundError(err)) throw err;
-    }
+    await assertKeychainItemAbsent(
+      client,
+      { service: opts.service, account: opts.account },
+      label,
+      'Re-run with --force to overwrite the existing Keychain item.',
+    );
   }
 
   await client.keychainSet({
@@ -392,19 +349,12 @@ async function importPlaintextEnv(opts: {
   const client = getDaemonClient();
   if (!opts.force) {
     for (const item of itemsToImport) {
-      try {
-        await client.keychainGet({
-          service: item.ref.service,
-          account: item.ref.account,
-          field: 'account',
-        });
-        throw new CliExitError(`Refusing to overwrite existing Keychain item for ${item.key}`, {
-          suggestion: 'Re-run with --force to overwrite existing env refs and Keychain items.',
-        });
-      } catch (err) {
-        if (err instanceof CliExitError) throw err;
-        if (!isKeychainItemNotFoundError(err)) throw err;
-      }
+      await assertKeychainItemAbsent(
+        client,
+        item.ref,
+        item.key,
+        'Re-run with --force to overwrite existing env refs and Keychain items.',
+      );
     }
   }
 
@@ -425,24 +375,63 @@ async function importPlaintextEnv(opts: {
   console.log(`Wrote refs to ${path.relative(process.cwd(), writePath) || writePath}.`);
 }
 
-export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
-  assertMacOS();
+function resolveProject(project?: string): string {
+  return project || path.basename(process.cwd());
+}
 
-  const positionals = (ctx.positionals ?? []).slice(ctx.commandPath?.length ?? 0);
-  const action = positionals[0] ?? 'list';
-  const service = String(ctx.values.service || 'varlock');
-  const account = ctx.values.account ? String(ctx.values.account) : undefined;
-  const keychain = ctx.values.keychain ? String(ctx.values.keychain) : undefined;
+// --- `varlock keychain list` ------------------------------------------------
 
-  if (action === 'list') {
-    await listKeychainItems(positionals[1], keychain);
-    return;
-  }
+const listCommand = define({
+  name: 'list',
+  description: 'List matching macOS Keychain items (metadata only)',
+  args: {
+    query: {
+      type: 'positional',
+      required: false,
+      description: 'Filter items by service name',
+    },
+    keychain: {
+      type: 'string',
+      description: 'Keychain name to search, such as Login or System',
+    },
+  },
+  run: async (ctx) => {
+    assertMacOS();
+    await trackCommand('keychain list', { command: 'keychain list' });
+    await listKeychainItems(ctx.values.query, ctx.values.keychain);
+  },
+});
 
-  if (action === 'fix-access') {
+// --- `varlock keychain fix-access` ------------------------------------------
+
+const fixAccessCommand = define({
+  name: 'fix-access',
+  description: "Grant Varlock's helper access to existing keychain() items",
+  args: {
+    service: {
+      type: 'string',
+      default: 'varlock',
+      description: 'Keychain service name (default: varlock)',
+    },
+    account: {
+      type: 'string',
+      description: 'Keychain account name',
+    },
+    keychain: {
+      type: 'string',
+      description: 'Keychain name to search, such as Login or System',
+    },
+    path: {
+      type: 'string',
+      description: 'Env file to fix access for every explicit keychain() ref',
+    },
+  },
+  run: async (ctx) => {
+    assertMacOS();
+    await trackCommand('keychain fix-access', { command: 'keychain fix-access' });
+
     if (ctx.values.path) {
-      const filePath = path.resolve(String(ctx.values.path));
-      const refs = extractKeychainRefsFromFile(filePath);
+      const refs = extractKeychainRefsFromFile(path.resolve(ctx.values.path));
       if (refs.length === 0) {
         console.log(ansis.gray('No explicit keychain() refs found.'));
         return;
@@ -451,27 +440,67 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
       return;
     }
 
-    if (!account) {
+    if (!ctx.values.account) {
       throw new CliExitError('Missing --account for keychain fix-access', {
         suggestion: 'Use --account "project:profile:KEY" or --path .env.profile',
       });
     }
 
-    await fixAccessForRefs([{ service, account, keychain }]);
-    return;
-  }
+    await fixAccessForRefs([
+      {
+        service: ctx.values.service,
+        account: ctx.values.account,
+        keychain: ctx.values.keychain,
+      },
+    ]);
+  },
+});
 
-  if (action === 'set') {
-    if (keychain) {
-      throw new CliExitError('keychain set does not support --keychain yet', {
-        suggestion: 'Omit --keychain to store the item in the default login keychain.',
-      });
-    }
+// --- `varlock keychain set` -------------------------------------------------
 
-    const key = positionals[1];
-    const profile = String(ctx.values.profile || 'local');
-    const project = String(ctx.values.project || path.basename(process.cwd()));
-    const targetAccount = account ?? (key ? getGeneratedAccount(project, profile, key) : undefined);
+const setCommand = define({
+  name: 'set',
+  description: 'Store a secret in macOS Keychain and optionally write a keychain() ref',
+  args: {
+    key: {
+      type: 'positional',
+      required: false,
+      description: 'Env var key to store (used to generate the account name and ref)',
+    },
+    service: {
+      type: 'string',
+      default: 'varlock',
+      description: 'Keychain service name (default: varlock)',
+    },
+    account: {
+      type: 'string',
+      description: 'Keychain account name (defaults to <project>:<profile>:<KEY>)',
+    },
+    profile: {
+      type: 'string',
+      default: 'local',
+      description: 'Profile name used in generated account names',
+    },
+    project: {
+      type: 'string',
+      description: 'Project slug used in generated account names (default: current directory name)',
+    },
+    write: {
+      type: 'string',
+      description: 'Env file to write the keychain() ref to',
+    },
+    force: {
+      type: 'boolean',
+      description: 'Overwrite existing Keychain item and env ref',
+    },
+  },
+  run: async (ctx) => {
+    assertMacOS();
+    await trackCommand('keychain set', { command: 'keychain set' });
+
+    const { key, service, account } = ctx.values;
+    const targetAccount = account
+      ?? (key ? getGeneratedAccount(resolveProject(ctx.values.project), ctx.values.profile, key) : undefined);
     if (!targetAccount) {
       throw new CliExitError('Missing env var key or --account for keychain set', {
         suggestion: 'Use `varlock keychain set API_KEY --profile local` or `varlock keychain set --account name`.',
@@ -482,29 +511,89 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
       key,
       service,
       account: targetAccount,
-      write: ctx.values.write ? String(ctx.values.write) : undefined,
+      write: ctx.values.write,
       force: Boolean(ctx.values.force),
     });
-    return;
-  }
+  },
+});
 
-  if (action === 'import') {
-    if (!ctx.values.from) throw new CliExitError('Missing --from for keychain import');
-    const profile = String(ctx.values.profile || 'local');
-    const project = String(ctx.values.project || path.basename(process.cwd()));
-    const write = ctx.values.write ? String(ctx.values.write) : `.env.${profile}`;
+// --- `varlock keychain import` ----------------------------------------------
+
+const importCommand = define({
+  name: 'import',
+  description: 'Import sensitive plaintext values from an env file into macOS Keychain',
+  args: {
+    from: {
+      type: 'string',
+      description: 'Plaintext env file to import from',
+    },
+    write: {
+      type: 'string',
+      description: 'Env file to write keychain() refs to (default: .env.<profile>)',
+    },
+    service: {
+      type: 'string',
+      default: 'varlock',
+      description: 'Keychain service name (default: varlock)',
+    },
+    profile: {
+      type: 'string',
+      default: 'local',
+      description: 'Profile name used in generated account names',
+    },
+    project: {
+      type: 'string',
+      description: 'Project slug used in generated account names (default: current directory name)',
+    },
+    force: {
+      type: 'boolean',
+      description: 'Overwrite existing Keychain items and env refs',
+    },
+  },
+  run: async (ctx) => {
+    assertMacOS();
+    await trackCommand('keychain import', { command: 'keychain import' });
+
+    if (!ctx.values.from) {
+      throw new CliExitError('Missing --from for keychain import', {
+        suggestion: 'Use `varlock keychain import --from .env --write .env.profile`.',
+      });
+    }
+
     await importPlaintextEnv({
-      from: String(ctx.values.from),
-      write,
-      service,
-      profile,
-      project,
+      from: ctx.values.from,
+      write: ctx.values.write ?? `.env.${ctx.values.profile}`,
+      service: ctx.values.service,
+      profile: ctx.values.profile,
+      project: resolveProject(ctx.values.project),
       force: Boolean(ctx.values.force),
     });
-    return;
-  }
+  },
+});
 
-  throw new CliExitError(`Unknown keychain action: ${action}`, {
-    suggestion: 'Use list, fix-access, import, or set.',
-  });
+// --- `varlock keychain` (parent) --------------------------------------------
+
+export const commandSpec = define({
+  name: 'keychain',
+  description: 'Manage macOS Keychain items used by keychain()',
+  subCommands: {
+    list: listCommand,
+    'fix-access': fixAccessCommand,
+    set: setCommand,
+    import: importCommand,
+  },
+  examples: `
+Examples:
+  varlock keychain list
+  varlock keychain fix-access --account "my-project:jb:API_KEY"
+  varlock keychain fix-access --path .env.jb
+  varlock keychain import --from .env --profile jb --write .env.jb
+  varlock keychain set API_KEY --profile jb --write .env.jb
+`.trim(),
+});
+
+/** Default `varlock keychain` with no subcommand: list matching items. */
+export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async () => {
+  assertMacOS();
+  await listKeychainItems();
 };

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -301,18 +301,29 @@ async function setKeychainSecret(opts: {
 
 async function importPlaintextEnv(opts: {
   from: string;
-  write: string;
+  /** When omitted, refs are written back into the source file in place (replacing plaintext). */
+  write?: string;
   service: string;
   profile: string;
   project: string;
   force: boolean;
 }) {
   const fromPath = path.resolve(opts.from);
-  const writePath = path.resolve(opts.write);
   if (!fs.existsSync(fromPath)) throw new CliExitError(`File not found: ${fromPath}`);
 
-  const envGraph = await loadVarlockEnvGraph({ entryFilePaths: [fromPath] });
+  // No --write means migrate the source file in place: replacing each plaintext
+  // value with its keychain() ref is the goal, not an accidental overwrite.
+  const inPlace = !opts.write;
+  const writePath = inPlace ? fromPath : path.resolve(opts.write!);
+
+  // Scan the source file's directory so the sibling .env.schema is loaded too —
+  // that schema is how we know which values are sensitive. Loading the file alone
+  // would never surface the schema.
+  const envGraph = await loadVarlockEnvGraph({ entryFilePaths: [path.dirname(fromPath)] });
   assertKeychainImportSchemaPresent(envGraph);
+  // Sensitivity is only finalized during resolution (type/resolver inference) — before
+  // this, every item reports isSensitive=true, which would import non-sensitive values.
+  await envGraph.resolveEnvValues();
   const sourceFile = parseEnvSpecDotEnvFile(fs.readFileSync(fromPath, 'utf-8'));
   const itemsToImport: Array<{ key: string; value: string; ref: KeychainRef }> = [];
 
@@ -336,8 +347,10 @@ async function importPlaintextEnv(opts: {
     return;
   }
 
-  const existingEnvKeys = getExistingEnvKeys(writePath);
-  if (!opts.force) {
+  // When redirecting to a different file, don't clobber unrelated refs already in it.
+  // (In-place mode is exempt — the keys are expected to be there as the plaintext we're replacing.)
+  if (!inPlace && !opts.force) {
+    const existingEnvKeys = getExistingEnvKeys(writePath);
     const existingKey = itemsToImport.find((item) => existingEnvKeys.has(item.key));
     if (existingKey) {
       throw new CliExitError(`Refusing to overwrite ${existingKey.key} in ${writePath}`, {
@@ -353,7 +366,7 @@ async function importPlaintextEnv(opts: {
         client,
         item.ref,
         item.key,
-        'Re-run with --force to overwrite existing env refs and Keychain items.',
+        'Re-run with --force to overwrite the existing Keychain item.',
       );
     }
   }
@@ -366,13 +379,17 @@ async function importPlaintextEnv(opts: {
       value: item.value,
       update: opts.force,
     });
-    writeEnvRef(writePath, item.key, formatKeychainRef(item.ref), opts.force);
+    // In-place always replaces the plaintext value; redirect mode appends (or replaces with --force).
+    writeEnvRef(writePath, item.key, formatKeychainRef(item.ref), inPlace || opts.force);
     imported++;
     console.log(`  Imported ${item.key}`);
   }
 
+  const relWritePath = path.relative(process.cwd(), writePath) || writePath;
   console.log(`\nImported ${imported} sensitive value${imported === 1 ? '' : 's'} into macOS Keychain.`);
-  console.log(`Wrote refs to ${path.relative(process.cwd(), writePath) || writePath}.`);
+  console.log(inPlace
+    ? `Replaced plaintext with keychain() refs in ${relWritePath}.`
+    : `Wrote refs to ${relWritePath}.`);
 }
 
 function resolveProject(project?: string): string {
@@ -521,15 +538,16 @@ const setCommand = define({
 
 const importCommand = define({
   name: 'import',
-  description: 'Import sensitive plaintext values from an env file into macOS Keychain',
+  description: 'Migrate sensitive plaintext values from an env file into macOS Keychain',
   args: {
-    from: {
-      type: 'string',
-      description: 'Plaintext env file to import from',
+    file: {
+      type: 'positional',
+      required: false,
+      description: 'Plaintext env file to import secrets from',
     },
     write: {
       type: 'string',
-      description: 'Env file to write keychain() refs to (default: .env.<profile>)',
+      description: 'Write refs to a different env file instead of editing the source in place',
     },
     service: {
       type: 'string',
@@ -547,22 +565,22 @@ const importCommand = define({
     },
     force: {
       type: 'boolean',
-      description: 'Overwrite existing Keychain items and env refs',
+      description: 'Overwrite existing Keychain items (and refs in a --write target)',
     },
   },
   run: async (ctx) => {
     assertMacOS();
     await trackCommand('keychain import', { command: 'keychain import' });
 
-    if (!ctx.values.from) {
-      throw new CliExitError('Missing --from for keychain import', {
-        suggestion: 'Use `varlock keychain import --from .env --write .env.profile`.',
+    if (!ctx.values.file) {
+      throw new CliExitError('Missing env file to import from', {
+        suggestion: 'Use `varlock keychain import .env` (edits the file in place) or add `--write .env.profile`.',
       });
     }
 
     await importPlaintextEnv({
-      from: ctx.values.from,
-      write: ctx.values.write ?? `.env.${ctx.values.profile}`,
+      from: ctx.values.file,
+      write: ctx.values.write,
       service: ctx.values.service,
       profile: ctx.values.profile,
       project: resolveProject(ctx.values.project),
@@ -587,7 +605,8 @@ Examples:
   varlock keychain list
   varlock keychain fix-access --account "my-project:jb:API_KEY"
   varlock keychain fix-access --path .env.jb
-  varlock keychain import --from .env --profile jb --write .env.jb
+  varlock keychain import .env --profile jb            # migrate .env in place
+  varlock keychain import .env --profile jb --write .env.jb
   varlock keychain set API_KEY --profile jb --write .env.jb
 `.trim(),
 });

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -1,0 +1,469 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import ansis from 'ansis';
+import { define } from 'gunshi';
+import { isCancel } from '@clack/prompts';
+import {
+  parseEnvSpecDotEnvFile,
+  ParsedEnvSpecFunctionCall,
+  ParsedEnvSpecKeyValuePair,
+  ParsedEnvSpecStaticValue,
+} from '@env-spec/parser';
+
+import { loadVarlockEnvGraph } from '../../lib/load-graph';
+import { writeBackValue } from '../../lib/local-encrypt/write-back';
+import { getDaemonClient } from '../../lib/local-encrypt';
+import { CliExitError } from '../helpers/exit-error';
+import { password } from '../helpers/prompts';
+import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
+
+type KeychainRef = {
+  key?: string;
+  service: string;
+  account?: string;
+  keychain?: string;
+};
+
+export const commandSpec = define({
+  name: 'keychain',
+  description: 'Manage macOS Keychain items used by keychain()',
+  args: {
+    service: {
+      type: 'string',
+      description: 'Keychain service name (default: varlock)',
+      default: 'varlock',
+    },
+    account: {
+      type: 'string',
+      description: 'Keychain account name',
+    },
+    keychain: {
+      type: 'string',
+      description: 'Keychain name to search, such as Login or System',
+    },
+    path: {
+      type: 'string',
+      description: 'Path to an env file containing keychain() refs',
+    },
+    from: {
+      type: 'string',
+      description: 'Plaintext env file to import from',
+    },
+    write: {
+      type: 'string',
+      description: 'Env file to write keychain() refs to',
+    },
+    profile: {
+      type: 'string',
+      description: 'Profile name used in generated account names',
+      default: 'local',
+    },
+    project: {
+      type: 'string',
+      description: 'Project slug used in generated account names (default: current directory name)',
+    },
+    force: {
+      type: 'boolean',
+      description: 'Overwrite existing Keychain items and env refs',
+    },
+  },
+  examples: `
+Examples:
+  varlock keychain list
+  varlock keychain fix-access --account "my-project:jb:API_KEY"
+  varlock keychain fix-access --path .env.jb
+  varlock keychain import --from .env --profile jb --write .env.jb
+  varlock keychain set API_KEY --profile jb --write .env.jb
+`.trim(),
+});
+
+function assertMacOS() {
+  if (process.platform !== 'darwin') {
+    throw new CliExitError('varlock keychain is only supported on macOS');
+  }
+}
+
+function quoteEnvString(value: string): string {
+  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+}
+
+function formatKeychainRef(ref: KeychainRef): string {
+  const parts = [`service=${quoteEnvString(ref.service)}`];
+  if (ref.account) parts.push(`account=${quoteEnvString(ref.account)}`);
+  if (ref.keychain) parts.push(`keychain=${quoteEnvString(ref.keychain)}`);
+  return `keychain(${parts.join(', ')})`;
+}
+
+function getGeneratedAccount(project: string, profile: string, key: string): string {
+  return `${project}:${profile}:${key}`;
+}
+
+function getStaticString(value: unknown): string | undefined {
+  if (value instanceof ParsedEnvSpecStaticValue && typeof value.value === 'string') {
+    return value.value;
+  }
+  return undefined;
+}
+
+export function extractKeychainRefFromCall(key: string, call: ParsedEnvSpecFunctionCall): KeychainRef | undefined {
+  if (call.name !== 'keychain') return undefined;
+
+  let service: string | undefined;
+  let account: string | undefined;
+  let keychain: string | undefined;
+
+  for (const arg of call.data.args.values) {
+    if (arg instanceof ParsedEnvSpecStaticValue) {
+      const value = getStaticString(arg);
+      if (value && value !== 'prompt' && !service) service = value;
+      continue;
+    }
+
+    if (!(arg instanceof ParsedEnvSpecKeyValuePair)) continue;
+
+    const value = getStaticString(arg.value);
+    if (typeof value !== 'string') continue;
+
+    if (arg.key === 'service') service = value;
+    if (arg.key === 'account') account = value;
+    if (arg.key === 'keychain') keychain = value;
+  }
+
+  if (!service) return undefined;
+  return {
+    key, service, account, keychain,
+  };
+}
+
+export function extractKeychainRefsFromFile(filePath: string): Array<KeychainRef> {
+  const contents = fs.readFileSync(filePath, 'utf-8');
+  const parsed = parseEnvSpecDotEnvFile(contents);
+  const refs: Array<KeychainRef> = [];
+
+  for (const item of parsed.configItems) {
+    if (item.value instanceof ParsedEnvSpecFunctionCall) {
+      const ref = extractKeychainRefFromCall(item.key, item.value);
+      if (ref) refs.push(ref);
+    }
+  }
+
+  return refs;
+}
+
+function appendEnvRef(filePath: string, key: string, ref: string) {
+  let current = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  if (current.length > 0 && !current.endsWith('\n')) current += '\n';
+  current += `${key}=${ref}\n`;
+  fs.writeFileSync(filePath, current);
+}
+
+function getExistingEnvKeys(filePath: string): Set<string> {
+  if (!fs.existsSync(filePath)) return new Set();
+  const parsed = parseEnvSpecDotEnvFile(fs.readFileSync(filePath, 'utf-8'));
+  return new Set(parsed.configItems.map((item) => item.key));
+}
+
+function writeEnvRef(filePath: string, key: string, ref: string, force: boolean) {
+  const existingKeys = getExistingEnvKeys(filePath);
+  if (!existingKeys.has(key)) {
+    appendEnvRef(filePath, key, ref);
+    return;
+  }
+
+  if (!force) {
+    throw new CliExitError(`Refusing to overwrite ${key} in ${filePath}`, {
+      suggestion: 'Re-run with --force to overwrite existing env refs.',
+    });
+  }
+
+  const result = writeBackValue(key, ref, filePath);
+  if (!result.updated) {
+    throw new CliExitError(`Failed to update ${key} in ${filePath}`);
+  }
+}
+
+async function listKeychainItems(query?: string, keychain?: string) {
+  const client = getDaemonClient();
+  const items = await client.keychainSearch({ query, keychain });
+  if (items.length === 0) {
+    console.log(ansis.gray('No matching Keychain items found.'));
+    return;
+  }
+
+  for (const item of items) {
+    const account = item.account ? ` ${ansis.gray(item.account)}` : '';
+    const kc = item.keychain ? ` ${ansis.gray(`[${item.keychain}]`)}` : '';
+    console.log(`${item.service}${account}${kc}`);
+  }
+}
+
+async function fixAccessForRefs(refs: Array<KeychainRef>) {
+  const client = getDaemonClient();
+  let updated = 0;
+  let unchanged = 0;
+  let failed = 0;
+
+  for (const ref of refs) {
+    try {
+      const result = await client.keychainFixAccess(ref);
+      if (result.modified) updated++;
+      else unchanged++;
+      const label = ref.key ? `${ref.key} ` : '';
+      console.log(`  ${label}${result.modified ? 'updated' : 'already allowed'}`);
+    } catch (err) {
+      failed++;
+      const label = ref.key ? `${ref.key}: ` : '';
+      console.error(ansis.red(`  ${label}${err instanceof Error ? err.message : err}`));
+    }
+  }
+
+  console.log(`\nChecked ${refs.length} item${refs.length === 1 ? '' : 's'}: ${updated} updated, ${unchanged} already allowed, ${failed} failed.`);
+  if (failed > 0) process.exitCode = 1;
+}
+
+async function readSecretForSet(label: string): Promise<string | undefined> {
+  if (!process.stdin.isTTY) {
+    const chunks: Array<Buffer> = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk as Buffer);
+    }
+    const rawValue = Buffer.concat(chunks).toString('utf-8').replace(/\r?\n$/, '');
+    if (!rawValue) throw new CliExitError('No value received on stdin');
+    return rawValue;
+  }
+
+  const prompted = await password({
+    message: `Enter secret value for ${label}`,
+    hint: 'for multi-line values, pipe via stdin',
+  });
+  if (isCancel(prompted)) return undefined;
+  if (!prompted) throw new CliExitError('Secret value cannot be empty');
+  return prompted;
+}
+
+async function setKeychainSecret(opts: {
+  key?: string;
+  service: string;
+  account: string;
+  write?: string;
+  force: boolean;
+}) {
+  if (opts.write && !opts.key) {
+    throw new CliExitError('Cannot write an env ref without an env var key', {
+      suggestion: 'Use `varlock keychain set API_KEY --write .env.profile`, or omit --write.',
+    });
+  }
+
+  const label = opts.key ?? opts.account;
+  const value = await readSecretForSet(label);
+  if (value === undefined) return;
+
+  const client = getDaemonClient();
+  if (!opts.force) {
+    try {
+      await client.keychainGet({
+        service: opts.service,
+        account: opts.account,
+        field: 'account',
+      });
+      throw new CliExitError(`Refusing to overwrite existing Keychain item for ${label}`, {
+        suggestion: 'Re-run with --force to overwrite the existing Keychain item.',
+      });
+    } catch (err) {
+      if (err instanceof CliExitError) throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      if (!message.includes('not found')) throw err;
+    }
+  }
+
+  await client.keychainSet({
+    service: opts.service,
+    account: opts.account,
+    value,
+    update: opts.force,
+  });
+
+  const ref = formatKeychainRef({ service: opts.service, account: opts.account });
+  if (opts.write && opts.key) {
+    writeEnvRef(path.resolve(opts.write), opts.key, ref, opts.force);
+  }
+
+  console.log(`Stored ${label} in macOS Keychain.`);
+  if (opts.write) {
+    console.log(`Wrote ref to ${opts.write}.`);
+  } else {
+    console.log(`Ref: ${ref}`);
+  }
+}
+
+async function importPlaintextEnv(opts: {
+  from: string;
+  write: string;
+  service: string;
+  profile: string;
+  project: string;
+  force: boolean;
+}) {
+  const fromPath = path.resolve(opts.from);
+  const writePath = path.resolve(opts.write);
+  if (!fs.existsSync(fromPath)) throw new CliExitError(`File not found: ${fromPath}`);
+
+  const envGraph = await loadVarlockEnvGraph();
+  const sourceFile = parseEnvSpecDotEnvFile(fs.readFileSync(fromPath, 'utf-8'));
+  const itemsToImport: Array<{ key: string; value: string; ref: KeychainRef }> = [];
+
+  for (const item of sourceFile.configItems) {
+    const schemaItem = envGraph.configSchema[item.key];
+    const markedSensitive = schemaItem?.defs.some((def) => (
+      def.itemDef.decorators?.some((decorator) => decorator.name === 'sensitive')
+    ));
+    if (!schemaItem?.isSensitive || !markedSensitive) continue;
+    if (!(item.value instanceof ParsedEnvSpecStaticValue)) continue;
+    const value = item.value.unescapedValue;
+    if (typeof value !== 'string' || value === '') continue;
+
+    itemsToImport.push({
+      key: item.key,
+      value,
+      ref: {
+        service: opts.service,
+        account: getGeneratedAccount(opts.project, opts.profile, item.key),
+      },
+    });
+  }
+
+  if (itemsToImport.length === 0) {
+    console.log('No sensitive plaintext values found to import.');
+    return;
+  }
+
+  const existingEnvKeys = getExistingEnvKeys(writePath);
+  if (!opts.force) {
+    const existingKey = itemsToImport.find((item) => existingEnvKeys.has(item.key));
+    if (existingKey) {
+      throw new CliExitError(`Refusing to overwrite ${existingKey.key} in ${writePath}`, {
+        suggestion: 'Re-run with --force to overwrite existing env refs and Keychain items.',
+      });
+    }
+  }
+
+  const client = getDaemonClient();
+  if (!opts.force) {
+    for (const item of itemsToImport) {
+      try {
+        await client.keychainGet({
+          service: item.ref.service,
+          account: item.ref.account,
+          field: 'account',
+        });
+        throw new CliExitError(`Refusing to overwrite existing Keychain item for ${item.key}`, {
+          suggestion: 'Re-run with --force to overwrite existing env refs and Keychain items.',
+        });
+      } catch (err) {
+        if (err instanceof CliExitError) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        if (!message.includes('not found')) throw err;
+      }
+    }
+  }
+
+  let imported = 0;
+  for (const item of itemsToImport) {
+    await client.keychainSet({
+      service: item.ref.service,
+      account: item.ref.account,
+      value: item.value,
+      update: opts.force,
+    });
+    writeEnvRef(writePath, item.key, formatKeychainRef(item.ref), opts.force);
+    imported++;
+    console.log(`  Imported ${item.key}`);
+  }
+
+  console.log(`\nImported ${imported} sensitive value${imported === 1 ? '' : 's'} into macOS Keychain.`);
+  console.log(`Wrote refs to ${path.relative(process.cwd(), writePath) || writePath}.`);
+}
+
+export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
+  assertMacOS();
+
+  const positionals = (ctx.positionals ?? []).slice(ctx.commandPath?.length ?? 0);
+  const action = positionals[0] ?? 'list';
+  const service = String(ctx.values.service || 'varlock');
+  const account = ctx.values.account ? String(ctx.values.account) : undefined;
+  const keychain = ctx.values.keychain ? String(ctx.values.keychain) : undefined;
+
+  if (action === 'list') {
+    await listKeychainItems(positionals[1], keychain);
+    return;
+  }
+
+  if (action === 'fix-access') {
+    if (ctx.values.path) {
+      const filePath = path.resolve(String(ctx.values.path));
+      const refs = extractKeychainRefsFromFile(filePath);
+      if (refs.length === 0) {
+        console.log(ansis.gray('No explicit keychain() refs found.'));
+        return;
+      }
+      await fixAccessForRefs(refs);
+      return;
+    }
+
+    if (!account) {
+      throw new CliExitError('Missing --account for keychain fix-access', {
+        suggestion: 'Use --account "project:profile:KEY" or --path .env.profile',
+      });
+    }
+
+    await fixAccessForRefs([{ service, account, keychain }]);
+    return;
+  }
+
+  if (action === 'set') {
+    if (keychain) {
+      throw new CliExitError('keychain set does not support --keychain yet', {
+        suggestion: 'Omit --keychain to store the item in the default login keychain.',
+      });
+    }
+
+    const key = positionals[1];
+    const profile = String(ctx.values.profile || 'local');
+    const project = String(ctx.values.project || path.basename(process.cwd()));
+    const targetAccount = account ?? (key ? getGeneratedAccount(project, profile, key) : undefined);
+    if (!targetAccount) {
+      throw new CliExitError('Missing env var key or --account for keychain set', {
+        suggestion: 'Use `varlock keychain set API_KEY --profile local` or `varlock keychain set --account name`.',
+      });
+    }
+
+    await setKeychainSecret({
+      key,
+      service,
+      account: targetAccount,
+      write: ctx.values.write ? String(ctx.values.write) : undefined,
+      force: Boolean(ctx.values.force),
+    });
+    return;
+  }
+
+  if (action === 'import') {
+    if (!ctx.values.from) throw new CliExitError('Missing --from for keychain import');
+    const profile = String(ctx.values.profile || 'local');
+    const project = String(ctx.values.project || path.basename(process.cwd()));
+    const write = ctx.values.write ? String(ctx.values.write) : `.env.${profile}`;
+    await importPlaintextEnv({
+      from: String(ctx.values.from),
+      write,
+      service,
+      profile,
+      project,
+      force: Boolean(ctx.values.force),
+    });
+    return;
+  }
+
+  throw new CliExitError(`Unknown keychain action: ${action}`, {
+    suggestion: 'Use list, fix-access, import, or set.',
+  });
+};

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -10,6 +10,7 @@ import {
   ParsedEnvSpecStaticValue,
 } from '@env-spec/parser';
 
+import { FileBasedDataSource } from '../../env-graph';
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
 import { writeBackValue } from '../../lib/local-encrypt/write-back';
 import { getDaemonClient } from '../../lib/local-encrypt';
@@ -337,19 +338,27 @@ async function importPlaintextEnv(opts: {
   const inPlace = !opts.write;
   const writePath = inPlace ? fromPath : path.resolve(opts.write!);
 
-  // Scan the source file's directory so the sibling .env.schema is loaded too —
-  // that schema is how we know which values are sensitive. Loading the file alone
-  // would never surface the schema.
-  const envGraph = await loadVarlockEnvGraph({ entryFilePaths: [path.dirname(fromPath)] });
+  // Load the project's env graph normally (respecting package.json varlock.loadPath) and
+  // locate the source file within it — same approach as `encrypt --file`. The schema tells
+  // us what's sensitive; resolution finalizes that (before resolution every item reports
+  // isSensitive=true). Values are read from the file's own parsed defs, never the resolved
+  // graph value (which a sibling like .env.local could override).
+  const envGraph = await loadVarlockEnvGraph();
   assertKeychainImportSchemaPresent(envGraph);
-  // Sensitivity is only finalized during resolution (type/resolver inference) — before
-  // this, every item reports isSensitive=true, which would import non-sensitive values.
   await envGraph.resolveEnvValues();
 
-  // Values come from the input file's own parse (not the resolved graph) — see
-  // collectSensitivePlaintextImports.
-  const sourceFile = parseEnvSpecDotEnvFile(fs.readFileSync(fromPath, 'utf-8'));
-  const itemsToImport = collectSensitivePlaintextImports(sourceFile.configItems, envGraph.configSchema)
+  const sourceFile = envGraph.sortedDataSources.find(
+    (source) => source instanceof FileBasedDataSource && source.fullPath === fromPath,
+  ) as FileBasedDataSource | undefined;
+  if (!sourceFile) {
+    throw new CliExitError(`File "${opts.from}" is not part of the loaded env graph`, {
+      suggestion: 'Make sure the file is in the project directory (or its varlock.loadPath) and covered by your .env.schema.',
+    });
+  }
+
+  const sourceItems = Object.entries(sourceFile.configItemDefs)
+    .map(([key, def]) => ({ key, value: def.parsedValue }));
+  const itemsToImport = collectSensitivePlaintextImports(sourceItems, envGraph.configSchema)
     .map(({ key, value }) => ({
       key,
       value,

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -135,6 +135,27 @@ export function getSensitivePlaintextImportValue(
   return unescapedValue;
 }
 
+type SchemaItemLike = { isSensitive?: boolean; defs?: Array<{ source?: { type?: string } }> };
+
+/**
+ * Select which config items to import, taking the value to store from the *input file's*
+ * own AST node (`item.value`) — never the resolved value from the env graph, which may have
+ * been overridden by another file (e.g. `.env.local`) in the scanned directory. The graph is
+ * consulted only for sensitivity via `configSchema`.
+ */
+export function collectSensitivePlaintextImports(
+  configItems: Array<{ key: string; value: unknown }>,
+  configSchema: Record<string, SchemaItemLike | undefined>,
+): Array<{ key: string; value: string }> {
+  const items: Array<{ key: string; value: string }> = [];
+  for (const item of configItems) {
+    const value = getSensitivePlaintextImportValue(configSchema[item.key], item.value);
+    if (value === undefined) continue;
+    items.push({ key: item.key, value });
+  }
+  return items;
+}
+
 function writeEnvRef(filePath: string, key: string, ref: string, force: boolean) {
   const existingKeys = getExistingEnvKeys(filePath);
   if (!existingKeys.has(key)) {
@@ -324,23 +345,19 @@ async function importPlaintextEnv(opts: {
   // Sensitivity is only finalized during resolution (type/resolver inference) — before
   // this, every item reports isSensitive=true, which would import non-sensitive values.
   await envGraph.resolveEnvValues();
+
+  // Values come from the input file's own parse (not the resolved graph) — see
+  // collectSensitivePlaintextImports.
   const sourceFile = parseEnvSpecDotEnvFile(fs.readFileSync(fromPath, 'utf-8'));
-  const itemsToImport: Array<{ key: string; value: string; ref: KeychainRef }> = [];
-
-  for (const item of sourceFile.configItems) {
-    const schemaItem = envGraph.configSchema[item.key];
-    const value = getSensitivePlaintextImportValue(schemaItem, item.value);
-    if (value === undefined) continue;
-
-    itemsToImport.push({
-      key: item.key,
+  const itemsToImport = collectSensitivePlaintextImports(sourceFile.configItems, envGraph.configSchema)
+    .map(({ key, value }) => ({
+      key,
       value,
       ref: {
         service: opts.service,
-        account: getGeneratedAccount(opts.project, opts.profile, item.key),
-      },
-    });
-  }
+        account: getGeneratedAccount(opts.project, opts.profile, key),
+      } satisfies KeychainRef,
+    }));
 
   if (itemsToImport.length === 0) {
     console.log('No sensitive plaintext values found to import.');

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -13,6 +13,7 @@ import {
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
 import { writeBackValue } from '../../lib/local-encrypt/write-back';
 import { getDaemonClient } from '../../lib/local-encrypt';
+import { DaemonError } from '../../lib/local-encrypt/daemon-client';
 import { CliExitError } from '../helpers/exit-error';
 import { password } from '../helpers/prompts';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
@@ -105,6 +106,10 @@ function getStaticString(value: unknown): string | undefined {
   return undefined;
 }
 
+export function isKeychainItemNotFoundError(error: unknown): boolean {
+  return error instanceof DaemonError && error.code === 'itemNotFound';
+}
+
 export function extractKeychainRefFromCall(key: string, call: ParsedEnvSpecFunctionCall): KeychainRef | undefined {
   if (call.name !== 'keychain') return undefined;
 
@@ -163,6 +168,18 @@ function getExistingEnvKeys(filePath: string): Set<string> {
   return new Set(parsed.configItems.map((item) => item.key));
 }
 
+export function getSensitivePlaintextImportValue(
+  schemaItem: { isSensitive?: boolean; defs?: Array<{ source?: { type?: string } }> } | undefined,
+  value: unknown,
+): string | undefined {
+  const hasSchemaDefinition = schemaItem?.defs?.some((def) => def.source?.type === 'schema');
+  if (!schemaItem?.isSensitive || !hasSchemaDefinition) return undefined;
+  if (!(value instanceof ParsedEnvSpecStaticValue)) return undefined;
+  const unescapedValue = value.unescapedValue;
+  if (typeof unescapedValue !== 'string' || unescapedValue === '') return undefined;
+  return unescapedValue;
+}
+
 function writeEnvRef(filePath: string, key: string, ref: string, force: boolean) {
   const existingKeys = getExistingEnvKeys(filePath);
   if (!existingKeys.has(key)) {
@@ -179,6 +196,20 @@ function writeEnvRef(filePath: string, key: string, ref: string, force: boolean)
   const result = writeBackValue(key, ref, filePath);
   if (!result.updated) {
     throw new CliExitError(`Failed to update ${key} in ${filePath}`);
+  }
+}
+
+export function assertKeychainImportSchemaPresent(envGraph: {
+  sortedDataSources?: Array<{ type?: string; fullPath?: string }>;
+}) {
+  const hasExplicitSchemaFile = envGraph.sortedDataSources?.some((source) => (
+    source.type === 'schema' && source.fullPath
+  ));
+
+  if (!hasExplicitSchemaFile) {
+    throw new CliExitError('Cannot import plaintext secrets without .env.schema for the input file', {
+      suggestion: 'Create .env.schema so Varlock knows which variables in the input env file are secrets, then mark them with @sensitive before running `varlock keychain import`.',
+    });
   }
 }
 
@@ -271,8 +302,7 @@ async function setKeychainSecret(opts: {
       });
     } catch (err) {
       if (err instanceof CliExitError) throw err;
-      const message = err instanceof Error ? err.message : String(err);
-      if (!message.includes('not found')) throw err;
+      if (!isKeychainItemNotFoundError(err)) throw err;
     }
   }
 
@@ -309,18 +339,14 @@ async function importPlaintextEnv(opts: {
   if (!fs.existsSync(fromPath)) throw new CliExitError(`File not found: ${fromPath}`);
 
   const envGraph = await loadVarlockEnvGraph();
+  assertKeychainImportSchemaPresent(envGraph);
   const sourceFile = parseEnvSpecDotEnvFile(fs.readFileSync(fromPath, 'utf-8'));
   const itemsToImport: Array<{ key: string; value: string; ref: KeychainRef }> = [];
 
   for (const item of sourceFile.configItems) {
     const schemaItem = envGraph.configSchema[item.key];
-    const markedSensitive = schemaItem?.defs.some((def) => (
-      def.itemDef.decorators?.some((decorator) => decorator.name === 'sensitive')
-    ));
-    if (!schemaItem?.isSensitive || !markedSensitive) continue;
-    if (!(item.value instanceof ParsedEnvSpecStaticValue)) continue;
-    const value = item.value.unescapedValue;
-    if (typeof value !== 'string' || value === '') continue;
+    const value = getSensitivePlaintextImportValue(schemaItem, item.value);
+    if (value === undefined) continue;
 
     itemsToImport.push({
       key: item.key,
@@ -361,8 +387,7 @@ async function importPlaintextEnv(opts: {
         });
       } catch (err) {
         if (err instanceof CliExitError) throw err;
-        const message = err instanceof Error ? err.message : String(err);
-        if (!message.includes('not found')) throw err;
+        if (!isKeychainItemNotFoundError(err)) throw err;
       }
     }
   }

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -273,7 +273,7 @@ async function setKeychainSecret(opts: {
 }) {
   if (opts.write && !opts.key) {
     throw new CliExitError('Cannot write an env ref without an env var key', {
-      suggestion: 'Use `varlock keychain set API_KEY --write .env.profile`, or omit --write.',
+      suggestion: 'Use `varlock keychain set API_KEY --write-to .env.profile`, or omit --write-to.',
     });
   }
 

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -288,9 +288,7 @@ async function setKeychainSecret(opts: {
     }
   }
 
-  const value = await readSecretForSet(label);
-  if (value === undefined) return;
-
+  // Check for an existing item before prompting, so we don't ask for a secret we'd refuse.
   const client = getDaemonClient();
   if (!opts.force) {
     await assertKeychainItemAbsent(
@@ -300,6 +298,9 @@ async function setKeychainSecret(opts: {
       'Re-run with --force to overwrite the existing Keychain item.',
     );
   }
+
+  const value = await readSecretForSet(label);
+  if (value === undefined) return;
 
   await client.keychainSet({
     service: opts.service,
@@ -397,18 +398,27 @@ async function importPlaintextEnv(opts: {
     }
   }
 
+  // Store the secret before writing its ref, so we never leave a ref pointing at a
+  // missing Keychain item. If a write fails mid-run, report progress: the stored secrets
+  // are safe and any remaining plaintext can be re-imported with --force.
   let imported = 0;
-  for (const item of itemsToImport) {
-    await client.keychainSet({
-      service: item.ref.service,
-      account: item.ref.account,
-      value: item.value,
-      update: opts.force,
-    });
-    // In-place always replaces the plaintext value; redirect mode appends (or replaces with --force).
-    writeEnvRef(writePath, item.key, formatKeychainRef(item.ref), inPlace || opts.force);
-    imported++;
-    console.log(`  Imported ${item.key}`);
+  try {
+    for (const item of itemsToImport) {
+      await client.keychainSet({
+        service: item.ref.service,
+        account: item.ref.account,
+        value: item.value,
+        update: opts.force,
+      });
+      // In-place always replaces the plaintext value; redirect mode appends (or replaces with --force).
+      writeEnvRef(writePath, item.key, formatKeychainRef(item.ref), inPlace || opts.force);
+      imported++;
+      console.log(`  Imported ${item.key}`);
+    }
+  } catch (err) {
+    console.error(ansis.red(`\nImport interrupted after ${imported}/${itemsToImport.length} value${imported === 1 ? '' : 's'}.`));
+    if (inPlace) console.error('Remaining plaintext is still in the source file — re-run with --force to finish.');
+    throw err;
   }
 
   const relWritePath = path.relative(process.cwd(), writePath) || writePath;

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -85,10 +85,10 @@ function assertMacOS() {
 }
 
 function quoteEnvString(value: string): string {
-  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('$', '\\$')}"`;
 }
 
-function formatKeychainRef(ref: KeychainRef): string {
+export function formatKeychainRef(ref: KeychainRef): string {
   const parts = [`service=${quoteEnvString(ref.service)}`];
   if (ref.account) parts.push(`account=${quoteEnvString(ref.account)}`);
   if (ref.keychain) parts.push(`keychain=${quoteEnvString(ref.keychain)}`);
@@ -134,7 +134,14 @@ export function extractKeychainRefFromCall(key: string, call: ParsedEnvSpecFunct
     if (arg.key === 'keychain') keychain = value;
   }
 
-  if (!service) return undefined;
+  if (!service) {
+    if (account) {
+      throw new CliExitError(`Cannot fix access for ${key}: account-only keychain() refs are not supported`, {
+        suggestion: 'Add an explicit service to the ref, for example keychain(service="varlock", account="...").',
+      });
+    }
+    return undefined;
+  }
   return {
     key, service, account, keychain,
   };
@@ -286,6 +293,15 @@ async function setKeychainSecret(opts: {
   }
 
   const label = opts.key ?? opts.account;
+  if (opts.write && opts.key && !opts.force) {
+    const writePath = path.resolve(opts.write);
+    if (getExistingEnvKeys(writePath).has(opts.key)) {
+      throw new CliExitError(`Refusing to overwrite ${opts.key} in ${writePath}`, {
+        suggestion: 'Re-run with --force to overwrite the existing env ref and Keychain item.',
+      });
+    }
+  }
+
   const value = await readSecretForSet(label);
   if (value === undefined) return;
 
@@ -338,7 +354,7 @@ async function importPlaintextEnv(opts: {
   const writePath = path.resolve(opts.write);
   if (!fs.existsSync(fromPath)) throw new CliExitError(`File not found: ${fromPath}`);
 
-  const envGraph = await loadVarlockEnvGraph();
+  const envGraph = await loadVarlockEnvGraph({ entryFilePaths: [fromPath] });
   assertKeychainImportSchemaPresent(envGraph);
   const sourceFile = parseEnvSpecDotEnvFile(fs.readFileSync(fromPath, 'utf-8'));
   const itemsToImport: Array<{ key: string; value: string; ref: KeychainRef }> = [];

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -519,7 +519,7 @@ const setCommand = define({
       type: 'string',
       description: 'Project slug used in generated account names (default: current directory name)',
     },
-    write: {
+    'write-to': {
       type: 'string',
       description: 'Env file to write the keychain() ref to',
     },
@@ -545,7 +545,7 @@ const setCommand = define({
       key,
       service,
       account: targetAccount,
-      write: ctx.values.write,
+      write: ctx.values['write-to'],
       force: Boolean(ctx.values.force),
     });
   },
@@ -562,7 +562,7 @@ const importCommand = define({
       required: false,
       description: 'Plaintext env file to import secrets from',
     },
-    write: {
+    'write-to': {
       type: 'string',
       description: 'Write refs to a different env file instead of editing the source in place',
     },
@@ -582,7 +582,7 @@ const importCommand = define({
     },
     force: {
       type: 'boolean',
-      description: 'Overwrite existing Keychain items (and refs in a --write target)',
+      description: 'Overwrite existing Keychain items (and refs in a --write-to target)',
     },
   },
   run: async (ctx) => {
@@ -591,13 +591,13 @@ const importCommand = define({
 
     if (!ctx.values.file) {
       throw new CliExitError('Missing env file to import from', {
-        suggestion: 'Use `varlock keychain import .env` (edits the file in place) or add `--write .env.profile`.',
+        suggestion: 'Use `varlock keychain import .env` (edits the file in place) or add `--write-to .env.profile`.',
       });
     }
 
     await importPlaintextEnv({
       from: ctx.values.file,
-      write: ctx.values.write,
+      write: ctx.values['write-to'],
       service: ctx.values.service,
       profile: ctx.values.profile,
       project: resolveProject(ctx.values.project),
@@ -623,8 +623,8 @@ Examples:
   varlock keychain fix-access --account "my-project:jb:API_KEY"
   varlock keychain fix-access --path .env.jb
   varlock keychain import .env --profile jb            # migrate .env in place
-  varlock keychain import .env --profile jb --write .env.jb
-  varlock keychain set API_KEY --profile jb --write .env.jb
+  varlock keychain import .env --profile jb --write-to .env.jb
+  varlock keychain set API_KEY --profile jb --write-to .env.jb
 `.trim(),
 });
 

--- a/packages/varlock/src/cli/commands/test/keychain.command.test.ts
+++ b/packages/varlock/src/cli/commands/test/keychain.command.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+import { parseEnvSpecDotEnvFile, ParsedEnvSpecFunctionCall } from '@env-spec/parser';
+
+import { extractKeychainRefFromCall } from '../keychain.command.js';
+
+function parseValue(source: string) {
+  const file = parseEnvSpecDotEnvFile(source);
+  const value = file.configItems[0]?.value;
+  if (!(value instanceof ParsedEnvSpecFunctionCall)) throw new Error('Expected function call');
+  return value;
+}
+
+describe('extractKeychainRefFromCall', () => {
+  test('extracts named service and account refs', () => {
+    const ref = extractKeychainRefFromCall(
+      'API_KEY',
+      parseValue('API_KEY=keychain(service="varlock", account="project:jb:API_KEY")'),
+    );
+
+    expect(ref).toEqual({
+      key: 'API_KEY',
+      service: 'varlock',
+      account: 'project:jb:API_KEY',
+      keychain: undefined,
+    });
+  });
+
+  test('extracts positional service shorthand', () => {
+    const ref = extractKeychainRefFromCall(
+      'DATABASE_PASSWORD',
+      parseValue('DATABASE_PASSWORD=keychain("com.company.database")'),
+    );
+
+    expect(ref).toEqual({
+      key: 'DATABASE_PASSWORD',
+      service: 'com.company.database',
+      account: undefined,
+      keychain: undefined,
+    });
+  });
+
+  test('ignores prompt mode refs', () => {
+    const ref = extractKeychainRefFromCall('API_KEY', parseValue('API_KEY=keychain(prompt)'));
+    expect(ref).toBeUndefined();
+  });
+});

--- a/packages/varlock/src/cli/commands/test/keychain.command.test.ts
+++ b/packages/varlock/src/cli/commands/test/keychain.command.test.ts
@@ -1,11 +1,24 @@
 import { describe, expect, test } from 'vitest';
 import { parseEnvSpecDotEnvFile, ParsedEnvSpecFunctionCall } from '@env-spec/parser';
 
-import { extractKeychainRefFromCall } from '../keychain.command.js';
+import {
+  assertKeychainImportSchemaPresent,
+  extractKeychainRefFromCall,
+  getSensitivePlaintextImportValue,
+  isKeychainItemNotFoundError,
+} from '../keychain.command.js';
+import { CliExitError } from '../../helpers/exit-error.js';
+import { DaemonError } from '../../../lib/local-encrypt/daemon-client.js';
+
+function parseConfigItem(source: string) {
+  const file = parseEnvSpecDotEnvFile(source);
+  const item = file.configItems[0];
+  if (!item) throw new Error('Expected config item');
+  return item;
+}
 
 function parseValue(source: string) {
-  const file = parseEnvSpecDotEnvFile(source);
-  const value = file.configItems[0]?.value;
+  const value = parseConfigItem(source).value;
   if (!(value instanceof ParsedEnvSpecFunctionCall)) throw new Error('Expected function call');
   return value;
 }
@@ -42,5 +55,55 @@ describe('extractKeychainRefFromCall', () => {
   test('ignores prompt mode refs', () => {
     const ref = extractKeychainRefFromCall('API_KEY', parseValue('API_KEY=keychain(prompt)'));
     expect(ref).toBeUndefined();
+  });
+});
+
+describe('assertKeychainImportSchemaPresent', () => {
+  test('allows import when an explicit schema file was loaded', () => {
+    expect(() => assertKeychainImportSchemaPresent({
+      sortedDataSources: [{ type: 'container' }, { type: 'schema', fullPath: '/project/.env.schema' }],
+    })).not.toThrow();
+  });
+
+  test('rejects import when only value env files were loaded', () => {
+    expect(() => assertKeychainImportSchemaPresent({
+      sortedDataSources: [{ type: 'container' }, { type: 'values', fullPath: '/project/.env' }],
+    })).toThrow(CliExitError);
+  });
+});
+
+describe('getSensitivePlaintextImportValue', () => {
+  test('imports schema-sensitive plaintext even without an explicit @sensitive decorator', () => {
+    const item = parseConfigItem('API_KEY=secret-value');
+
+    expect(getSensitivePlaintextImportValue({
+      isSensitive: true,
+      defs: [{ source: { type: 'schema' } }],
+    }, item.value)).toBe('secret-value');
+  });
+
+  test('skips non-sensitive plaintext values', () => {
+    const item = parseConfigItem('PUBLIC_VALUE=hello');
+
+    expect(getSensitivePlaintextImportValue({
+      isSensitive: false,
+      defs: [{ source: { type: 'schema' } }],
+    }, item.value)).toBeUndefined();
+  });
+
+  test('skips values that were not defined by the schema file', () => {
+    const item = parseConfigItem('UNSCHEMAED_SECRET=secret-value');
+
+    expect(getSensitivePlaintextImportValue({
+      isSensitive: true,
+      defs: [{ source: { type: 'values' } }],
+    }, item.value)).toBeUndefined();
+  });
+});
+
+describe('isKeychainItemNotFoundError', () => {
+  test('uses stable daemon error codes instead of localized text', () => {
+    expect(isKeychainItemNotFoundError(new DaemonError('localized message', 'itemNotFound'))).toBe(true);
+    expect(isKeychainItemNotFoundError(new DaemonError('Keychain item not found'))).toBe(false);
   });
 });

--- a/packages/varlock/src/cli/commands/test/keychain.command.test.ts
+++ b/packages/varlock/src/cli/commands/test/keychain.command.test.ts
@@ -4,6 +4,7 @@ import { parseEnvSpecDotEnvFile, ParsedEnvSpecFunctionCall } from '@env-spec/par
 import {
   assertKeychainImportSchemaPresent,
   extractKeychainRefFromCall,
+  formatKeychainRef,
   getSensitivePlaintextImportValue,
   isKeychainItemNotFoundError,
 } from '../keychain.command.js';
@@ -55,6 +56,22 @@ describe('extractKeychainRefFromCall', () => {
   test('ignores prompt mode refs', () => {
     const ref = extractKeychainRefFromCall('API_KEY', parseValue('API_KEY=keychain(prompt)'));
     expect(ref).toBeUndefined();
+  });
+
+  test('rejects account-only refs because fix-access requires a service', () => {
+    expect(() => extractKeychainRefFromCall(
+      'API_KEY',
+      parseValue('API_KEY=keychain(account="project:jb:API_KEY")'),
+    )).toThrow(CliExitError);
+  });
+});
+
+describe('formatKeychainRef', () => {
+  test('escapes env-spec expansion syntax in generated refs', () => {
+    expect(formatKeychainRef({
+      service: 'var$lock',
+      account: 'project:$(whoami):API_KEY',
+    })).toBe('keychain(service="var\\$lock", account="project:\\$(whoami):API_KEY")');
   });
 });
 

--- a/packages/varlock/src/cli/commands/test/keychain.command.test.ts
+++ b/packages/varlock/src/cli/commands/test/keychain.command.test.ts
@@ -3,6 +3,7 @@ import { parseEnvSpecDotEnvFile, ParsedEnvSpecFunctionCall } from '@env-spec/par
 
 import {
   assertKeychainImportSchemaPresent,
+  collectSensitivePlaintextImports,
   extractKeychainRefFromCall,
   formatKeychainRef,
   getSensitivePlaintextImportValue,
@@ -115,6 +116,27 @@ describe('getSensitivePlaintextImportValue', () => {
       isSensitive: true,
       defs: [{ source: { type: 'values' } }],
     }, item.value)).toBeUndefined();
+  });
+});
+
+describe('collectSensitivePlaintextImports', () => {
+  const schema = {
+    API_KEY: { isSensitive: true, defs: [{ source: { type: 'schema' } }] },
+    PUBLIC_URL: { isSensitive: false, defs: [{ source: { type: 'schema' } }] },
+  };
+
+  test('imports only schema-sensitive items, taking values from the input file', () => {
+    const file = parseEnvSpecDotEnvFile('API_KEY=from-input-file\nPUBLIC_URL=https://example.com\n');
+
+    expect(collectSensitivePlaintextImports(file.configItems, schema)).toEqual([{ key: 'API_KEY', value: 'from-input-file' }]);
+  });
+
+  test('uses the input file value verbatim, never an overriding graph value', () => {
+    // The env graph (configSchema) only decides sensitivity; the value to store must come
+    // from the input file's own parsed item, even if another file would override it.
+    const file = parseEnvSpecDotEnvFile('API_KEY=the-real-input-value\n');
+
+    expect(collectSensitivePlaintextImports(file.configItems, schema)).toEqual([{ key: 'API_KEY', value: 'the-real-input-value' }]);
   });
 });
 

--- a/packages/varlock/src/lib/local-encrypt/daemon-client.ts
+++ b/packages/varlock/src/lib/local-encrypt/daemon-client.ts
@@ -23,7 +23,9 @@ import { spawn } from 'node:child_process';
 import { getUserVarlockDir } from '../user-config-dir';
 import { resolveNativeBinary } from './binary-resolver';
 import { isWSL } from './wsl-detect';
-import type { KeychainItemMeta, KeychainItemRef } from './types';
+import type {
+  KeychainFixAccessResult, KeychainItemMeta, KeychainItemRef, KeychainSetResult,
+} from './types';
 
 /** Timeout for daemon IPC messages that don't involve user interaction */
 const SEND_TIMEOUT_MS = 30_000;
@@ -375,6 +377,37 @@ export class DaemonClient {
         if (err instanceof Error && err.message === 'cancelled') return undefined;
         throw err;
       }
+    });
+  }
+
+  async keychainFixAccess(opts: {
+    service: string;
+    account?: string;
+    keychain?: string;
+  }): Promise<KeychainFixAccessResult> {
+    return this.withRetry(async () => {
+      await this.ensureConnected();
+      const result = await this.sendMessage({
+        action: 'keychain-fix-access',
+        payload: opts,
+      }, INTERACTIVE_TIMEOUT_MS);
+      return result as KeychainFixAccessResult;
+    });
+  }
+
+  async keychainSet(opts: {
+    service: string;
+    account?: string;
+    value: string;
+    update?: boolean;
+  }): Promise<KeychainSetResult> {
+    return this.withRetry(async () => {
+      await this.ensureConnected();
+      const result = await this.sendMessage({
+        action: 'keychain-set',
+        payload: opts,
+      }, BIOMETRIC_TIMEOUT_MS);
+      return result as KeychainSetResult;
     });
   }
 

--- a/packages/varlock/src/lib/local-encrypt/daemon-client.ts
+++ b/packages/varlock/src/lib/local-encrypt/daemon-client.ts
@@ -41,6 +41,13 @@ const INTERACTIVE_TIMEOUT_MS = 5 * 60_000;
 /** How long to wait for SIGTERM before escalating to SIGKILL */
 const KILL_GRACE_MS = 2_000;
 
+export class DaemonError extends Error {
+  constructor(message: string, readonly code?: string) {
+    super(message);
+    this.name = 'DaemonError';
+  }
+}
+
 function debug(msg: string) {
   if (process.env.VARLOCK_DEBUG) {
     process.stderr.write(`[varlock:daemon-client] ${msg}\n`);
@@ -520,7 +527,7 @@ export class DaemonClient {
           const { resolve: res, reject: rej } = this.messageQueue.get(message.id)!;
           this.messageQueue.delete(message.id);
           if (message.error) {
-            rej(new Error(message.error));
+            rej(new DaemonError(String(message.error), message.errorCode));
           } else {
             res(message.result);
           }

--- a/packages/varlock/src/lib/local-encrypt/types.ts
+++ b/packages/varlock/src/lib/local-encrypt/types.ts
@@ -25,7 +25,7 @@ export interface BackendInfo {
 export interface DaemonMessage {
   id: string;
   action: 'decrypt' | 'encrypt' | 'prompt-secret' | 'ping' | 'invalidate-session'
-    | 'keychain-get' | 'keychain-search' | 'keychain-pick';
+    | 'keychain-get' | 'keychain-search' | 'keychain-pick' | 'keychain-fix-access' | 'keychain-set';
   payload?: Record<string, unknown>;
 }
 
@@ -51,6 +51,16 @@ export interface KeychainItemRef {
   account?: string;
   keychain?: string;
   label?: string;
+}
+
+/** Result from adding VarlockEnclave to a keychain item's access list */
+export interface KeychainFixAccessResult {
+  modified: boolean;
+}
+
+/** Result from creating or updating a keychain item */
+export interface KeychainSetResult {
+  updated: boolean;
 }
 
 /** Result from the status command of a native binary */

--- a/packages/varlock/src/lib/local-encrypt/types.ts
+++ b/packages/varlock/src/lib/local-encrypt/types.ts
@@ -34,6 +34,7 @@ export interface DaemonResponse {
   id: string;
   result?: unknown;
   error?: string;
+  errorCode?: string;
 }
 
 /** Metadata about a keychain item (no secret values) */


### PR DESCRIPTION
Supersedes #820 (original work by @bjesuiter) — rebased onto `main` and pushed to this repo so it can be iterated on without the fork.

Adds a native `varlock keychain` CLI namespace for managing macOS Keychain-backed secrets, built on gunshi subcommands (matching `cache`):

- `keychain list` — metadata-only view of matching Keychain items (filter + `--keychain`)
- `keychain set` — store a secret (masked prompt or stdin) and optionally write a matching `keychain(...)` ref with `--write-to`
- `keychain import <file>` — migrate sensitive plaintext values into Keychain. **Edits the file in place by default** (replacing each plaintext value with its `keychain(...)` ref); `--write-to` redirects refs to a different file and leaves the source untouched
- `keychain fix-access` — grant Varlock's helper access to existing `keychain(...)` refs (by `--account` or `--path`)

Includes the Swift daemon actions (`keychain-set`, `keychain-fix-access`) with stable error codes, plus docs and tests.

### Fixes beyond the original
- `import` now loads the project env graph normally (respecting `package.json` `varlock.loadPath`) and locates the source file via its `FileBasedDataSource`, mirroring `encrypt --file`. Previously it loaded just the single file and always errored "without .env.schema".
- `import` resolves the env graph before reading sensitivity (sensitivity is only finalized during resolution, so it was importing non-sensitive values), and stores the value from the **input file's own parsed def** rather than a resolved/overridden graph value (e.g. a `.env.local` override).