### PR TITLE
framework-tests speedup + fix nextjs dev env reload on turbopack/next 16

### DIFF
--- a/.bumpy/nextjs-dev-env-reload.md
+++ b/.bumpy/nextjs-dev-env-reload.md
@@ -1,0 +1,5 @@
+---
+"@varlock/nextjs-integration": patch
+---
+
+Fix dev-server env file reloading on turbopack and Next 16. Two issues: (1) on Next 16 only the render worker calls `loadEnvConfig`, so the extra env-file watchers were never installed — watcher ownership is now claimed by whichever process loads env first; (2) on turbopack, non-sensitive `ENV.x` values were statically inlined into server files at compile time, so reloaded values were never served — in dev, server-side (node runtime) files now read env through the runtime proxy, which stays fresh across reloads. Client components and edge files still inline values (required), so those keep needing a page refresh after a full recompile.

--- a/.github/workflows/nextjs-canary.yaml
+++ b/.github/workflows/nextjs-canary.yaml
@@ -1,0 +1,49 @@
+name: Next.js Canary Tests
+
+# Early warning for upstream Next.js changes that break the nextjs integration's
+# version-coupled mechanisms (@next/env override, env watch list, runtime
+# injection). Runs the full nextjs framework test suite against next@canary.
+# Failures here are informational — they never block PRs.
+
+on:
+  schedule:
+    - cron: '17 6 * * 1' # weekly, monday morning UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    name: Framework Tests (nextjs canary)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Enable turborepo build cache
+        uses: rharkor/caching-for-turbo@56219402aacc0d06b650d898c222996dbc1191ec # v2.3.14
+
+      - name: Build libraries
+        run: bun run build:libs
+
+      - name: Run nextjs canary framework tests
+        run: cd framework-tests && bun install && NEXTJS_CANARY=1 bun run test -- --reporter=verbose frameworks/nextjs/nextjs-canary.test.ts
+        timeout-minutes: 15
+        env:
+          NEXT_TELEMETRY_DISABLED: '1'

--- a/framework-tests/frameworks/nextjs/files/pages/client-page.tsx
+++ b/framework-tests/frameworks/nextjs/files/pages/client-page.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { ENV } from 'varlock/env';
+
+export default function ClientPage() {
+  // sensitive vars can be referenced from client code without breaking the
+  // build — the value just must not appear in any client-visible output
+  const hasSensitive = !!ENV.SENSITIVE_VAR;
+
+  return (
+    <main>
+      <h1>Varlock Client Component Page</h1>
+      <p>Next prefixed var: {ENV.NEXT_PUBLIC_VAR}</p>
+      <p>Unprefixed var: {ENV.PUBLIC_VAR}</p>
+      <p>Env specific var: {ENV.ENV_SPECIFIC_VAR}</p>
+      <p>Has sensitive: {hasSensitive ? 'yes' : 'no'}</p>
+    </main>
+  );
+}

--- a/framework-tests/frameworks/nextjs/nextjs-canary.test.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-canary.test.ts
@@ -1,0 +1,14 @@
+import { describe } from 'vitest';
+import { defineNextjsTests } from './nextjs-shared';
+
+// Early-warning canary against next@canary — the integration relies on several
+// version-coupled mechanisms (@next/env override surface, env file watch list,
+// which process loads env, turbopack runtime file layout), so we want to hear
+// about upstream changes before a stable release ships them.
+//
+// Runs on a schedule via nextjs-canary.yaml, NOT as part of PR CI (canary
+// breakage shouldn't block unrelated PRs). Gated by env var so plain local
+// `bun run test` doesn't pull next@canary either.
+describe.skipIf(!process.env.NEXTJS_CANARY)('next@canary', () => {
+  defineNextjsTests('canary', import.meta.dirname);
+});

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -109,6 +109,12 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
 
       const buildCommand = `next build ${buildToolFlag}`;
 
+      // Turbopack production builds only became stable in Next 16, and on v15 there
+      // is no persistent build cache, so every build scenario is a slow cold compile
+      // (25-54s each vs 5-10s on v16). Real-world v15 turbopack usage is dev-only,
+      // so only run the dev scenarios there.
+      const runBuildScenarios = !(nextVersion === 15 && webpackOrTurbo === 'turbopack');
+
       describe(`bundler=${webpackOrTurbo}`, () => {
         const devPort = 14000 + (nextVersion * 10) + (webpackOrTurbo === 'turbopack' ? 1 : 0);
         const devCommand = `next dev ${buildToolFlag} --port ${devPort}`.replace(/\s+/g, ' ').trim();
@@ -168,7 +174,7 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
           ],
         });
 
-        describe('output=export', () => {
+        describe.skipIf(!runBuildScenarios)('output=export', () => {
           nextEnv.describeScenario('basic page', {
             command: buildCommand,
             templateFiles: {
@@ -257,7 +263,7 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
           });
         });
 
-        describe('default output mode', () => {
+        describe.skipIf(!runBuildScenarios)('default output mode', () => {
           nextEnv.describeScenario('basic static page', {
             command: buildCommand,
             templateFiles: {

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -115,11 +115,23 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
       // so only run the dev scenarios there.
       const runBuildScenarios = !(nextVersion === 15 && webpackOrTurbo === 'turbopack');
 
+      const defaultBundler = nextVersion >= 16 ? 'turbopack' : 'webpack';
+
       describe(`bundler=${webpackOrTurbo}`, () => {
         const devPort = 14000 + (nextVersion * 10) + (webpackOrTurbo === 'turbopack' ? 1 : 0);
         const devCommand = `next dev ${buildToolFlag} --port ${devPort}`.replace(/\s+/g, ' ').trim();
 
-        nextEnv.describeDevScenario('dev: unchanged extra env file content does not trigger reload', {
+        // KNOWN GAP: after changing an extra env file, the updated value is served
+        // on webpack dev for next <= 15, but on turbopack dev and all of next 16
+        // the stale value is served indefinitely (Next never fires its env reload).
+        // Only assert the updated value where the behavior currently works, so a
+        // regression there still fails loudly.
+        const devEnvReloadWorks = nextVersion <= 15 && webpackOrTurbo === 'webpack';
+
+        // One dev-server session covers both env file watching behaviors:
+        // rewriting the file with identical content must not churn the server,
+        // and actually changing the content must reload env and serve the new value.
+        nextEnv.describeDevScenario('dev: extra env file watching', {
           command: devCommand,
           readyPattern: /Ready in|Starting\.\.\./,
           readyTimeout: 40_000,
@@ -128,12 +140,14 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
           },
           requests: [
             {
+              label: 'initial page load serves dev env value',
               path: '/',
               bodyAssertions: {
-                shouldContain: ['Varlock Framework Test - Next.js'],
+                shouldContain: ['Varlock Framework Test - Next.js', 'env-specific-var--dev'],
               },
             },
             {
+              label: 'rewrite with unchanged content: does not reload, same value served',
               path: '/',
               fileEdits: {
                 '.env.dev': 'ENV_SPECIFIC_VAR=env-specific-var--dev',
@@ -141,58 +155,63 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
               // Watchers are debounced; wait long enough to assert no reload path.
               fileEditDelay: 2000,
               bodyAssertions: {
-                shouldContain: ['Varlock Framework Test - Next.js'],
-              },
-            },
-          ],
-        });
-
-        nextEnv.describeDevScenario('dev: changed extra env file content triggers reload', {
-          command: devCommand,
-          readyPattern: /Ready in|Starting\.\.\./,
-          readyTimeout: 40_000,
-          templateFiles: {
-            'app/page.tsx': 'pages/basic-page.tsx',
-          },
-          requests: [
-            {
-              path: '/',
-              bodyAssertions: {
-                shouldContain: ['Varlock Framework Test - Next.js'],
+                shouldContain: ['Varlock Framework Test - Next.js', 'env-specific-var--dev'],
               },
             },
             {
+              label: devEnvReloadWorks
+                ? 'change to content: env is reloaded, updated value served'
+                : 'change to content: server keeps serving (env reload gap, see comment)',
               path: '/',
               fileEdits: {
                 '.env.dev': 'ENV_SPECIFIC_VAR=env-specific-var--dev-updated',
               },
               fileEditDelay: 2500,
               bodyAssertions: {
-                shouldContain: ['Varlock Framework Test - Next.js'],
+                shouldContain: [
+                  'Varlock Framework Test - Next.js',
+                  ...devEnvReloadWorks ? ['env-specific-var--dev-updated'] : [],
+                ],
               },
             },
           ],
         });
 
         describe.skipIf(!runBuildScenarios)('output=export', () => {
-          nextEnv.describeScenario('basic page', {
+          // One build with two routes: a server component page and a client
+          // component page, each asserted against its own output file.
+          nextEnv.describeScenario('static pages (server + client component)', {
             command: buildCommand,
             templateFiles: {
               'app/page.tsx': 'pages/basic-page.tsx',
+              'app/client-page/page.tsx': 'pages/client-page.tsx',
               'next.config.mjs': EXPORT_CONFIG,
             },
             fileAssertions: [
               {
-                description: 'env vars are injected into output',
-                fileGlob: 'out/**/*.html',
+                description: 'server page: env vars are injected into output',
+                filePath: 'out/index.html',
                 shouldContain: [
                   'next-prefixed-public-var',
                   'unprefixed-public-var',
                   'env-specific-var--dev',
                   'sensitive-var-available',
                 ],
+              },
+              {
+                description: 'client component page: public env vars are inlined',
+                filePath: 'out/client-page.html',
+                shouldContain: [
+                  'next-prefixed-public-var',
+                  'unprefixed-public-var',
+                  'env-specific-var--dev',
+                ],
+              },
+              {
+                description: 'no secrets or wrong-env values in any static output',
+                fileGlob: 'out/**/*.html',
                 shouldNotContain: [
-                  'super-secret-value',
+                  'super-secret-var',
                   'env-specific-var--prod',
                 ],
               },
@@ -221,29 +240,6 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
             ],
           });
 
-          nextEnv.describeScenario('client component page', {
-            command: buildCommand,
-            templateFiles: {
-              'app/page.tsx': {
-                path: 'pages/basic-page.tsx',
-                prepend: "'use client';",
-              },
-              'next.config.mjs': EXPORT_CONFIG,
-            },
-            fileAssertions: [
-              {
-                description: 'public env vars are inlined into client output',
-                fileGlob: 'out/**/*.html',
-                shouldContain: [
-                  'next-prefixed-public-var',
-                  'unprefixed-public-var',
-                  'env-specific-var--dev',
-                ],
-                shouldNotContain: ['super-secret-value'],
-              },
-            ],
-          });
-
           nextEnv.describeScenario('leaky client page', {
             command: buildCommand,
             templateFiles: {
@@ -264,24 +260,39 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
         });
 
         describe.skipIf(!runBuildScenarios)('default output mode', () => {
-          nextEnv.describeScenario('basic static page', {
+          // One build with two routes: a server component page and a client
+          // component page, each asserted against its own pre-rendered output.
+          nextEnv.describeScenario('static pages (server + client component)', {
             command: buildCommand,
             templateFiles: {
               'app/page.tsx': 'pages/basic-page.tsx',
+              'app/client-page/page.tsx': 'pages/client-page.tsx',
             },
             fileAssertions: [
               {
-                description: 'env vars are injected into output',
-                // pre-rendered HTML files
-                fileGlob: '.next/**/*.html',
+                description: 'server page: env vars are injected into output',
+                filePath: '.next/server/app/index.html',
                 shouldContain: [
                   'next-prefixed-public-var',
                   'unprefixed-public-var',
                   'env-specific-var--dev',
                   'sensitive-var-available',
                 ],
+              },
+              {
+                description: 'client component page: public env vars are inlined',
+                filePath: '.next/server/app/client-page.html',
+                shouldContain: [
+                  'next-prefixed-public-var',
+                  'unprefixed-public-var',
+                  'env-specific-var--dev',
+                ],
+              },
+              {
+                description: 'no secrets or wrong-env values in any pre-rendered output',
+                fileGlob: '.next/**/*.html',
                 shouldNotContain: [
-                  'super-secret-value',
+                  'super-secret-var',
                   'env-specific-var--prod',
                 ],
               },
@@ -314,28 +325,6 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
             ],
           });
 
-          nextEnv.describeScenario('client component page', {
-            command: buildCommand,
-            templateFiles: {
-              'app/page.tsx': {
-                path: 'pages/basic-page.tsx',
-                prepend: "'use client';",
-              },
-            },
-            fileAssertions: [
-              {
-                description: 'public env vars are inlined into client output',
-                fileGlob: '.next/**/*.html',
-                shouldContain: [
-                  'next-prefixed-public-var',
-                  'unprefixed-public-var',
-                  'env-specific-var--dev',
-                ],
-                shouldNotContain: ['super-secret-value'],
-              },
-            ],
-          });
-
           nextEnv.describeScenario('leaky client page', {
             command: buildCommand,
             templateFiles: {
@@ -353,7 +342,10 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
             ],
           });
 
+          // The encrypted blob is produced by varlock before bundling, so bundler
+          // choice doesn't affect it — only run on the version's default bundler.
           nextEnv.describeScenario('encrypted env blob with _VARLOCK_ENV_KEY', {
+            skip: webpackOrTurbo !== defaultBundler,
             command: buildCommand,
             env: { _VARLOCK_ENV_KEY: randomBytes(32).toString('hex') },
             templateFiles: {

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -121,13 +121,6 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
         const devPort = 14000 + (nextVersion * 10) + (webpackOrTurbo === 'turbopack' ? 1 : 0);
         const devCommand = `next dev ${buildToolFlag} --port ${devPort}`.replace(/\s+/g, ' ').trim();
 
-        // KNOWN GAP: after changing an extra env file, the updated value is served
-        // on webpack dev for next <= 15, but on turbopack dev and all of next 16
-        // the stale value is served indefinitely (Next never fires its env reload).
-        // Only assert the updated value where the behavior currently works, so a
-        // regression there still fails loudly.
-        const devEnvReloadWorks = nextVersion <= 15 && webpackOrTurbo === 'webpack';
-
         // One dev-server session covers both env file watching behaviors:
         // rewriting the file with identical content must not churn the server,
         // and actually changing the content must reload env and serve the new value.
@@ -159,19 +152,14 @@ export function defineNextjsTests(nextVersion: number, testDir: string) {
               },
             },
             {
-              label: devEnvReloadWorks
-                ? 'change to content: env is reloaded, updated value served'
-                : 'change to content: server keeps serving (env reload gap, see comment)',
+              label: 'change to content: env is reloaded, updated value served',
               path: '/',
               fileEdits: {
                 '.env.dev': 'ENV_SPECIFIC_VAR=env-specific-var--dev-updated',
               },
               fileEditDelay: 2500,
               bodyAssertions: {
-                shouldContain: [
-                  'Varlock Framework Test - Next.js',
-                  ...devEnvReloadWorks ? ['env-specific-var--dev-updated'] : [],
-                ],
+                shouldContain: ['Varlock Framework Test - Next.js', 'env-specific-var--dev-updated'],
               },
             },
           ],

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -22,18 +22,24 @@ const EXPORT_CONFIG = {
 function getBuildToolFlag(nextVersion: number, bundler: string): string {
   if (nextVersion === 14) return bundler === 'turbopack' ? '--turbo' : '';
   if (nextVersion === 15) return bundler === 'turbopack' ? '--turbopack' : '';
-  if (nextVersion === 16) return bundler === 'turbopack' ? '' : '--webpack';
+  if (nextVersion >= 16) return bundler === 'turbopack' ? '' : '--webpack';
   throw new Error(`Unsupported Next.js version: ${nextVersion}`);
 }
 
-export function defineNextjsTests(nextVersion: number, testDir: string) {
-  describe(`Next.js v${nextVersion}`, () => {
+export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: string) {
+  const isCanary = versionOrCanary === 'canary';
+  // canary follows the newest major's CLI flags / bundler defaults;
+  // 99 keeps the version-derived dev ports out of the pinned versions' range
+  const nextVersion = isCanary ? 99 : versionOrCanary;
+  const label = isCanary ? 'canary' : `v${versionOrCanary}`;
+
+  describe(`Next.js ${label}`, () => {
     const nextEnv = new FrameworkTestEnv({
       testDir,
-      framework: `next-v${nextVersion}`,
+      framework: `next-${label}`,
       packageManager: 'pnpm',
       dependencies: {
-        next: `^${nextVersion}`,
+        next: isCanary ? 'canary' : `^${versionOrCanary}`,
         react: '^19',
         'react-dom': '^19',
         '@types/react': '^19',

--- a/framework-tests/harness/test-fixture.ts
+++ b/framework-tests/harness/test-fixture.ts
@@ -81,6 +81,8 @@ export class FrameworkTestEnv {
   dir!: string;
   private filesDir: string;
   private label: string;
+  /** Files written by the previous scenario, restored before the next one runs */
+  private prevScenarioFiles = new Set<string>();
 
   constructor(public config: TestFixtureConfig) {
     this.filesDir = join(config.testDir, 'files');
@@ -222,14 +224,30 @@ export class FrameworkTestEnv {
 
   /**
    * Apply template files and inline files to the test project directory.
+   * Files written by the previous scenario are first restored to their _base
+   * version (or removed if not part of the skeleton), so scenarios stay
+   * isolated — e.g. a config override or extra route from one scenario
+   * doesn't silently carry over into the next.
    */
   private applyFiles(scenario: Pick<TestScenario, 'templateFiles' | 'files'>): void {
+    for (const dest of this.prevScenarioFiles) {
+      const basePath = join(this.filesDir, '_base', dest);
+      const destPath = join(this.dir, dest);
+      if (existsSync(basePath)) {
+        cpSync(basePath, destPath);
+      } else {
+        rmSync(destPath, { force: true });
+      }
+    }
+    this.prevScenarioFiles = new Set();
+
     // Copy template files: fixture defaults merged with scenario overrides
     const templateFiles = {
       ...this.config.templateFiles,
       ...scenario.templateFiles,
     };
     for (const [dest, source] of Object.entries(templateFiles)) {
+      this.prevScenarioFiles.add(dest);
       const srcRef = typeof source === 'string' ? { path: source } : source;
       const srcPath = join(this.filesDir, srcRef.path);
       const destPath = join(this.dir, dest);
@@ -260,6 +278,7 @@ export class FrameworkTestEnv {
     // Write inline files
     if (scenario.files) {
       for (const file of scenario.files) {
+        this.prevScenarioFiles.add(file.path);
         const destPath = join(this.dir, file.path);
         mkdirSync(dirname(destPath), { recursive: true });
         writeFileSync(destPath, file.content);
@@ -387,9 +406,9 @@ export class FrameworkTestEnv {
 
       for (let i = 0; i < scenario.requests.length; i++) {
         const req = scenario.requests[i];
-        const testLabel = req.fileEdits
+        const testLabel = req.label ?? (req.fileEdits
           ? `GET ${req.path} returns expected response (after file edit)`
-          : `GET ${req.path} returns expected response`;
+          : `GET ${req.path} returns expected response`);
         test(testLabel, () => {
           const resp = ctx.result!.responses[i];
           expect(resp, `No response for request ${i} (GET ${req.path})`).toBeDefined();

--- a/framework-tests/harness/types.ts
+++ b/framework-tests/harness/types.ts
@@ -131,6 +131,8 @@ export interface BuildResult {
 export interface DevServerRequest {
   /** URL path, e.g. "/" or "/api/health" */
   path: string;
+  /** Test name for this request (default: auto-generated from path) */
+  label?: string;
   /** Expected HTTP status (default: 200) */
   expectedStatus?: number;
   /** Assertions on the response body */

--- a/packages/integrations/nextjs/src/loader.ts
+++ b/packages/integrations/nextjs/src/loader.ts
@@ -10,7 +10,7 @@ type LoaderContext = {
   cacheable(flag: boolean): void;
   resourcePath: string;
   rootContext: string;
-  getOptions?(): { bundler?: 'webpack' | 'turbopack'; isEdge?: boolean };
+  getOptions?(): { bundler?: 'webpack' | 'turbopack'; isEdge?: boolean; dev?: boolean };
 };
 
 function isTurbopackWorker() {
@@ -29,6 +29,11 @@ function escapeRegExp(str: string) {
 // detect 'use client' directive at top of file (before any code, after optional comments)
 // uses [^\S\n]* (horizontal whitespace) instead of \s* to avoid exponential backtracking
 const USE_CLIENT_RE = /^(?:[^\S\n]*\/\/[^\n]*\n|[^\S\n]*\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/[^\S\n]*\n|[^\S\n]*\n)*[^\S\n]*['"]use client['"]/;
+
+// detect files compiled for the edge runtime — turbopack has a single global
+// loader rule (no per-compiler split like webpack), so we sniff the source
+const EDGE_RUNTIME_RE = /export\s+const\s+runtime\s*=\s*['"](?:edge|experimental-edge)['"]/;
+const MIDDLEWARE_FILE_RE = /(?:^|[\\/])middleware\.(?:ts|js|mts|mjs)$/;
 
 // match directive prologue ('use server', 'use client', etc.) + optional trailing semicolons/newlines
 // captures the directive block so we can inject code after it
@@ -120,16 +125,31 @@ function webpackLoader(this: LoaderContext, source: string) {
   // static replacements for non-sensitive env vars
   // webpack uses DefinePlugin for this, so only needed for turbopack
   if (isTurbopack && source.includes('ENV.')) {
-    // disable caching only for files that reference ENV — their output depends on env values
-    this.cacheable(false);
-    for (const [key, item] of Object.entries(envGraph.config)) {
-      if (item.isSensitive) continue;
+    const isDev = loaderOptions.dev ?? process.env.NODE_ENV === 'development';
+    const isEdgeFile = isEdge
+      || EDGE_RUNTIME_RE.test(source)
+      || MIDDLEWARE_FILE_RE.test(this.resourcePath);
 
-      // TODO: smarter replacement (vite version uses AST?)
+    // In dev, server-side (node runtime) files read env through the runtime
+    // proxy instead, which stays fresh when env files change and reload —
+    // inlined values can't be refreshed without a recompile, which turbopack
+    // won't do for env-only changes. Inlining is still required for client
+    // components (the browser can't read server env) and edge files (env is
+    // injected at sandbox init), and for all files during builds.
+    const inlineStaticValues = !isDev || isClientComponent || isEdgeFile;
 
-      // match ENV.KEY as a member expression (word boundary before ENV, not followed by more identifier chars)
-      const pattern = new RegExp(`\\bENV\\.${escapeRegExp(key)}(?![\\w$])`, 'g');
-      result = result.replace(pattern, JSON.stringify(item.value));
+    if (inlineStaticValues) {
+      // disable caching only for files that embed ENV values — their output depends on env values
+      this.cacheable(false);
+      for (const [key, item] of Object.entries(envGraph.config)) {
+        if (item.isSensitive) continue;
+
+        // TODO: smarter replacement (vite version uses AST?)
+
+        // match ENV.KEY as a member expression (word boundary before ENV, not followed by more identifier chars)
+        const pattern = new RegExp(`\\bENV\\.${escapeRegExp(key)}(?![\\w$])`, 'g');
+        result = result.replace(pattern, JSON.stringify(item.value));
+      }
     }
   }
 

--- a/packages/integrations/nextjs/src/loader.ts
+++ b/packages/integrations/nextjs/src/loader.ts
@@ -39,6 +39,22 @@ const MIDDLEWARE_FILE_RE = /(?:^|[\\/])middleware\.(?:ts|js|mts|mjs)$/;
 // captures the directive block so we can inject code after it
 const DIRECTIVE_PROLOGUE_RE = /^((?:[^\S\n]*\/\/[^\n]*\n|[^\S\n]*\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/[^\S\n]*\n|[^\S\n]*\n)*[^\S\n]*['"]use (?:server|client|strict)['"][^\S\n]*;?[^\S\n]*\n?)/;
 
+// the loader runs for every project file, so cache the env graph parse
+// (keyed on the raw string — env reloads produce a new string)
+let cachedRawEnv: string | undefined;
+let cachedEnvGraph: SerializedEnvGraph | undefined;
+function parseEnvGraphCached(rawEnv: string): SerializedEnvGraph | undefined {
+  if (rawEnv !== cachedRawEnv) {
+    cachedRawEnv = rawEnv;
+    try {
+      cachedEnvGraph = JSON.parse(rawEnv);
+    } catch {
+      cachedEnvGraph = undefined;
+    }
+  }
+  return cachedEnvGraph;
+}
+
 /** Prepend code after any directive prologue (e.g. 'use server') to avoid breaking it */
 function prependAfterDirectives(source: string, codeToPrepend: string): string {
   const match = source.match(DIRECTIVE_PROLOGUE_RE);
@@ -81,13 +97,8 @@ function webpackLoader(this: LoaderContext, source: string) {
     throw new Error('expected __VARLOCK_ENV to be set');
   }
 
-  // TODO: avoid parsing on every file
-  let envGraph: SerializedEnvGraph;
-  try {
-    envGraph = JSON.parse(rawEnv);
-  } catch {
-    return source;
-  }
+  const envGraph = parseEnvGraphCached(rawEnv);
+  if (!envGraph) return source;
 
   const loaderOptions = this.getOptions?.() ?? {};
 

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -136,6 +136,20 @@ const NEXT_WATCHED_ENV_FILES = ['.env', '.env.local', '.env.development', '.env.
 const watchedExtraFiles = new Set<string>();
 const pendingReloadFiles = new Set<string>();
 
+// Exactly one process should own the extra-file watchers. Which process calls
+// loadEnvConfig varies by Next version: on next <= 15 the router server loads
+// env itself (before spawning render workers), but on next 16 ONLY the render
+// worker ever calls loadEnvConfig. The first process to install watchers claims
+// ownership via this env var — child processes inherit it at spawn and skip,
+// so we don't end up with multiple processes touching the trigger file.
+const WATCHER_OWNER_ENV_KEY = '__VARLOCK_NEXT_ENV_WATCHER_PID';
+function claimExtraFileWatcherOwnership(): boolean {
+  const ownerPid = process.env[WATCHER_OWNER_ENV_KEY];
+  if (ownerPid && ownerPid !== String(process.pid)) return false;
+  process.env[WATCHER_OWNER_ENV_KEY] = String(process.pid);
+  return true;
+}
+
 function formatChangedFilesSummary(paths: Array<string>): string {
   if (!paths.length) return 'no files';
   const displayPaths = paths.map((filePath) => {
@@ -162,7 +176,8 @@ function getEnvFromNextCommand(dev: boolean): string {
 }
 
 function enableExtraFileWatchers(sources: SerializedEnvGraph['sources'], basePath?: string) {
-  if (IS_WORKER || !rootDir) return;
+  if (!rootDir) return;
+  if (!claimExtraFileWatcherOwnership()) return;
 
   // Collect absolute paths of source files that Next.js does NOT already watch
   const nextWatchedAbsolute = new Set(NEXT_WATCHED_ENV_FILES.map((f) => path.join(rootDir!, f)));

--- a/packages/integrations/nextjs/src/plugin.ts
+++ b/packages/integrations/nextjs/src/plugin.ts
@@ -318,7 +318,12 @@ export function varlockNextConfigPlugin(_pluginOptions?: VarlockPluginOptions) {
 
         // inject loader rules
         const loaderRule = {
-          loaders: [require.resolve('./loader')],
+          loaders: [
+            {
+              loader: require.resolve('./loader'),
+              options: { bundler: 'turbopack', dev: !isBuild },
+            },
+          ],
         };
         turbopackConfig.rules ||= {};
         turbopackConfig.rules['*.{js,jsx,ts,tsx,mjs,mts}'] = loaderRule;

--- a/scripts/detect-changed-integrations.ts
+++ b/scripts/detect-changed-integrations.ts
@@ -42,6 +42,16 @@ const QUICK_TEST_PATHS: Record<string, string> = {
   nextjs: 'nextjs/nextjs-v16.test.ts',
 };
 
+// Full suites slow enough to split into parallel matrix jobs — each part
+// becomes its own matrix entry and runs on its own runner.
+const SPLIT_TEST_PATHS: Record<string, Record<string, string>> = {
+  nextjs: {
+    v14: 'nextjs/nextjs-v14.test.ts',
+    v15: 'nextjs/nextjs-v15.test.ts',
+    v16: 'nextjs/nextjs-v16.test.ts',
+  },
+};
+
 type IntegrationEntry = { name: string; testPath: string };
 
 const ALL_INTEGRATIONS = Object.keys(INTEGRATION_PACKAGES);
@@ -57,11 +67,15 @@ function writeGithubOutputs(outputs: Record<string, string>) {
 
 const REPO_ROOT = join(import.meta.dirname, '..');
 
-function toEntry(name: string, mode: 'full' | 'quick' = 'full'): IntegrationEntry {
+function toEntries(name: string, mode: 'full' | 'quick' = 'full'): Array<IntegrationEntry> {
   if (mode === 'quick' && QUICK_TEST_PATHS[name]) {
-    return { name: `${name} (quick)`, testPath: QUICK_TEST_PATHS[name] };
+    return [{ name: `${name} (quick)`, testPath: QUICK_TEST_PATHS[name] }];
   }
-  return { name, testPath: `${name}/` };
+  if (SPLIT_TEST_PATHS[name]) {
+    return Object.entries(SPLIT_TEST_PATHS[name])
+      .map(([part, testPath]) => ({ name: `${name} (${part})`, testPath }));
+  }
+  return [{ name, testPath: `${name}/` }];
 }
 
 function writeResults(entries: Array<IntegrationEntry>) {
@@ -77,7 +91,7 @@ function writeResults(entries: Array<IntegrationEntry>) {
 
 // --all flag: test everything (full suite)
 if (forceAll) {
-  writeResults(ALL_INTEGRATIONS.map((name) => toEntry(name, 'full')));
+  writeResults(ALL_INTEGRATIONS.flatMap((name) => toEntries(name, 'full')));
   process.exit(0);
 }
 
@@ -98,7 +112,7 @@ if (isReleasePR) {
     });
   } catch (e) {
     console.error('Failed to diff against origin/main:', e);
-    writeResults(ALL_INTEGRATIONS.map((name) => toEntry(name, 'full')));
+    writeResults(ALL_INTEGRATIONS.flatMap((name) => toEntries(name, 'full')));
     process.exit(0);
   }
 
@@ -133,7 +147,7 @@ if (isReleasePR) {
   } catch (e) {
     console.error('Failed to diff against origin/main:', e);
     // If we can't diff, fall back to running all tests
-    writeResults(ALL_INTEGRATIONS.map((name) => toEntry(name, 'full')));
+    writeResults(ALL_INTEGRATIONS.flatMap((name) => toEntries(name, 'full')));
     process.exit(0);
   }
 
@@ -173,7 +187,7 @@ if (isReleasePR) {
 if (changedPackages.has('varlock')) {
   if (isReleasePR) {
     console.log('Core varlock package changed on release PR — running all integration tests');
-    writeResults(ALL_INTEGRATIONS.map((name) => toEntry(name, 'full')));
+    writeResults(ALL_INTEGRATIONS.flatMap((name) => toEntries(name, 'full')));
     process.exit(0);
   } else {
     console.log('Core varlock package changed — triggering core-only test suites');
@@ -212,18 +226,18 @@ const entries: Array<IntegrationEntry> = [];
 for (const [name, packages] of Object.entries(INTEGRATION_PACKAGES)) {
   // Test files changed or integration package changed → full suite
   if (changedTestIntegrations.has(name) || packages.some((pkg) => changedPackages.has(pkg))) {
-    entries.push(toEntry(name, 'full'));
+    entries.push(...toEntries(name, 'full'));
     continue;
   }
   // Harness changed → run all integrations, but only full if the integration's
   // own package also changed (already handled above), otherwise quick
   if (harnessChanged) {
-    entries.push(toEntry(name, 'quick'));
+    entries.push(...toEntries(name, 'quick'));
     continue;
   }
   // Suites with no integration packages are triggered by core varlock changes (quick)
   if (packages.length === 0 && changedPackages.has('varlock')) {
-    entries.push(toEntry(name, 'quick'));
+    entries.push(...toEntries(name, 'quick'));
     continue;
   }
 }


### PR DESCRIPTION
## Problem

The nextjs framework-tests job took **~13.5 min** while every other framework finishes in 1–3 min ([example run](https://github.com/dmno-dev/varlock/actions/runs/28682740454)). While making the suite faster and its assertions honest, the stronger assertions exposed a real integration bug, which this PR also fixes.

## Commit 1: skip v15 turbopack builds + split the matrix

- **Skip build scenarios for Next 15 + turbopack** (~5 min saved): turbopack production builds only became stable in Next 16, and v15 has no persistent build cache, so every scenario was a 25–54s cold compile. Dev scenarios still run.
- **Split the nextjs matrix into per-version jobs** via `SPLIT_TEST_PATHS`: `nextjs (v14/v15/v16)` parallelize across standard runners. Verified on this PR: slowest job 2.9 min vs 13.5 before.

## Commit 2: consolidate scenarios + isolate scenario files

- Merge 'basic page' + 'client component page' into one **multi-route build** per bundler/output-mode with per-route file assertions; merge the two dev env-watching scenarios into **one dev session** with three labeled requests (harness gains a `label` field on dev requests).
- Run the encrypted-env-blob scenario on each version's default bundler only.
- **Harness: per-scenario file isolation** — files written by a scenario are restored (from `_base`, or deleted) before the next one. This exposed that `next.config.mjs` with `output: 'export'` had been leaking into the 'default output mode' describes, which were silently building in export mode. All other framework suites audited: none relied on leakage (their CI suites all passed against this change).
- Fixed vacuous assertions: `shouldNotContain: 'super-secret-value'` never matched anything — the fixture's real value is `super-secret-var`.

## Commit 3: fix dev env file reloading on turbopack and Next 16

Asserting that a changed env file's **updated value is actually served** revealed reload was broken everywhere except webpack on next ≤ 15. Two separate causes, both in `@varlock/nextjs-integration`:

1. **Watchers never installed on Next 16.** The compat layer skipped watcher setup in `NEXT_PRIVATE_WORKER` processes, assuming the router server loads env and owns watching — true on next ≤ 15, but on next 16 *only* the render worker calls `loadEnvConfig`, so nobody watched. Watcher ownership is now claimed by the first process to install watchers (env-var handshake inherited by child processes, preserving single-owner semantics on next ≤ 15).

2. **Turbopack statically inlines non-sensitive `ENV.x` into server files** and never recompiles on env-only changes (webpack rebuilds with fresh DefinePlugin values, which is why it worked). In dev, server-side node-runtime files now keep runtime `ENV.x` reads through the proxy, which was verified to stay fresh across reloads. Inlining is unchanged for builds, client components, and edge files (edge detected by source sniff since turbopack has one global loader rule).

Known remaining limitation (pre-existing class): client components and edge pages in dev keep their inlined values until a recompile — same behavior as before, now the server-page path is correct.

Includes a bumpy changeset (patch for `@varlock/nextjs-integration`); the KNOWN GAP guard from commit 2 is removed.

## Verification

- `dev: extra env file watching` passes on **all five combos** (v14 webpack, v15 webpack/turbopack, v16 webpack/turbopack) with the updated-value assertion
- Full local suite: 114 passed / 24 expected skips across v14+v15+v16 (builds + dev)
- Manually traced the full chain on v16 turbopack: watch event → trigger-file touch → Next reload → worker re-resolves env → updated value served; edge page still renders env values

## Commits 4–5: loader parse cache + next@canary early-warning job

- **Loader perf**: `__VARLOCK_ENV` was JSON.parsed for every project file; now cached on the raw string (env reloads produce a new string, so freshness is preserved).
- **Weekly `next@canary` job** (`nextjs-canary.yaml`): runs the full nextjs suite against canary on a Monday cron + manual dispatch, so upstream changes to the version-coupled mechanisms this integration depends on surface before a stable Next release. Gated behind `NEXTJS_CANARY` — PR CI and local runs never pull canary, and the job never blocks PRs. Verified against today's canary: 53/53 pass.