### PR TITLE
fix(framework-tests): strip VITEST env from spawned dev servers

### DIFF
--- a/framework-tests/harness/dev-server.ts
+++ b/framework-tests/harness/dev-server.ts
@@ -201,6 +201,17 @@ export async function runDevServer(
     ASTRO_DEV_BACKGROUND: '0',
     ...scenario.env,
   };
+
+  // The harness runs under vitest, so process.env carries VITEST / VITEST_* vars.
+  // Astro v7's dev server plugin (vite-plugin-astro-server) bails out of mounting
+  // its SSR request handler when it sees process.env.VITEST — an escape hatch for
+  // Astro's own vitest suite — which makes every SSR route 404 ("Cannot GET").
+  // Strip these so the spawned dev server doesn't think it's running under vitest.
+  for (const key of Object.keys(spawnEnv)) {
+    if (key === 'VITEST' || key.startsWith('VITEST_')) {
+      delete (spawnEnv as Record<string, string | undefined>)[key];
+    }
+  }
   log(`Spawning: ${command}`);
   let child: ChildProcess;
   try {


### PR DESCRIPTION
## What

Strips `VITEST` / `VITEST_*` from the environment passed to dev servers spawned by the framework-test harness.

## Why

The astro framework tests were failing on `main` (all SSR dev scenarios). Astro v7's dev server plugin (`vite-plugin-astro-server`) has an escape hatch for Astro's own vitest suite:

```js
async configureServer(viteServer) {
  if (process.env.VITEST) return; // never mounts the SSR request handler
```

The harness runs under vitest, so `process.env.VITEST` was leaking into the spawned `astro dev` child via `{ ...process.env }`. Astro then skipped mounting SSR entirely and every SSR route fell through to Vite's connect `Cannot GET` 404. This surfaced with the astro v7 bump (astro 7.0.6); v5/v6 have no such guard.

## Validation

- `astro-v7` full suite: 33 passed / 3 skipped (was failing)
- `astro-v6` server scenarios still green