### PR TITLE
local-encrypt: document unattended/headless threat model

### DIFF
--- a/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
+++ b/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
@@ -92,6 +92,35 @@ Varlock chooses the best available backend automatically:
 
 If native capabilities are unavailable, varlock falls back to file-based local encryption.
 
+## Unattended decryption (headless servers & CI)
+
+Local encryption isn't just for laptops. On a headless host with a TPM — a home server, a CI runner, a container host — varlock seals the key to the machine's TPM and decrypts automatically at load with **no prompt**. That makes it a good way to store a "secret-zero" (like a 1Password service account token) that bootstraps the rest of your secrets:
+
+```env-spec title=".env.schema"
+# @type=opServiceAccountToken @sensitive @internal
+OP_TOKEN=varlock("local:...")
+```
+
+On Linux this requires `tpm2-tools` and a TPM (see [Linux setup](#linux) below). The sealed value survives reboots and is bound to that specific machine — it can't be copied to another host.
+
+This unattended path applies to backends whose key is unsealed to the host — Linux (TPM2) and Windows (NCrypt/TPM). **macOS is different:** Secure Enclave keys never leave the enclave, and every decrypt requires user presence (Touch ID or password), so there is no unattended decrypt on macOS. A headless Mac or CI runner falls back to file-based encryption instead.
+
+### What this protects (and what it doesn't)
+
+Hardware-backed encryption protects your secrets **at rest**: a stolen disk, a leaked backup, or an env file committed by mistake can't be decrypted off the machine.
+
+It does **not** protect against an attacker who is already running code as your user on that machine — they can ask the TPM to unseal the value exactly like varlock does. This is the same trade-off as tools like [`systemd-creds`](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html), and it's inherent to unattended decryption: if no human is present to approve, anything running as you can decrypt.
+
+If you want a presence gate (fingerprint / password / YubiKey via polkit + PAM) on every decrypt, register the policy:
+
+```bash
+sudo varlock-local-encrypt setup --linux-biometrics
+```
+
+Once configured, varlock's normal decrypt flow requires user presence, so everyday loads are no longer unattended — enable this only on interactive machines, not headless servers.
+
+Treat this gate as a **consent prompt**, not an at-rest boundary. On Linux the TPM unseal isn't bound to polkit, so — as noted above — other code already running as your user can still unseal directly. It means "a human approved this load," not "only a human can ever decrypt."
+
 ## Platform details & setup
 
 ### macOS


### PR DESCRIPTION
## What & why

Documents the threat model for varlock's local encryption in **headless / unattended** environments — the posture was real but implicit and undocumented.

This started from a real question (a self-hoster storing a 1Password service account token as "secret-zero" on a headless Ubuntu box, hand-rolling TPM sealing via `systemd-creds`). Digging in surfaced that we already do exactly this natively: on Linux with a TPM the key seals to the TPM and `varlock load` decrypts unattended, with zero setup. The gap was never "make it work headless" — it's that the unattended posture happens implicitly (whenever no presence gate is set up) and was never written down.

> **Note:** this PR was rebased after #854 (Windows TPM support) merged. The original code changes here — the `varlock encrypt` unattended note and the `types.ts`/`index.ts` backend-comment fixes — landed via #854, so this branch is now **docs-only**.

## Changes

- **New "Unattended decryption (headless servers & CI)" section** in the local-encryption guide:
  - the TPM-sealed secret-zero pattern and that it decrypts with no prompt on a headless host
  - what it protects (**at rest**) vs. what it doesn't (a process already running as your user), with the explicit parallel to `systemd-creds`
  - `setup --linux-biometrics` as the opt-*in* presence gate for interactive machines
  - that the presence gate is a **consent prompt, not an at-rest boundary** — on Linux the TPM unseal isn't bound to polkit, so same-uid code can unseal directly regardless of the gate
  - a scope note that this unattended path is Linux/Windows only — macOS Secure Enclave always requires presence, so there is no unattended decrypt on macOS (headless Mac / CI falls back to file-based)

## Design decision: no opt-in gate

We considered gating unattended decrypt behind an explicit opt-in (refuse-by-default unless a flag says unattended is intended) and **decided against it**:

- It changes **no security properties** — unattended hardware decrypt protects at rest, not against a live same-uid attacker, with or without a flag. (Reinforced by the finding above: the Linux gate isn't even a boundary against that attacker — it's consent-grade.)
- The presence gate is **already** opt-in (Linux requires a root `setup --linux-biometrics` step). "No gate" is the deliberate default, not a silent downgrade.
- On a server an opt-in is pure friction — it'd be set 100% of the time, and forgetting it becomes a confusing deploy failure.
- Binding "unattended" to the key at creation was also rejected: presence-gate availability is a property of the *machine over time*, not of the key — a key-level flag goes stale.

So the right move was honesty (docs), not a gate.

## Follow-up (not in this PR)

**Fail-open edge.** A machine that *had* a presence gate and loses it (polkit removed, `pkcheck` gone) silently falls through to unattended decrypt instead of prompting. Because the Linux gate is consent-grade, the security delta is ~nil — but the lost *consent prompt* is a real UX surprise. The planned fix is a **per-machine** "a gate was configured here" marker + a TTY-only warning when it disappears (never on headless/CI, to keep deploys quiet) — deliberately *not* per-key (staleness trap). This would cover Linux and the now-merged Windows path together, so it's tracked as a unified follow-up rather than bolted onto this docs PR.
