### PR TITLE
chore: update bumpy to 1.18.1 and add issue-note workflow

### DIFF
--- a/.github/workflows/bumpy-issue-note.yaml
+++ b/.github/workflows/bumpy-issue-note.yaml
@@ -1,0 +1,45 @@
+name: Bumpy issue note
+
+# When a PR that closes linked issues is merged, GitHub auto-closes those
+# issues — but the fix isn't published yet. This workflow leaves a note on each
+# auto-closed issue clarifying that the change ships in the next release.
+#
+# SECURITY: runs on `pull_request_target` (trusted context with an `issues:write`
+# token) and NEVER checks out or executes PR code — it only calls `gh`, resolving
+# the linked issues from the trusted event payload.
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  issues: write
+
+jobs:
+  note:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on auto-closed issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          issues=$(gh api graphql \
+            -f query='
+              query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    closingIssuesReferences(first: 50) { nodes { number } }
+                  }
+                }
+              }' \
+            -f owner="${REPO%/*}" -f repo="${REPO#*/}" -F pr="$PR" \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number')
+          [ -z "$issues" ] && { echo "PR #$PR closed no linked issues."; exit 0; }
+          for n in $issues; do
+            gh issue comment "$n" --repo "$REPO" --body \
+          "✅ A fix has been merged to \`main\` in #${PR} and will ship in the next release. GitHub auto-closed this issue on merge, but the change isn't published yet."
+          done

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@types/node": "catalog:",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.56.1",
-        "@varlock/bumpy": "^1.18.0",
+        "@varlock/bumpy": "^1.18.1",
         "@varlock/tsconfig": "workspace:*",
         "eslint": "^10.0.2",
         "eslint-plugin-es-x": "^9.5.0",
@@ -1437,7 +1437,7 @@
 
     "@varlock/bitwarden-plugin": ["@varlock/bitwarden-plugin@workspace:packages/plugins/bitwarden"],
 
-    "@varlock/bumpy": ["@varlock/bumpy@1.18.0", "", { "bin": { "bumpy": "dist/cli.mjs" } }, "sha512-0LBdmKG28V9xgg2clbxZbZG2Z94X/TEJ2sMgercYX0INj2Z84xPpk4/vy83i2+xA0kDxvafqDI7DetRnPGPIzw=="],
+    "@varlock/bumpy": ["@varlock/bumpy@1.18.1", "", { "bin": { "bumpy": "dist/cli.mjs" } }, "sha512-u6PHUr+laAgWWm/c3wdExHBCcvYkkTb+KsiRNR9GCFIbCDrCN9CyOZO/crtRZ5u4KWMKtUTeA7U/s+AA0k7Dcg=="],
 
     "@varlock/ci-env-info": ["@varlock/ci-env-info@workspace:packages/ci-env-info"],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/node": "catalog:",
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.56.1",
-    "@varlock/bumpy": "^1.18.0",
+    "@varlock/bumpy": "^1.18.1",
     "@varlock/tsconfig": "workspace:*",
     "eslint": "^10.0.2",
     "eslint-plugin-es-x": "^9.5.0",


### PR DESCRIPTION
Updates `@varlock/bumpy` to 1.18.1 and adds bumpy's issue-note workflow.

## Changes
- **Bump `@varlock/bumpy`** `^1.18.0` → `^1.18.1`.
- **Add `.github/workflows/bumpy-issue-note.yaml`** — when a PR that closes linked issues merges to `main`, GitHub auto-closes those issues even though the fix isn't published yet. This posts a note on each auto-closed issue clarifying that the change ships in the next release.

The workflow runs on `pull_request_target` (trusted context, `issues: write`) and never checks out or executes PR code — it only calls `gh`, resolving linked issues from the trusted event payload.