### PR TITLE
feat(cli): reject unknown/misspelled flags

### DIFF
--- a/.bumpy/strict-cli-flags.md
+++ b/.bumpy/strict-cli-flags.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Reject unknown or misspelled CLI flags with a did-you-mean suggestion instead of silently ignoring them

--- a/packages/varlock/src/cli/cli-executable.ts
+++ b/packages/varlock/src/cli/cli-executable.ts
@@ -2,6 +2,8 @@ import { cli, type Command } from 'gunshi';
 import completion from '@gunshi/plugin-completion';
 import { gracefulExit } from 'exit-hook';
 
+import { strictFlags } from './strict-flags-plugin';
+
 import { VARLOCK_BANNER_COLOR } from '../lib/ascii-art';
 import { CliExitError } from './helpers/exit-error';
 import { fmt } from './helpers/pretty-format';
@@ -125,7 +127,7 @@ subCommands.set('keychain', buildLazyCommand(keychainCommandSpec, async () => aw
       description: 'Encrypt and protect your env vars',
       version: versionId,
       subCommands,
-      plugins: [completion()],
+      plugins: [completion(), strictFlags()],
       renderHeader: async (ctx) => {
         // do not show header if we are running a sub-command
         if (ctx.name) return '';

--- a/packages/varlock/src/cli/helpers/pretty-format.ts
+++ b/packages/varlock/src/cli/helpers/pretty-format.ts
@@ -19,6 +19,7 @@ export const fmt = {
     return ansis.green.italic(s);
   },
   packageName: (s: string) => ansis.green.italic(s),
+  flag: (s: string) => ansis.yellow(s),
 };
 
 export const logLines = (lines: Array<string | false | undefined>) => {

--- a/packages/varlock/src/cli/strict-flags-plugin.test.ts
+++ b/packages/varlock/src/cli/strict-flags-plugin.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import type { ArgToken, Args } from 'gunshi/plugin';
+
+import {
+  findUnknownFlags, suggestFlag, assertNoUnknownFlags, levenshtein,
+} from './strict-flags-plugin';
+import { CliExitError } from './helpers/exit-error';
+
+// mirrors the shape of a real command arg schema (kebab-case names, shorts, negatable)
+const ARGS: Args = {
+  'redact-stdout': { type: 'boolean', negatable: true },
+  inject: { type: 'string', short: 'i' },
+  path: { type: 'string', short: 'p' },
+  'clear-cache': { type: 'boolean' },
+  'allow-reload': { type: 'boolean' },
+};
+
+function option(name: string, index = 0): ArgToken {
+  return {
+    kind: 'option', index, name, rawName: name.length === 1 ? `-${name}` : `--${name}`,
+  };
+}
+function positional(value: string, index = 0): ArgToken {
+  return { kind: 'positional', index, value };
+}
+const terminator: ArgToken = { kind: 'option-terminator', index: 99 };
+
+describe('findUnknownFlags', () => {
+  it('flags an unknown/misspelled option', () => {
+    expect(findUnknownFlags([option('alow-reload')], ARGS)).toEqual(['--alow-reload']);
+  });
+
+  it('accepts a correctly spelled long flag', () => {
+    expect(findUnknownFlags([option('clear-cache')], ARGS)).toEqual([]);
+  });
+
+  it('accepts a declared short alias', () => {
+    expect(findUnknownFlags([option('p'), option('i')], ARGS)).toEqual([]);
+  });
+
+  it('accepts --no-<name> for a negatable flag', () => {
+    expect(findUnknownFlags([option('no-redact-stdout')], ARGS)).toEqual([]);
+  });
+
+  it('always allows --help/-h and --version/-v', () => {
+    expect(findUnknownFlags(
+      [option('help'), option('h'), option('version'), option('v')],
+      ARGS,
+    )).toEqual([]);
+  });
+
+  it('ignores everything after the -- terminator (child passthrough)', () => {
+    const tokens: Array<ArgToken> = [
+      option('clear-cache', 0),
+      terminator,
+      positional('node', 1),
+      // even if a later option-looking token slips through, it must not be rejected
+      {
+        kind: 'option', index: 2, name: 'experimental-foo', rawName: '--experimental-foo',
+      },
+    ];
+    expect(findUnknownFlags(tokens, ARGS)).toEqual([]);
+  });
+
+  it('collects multiple unknown flags', () => {
+    expect(findUnknownFlags([option('alow-reload'), option('totally-bogus')], ARGS))
+      .toEqual(['--alow-reload', '--totally-bogus']);
+  });
+});
+
+describe('suggestFlag', () => {
+  it('suggests the closest declared flag within edit distance 2', () => {
+    expect(suggestFlag('--alow-reload', ARGS)).toBe('--allow-reload');
+  });
+
+  it('returns undefined when nothing is close', () => {
+    expect(suggestFlag('--totally-bogus', ARGS)).toBeUndefined();
+  });
+});
+
+describe('levenshtein', () => {
+  it('computes small edit distances', () => {
+    expect(levenshtein('alow-reload', 'allow-reload')).toBe(1);
+    expect(levenshtein('same', 'same')).toBe(0);
+  });
+});
+
+describe('assertNoUnknownFlags', () => {
+  it('throws a CliExitError for an unknown flag', () => {
+    expect(() => assertNoUnknownFlags({ name: 'proxy', tokens: [option('alow-reload')], args: ARGS }))
+      .toThrow(CliExitError);
+    try {
+      assertNoUnknownFlags({ name: 'proxy', tokens: [option('alow-reload')], args: ARGS });
+    } catch (err) {
+      expect((err as CliExitError).message).toContain('Unknown flag: --alow-reload');
+      expect((err as CliExitError).getFormattedOutput()).toContain('Did you mean');
+    }
+  });
+
+  it('does not throw for known flags', () => {
+    expect(() => assertNoUnknownFlags({ name: 'run', tokens: [option('clear-cache')], args: ARGS }))
+      .not.toThrow();
+  });
+
+  it('skips the internal `complete` command', () => {
+    expect(() => assertNoUnknownFlags({ name: 'complete', tokens: [option('anything')], args: {} }))
+      .not.toThrow();
+  });
+});

--- a/packages/varlock/src/cli/strict-flags-plugin.ts
+++ b/packages/varlock/src/cli/strict-flags-plugin.ts
@@ -1,0 +1,136 @@
+import { plugin, type ArgToken, type Args } from 'gunshi/plugin';
+
+import { CliExitError } from './helpers/exit-error';
+import { fmt } from './helpers/pretty-format';
+
+// gunshi silently ignores unknown/misspelled flags (there is no built-in strict
+// option). This plugin decorates every command and rejects any option token that
+// does not map to a declared arg, so a typo like `--alow-reload` errors loudly
+// instead of being dropped.
+
+// flags that gunshi handles itself and that every command implicitly accepts
+const ALWAYS_ALLOWED = new Set(['help', 'h', 'version', 'v']);
+
+// commands whose flags we intentionally do not police (internal / dynamic surface)
+const SKIP_COMMANDS = new Set(['complete']);
+
+function camelToKebab(name: string) {
+  return name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+/** Levenshtein distance, kept dependency-free for the "did you mean" suggestion. */
+export function levenshtein(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const dist: Array<Array<number>> = Array.from({ length: rows }, () => new Array(cols).fill(0));
+  for (let i = 0; i < rows; i++) dist[i][0] = i;
+  for (let j = 0; j < cols; j++) dist[0][j] = j;
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dist[i][j] = Math.min(
+        dist[i - 1][j] + 1,
+        dist[i][j - 1] + 1,
+        dist[i - 1][j - 1] + cost,
+      );
+    }
+  }
+  return dist[a.length][b.length];
+}
+
+interface KnownFlags {
+  /** long names as typed on the CLI (kebab-case), used for matching and suggestions */
+  long: Set<string>;
+  /** single-character short aliases */
+  short: Set<string>;
+}
+
+/** Build the set of accepted flag names from a command's declared arg schema. */
+export function buildKnownFlags(args: Args | undefined): KnownFlags {
+  const long = new Set<string>();
+  const short = new Set<string>();
+  for (const [argName, schema] of Object.entries(args ?? {})) {
+    if (!schema || schema.type === 'positional') continue;
+    const kebab = camelToKebab(argName);
+    long.add(argName);
+    long.add(kebab);
+    if (schema.negatable) {
+      long.add(`no-${argName}`);
+      long.add(`no-${kebab}`);
+    }
+    if (schema.short) short.add(schema.short);
+  }
+  return { long, short };
+}
+
+/**
+ * Walk the parsed tokens and return the raw names (e.g. `--alow-reload`) of any
+ * option that is not declared by the command. Only option tokens before the `--`
+ * terminator are checked, so child-process passthrough (`run`/`proxy run`) is
+ * never rejected.
+ */
+export function findUnknownFlags(tokens: Array<ArgToken>, args: Args | undefined): Array<string> {
+  const known = buildKnownFlags(args);
+  const unknown: Array<string> = [];
+  for (const token of tokens) {
+    if (token.kind === 'option-terminator') break;
+    if (token.kind !== 'option') continue;
+    const name = token.name;
+    if (!name) continue;
+    if (ALWAYS_ALLOWED.has(name)) continue;
+    // short aliases arrive as a single character (e.g. `-p` => name `p`)
+    if (name.length === 1 && known.short.has(name)) continue;
+    if (known.long.has(name)) continue;
+    unknown.push(token.rawName ?? `--${name}`);
+  }
+  return unknown;
+}
+
+/** Closest declared long flag within edit distance 2, formatted as `--name`. */
+export function suggestFlag(rawName: string, args: Args | undefined): string | undefined {
+  const typed = rawName.replace(/^-+/, '').replace(/^no-/, '');
+  const candidates = [...buildKnownFlags(args).long];
+  let best: { name: string, distance: number } | undefined;
+  for (const candidate of candidates) {
+    const distance = levenshtein(typed, candidate);
+    if (distance <= 2 && (!best || distance < best.distance)) {
+      best = { name: candidate, distance };
+    }
+  }
+  return best ? `--${best.name}` : undefined;
+}
+
+/** Throw a CliExitError if the command was invoked with any unrecognized flag. */
+export function assertNoUnknownFlags(ctx: { name?: string, tokens?: Array<ArgToken>, args?: Args }) {
+  if (ctx.name && SKIP_COMMANDS.has(ctx.name)) return;
+  const tokens = ctx.tokens ?? [];
+  const unknown = findUnknownFlags(tokens, ctx.args);
+  if (unknown.length === 0) return;
+
+  const label = unknown.length === 1 ? 'Unknown flag' : 'Unknown flags';
+  const suggestions: Array<string> = [];
+  for (const rawName of unknown) {
+    const suggestion = suggestFlag(rawName, ctx.args);
+    if (suggestion) suggestions.push(`Did you mean ${fmt.flag(suggestion)}?`);
+  }
+
+  const helpCommand = ctx.name ? `varlock ${ctx.name} --help` : 'varlock --help';
+  throw new CliExitError(`${label}: ${unknown.join(', ')}`, {
+    details: suggestions.length ? suggestions : undefined,
+    suggestion: `Run \`${fmt.command(helpCommand, { jsPackageManager: true })}\` to see the available flags.`,
+  });
+}
+
+/** gunshi plugin that rejects unknown/misspelled flags on every subcommand. */
+export function strictFlags() {
+  return plugin({
+    id: 'varlock:strict-flags',
+    name: 'strict-flags',
+    setup(ctx) {
+      ctx.decorateCommand((baseRunner) => (cmdCtx) => {
+        assertNoUnknownFlags(cmdCtx);
+        return baseRunner(cmdCtx);
+      });
+    },
+  });
+}


### PR DESCRIPTION
## What

gunshi silently ignores unrecognized options, so a typo like `varlock proxy rules --alow-reload` parsed to nothing and the command ran as if the flag were never passed, silently dropping the user's intent.

This adds a gunshi plugin that decorates every subcommand and rejects any option token that does not map to a declared arg, exiting non-zero with a "did you mean" suggestion:

```
Unknown flag: --alow-reload
Did you mean --allow-reload?
```

## How

- New `strict-flags-plugin.ts` uses `decorateCommand` to run a validation pass before each command.
- Only option tokens **before** the `--` terminator are checked, so child-process passthrough (`run`, `proxy run`) is untouched, e.g. `varlock run -- node --experimental-foo app.js` still works.
- Accepts declared `short` aliases, `--no-<name>` for negatable booleans, both `--flag=value` and `--flag value` forms, and always allows `--help`/`--version`.
- Dependency-free Levenshtein for the suggestion. Skips the internal `complete` command.

## Tests

Pure token-validation helpers are unit tested (unknown flags, short aliases, negatable, `--` passthrough, help/version, multi-unknown, suggestions), plus the `assertNoUnknownFlags` throwing path.