### PR TITLE
fix(azure-key-vault): select cached CLI token by tenant

### DIFF
--- a/.bumpy/fix-azure-kv-cached-token-tenant.md
+++ b/.bumpy/fix-azure-kv-cached-token-tenant.md
@@ -1,0 +1,5 @@
+---
+'@varlock/azure-key-vault-plugin': patch
+---
+
+Fixed Azure CLI token selection to respect the configured `tenantId`. With multiple `az login` accounts, a cached `vault.azure.net` token from another tenant could be picked and rejected by Key Vault with a misleading 401 ("token expired or invalid"). Cached tokens are now matched against the configured tenant, and the direct `az` fallback is scoped to it.

--- a/packages/plugins/azure-key-vault/src/plugin.ts
+++ b/packages/plugins/azure-key-vault/src/plugin.ts
@@ -121,9 +121,14 @@ class AzurePluginInstance {
       const now = new Date();
       const validToken = tokens.find((t: any) => {
         const expiresOn = new Date(t.expiresOn);
+        // `_authority` looks like https://login.microsoftonline.com/<tenant>; only accept a
+        // cached token whose issuing tenant matches the configured one (see MSAL note below).
+        const tenantMatches = !this.tenantId
+          || (typeof t._authority === 'string' && t._authority.includes(this.tenantId));
         return t.resource === 'https://vault.azure.net'
           && expiresOn > now
-          && t.tokenType === 'Bearer';
+          && t.tokenType === 'Bearer'
+          && tenantMatches;
       });
 
       if (validToken) {
@@ -152,11 +157,19 @@ class AzurePluginInstance {
       const accessTokens = msalCache.AccessToken || {};
       const now = Math.floor(Date.now() / 1000);
 
-      // Find a valid token for vault.azure.net
+      // Find a valid token for vault.azure.net.
+      // When a tenantId is configured we must match it against the token's `realm`
+      // (the tenant that issued the token). With multiple `az login` accounts the cache
+      // can hold valid vault.azure.net tokens for several tenants; handing a token from
+      // the wrong tenant to the vault yields a confusing 401 ("token expired or invalid").
       for (const [_key, token] of Object.entries(accessTokens) as Array<[string, any]>) {
         if (token.target?.includes('https://vault.azure.net/.default')
           && token.expires_on > now
           && token.secret) {
+          if (this.tenantId && token.realm !== this.tenantId) {
+            debug(`Skipping cached MSAL token for tenant ${token.realm} (need ${this.tenantId})`);
+            continue;
+          }
           debug('Found valid Azure CLI token from MSAL cache');
 
           // Cache it
@@ -175,7 +188,9 @@ class AzurePluginInstance {
     // If no cached token found, try to get one directly from az CLI
     try {
       debug('No cached token found, attempting to get token from az CLI directly');
-      const result = execSync('az account get-access-token --resource https://vault.azure.net', {
+      // Scope the request to the configured tenant so we don't get a token for the wrong account.
+      const tenantArg = this.tenantId ? ` --tenant ${this.tenantId}` : '';
+      const result = execSync(`az account get-access-token --resource https://vault.azure.net${tenantArg}`, {
         encoding: 'utf-8',
         timeout: 10000,
         stdio: ['ignore', 'pipe', 'ignore'], // Suppress stderr


### PR DESCRIPTION
Hi friends!
I got an issue on my machine after I had switched between two Azure tenants. It appears like the plugin cached the access token I obtained from my first login (tenant A) when trying to access a keyvault in tenant B. 

getAzureCliToken() matched cached vault.azure.net tokens by scope and expiry only, never by tenant. With multiple `az login` accounts the MSAL cache can hold valid vault tokens for several tenants; the first match won regardless of which tenant issued it. Presenting a cross-tenant token to a Key Vault returns a 401 ("token expired or invalid").

Now, when a tenantId is configured:
- MSAL cache entries are filtered by `realm` (issuing tenant)
- legacy accessTokens.json entries are filtered via `_authority`
- the direct `az account get-access-token` fallback passes `--tenant`

All guards are no-ops when no tenantId is configured.