### PR TITLE
fix(ci): keep binary/docker release jobs from being skipped on every release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -431,7 +431,12 @@ jobs:
   release-binaries:
     name: Release varlock CLI binaries
     needs: [plan, release]
-    if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
+    # `release` always has a by-design skipped dependency (the native-binary cache
+    # logic skips either verify-native-macos on a miss, or build/notarize on a hit),
+    # and GitHub propagates that skip through `release`'s always() into the implicit
+    # success() of any downstream job — which would skip this job on every release.
+    # Mirror the `release` job's guard to break that propagation.
+    if: always() && !failure() && !cancelled() && needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -515,7 +520,9 @@ jobs:
   release-docker:
     name: Release varlock Docker image
     needs: [plan, release-binaries]
-    if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
+    # Same as release-binaries: the upstream skip propagates through always() jobs,
+    # so guard with !failure() instead of relying on the implicit success().
+    if: always() && !failure() && !cancelled() && needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-varlock == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What

`release-binaries` and `release-docker` are gated by an implicit `success()` (their `if` had no status-check function). They `needs` the `release` job, which runs via `always() && !failure() && !cancelled()` and **always** has a by-design skipped dependency — the native-binary cache logic skips either `verify-native-macos` (cache miss) or `build`/`notarize` (cache hit). GitHub propagates that skipped status through the `always()` job into the downstream implicit `success()`, so both jobs skip on **every** release.

This is exactly what happened on the `varlock@1.9.0` release: npm published fine, but the GitHub release got no binaries, the Homebrew tap wasn't bumped, and no Docker image was pushed.

## Fix

Mirror the guard the `release` job already uses (`always() && !failure() && !cancelled() && …`) on both `release-binaries` and `release-docker`, which breaks the skip propagation while still bailing if `release` actually fails.

Refs: [actions/runner#2205](https://github.com/actions/runner/issues/2205), [community#45058](https://github.com/orgs/community/discussions/45058)