### PR TITLE
windows tpm support

### DIFF
--- a/.bumpy/windows-tpm-key-storage.md
+++ b/.bumpy/windows-tpm-key-storage.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Windows local encryption now uses TPM-sealed keys via NCrypt when available; existing DPAPI keys auto-upgrade on the next decrypt.

--- a/packages/encryption-binary-rust/README.md
+++ b/packages/encryption-binary-rust/README.md
@@ -2,7 +2,7 @@
 
 Cross-platform local encryption binary for Varlock (Windows and Linux).
 
-Provides DPAPI key protection on Windows (with optional Windows Hello biometric), and TPM2 key protection on Linux, with a file-based plaintext fallback on both.
+Provides **NCrypt TPM-sealed** key protection on Windows when a TPM is available (with optional Windows Hello biometric), **DPAPI** as fallback, and TPM2 key protection on Linux, with a file-based plaintext fallback on both.
 
 ## Prerequisites
 
@@ -51,8 +51,11 @@ The build script automatically applies UPX compression on Linux (not macOS or Wi
 - `src/main.rs` — CLI interface (generate-key, encrypt, decrypt, status, daemon)
 - `src/crypto.rs` — ECIES encryption using pure Rust crates (no OpenSSL)
 - `src/key_store/` — Platform-specific key protection:
-  - `windows.rs` — DPAPI + Windows Hello
+  - `windows_tpm.rs` — NCrypt TPM seal (Platform Crypto Provider)
+  - `windows.rs` — DPAPI fallback
+  - `windows_hello.rs` — Windows Hello presence gate (daemon)
   - `linux.rs` — TPM2 via tpm2-tools
+  - `scalar.rs` — shared P-256 scalar ↔ PKCS8 helpers
 - `src/daemon.rs` — Long-lived IPC daemon for biometric session caching
 - `src/ipc.rs` — IPC server (Unix socket on Linux, named pipe on Windows)
 - `src/daemon_client.rs` — Named pipe client for `--via-daemon` mode (WSL2 support)
@@ -64,6 +67,27 @@ When running from WSL2, the TypeScript side calls this Windows `.exe` directly (
 - `decrypt --via-daemon` routes requests through a Windows named-pipe daemon for biometric session caching.
 - The WSL caller prestarts the daemon from native PowerShell and then polls readiness via `ping-daemon` before the first decrypt. This avoids first-invocation startup timeouts.
 - `start-daemon` remains available for manual troubleshooting from native Windows terminals.
+
+### WSL2 manual test checklist
+
+After changes to Windows key storage or daemon behavior, verify:
+
+1. **Native Windows + Hello + TPM:** `varlock-local-encrypt status` shows `hardwareBacked: true`; decrypt prompts Hello; warm session skips re-prompt for ~5 min
+2. **WSL2 decrypt:** from a Linux shell, `varlock run` / load path triggers fingerprint via Windows UI; `--via-daemon` path unchanged
+3. **Cold WSL start:** no daemon running → first decrypt prestarts via PowerShell → succeeds
+4. **Auto-rewrap:** existing DPAPI keys upgrade to `ncrypt` on the next decrypt (no `.env` changes)
+
+## Native helper commands
+
+The `varlock-local-encrypt` binary (bundled with varlock on Windows/Linux) exposes additional commands:
+
+```powershell
+# Optional: re-wrap without decrypting (normally happens automatically on decrypt)
+varlock-local-encrypt rewrap-key --key-id varlock-default
+
+# Check platform capabilities
+varlock-local-encrypt status
+```
 
 ## CI
 

--- a/packages/encryption-binary-rust/src/key_store/mod.rs
+++ b/packages/encryption-binary-rust/src/key_store/mod.rs
@@ -1,7 +1,8 @@
 //! Key storage abstraction.
 //!
 //! Each platform backend stores the P-256 private key in a protected manner:
-//!   - Windows: DPAPI (CryptProtectData) — encrypted to the current user session
+//!   - Windows (preferred): NCrypt TPM seal via Platform Crypto Provider
+//!   - Windows (fallback): DPAPI (CryptProtectData) — encrypted to the current user session
 //!   - Linux (preferred): Secret Service (libsecret / GNOME Keyring / KWallet),
 //!     optionally layered with TPM2 sealing for defense-in-depth on hardware
 //!     that supports it
@@ -15,7 +16,7 @@
 //!     "keyId": "varlock-default",
 //!     "publicKey": "<base64 uncompressed SEC1>",
 //!     "protectedPrivateKey": "<base64 platform-encrypted PKCS8 or empty>",
-//!     "protection": "dpapi" | "tpm2" | "secret-service" | "secret-service-tpm2" | "none",
+//!     "protection": "dpapi" | "ncrypt" | "tpm2" | "secret-service" | "secret-service-tpm2" | "none",
 //!     "createdAt": "2024-01-01T00:00:00Z"
 //!   }
 //!
@@ -27,14 +28,11 @@
 //! equivalent to the JS file-based backend. Used as an absolute fallback.
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-#[cfg(target_os = "linux")]
-use p256::SecretKey as P256SecretKey;
-#[cfg(target_os = "linux")]
-use elliptic_curve::pkcs8::{DecodePrivateKey, EncodePrivateKey};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
+pub(crate) mod scalar;
 #[cfg(target_os = "linux")]
 pub(crate) mod linux;
 #[cfg(target_os = "linux")]
@@ -44,6 +42,8 @@ pub(crate) mod secret_service;
 #[cfg(target_os = "windows")]
 mod windows;
 #[cfg(target_os = "windows")]
+pub(crate) mod windows_tpm;
+#[cfg(target_os = "windows")]
 pub(crate) mod windows_hello;
 
 /// Which protection mechanism is used for the private key.
@@ -52,6 +52,8 @@ pub(crate) mod windows_hello;
 pub enum Protection {
     /// Windows DPAPI — encrypted to current user session
     Dpapi,
+    /// Windows NCrypt — TPM-sealed scalar via Platform Crypto Provider
+    Ncrypt,
     /// Linux TPM2 — sealed to hardware TPM chip (stored on disk)
     Tpm2,
     /// Linux Secret Service (libsecret / GNOME Keyring / KWallet)
@@ -66,6 +68,7 @@ impl std::fmt::Display for Protection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Protection::Dpapi => write!(f, "dpapi"),
+            Protection::Ncrypt => write!(f, "ncrypt"),
             Protection::Tpm2 => write!(f, "tpm2"),
             Protection::SecretService => write!(f, "secret-service"),
             Protection::SecretServiceTpm2 => write!(f, "secret-service-tpm2"),
@@ -153,6 +156,16 @@ fn protect_private_key(key_id: &str, private_key_der: &[u8]) -> (String, Protect
     #[cfg(target_os = "windows")]
     {
         let _ = key_id;
+        if windows_tpm::is_ncrypt_available() {
+            let scalar = scalar::pkcs8_to_raw_scalar(private_key_der)
+                .unwrap_or_else(|| private_key_der.to_vec());
+            match windows_tpm::ncrypt_protect(&scalar) {
+                Ok(sealed) => return (BASE64.encode(&sealed), Protection::Ncrypt),
+                Err(e) => {
+                    eprintln!("Warning: NCrypt TPM seal failed ({e}), trying DPAPI");
+                }
+            }
+        }
         match windows::dpapi_protect(private_key_der) {
             Ok(protected) => (BASE64.encode(&protected), Protection::Dpapi),
             Err(e) => {
@@ -171,7 +184,7 @@ fn protect_private_key(key_id: &str, private_key_der: &[u8]) -> (String, Protect
         if ss_available && tpm2_available {
             // TPM2 can only seal up to 128 bytes; PKCS8 may be larger due to embedded public key.
             // Seal only the raw 32-byte P-256 scalar — it's the actual secret.
-            let tpm_payload = pkcs8_to_raw_scalar(private_key_der)
+            let tpm_payload = scalar::pkcs8_to_raw_scalar(private_key_der)
                 .unwrap_or_else(|| private_key_der.to_vec());
             match linux::tpm2_protect(&tpm_payload) {
                 Ok(sealed) => match secret_service::store(key_id, &sealed) {
@@ -199,7 +212,7 @@ fn protect_private_key(key_id: &str, private_key_der: &[u8]) -> (String, Protect
 
         // Tier 3: TPM2 alone (headless hosts with a TPM)
         if tpm2_available {
-            let tpm_payload = pkcs8_to_raw_scalar(private_key_der)
+            let tpm_payload = scalar::pkcs8_to_raw_scalar(private_key_der)
                 .unwrap_or_else(|| private_key_der.to_vec());
             if let Ok(sealed) = linux::tpm2_protect(&tpm_payload) {
                 return (BASE64.encode(&sealed), Protection::Tpm2);
@@ -243,13 +256,22 @@ fn unprotect_private_key(
             windows::dpapi_unprotect(&bytes)
         }
 
+        #[cfg(target_os = "windows")]
+        Protection::Ncrypt => {
+            let bytes = BASE64
+                .decode(protected_base64)
+                .map_err(|e| format!("Invalid base64: {e}"))?;
+            let raw = windows_tpm::ncrypt_unprotect(&bytes)?;
+            scalar::raw_scalar_to_pkcs8(&raw)
+        }
+
         #[cfg(target_os = "linux")]
         Protection::Tpm2 => {
             let bytes = BASE64
                 .decode(protected_base64)
                 .map_err(|e| format!("Invalid base64: {e}"))?;
             let raw = linux::tpm2_unprotect(&bytes)?;
-            raw_scalar_to_pkcs8(&raw)
+            scalar::raw_scalar_to_pkcs8(&raw)
         }
 
         #[cfg(target_os = "linux")]
@@ -259,7 +281,7 @@ fn unprotect_private_key(
         Protection::SecretServiceTpm2 => {
             let sealed = secret_service::retrieve(key_id)?;
             let raw = linux::tpm2_unprotect(&sealed)?;
-            raw_scalar_to_pkcs8(&raw)
+            scalar::raw_scalar_to_pkcs8(&raw)
         }
 
         #[allow(unreachable_patterns)]
@@ -269,30 +291,36 @@ fn unprotect_private_key(
     }
 }
 
-// ── TPM key format helpers ─────────────────────────────────────
-
-/// Extract the raw 32-byte P-256 private key scalar from PKCS8 DER.
-/// Returns None if parsing fails (caller should fall back to full DER).
-#[cfg(target_os = "linux")]
-fn pkcs8_to_raw_scalar(pkcs8_der: &[u8]) -> Option<Vec<u8>> {
-    let sk = P256SecretKey::from_pkcs8_der(pkcs8_der).ok()?;
-    Some(sk.to_bytes().to_vec())
+/// Relative strength of at-rest protection (higher = better). Used to avoid downgrades on auto-rewrap.
+fn protection_rank(protection: &Protection) -> u8 {
+    match protection {
+        Protection::None => 0,
+        Protection::Dpapi => 1,
+        Protection::Tpm2 => 2,
+        Protection::Ncrypt | Protection::SecretService => 3,
+        Protection::SecretServiceTpm2 => 4,
+    }
 }
 
-/// Reconstruct PKCS8 DER from a raw 32-byte P-256 scalar.
-/// If input is not 32 bytes, return it unchanged (backward compat).
-#[cfg(target_os = "linux")]
-fn raw_scalar_to_pkcs8(raw: &[u8]) -> Result<Vec<u8>, String> {
-    if raw.len() != 32 {
-        // Not a raw scalar — return as-is (may already be PKCS8)
-        return Ok(raw.to_vec());
+/// After a successful unprotect, upgrade on-disk protection when a stronger tier is available.
+/// Best-effort: decrypt still succeeds if the rewrite fails.
+fn maybe_auto_rewrap(key_id: &str, stored: &mut StoredKey, private_key_der: &[u8]) {
+    let (protected, new_protection) = protect_private_key(key_id, private_key_der);
+    if new_protection == stored.protection {
+        return;
     }
-    let scalar = elliptic_curve::ScalarPrimitive::<p256::NistP256>::from_slice(raw)
-        .map_err(|e| format!("Invalid P-256 scalar: {e}"))?;
-    let sk = P256SecretKey::new(scalar);
-    sk.to_pkcs8_der()
-        .map(|d| d.as_bytes().to_vec())
-        .map_err(|e| format!("Failed to encode PKCS8: {e}"))
+    if protection_rank(&new_protection) <= protection_rank(&stored.protection) {
+        return;
+    }
+
+    stored.protected_private_key = protected;
+    stored.protection = new_protection.clone();
+    if let Err(e) = write_stored_key(stored) {
+        eprintln!(
+            "Warning: failed to auto-rewrap key '{}' to {new_protection}: {e}",
+            stored.key_id
+        );
+    }
 }
 
 // ── Public API ───────────────────────────────────────────────────
@@ -302,11 +330,22 @@ pub fn get_platform_info() -> PlatformInfo {
     #[cfg(target_os = "windows")]
     {
         let hello_available = windows_hello::is_hello_available();
+        let ncrypt_available = windows_tpm::is_ncrypt_available();
+        let backend = match (ncrypt_available, hello_available) {
+            (true, true) => "windows-ncrypt+hello",
+            (true, false) => "windows-ncrypt",
+            (false, true) => "windows-hello",
+            (false, false) => "windows-dpapi",
+        };
         PlatformInfo {
-            backend: if hello_available { "windows-hello" } else { "windows-dpapi" }.into(),
-            hardware_backed: false, // DPAPI is software-based; TPM NCrypt is TODO
+            backend: backend.into(),
+            hardware_backed: ncrypt_available,
             biometric_available: hello_available,
-            protection: Protection::Dpapi,
+            protection: if ncrypt_available {
+                Protection::Ncrypt
+            } else {
+                Protection::Dpapi
+            },
         }
     }
 
@@ -343,6 +382,12 @@ pub fn get_platform_info() -> PlatformInfo {
 #[cfg(target_os = "linux")]
 pub fn get_tpm2_setup_hint() -> Option<String> {
     linux::get_tpm2_setup_hint()
+}
+
+/// Get a setup hint for NCrypt/TPM on Windows when sealing is unavailable.
+#[cfg(target_os = "windows")]
+pub fn get_ncrypt_setup_hint() -> Option<String> {
+    windows_tpm::get_ncrypt_setup_hint()
 }
 
 /// Check if a key exists.
@@ -387,41 +432,73 @@ pub fn generate_key(key_id: &str) -> Result<String, String> {
         created_at: now_iso8601(),
     };
 
-    // Write to disk — restrict directory permissions to owner only
+    write_stored_key(&stored)?;
+
+    Ok(key_pair.public_key)
+}
+
+/// Re-wrap an existing key with the best available protection (e.g. DPAPI → NCrypt).
+/// Returns the new protection type. Public key and key id are preserved.
+///
+/// Normally this happens automatically on the next decrypt ([`load_key`]); this command
+/// is for upgrading without decrypting (e.g. audit/migration scripts).
+pub fn rewrap_key(key_id: &str) -> Result<Protection, String> {
+    let path = get_key_file_path(key_id);
+    let data = fs::read_to_string(&path).map_err(|_| format!("Key not found: {key_id}"))?;
+    let mut stored: StoredKey =
+        serde_json::from_str(&data).map_err(|e| format!("Corrupted key file: {e}"))?;
+
+    let private_key_der =
+        unprotect_private_key(key_id, &stored.protected_private_key, &stored.protection)?;
+
+    let (protected, protection) = protect_private_key(key_id, &private_key_der);
+    if protection == stored.protection {
+        return Err(format!(
+            "Key is already using the best available protection ({protection})"
+        ));
+    }
+
+    stored.protected_private_key = protected;
+    stored.protection = protection.clone();
+    write_stored_key(&stored)?;
+
+    Ok(protection)
+}
+
+fn write_stored_key(stored: &StoredKey) -> Result<(), String> {
     let dir = get_key_store_dir();
     fs::create_dir_all(&dir).map_err(|e| format!("Failed to create key store: {e}"))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        // Set key store directory to 0700 — prevents other users from listing key files
         let _ = fs::set_permissions(&dir, fs::Permissions::from_mode(0o700));
-        // Also restrict parent directories
         if let Some(parent) = dir.parent() {
             let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o700));
         }
     }
 
-    let path = get_key_file_path(key_id);
-    let json = serde_json::to_string_pretty(&stored)
+    let path = get_key_file_path(&stored.key_id);
+    let json = serde_json::to_string_pretty(stored)
         .map_err(|e| format!("Failed to serialize key: {e}"))?;
 
-    // Write with restricted permissions
     #[cfg(unix)]
     {
+        use std::io::Write;
         use std::os::unix::fs::OpenOptionsExt;
         let mut opts = fs::OpenOptions::new();
         opts.write(true).create(true).truncate(true).mode(0o600);
-        use std::io::Write;
         let mut file = opts.open(&path).map_err(|e| format!("Failed to write key file: {e}"))?;
         file.write_all(json.as_bytes())
             .map_err(|e| format!("Failed to write key file: {e}"))?;
     }
     #[cfg(not(unix))]
     {
-        fs::write(&path, &json).map_err(|e| format!("Failed to write key file: {e}"))?;
+        let tmp = path.with_extension("json.tmp");
+        fs::write(&tmp, &json).map_err(|e| format!("Failed to write key file: {e}"))?;
+        fs::rename(&tmp, &path).map_err(|e| format!("Failed to write key file: {e}"))?;
     }
 
-    Ok(key_pair.public_key)
+    Ok(())
 }
 
 /// Delete a key. Also removes any associated keyring entry on Linux.
@@ -451,11 +528,14 @@ pub fn delete_key(key_id: &str) -> bool {
 pub fn load_key(key_id: &str) -> Result<(Vec<u8>, String), String> {
     let path = get_key_file_path(key_id);
     let data = fs::read_to_string(&path).map_err(|_| format!("Key not found: {key_id}"))?;
-    let stored: StoredKey =
+    let mut stored: StoredKey =
         serde_json::from_str(&data).map_err(|e| format!("Corrupted key file: {e}"))?;
 
     let private_key_der =
         unprotect_private_key(key_id, &stored.protected_private_key, &stored.protection)?;
+
+    maybe_auto_rewrap(key_id, &mut stored, &private_key_der);
+
     Ok((private_key_der, stored.public_key))
 }
 
@@ -512,4 +592,37 @@ fn now_iso8601() -> String {
 
 fn is_leap_year(y: i64) -> bool {
     (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{protection_rank, scalar, Protection};
+    use crate::crypto;
+
+    #[test]
+    fn protection_ncrypt_serializes_as_kebab_case() {
+        let json = serde_json::to_string(&Protection::Ncrypt).unwrap();
+        assert_eq!(json, "\"ncrypt\"");
+    }
+
+    #[test]
+    fn scalar_helpers_round_trip_via_mod() {
+        let kp = crypto::generate_key_pair().unwrap();
+        let pkcs8 = base64::Engine::decode(
+            &base64::engine::general_purpose::STANDARD,
+            &kp.private_key,
+        )
+        .unwrap();
+        let scalar_bytes = scalar::pkcs8_to_raw_scalar(&pkcs8).unwrap();
+        assert_eq!(scalar_bytes.len(), 32);
+        let restored = scalar::raw_scalar_to_pkcs8(&scalar_bytes).unwrap();
+        assert_eq!(restored, pkcs8);
+    }
+
+    #[test]
+    fn protection_rank_orders_tiers() {
+        assert!(protection_rank(&Protection::Ncrypt) > protection_rank(&Protection::Dpapi));
+        assert!(protection_rank(&Protection::Dpapi) > protection_rank(&Protection::None));
+        assert!(protection_rank(&Protection::SecretServiceTpm2) > protection_rank(&Protection::Tpm2));
+    }
 }

--- a/packages/encryption-binary-rust/src/key_store/scalar.rs
+++ b/packages/encryption-binary-rust/src/key_store/scalar.rs
@@ -1,0 +1,49 @@
+//! Shared helpers for P-256 private key scalar ↔ PKCS8 conversion.
+//!
+//! TPM/NCrypt sealing stores the raw 32-byte scalar (not full PKCS8) because
+//! PKCS8 DER is larger and the actual secret is the scalar.
+
+use elliptic_curve::pkcs8::{DecodePrivateKey, EncodePrivateKey};
+use p256::SecretKey as P256SecretKey;
+
+/// Extract the raw 32-byte P-256 private key scalar from PKCS8 DER.
+/// Returns None if parsing fails (caller should fall back to full DER).
+pub fn pkcs8_to_raw_scalar(pkcs8_der: &[u8]) -> Option<Vec<u8>> {
+    let sk = P256SecretKey::from_pkcs8_der(pkcs8_der).ok()?;
+    Some(sk.to_bytes().to_vec())
+}
+
+/// Reconstruct PKCS8 DER from a raw 32-byte P-256 scalar.
+/// If input is not 32 bytes, return it unchanged (backward compat).
+pub fn raw_scalar_to_pkcs8(raw: &[u8]) -> Result<Vec<u8>, String> {
+    if raw.len() != 32 {
+        // Not a raw scalar — return as-is (may already be PKCS8)
+        return Ok(raw.to_vec());
+    }
+    let scalar = elliptic_curve::ScalarPrimitive::<p256::NistP256>::from_slice(raw)
+        .map_err(|e| format!("Invalid P-256 scalar: {e}"))?;
+    let sk = P256SecretKey::new(scalar);
+    sk.to_pkcs8_der()
+        .map(|d| d.as_bytes().to_vec())
+        .map_err(|e| format!("Failed to encode PKCS8: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto;
+
+    #[test]
+    fn scalar_round_trip() {
+        let kp = crypto::generate_key_pair().unwrap();
+        let pkcs8 = base64::Engine::decode(
+            &base64::engine::general_purpose::STANDARD,
+            &kp.private_key,
+        )
+        .unwrap();
+        let scalar = pkcs8_to_raw_scalar(&pkcs8).unwrap();
+        assert_eq!(scalar.len(), 32);
+        let restored = raw_scalar_to_pkcs8(&scalar).unwrap();
+        assert_eq!(restored, pkcs8);
+    }
+}

--- a/packages/encryption-binary-rust/src/key_store/windows.rs
+++ b/packages/encryption-binary-rust/src/key_store/windows.rs
@@ -10,7 +10,7 @@
 //!   - Encrypted to the current user's master key (derived from password)
 //!   - Cannot be decrypted by other users or on other machines
 //!   - Survives reboots (unlike Linux keyring)
-//!   - Does NOT require TPM (software-only, but user-scoped)
+//!   - Does NOT use TPM directly (see windows_tpm.rs for NCrypt/TPM sealing)
 
 use windows::Win32::Security::Cryptography::{
     CryptProtectData, CryptUnprotectData, CRYPT_INTEGER_BLOB,

--- a/packages/encryption-binary-rust/src/key_store/windows_tpm.rs
+++ b/packages/encryption-binary-rust/src/key_store/windows_tpm.rs
@@ -1,0 +1,249 @@
+//! Windows TPM key protection via NCrypt (Microsoft Platform Crypto Provider).
+//!
+//! A persistent RSA key in the TPM OAEP-wraps the 32-byte P-256 scalar.
+//! The seal key is shared per user (`VarlockLocalEncryptSealKey`); each
+//! varlock key file stores its own wrapped scalar blob.
+
+use std::ffi::OsStr;
+use std::os::windows::ffi::OsStrExt;
+use std::ptr;
+
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::NTE_BAD_KEYSET;
+use windows::Win32::Security::Cryptography::{
+    NCryptCreatePersistedKey, NCryptDecrypt, NCryptEncrypt, NCryptFinalizeKey,
+    NCryptFreeObject, NCryptOpenKey, NCryptOpenStorageProvider, BCRYPT_OAEP_PADDING_INFO,
+    BCRYPT_RSA_ALGORITHM, BCRYPT_SHA256_ALGORITHM, CERT_KEY_SPEC, MS_PLATFORM_CRYPTO_PROVIDER,
+    NCRYPT_FLAGS, NCRYPT_KEY_HANDLE, NCRYPT_PAD_OAEP_FLAG, NCRYPT_PROV_HANDLE,
+};
+
+/// Persistent RSA seal key name in the Platform Crypto Provider.
+const SEAL_KEY_NAME: &str = "VarlockLocalEncryptSealKey";
+
+/// Detailed result of NCrypt/TPM availability check.
+pub enum NcryptStatus {
+    /// TPM + PCP available and seal key can be opened or created
+    Available,
+    /// Microsoft Platform Crypto Provider could not be opened
+    ProviderFailed(String),
+}
+
+fn to_wide_null(s: &str) -> Vec<u16> {
+    OsStr::new(s).encode_wide().chain(std::iter::once(0)).collect()
+}
+
+struct SealKeySession {
+    _provider: NCRYPT_PROV_HANDLE,
+    key: NCRYPT_KEY_HANDLE,
+}
+
+impl Drop for SealKeySession {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = NCryptFreeObject(self.key);
+            let _ = NCryptFreeObject(self._provider);
+        }
+    }
+}
+
+impl SealKeySession {
+    fn open() -> Result<Self, String> {
+        let mut provider = NCRYPT_PROV_HANDLE::default();
+        unsafe {
+            NCryptOpenStorageProvider(
+                &mut provider,
+                PCWSTR(MS_PLATFORM_CRYPTO_PROVIDER.as_ptr()),
+                0,
+            )
+            .map_err(|e| format!("NCryptOpenStorageProvider failed: {e}"))?;
+        }
+
+        let key_name = to_wide_null(SEAL_KEY_NAME);
+        let mut key = NCRYPT_KEY_HANDLE::default();
+
+        let open_result = unsafe {
+            NCryptOpenKey(
+                provider,
+                &mut key,
+                PCWSTR(key_name.as_ptr()),
+                CERT_KEY_SPEC(0),
+                NCRYPT_FLAGS(0),
+            )
+        };
+
+        if open_result.is_err() {
+            let err = open_result.unwrap_err();
+            if err.code() != NTE_BAD_KEYSET.into() {
+                unsafe {
+                    let _ = NCryptFreeObject(provider);
+                }
+                return Err(format!("NCryptOpenKey failed: {err}"));
+            }
+
+            key = create_seal_key(provider, &key_name)?;
+        }
+
+        Ok(Self {
+            _provider: provider,
+            key,
+        })
+    }
+
+    fn wrap_scalar(&self, scalar: &[u8]) -> Result<Vec<u8>, String> {
+        if scalar.len() != 32 {
+            return Err(format!(
+                "NCrypt seal expects 32-byte scalar, got {} bytes",
+                scalar.len()
+            ));
+        }
+
+        let padding_info = BCRYPT_OAEP_PADDING_INFO {
+            pszAlgId: PCWSTR(BCRYPT_SHA256_ALGORITHM.as_ptr()),
+            pbLabel: ptr::null_mut(),
+            cbLabel: 0,
+        };
+
+        let mut size: u32 = 0;
+        unsafe {
+            NCryptEncrypt(
+                self.key,
+                Some(scalar),
+                Some(&padding_info as *const _ as *const _),
+                None,
+                &mut size,
+                NCRYPT_PAD_OAEP_FLAG,
+            )
+            .map_err(|e| format!("NCryptEncrypt size query failed: {e}"))?;
+        }
+
+        let mut wrapped = vec![0u8; size as usize];
+        unsafe {
+            NCryptEncrypt(
+                self.key,
+                Some(scalar),
+                Some(&padding_info as *const _ as *const _),
+                Some(wrapped.as_mut_slice()),
+                &mut size,
+                NCRYPT_PAD_OAEP_FLAG,
+            )
+            .map_err(|e| format!("NCryptEncrypt failed: {e}"))?;
+        }
+        wrapped.truncate(size as usize);
+        Ok(wrapped)
+    }
+
+    fn unwrap_scalar(&self, wrapped: &[u8]) -> Result<Vec<u8>, String> {
+        let padding_info = BCRYPT_OAEP_PADDING_INFO {
+            pszAlgId: PCWSTR(BCRYPT_SHA256_ALGORITHM.as_ptr()),
+            pbLabel: ptr::null_mut(),
+            cbLabel: 0,
+        };
+
+        let mut size: u32 = 0;
+        unsafe {
+            NCryptDecrypt(
+                self.key,
+                Some(wrapped),
+                Some(&padding_info as *const _ as *const _),
+                None,
+                &mut size,
+                NCRYPT_PAD_OAEP_FLAG,
+            )
+            .map_err(|e| format!("NCryptDecrypt size query failed: {e}"))?;
+        }
+
+        let mut plain = vec![0u8; size as usize];
+        unsafe {
+            NCryptDecrypt(
+                self.key,
+                Some(wrapped),
+                Some(&padding_info as *const _ as *const _),
+                Some(plain.as_mut_slice()),
+                &mut size,
+                NCRYPT_PAD_OAEP_FLAG,
+            )
+            .map_err(|e| format!("NCryptDecrypt failed: {e}"))?;
+        }
+        plain.truncate(size as usize);
+        Ok(plain)
+    }
+}
+
+fn create_seal_key(
+    provider: NCRYPT_PROV_HANDLE,
+    key_name: &[u16],
+) -> Result<NCRYPT_KEY_HANDLE, String> {
+    let mut key = NCRYPT_KEY_HANDLE::default();
+    unsafe {
+        NCryptCreatePersistedKey(
+            provider,
+            &mut key,
+            PCWSTR(BCRYPT_RSA_ALGORITHM.as_ptr()),
+            PCWSTR(key_name.as_ptr()),
+            CERT_KEY_SPEC(0),
+            NCRYPT_FLAGS(0),
+        )
+        .map_err(|e| format!("NCryptCreatePersistedKey failed: {e}"))?;
+
+        NCryptFinalizeKey(key, NCRYPT_FLAGS(0))
+            .map_err(|e| {
+                let _ = NCryptFreeObject(key);
+                format!("NCryptFinalizeKey failed: {e}")
+            })?;
+    }
+    Ok(key)
+}
+
+/// Check if NCrypt/TPM sealing is available on this machine.
+pub fn check_ncrypt_status() -> NcryptStatus {
+    match SealKeySession::open() {
+        Ok(_) => NcryptStatus::Available,
+        Err(e) => NcryptStatus::ProviderFailed(e),
+    }
+}
+
+/// Simple check: is NCrypt/TPM sealing available?
+pub fn is_ncrypt_available() -> bool {
+    matches!(check_ncrypt_status(), NcryptStatus::Available)
+}
+
+/// Protect a 32-byte P-256 scalar using TPM-backed NCrypt sealing.
+pub fn ncrypt_protect(scalar: &[u8]) -> Result<Vec<u8>, String> {
+    let session = SealKeySession::open()?;
+    session.wrap_scalar(scalar)
+}
+
+/// Unprotect an NCrypt-sealed scalar blob.
+pub fn ncrypt_unprotect(wrapped: &[u8]) -> Result<Vec<u8>, String> {
+    let session = SealKeySession::open()?;
+    session.unwrap_scalar(wrapped)
+}
+
+/// Setup hint when TPM/PCP might be available but isn't working.
+pub fn get_ncrypt_setup_hint() -> Option<String> {
+    match check_ncrypt_status() {
+        NcryptStatus::Available => None,
+        NcryptStatus::ProviderFailed(msg) => Some(format!(
+            "TPM sealing unavailable ({msg}). Keys will use DPAPI instead. \
+             Ensure TPM 2.0 is enabled in firmware and the device is not in a restricted mode."
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn ncrypt_round_trip_if_available() {
+        if !is_ncrypt_available() {
+            eprintln!("Skipping NCrypt test: TPM/PCP not available");
+            return;
+        }
+        let scalar = [0x42u8; 32];
+        let wrapped = ncrypt_protect(&scalar).expect("protect");
+        let unwrapped = ncrypt_unprotect(&wrapped).expect("unprotect");
+        assert_eq!(unwrapped, scalar);
+    }
+}

--- a/packages/encryption-binary-rust/src/main.rs
+++ b/packages/encryption-binary-rust/src/main.rs
@@ -23,6 +23,7 @@ fn main() {
 
     match command {
         "generate-key" => cmd_generate_key(&args),
+        "rewrap-key" => cmd_rewrap_key(&args),
         "delete-key" => cmd_delete_key(&args),
         "list-keys" => cmd_list_keys(),
         "key-exists" => cmd_key_exists(&args),
@@ -97,6 +98,18 @@ fn cmd_delete_key(args: &[String]) {
         "keyId": key_id,
         "deleted": deleted,
     }));
+}
+
+fn cmd_rewrap_key(args: &[String]) {
+    let key_id = get_key_id(args);
+    match key_store::rewrap_key(&key_id) {
+        Ok(protection) => json_success(json!({
+            "keyId": key_id,
+            "protection": protection.to_string(),
+            "rewrapped": true,
+        })),
+        Err(e) => json_error(&e),
+    }
 }
 
 fn cmd_list_keys() {
@@ -248,10 +261,18 @@ fn cmd_status() {
     }
     #[cfg(target_os = "windows")]
     {
+        if !info.hardware_backed {
+            if let Some(hint) = key_store::get_ncrypt_setup_hint() {
+                result.as_object_mut().unwrap().insert(
+                    "setupHint".to_string(),
+                    serde_json::Value::String(hint),
+                );
+            }
+        }
         if !info.biometric_available {
             if let Some(hint) = key_store::windows_hello::get_setup_hint() {
                 result.as_object_mut().unwrap().insert(
-                    "setupHint".to_string(),
+                    "biometricSetupHint".to_string(),
                     serde_json::Value::String(hint),
                 );
             }
@@ -345,6 +366,7 @@ fn cmd_help() {
 
 COMMANDS:
   generate-key [--key-id <id>]    Create a new encryption key
+  rewrap-key [--key-id <id>]      Re-wrap key with best available protection (optional; auto on decrypt)
   delete-key [--key-id <id>]      Delete an encryption key
   list-keys                       List all Varlock encryption keys
   key-exists [--key-id <id>]      Check if a key exists
@@ -372,7 +394,8 @@ OPTIONS:
   --via-daemon        Route decrypt through daemon for biometric + session caching
 
 PLATFORM PROTECTION:
-  Windows: DPAPI (user-session-scoped encryption)
+  Windows: NCrypt TPM seal (Platform Crypto Provider) when available,
+           otherwise DPAPI (user-session-scoped encryption)
   Linux:   Secret Service (GNOME Keyring / KWallet), layered with TPM2 when
            available; falls back to TPM2-only or plaintext if neither is present
 

--- a/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
+++ b/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
@@ -86,7 +86,7 @@ Varlock chooses the best available backend automatically:
 | Platform | Backend | Key Storage | Biometric |
 |----------|---------|-------------|-----------|
 | macOS | Secure Enclave | Hardware Secure Enclave | Touch ID |
-| Windows | DPAPI + Windows Hello | Windows credential store | Windows Hello (face/fingerprint/PIN) |
+| Windows | NCrypt TPM + Windows Hello | TPM (when available), else DPAPI | Windows Hello (face/fingerprint/PIN) |
 | Linux | TPM2 / Secret Service | TPM2 and/or system key store | Yes (when configured via polkit/PAM) |
 | All platforms | File-based fallback | `~/.varlock/` directory | No |
 
@@ -105,13 +105,18 @@ If native capabilities are unavailable, varlock falls back to file-based local e
 
 ### Windows
 
-- Native helper with DPAPI-based key protection
-- Windows native and WSL workflows are both supported
+- Native helper with **TPM-sealed** key protection when a TPM 2.0 chip is available (via NCrypt / Platform Crypto Provider)
+- Falls back to **DPAPI** (user-session-scoped) when TPM sealing is unavailable
+- **Windows Hello** gates interactive decrypts (fingerprint/face/PIN) — separate from at-rest protection, same as before
+- Windows native and **WSL** workflows are both supported (WSL uses the Windows `.exe` via `--via-daemon`; Hello + TPM behavior is identical)
 - Automated daemon startup/installation behavior is built in for biometric session flows
 - WSL decrypt flows use a native bridge to the Windows daemon path
-- Biometric-capable session behavior where Windows Hello is available
 
 ✅ No additional install/setup steps required
+
+#### Upgrading existing keys to TPM
+
+New keys automatically use TPM sealing when available. Existing **DPAPI** keys are **auto-upgraded to TPM sealing on the next successful decrypt** (public key unchanged — no re-encryption of `.env` values). To upgrade without decrypting, use `varlock-local-encrypt rewrap-key --key-id varlock-default`.
 
 #### Windows Defender false positives
 

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -391,7 +391,9 @@ You can also set it up manually -- see the [Secrets guide](/guides/secrets/#scan
 
 Encrypts sensitive values using device-local encryption. Encrypted values are stored in `.env` files using the `varlock()` resolver function and are automatically decrypted at load time.
 
-On macOS, encryption is hardware-backed via the Secure Enclave (with Touch ID / biometric authentication). On Windows and Linux, platform-specific secure storage is used. A pure-JavaScript file-based fallback is available on all platforms.
+On macOS, encryption is hardware-backed via the Secure Enclave (with Touch ID / biometric authentication). On Windows, keys are TPM-sealed when a TPM is available (Windows Hello gates interactive decrypts). On Linux, TPM2 and/or Secret Service is used. A pure-JavaScript file-based fallback is available on all platforms.
+
+See the [local encryption guide](/guides/local-encryption/) for platform details. On Windows, existing DPAPI keys are automatically upgraded to TPM sealing on the next decrypt.
 
 ```bash
 varlock encrypt [options]

--- a/packages/varlock/src/cli/commands/encrypt.command.ts
+++ b/packages/varlock/src/cli/commands/encrypt.command.ts
@@ -147,6 +147,20 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
 
   console.log(`Using ${backend.type} backend (${backend.hardwareBacked ? 'hardware-backed' : 'file-based'})`);
 
+  // Hardware-backed but no presence gate → decryption is unattended (headless/CI hosts).
+  if (backend.hardwareBacked && !backend.biometricAvailable) {
+    let platformHint = '';
+    if (process.platform === 'linux') {
+      platformHint = '\nTo require presence on decrypt, run: sudo varlock-local-encrypt setup --linux-biometrics';
+    } else if (process.platform === 'win32' || process.env.WSL_DISTRO_NAME) {
+      platformHint = '\nConfigure Windows Hello to require fingerprint/PIN on interactive decrypts.';
+    }
+    console.log(
+      '\nNote: no presence gate is configured, so values decrypt unattended (suitable for headless/CI hosts).'
+      + `\nThis protects secrets at rest, but not against a process already running as your user.${platformHint}`,
+    );
+  }
+
   const filePath = ctx.values.file;
 
   // --file mode: encrypt all sensitive plaintext values in a .env file

--- a/packages/varlock/src/lib/local-encrypt/index.ts
+++ b/packages/varlock/src/lib/local-encrypt/index.ts
@@ -5,8 +5,8 @@
  * available backend on the current platform:
  *
  *   1. macOS Secure Enclave (Swift binary) — hardware-backed, Touch ID
- *   2. Windows TPM/Hello (Rust binary) — hardware-backed, Windows Hello (TODO)
- *   3. Linux TPM2 (Rust binary) — hardware-backed (TODO)
+ *   2. Windows NCrypt TPM + Hello (Rust binary) — TPM at-rest; Hello presence gate
+ *   3. Linux TPM2 / Secret Service (Rust binary) — hardware-backed on TPM hosts; polkit/PAM presence
  *   4. File-based (pure JS) — universal fallback, no native binary needed
  */
 

--- a/packages/varlock/src/lib/local-encrypt/types.ts
+++ b/packages/varlock/src/lib/local-encrypt/types.ts
@@ -5,8 +5,8 @@
 /** Which encryption backend is active */
 export type BackendType = (
   | 'secure-enclave' // macOS Secure Enclave (Swift binary)
-  | 'windows-tpm' // Windows native (Rust binary) — DPAPI now, TPM/Hello planned
-  | 'linux-tpm' // Linux native (Rust binary) — kernel keyring now, TPM planned
+  | 'windows-tpm' // Windows native (Rust binary) — NCrypt TPM seal + Windows Hello presence; DPAPI fallback
+  | 'linux-tpm' // Linux native (Rust binary) — TPM2 seal/unseal and/or Secret Service; polkit/PAM presence
   | 'file' // Pure JS file-based (universal fallback)
 );
 


### PR DESCRIPTION
## Summary

Adds hardware-backed at-rest key protection on Windows using NCrypt and the Platform Crypto Provider (TPM), while preserving Windows Hello and WSL behavior.

Previously, Windows local encryption was DPAPI plus an optional Hello presence gate — fingerprint auth did not mean the private key was TPM-bound. This change seals the P-256 scalar to the TPM (RSA-OAEP wrap via PCP), matching the Linux TPM2 pattern: TPM for at-rest storage, software ECIES for decrypt, Hello as a separate presence gate.

- New `ncrypt` protection tier — preferred when TPM/PCP is available; falls back to DPAPI, then plaintext
- `hardwareBacked: true` in `status` when NCrypt sealing works
- Auto-rewrap on decrypt — existing DPAPI keys upgrade to TPM sealing on the next successful decrypt (public key unchanged; no `.env` re-encryption)
- `rewrap-key` CLI — optional manual upgrade without decrypting
- Unattended note at `varlock encrypt` when hardware-backed but no presence gate (headless/CI)
- Hello + WSL unchanged — daemon, `UserConsentVerifier`, `--via-daemon`, PowerShell prestart, and `schtasks` fallback are untouched

## Design notes

- Hello is not replaced — still a pre-check in the daemon before unseal, not NGC/Passport KSP key-use integration (future work for Secure Enclave–like semantics)
- No downgrade — if a key is already `ncrypt` and TPM becomes unavailable, auto-rewrap will not rewrite it to DPAPI

## Test plan

- [x] Native Windows + TPM + Hello: `status` shows `hardwareBacked: true`; first decrypt prompts Hello; warm session ~5 min
- [x] Native Windows + TPM, no Hello: direct decrypt works unattended; `varlock encrypt` shows unattended note
- [x] Existing DPAPI key: decrypt once → key file becomes `protection: "ncrypt"`; encrypted values still decrypt
- [x] WSL2: decrypt via `--via-daemon` + fingerprint prompt unchanged
- [x] WSL2 cold start: daemon prestart / `schtasks` fallback still works
- [x] Machine without TPM: falls back to DPAPI (same as today)
- [x] `cargo test` in `packages/encryption-binary-rust`