### PR TITLE
fix(vscode-plugin): don't highlight email-like text in trailing comments as decorators

### DIFF
--- a/.bumpy/fix-email-comment-decorator-highlight.md
+++ b/.bumpy/fix-email-comment-decorator-highlight.md
@@ -1,0 +1,5 @@
+---
+env-spec-language: patch
+---
+
+Fix email-like text (user@host) in trailing comments highlighting as a decorator

--- a/packages/vscode-plugin/language/env-spec.tmLanguage.json
+++ b/packages/vscode-plugin/language/env-spec.tmLanguage.json
@@ -331,8 +331,19 @@
     },
 
     "post-value-comment": {
-      "comment": "Post-value comment",
-      "begin": "(#)\\s?",
+      "comment": "Post-value comment — decorator styling only applies when the comment starts with `@` (mirrors the parser, which only treats such comments as decorator comments)",
+      "patterns": [
+        {
+          "include": "#post-value-comment--decorators"
+        },
+        {
+          "include": "#post-value-comment--plain"
+        }
+      ]
+    },
+    "post-value-comment--decorators": {
+      "comment": "Post-value comment starting with a decorator",
+      "begin": "(#)\\s?(?=@)",
       "end": "(\\s*#.*)?$",
       "name": "comment.line.env-spec",
       "beginCaptures": {
@@ -350,6 +361,22 @@
         {
           "include": "#decorator"
         },
+        {
+          "include": "#comment-markup"
+        }
+      ]
+    },
+    "post-value-comment--plain": {
+      "comment": "Post-value comment - plain text (an email-like `foo@bar` must not highlight as a decorator)",
+      "begin": "(#)\\s?",
+      "end": "$",
+      "name": "comment.line.env-spec",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment"
+        }
+      },
+      "patterns": [
         {
           "include": "#comment-markup"
         }

--- a/packages/vscode-plugin/test/fixtures/.env.comments
+++ b/packages/vscode-plugin/test/fixtures/.env.comments
@@ -1,0 +1,6 @@
+# email@asdf.com
+VAL1=foo # contact email@asdf.com
+VAL2=bar # see docs at https://example.com or ping user@host.io
+VAL3=baz # @required @sensitive=false
+# @type=string(startsWith=abc)
+VAL4=

--- a/packages/vscode-plugin/test/fixtures/.env.comments.snap
+++ b/packages/vscode-plugin/test/fixtures/.env.comments.snap
@@ -1,0 +1,47 @@
+># email@asdf.com
+#^ source.env-spec comment.line.env-spec punctuation.definition.comment
+# ^ source.env-spec comment.line.env-spec
+#  ^^^^^^^^^^^^^^ source.env-spec comment.line.env-spec
+>VAL1=foo # contact email@asdf.com
+#^^^^ source.env-spec entity.name.tag.env-spec
+#    ^ source.env-spec keyword.operator.assignment.env-spec
+#     ^^^^ source.env-spec string.unquoted.env-spec
+#         ^ source.env-spec comment.line.env-spec comment.line.env-spec punctuation.definition.comment
+#          ^ source.env-spec comment.line.env-spec comment.line.env-spec
+#           ^^^^^^^^^^^^^^^^^^^^^^ source.env-spec comment.line.env-spec comment.line.env-spec
+>VAL2=bar # see docs at https://example.com or ping user@host.io
+#^^^^ source.env-spec entity.name.tag.env-spec
+#    ^ source.env-spec keyword.operator.assignment.env-spec
+#     ^^^^ source.env-spec string.unquoted.env-spec
+#         ^ source.env-spec comment.line.env-spec comment.line.env-spec punctuation.definition.comment
+#          ^ source.env-spec comment.line.env-spec comment.line.env-spec
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.env-spec comment.line.env-spec comment.line.env-spec
+>VAL3=baz # @required @sensitive=false
+#^^^^ source.env-spec entity.name.tag.env-spec
+#    ^ source.env-spec keyword.operator.assignment.env-spec
+#     ^^^^ source.env-spec string.unquoted.env-spec
+#         ^ source.env-spec comment.line.env-spec comment.line.env-spec punctuation.definition.comment
+#          ^ source.env-spec comment.line.env-spec comment.line.env-spec
+#           ^ source.env-spec comment.line.env-spec comment.line.env-spec variable.annotation.env-spec punctuation.definition.annotation.env-spec
+#            ^^^^^^^^ source.env-spec comment.line.env-spec comment.line.env-spec variable.annotation.env-spec
+#                    ^ source.env-spec comment.line.env-spec comment.line.env-spec
+#                     ^ source.env-spec comment.line.env-spec comment.line.env-spec variable.annotation.env-spec punctuation.definition.annotation.env-spec
+#                      ^^^^^^^^^ source.env-spec comment.line.env-spec comment.line.env-spec variable.annotation.env-spec
+#                               ^ source.env-spec comment.line.env-spec comment.line.env-spec keyword.operator.assignment.env-spec
+#                                ^^^^^ source.env-spec comment.line.env-spec comment.line.env-spec constant.language.boolean.env-spec
+># @type=string(startsWith=abc)
+#^ source.env-spec punctuation.definition.comment comment.line.env-spec
+# ^ source.env-spec
+#  ^ source.env-spec variable.annotation.env-spec punctuation.definition.annotation.env-spec
+#   ^^^^ source.env-spec variable.annotation.env-spec
+#       ^ source.env-spec keyword.operator.assignment.env-spec
+#        ^^^^^^ source.env-spec meta.function-call.env-spec variable.function.env-spec variable.function.env-spec
+#              ^ source.env-spec meta.function-call.env-spec variable.function.env-spec punctuation.section.parens.begin.env-spec
+#               ^^^^^^^^^^ source.env-spec meta.function-call.env-spec variable.function.env-spec variable.parameters.env-spec entity.other.attribute-name.env-spec
+#                         ^ source.env-spec meta.function-call.env-spec variable.function.env-spec variable.parameters.env-spec keyword.operator.assignment.env-spec
+#                          ^^^ source.env-spec meta.function-call.env-spec variable.function.env-spec variable.parameters.env-spec string.unquoted.env-spec
+#                             ^ source.env-spec meta.function-call.env-spec variable.function.env-spec punctuation.section.parens.end.env-spec
+>VAL4=
+#^^^^ source.env-spec entity.name.tag.env-spec
+#    ^ source.env-spec keyword.operator.assignment.env-spec
+>


### PR DESCRIPTION
A trailing comment like `VAL=foo # contact email@asdf.com` highlighted `@asdf.com` with decorator annotation styling.

The `post-value-comment` TextMate rule included decorator styling unconditionally. It is now split into two variants: decorator styling only applies when the comment starts with `@`, mirroring the parser (which only treats comments starting with a decorator as decorator comments). Plain trailing comments — including email addresses and `@` mentions mid-text — render as regular comment text.

Adds a `.env.comments` snapshot fixture covering email-like text in standalone and trailing comments alongside real inline decorators.