### PR TITLE
fix(nextjs-integration): make turbopack ENV inlining string/comment-safe

### DIFF
--- a/.bumpy/nextjs-turbopack-ast-replacement.md
+++ b/.bumpy/nextjs-turbopack-ast-replacement.md
@@ -1,0 +1,5 @@
+---
+"@varlock/nextjs-integration": patch
+---
+
+fix turbopack static ENV replacement corrupting ENV.x references inside string literals and comments — replacement is now AST-based, matching the vite integration

--- a/.bumpy/vite-shared-ast-replacer.md
+++ b/.bumpy/vite-shared-ast-replacer.md
@@ -1,0 +1,5 @@
+---
+"@varlock/vite-integration": patch
+---
+
+internal refactor: static ENV.x replacement code moved to a shared internal package (no behavior change)

--- a/bun.lock
+++ b/bun.lock
@@ -133,6 +133,8 @@
       "name": "@varlock/nextjs-integration",
       "version": "1.1.3",
       "devDependencies": {
+        "@babel/parser": "^7.29.3",
+        "@env-spec/utils": "workspace:^",
         "@types/node": "catalog:",
         "tsup": "catalog:",
         "varlock": "workspace:^",
@@ -147,8 +149,8 @@
       "name": "@varlock/vite-integration",
       "version": "1.2.0",
       "devDependencies": {
+        "@env-spec/utils": "workspace:^",
         "@types/node": "catalog:",
-        "ast-matcher": "^1.2.0",
         "magic-string": "^0.30.17",
         "rollup": "^4.46.2",
         "tsup": "catalog:",
@@ -425,6 +427,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@sindresorhus/is": "catalog:",
+        "ast-matcher": "^1.2.0",
+        "magic-string": "^0.30.17",
       },
       "devDependencies": {
         "@types/node": "catalog:",

--- a/framework-tests/frameworks/nextjs/files/pages/client-page.tsx
+++ b/framework-tests/frameworks/nextjs/files/pages/client-page.tsx
@@ -7,6 +7,11 @@ export default function ClientPage() {
   // build — the value just must not appear in any client-visible output
   const hasSensitive = !!ENV.SENSITIVE_VAR;
 
+  // ENV references inside string literals and template literal text must be
+  // rendered verbatim — static inlining only rewrites real member expressions
+  const envRefInString = 'ENV.PUBLIC_VAR mentioned in a string';
+  const envRefInTemplate = `ENV.PUBLIC_VAR in template text, interpolated: ${ENV.PUBLIC_VAR}`;
+
   return (
     <main>
       <h1>Varlock Client Component Page</h1>
@@ -14,6 +19,8 @@ export default function ClientPage() {
       <p>Unprefixed var: {ENV.PUBLIC_VAR}</p>
       <p>Env specific var: {ENV.ENV_SPECIFIC_VAR}</p>
       <p>Has sensitive: {hasSensitive ? 'yes' : 'no'}</p>
+      <p>String ref: {envRefInString}</p>
+      <p>Template ref: {envRefInTemplate}</p>
     </main>
   );
 }

--- a/framework-tests/frameworks/nextjs/files/pages/client-page.tsx
+++ b/framework-tests/frameworks/nextjs/files/pages/client-page.tsx
@@ -21,6 +21,7 @@ export default function ClientPage() {
       <p>Has sensitive: {hasSensitive ? 'yes' : 'no'}</p>
       <p>String ref: {envRefInString}</p>
       <p>Template ref: {envRefInTemplate}</p>
+      <p>Jsx text ref: ENV.PUBLIC_VAR as jsx text</p>
     </main>
   );
 }

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -199,6 +199,9 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
                   'next-prefixed-public-var',
                   'unprefixed-public-var',
                   'env-specific-var--dev',
+                  // ENV refs in string/template-literal text render verbatim (inlining must not rewrite them)
+                  'ENV.PUBLIC_VAR mentioned in a string',
+                  'ENV.PUBLIC_VAR in template text, interpolated: unprefixed-public-var',
                 ],
               },
               {
@@ -280,6 +283,9 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
                   'next-prefixed-public-var',
                   'unprefixed-public-var',
                   'env-specific-var--dev',
+                  // ENV refs in string/template-literal text render verbatim (inlining must not rewrite them)
+                  'ENV.PUBLIC_VAR mentioned in a string',
+                  'ENV.PUBLIC_VAR in template text, interpolated: unprefixed-public-var',
                 ],
               },
               {

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -202,6 +202,7 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
                   // ENV refs in string/template-literal text render verbatim (inlining must not rewrite them)
                   'ENV.PUBLIC_VAR mentioned in a string',
                   'ENV.PUBLIC_VAR in template text, interpolated: unprefixed-public-var',
+                  'ENV.PUBLIC_VAR as jsx text',
                 ],
               },
               {
@@ -286,6 +287,7 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
                   // ENV refs in string/template-literal text render verbatim (inlining must not rewrite them)
                   'ENV.PUBLIC_VAR mentioned in a string',
                   'ENV.PUBLIC_VAR in template text, interpolated: unprefixed-public-var',
+                  'ENV.PUBLIC_VAR as jsx text',
                 ],
               },
               {

--- a/packages/integrations/nextjs/package.json
+++ b/packages/integrations/nextjs/package.json
@@ -18,6 +18,8 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "rm -rf dist && tsup",
+    "test": "vitest",
+    "test:ci": "vitest --run",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [
@@ -44,6 +46,8 @@
     "next": ">=14"
   },
   "devDependencies": {
+    "@babel/parser": "^7.29.3",
+    "@env-spec/utils": "workspace:^",
     "@types/node": "catalog:",
     "tsup": "catalog:",
     "varlock": "workspace:^",

--- a/packages/integrations/nextjs/src/loader.ts
+++ b/packages/integrations/nextjs/src/loader.ts
@@ -1,3 +1,5 @@
+import { parse as babelParse, type ParserPlugin } from '@babel/parser';
+import { createReplacerTransformFn } from '@env-spec/utils/ast-replacer';
 import type { SerializedEnvGraph } from 'varlock';
 
 function debug(...args: Array<any>) {
@@ -53,6 +55,77 @@ function parseEnvGraphCached(rawEnv: string): SerializedEnvGraph | undefined {
     }
   }
   return cachedEnvGraph;
+}
+
+// replacer is derived from the env graph, so cache it alongside (keyed on graph identity)
+let cachedReplacerGraph: SerializedEnvGraph | undefined;
+let cachedReplacerTransform: ReturnType<typeof createReplacerTransformFn> | undefined;
+function getReplacerTransformCached(envGraph: SerializedEnvGraph) {
+  if (envGraph !== cachedReplacerGraph) {
+    cachedReplacerGraph = envGraph;
+    const replacements: Record<string, string> = {};
+    for (const [key, item] of Object.entries(envGraph.config)) {
+      if (item.isSensitive) continue;
+      // 'undefined' as a string so it gets spliced in as a literal
+      replacements[`ENV.${key}`] = item.value === undefined ? 'undefined' : JSON.stringify(item.value);
+    }
+    cachedReplacerTransform = createReplacerTransformFn({ replacements });
+  }
+  return cachedReplacerTransform!;
+}
+
+/** babel parse ctx with plugins appropriate for the file extension */
+function makeBabelParseCtx(filePath: string) {
+  const fileExt = filePath.split('?')[0].split('#')[0].split('.').pop() || '';
+  const plugins: Array<ParserPlugin> = ['decorators-legacy', 'importAttributes'];
+  if (fileExt === 'ts' || fileExt === 'mts' || fileExt === 'cts') {
+    plugins.push('typescript');
+  } else if (fileExt === 'tsx') {
+    plugins.push('typescript', 'jsx');
+  } else {
+    plugins.push('jsx');
+  }
+  return {
+    parse: (code: string) => babelParse(code, {
+      sourceType: 'unambiguous',
+      plugins,
+      // still produce an AST when possible for code with recoverable errors
+      errorRecovery: true,
+    }),
+  };
+}
+
+const parseFailureWarnedFiles = new Set<string>();
+
+/**
+ * Replace `ENV.KEY` member expressions with literal values via AST matching
+ * (shared with the vite integration) so references inside string literals,
+ * comments, and template literal text are never touched.
+ * Falls back to regex replacement if the file fails to parse.
+ */
+function inlineEnvValues(source: string, filePath: string, envGraph: SerializedEnvGraph): string {
+  const replacerTransform = getReplacerTransformCached(envGraph);
+  try {
+    const magicString = replacerTransform(makeBabelParseCtx(filePath), source, filePath);
+    return magicString ? magicString.toString() : source;
+  } catch (err) {
+    if (!parseFailureWarnedFiles.has(filePath)) {
+      parseFailureWarnedFiles.add(filePath);
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[varlock] failed to parse ${filePath} for ENV replacement — falling back to regex replacement`,
+        err instanceof Error ? `(${err.message})` : '',
+      );
+    }
+    let result = source;
+    for (const [key, item] of Object.entries(envGraph.config)) {
+      if (item.isSensitive) continue;
+      // match ENV.KEY as a member expression (word boundary before ENV, not followed by more identifier chars)
+      const pattern = new RegExp(`\\bENV\\.${escapeRegExp(key)}(?![\\w$])`, 'g');
+      result = result.replace(pattern, item.value === undefined ? 'undefined' : JSON.stringify(item.value));
+    }
+    return result;
+  }
 }
 
 /** Prepend code after any directive prologue (e.g. 'use server') to avoid breaking it */
@@ -152,15 +225,7 @@ function webpackLoader(this: LoaderContext, source: string) {
     if (inlineStaticValues) {
       // disable caching only for files that embed ENV values — their output depends on env values
       this.cacheable(false);
-      for (const [key, item] of Object.entries(envGraph.config)) {
-        if (item.isSensitive) continue;
-
-        // TODO: smarter replacement (vite version uses AST?)
-
-        // match ENV.KEY as a member expression (word boundary before ENV, not followed by more identifier chars)
-        const pattern = new RegExp(`\\bENV\\.${escapeRegExp(key)}(?![\\w$])`, 'g');
-        result = result.replace(pattern, JSON.stringify(item.value));
-      }
+      result = inlineEnvValues(result, this.resourcePath, envGraph);
     }
   }
 

--- a/packages/integrations/nextjs/test/loader.test.ts
+++ b/packages/integrations/nextjs/test/loader.test.ts
@@ -104,6 +104,12 @@ describe('static ENV.x replacement (turbopack)', () => {
     expect(result).toContain('const c = ENVX.PUBLIC_VAR;');
   });
 
+  it('does NOT replace matches inside JSX text', () => {
+    const source = `${USE_CLIENT}const el = <p>ENV.PUBLIC_VAR as jsx text: {ENV.PUBLIC_VAR}</p>;`;
+    const result = runLoader(source);
+    expect(result).toContain('<p>ENV.PUBLIC_VAR as jsx text: {"public-value"}</p>');
+  });
+
   it('does NOT replace nested member expressions like foo.ENV.KEY', () => {
     const source = `${USE_CLIENT}const a = someObj.ENV.PUBLIC_VAR;`;
     expect(runLoader(source)).toContain('const a = someObj.ENV.PUBLIC_VAR;');

--- a/packages/integrations/nextjs/test/loader.test.ts
+++ b/packages/integrations/nextjs/test/loader.test.ts
@@ -1,0 +1,191 @@
+import {
+  describe, it, expect, beforeEach, vi,
+} from 'vitest';
+// the loader only has a CJS `module.exports =` export (required by webpack's
+// loader-runner) — vitest surfaces it as the namespace default
+import * as loaderModule from '../src/loader';
+
+type LoaderOptions = { bundler?: 'webpack' | 'turbopack'; isEdge?: boolean; dev?: boolean };
+type LoaderContext = {
+  cacheable(flag: boolean): void;
+  resourcePath: string;
+  rootContext: string;
+  getOptions(): LoaderOptions;
+};
+const loader = (loaderModule as any).default as (this: LoaderContext, source: string) => string;
+
+const PROJECT_ROOT = '/proj';
+
+function runLoader(source: string, opts?: {
+  resourcePath?: string;
+  options?: LoaderOptions;
+}) {
+  const ctx: LoaderContext = {
+    cacheable: () => undefined,
+    resourcePath: opts?.resourcePath ?? `${PROJECT_ROOT}/app/page.tsx`,
+    rootContext: PROJECT_ROOT,
+    getOptions: () => opts?.options ?? { bundler: 'turbopack' as const, dev: false },
+  };
+  return loader.call(ctx, source);
+}
+
+function setEnvGraph(config: Record<string, { value: any, isSensitive: boolean }>) {
+  process.env.__VARLOCK_ENV = JSON.stringify({
+    config,
+    settings: {},
+    sources: [],
+  });
+}
+
+beforeEach(() => {
+  setEnvGraph({
+    PUBLIC_VAR: { value: 'public-value', isSensitive: false },
+    OTHER_VAR: { value: 123, isSensitive: false },
+    UNDEF_VAR: { value: undefined, isSensitive: false },
+    SECRET_VAR: { value: 'shh', isSensitive: true },
+  });
+});
+
+// all sources are marked as client components so results are not
+// cluttered with the injected server init guard
+const USE_CLIENT = "'use client';\n";
+
+describe('static ENV.x replacement (turbopack)', () => {
+  it('replaces legitimate member expressions', () => {
+    const result = runLoader(USE_CLIENT + [
+      'const a = ENV.PUBLIC_VAR;',
+      'fn(ENV.PUBLIC_VAR, ENV.OTHER_VAR);',
+      'if (ENV.PUBLIC_VAR) {}',
+      'const el = <div title={ENV.PUBLIC_VAR} />;',
+    ].join('\n'));
+    expect(result).toContain('const a = "public-value";');
+    expect(result).toContain('fn("public-value", 123);');
+    expect(result).toContain('if ("public-value") {}');
+    expect(result).toContain('<div title={"public-value"} />');
+  });
+
+  it('does NOT replace matches inside string literals', () => {
+    const source = USE_CLIENT + [
+      'console.log("ENV.PUBLIC_VAR is set");',
+      "const s = 'text ENV.PUBLIC_VAR more';",
+    ].join('\n');
+    const result = runLoader(source);
+    expect(result).toContain('console.log("ENV.PUBLIC_VAR is set");');
+    expect(result).toContain("const s = 'text ENV.PUBLIC_VAR more';");
+  });
+
+  it('does NOT replace matches inside comments', () => {
+    const source = USE_CLIENT + [
+      'const a = ENV.PUBLIC_VAR; // uses ENV.PUBLIC_VAR here',
+      '/* block comment mentioning ENV.PUBLIC_VAR */',
+      'const b = 1;',
+    ].join('\n');
+    const result = runLoader(source);
+    expect(result).toContain('const a = "public-value"; // uses ENV.PUBLIC_VAR here');
+    expect(result).toContain('/* block comment mentioning ENV.PUBLIC_VAR */');
+  });
+
+  it('replaces interpolations but not text in template literals', () => {
+    const source = `${USE_CLIENT}const t = \`text ENV.PUBLIC_VAR and \${ENV.PUBLIC_VAR}\`;`;
+    const result = runLoader(source);
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(result).toContain('`text ENV.PUBLIC_VAR and ${"public-value"}`');
+  });
+
+  it('does NOT replace ENV.KEY as part of a longer identifier', () => {
+    const source = USE_CLIENT + [
+      'const a = ENV.PUBLIC_VAR_LONGER;',
+      'const b = MY_ENV.PUBLIC_VAR;',
+      'const c = ENVX.PUBLIC_VAR;',
+    ].join('\n');
+    const result = runLoader(source);
+    expect(result).toContain('const a = ENV.PUBLIC_VAR_LONGER;');
+    expect(result).toContain('const b = MY_ENV.PUBLIC_VAR;');
+    expect(result).toContain('const c = ENVX.PUBLIC_VAR;');
+  });
+
+  it('does NOT replace nested member expressions like foo.ENV.KEY', () => {
+    const source = `${USE_CLIENT}const a = someObj.ENV.PUBLIC_VAR;`;
+    expect(runLoader(source)).toContain('const a = someObj.ENV.PUBLIC_VAR;');
+  });
+
+  it('never inlines sensitive values', () => {
+    const source = `${USE_CLIENT}const a = ENV.SECRET_VAR;`;
+    const result = runLoader(source);
+    expect(result).toContain('const a = ENV.SECRET_VAR;');
+    expect(result).not.toContain('shh');
+  });
+
+  it('inlines undefined values as a literal', () => {
+    const source = `${USE_CLIENT}const a = ENV.UNDEF_VAR;`;
+    expect(runLoader(source)).toContain('const a = undefined;');
+  });
+
+  it('handles typescript syntax (types, satisfies, casts)', () => {
+    const source = USE_CLIENT + [
+      'const a: string = ENV.PUBLIC_VAR as string;',
+      'type Foo = { key: typeof ENV.PUBLIC_VAR };',
+    ].join('\n');
+    const result = runLoader(source, { resourcePath: `${PROJECT_ROOT}/lib/thing.ts` });
+    expect(result).toContain('const a: string = "public-value" as string;');
+  });
+
+  it('falls back to regex replacement when the file cannot be parsed', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      // unclosed brace makes this unparseable even with errorRecovery
+      const source = `${USE_CLIENT}function broken( { const a = ENV.PUBLIC_VAR;`;
+      const result = runLoader(source);
+      expect(result).toContain('const a = "public-value";');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('falling back to regex replacement'),
+        expect.anything(),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe('inlining gate (dev vs build, client vs server vs edge)', () => {
+  const SERVER_SOURCE = 'const a = ENV.PUBLIC_VAR;';
+
+  it('does NOT inline into server files in dev (runtime proxy reads stay fresh)', () => {
+    const result = runLoader(SERVER_SOURCE, { options: { bundler: 'turbopack', dev: true } });
+    expect(result).toContain('const a = ENV.PUBLIC_VAR;');
+  });
+
+  it('inlines into server files during builds', () => {
+    const result = runLoader(SERVER_SOURCE, { options: { bundler: 'turbopack', dev: false } });
+    expect(result).toContain('const a = "public-value";');
+  });
+
+  it('inlines into client components in dev', () => {
+    const result = runLoader(USE_CLIENT + SERVER_SOURCE, { options: { bundler: 'turbopack', dev: true } });
+    expect(result).toContain('const a = "public-value";');
+  });
+
+  it('inlines into middleware files in dev (edge sniff by path)', () => {
+    const result = runLoader(SERVER_SOURCE, {
+      resourcePath: `${PROJECT_ROOT}/middleware.ts`,
+      options: { bundler: 'turbopack', dev: true },
+    });
+    expect(result).toContain('const a = "public-value";');
+  });
+
+  it('inlines into edge runtime files in dev (edge sniff by source)', () => {
+    const source = `export const runtime = 'edge';\n${SERVER_SOURCE}`;
+    const result = runLoader(source, { options: { bundler: 'turbopack', dev: true } });
+    expect(result).toContain('const a = "public-value";');
+  });
+
+  it('still injects the init guard into server files', () => {
+    const result = runLoader(SERVER_SOURCE, { options: { bundler: 'turbopack', dev: false } });
+    expect(result).toContain('globalThis.__varlockBuildInit');
+  });
+
+  it('does not inject the init guard into client components', () => {
+    const result = runLoader(USE_CLIENT + SERVER_SOURCE);
+    expect(result).not.toContain('globalThis.__varlockBuildInit');
+  });
+});

--- a/packages/integrations/vite/package.json
+++ b/packages/integrations/vite/package.json
@@ -47,8 +47,8 @@
     "vite": ">=5"
   },
   "devDependencies": {
+    "@env-spec/utils": "workspace:^",
     "@types/node": "catalog:",
-    "ast-matcher": "^1.2.0",
     "magic-string": "^0.30.17",
     "rollup": "^4.46.2",
     "tsup": "catalog:",

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -12,7 +12,7 @@ import { createDebug, type SerializedEnvGraph } from 'varlock';
 import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';
 import { encryptEnvBlobSync, generateEncryptionKeyHex } from 'varlock/encrypt-env';
 
-import { createReplacerTransformFn, SUPPORTED_FILES } from './transform';
+import { createReplacerTransformFn, SUPPORTED_FILES } from '@env-spec/utils/ast-replacer';
 
 import { ansiToHtml } from './ansi-to-html';
 export { ansiToHtml };

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,6 +23,8 @@
     "vitest": "catalog:"
   },
   "dependencies": {
-    "@sindresorhus/is": "catalog:"
+    "@sindresorhus/is": "catalog:",
+    "ast-matcher": "^1.2.0",
+    "magic-string": "^0.30.17"
   }
 }

--- a/packages/utils/src/ast-replacer.ts
+++ b/packages/utils/src/ast-replacer.ts
@@ -1,17 +1,27 @@
 /*
+  AST-based static replacement of expressions (e.g. `ENV.SOME_KEY` -> literal values).
+
   Used https://www.npmjs.com/package/rollup-plugin-define as a starting point
   Initially we were using @rollup/plugin-replace, but it would replace text in strings
 
-  This instead replaces nodes in a parsed AST rather than text in a string.
-  But we've simplified things slightly and removed some dependencies.
+  This instead replaces nodes in a parsed AST rather than text in a string,
+  so references inside string literals, comments, and template literal text
+  are never touched.
+
+  Shared by the vite integration (which passes rollup's `parse`) and the
+  nextjs integration's turbopack loader (which passes @babel/parser).
+  The parser just needs to produce an estree-compliant tree with node
+  start/end offsets (ast-matcher also accepts @babel/parser `File` nodes).
 */
-import type { PluginContext, TransformPluginContext } from 'rollup';
 
 import MagicString from 'magic-string';
 import astMatcher from 'ast-matcher';
 
 type Edit = [number, number];
 type AstNode = { start: number; end: number };
+
+/** parse fn producing an estree-compliant AST with start/end offsets on nodes */
+export type AstParseFn = (code: string, opts?: any) => any;
 
 function escapeStringRegexp(string: string) {
   if (typeof string !== 'string') throw new TypeError('Expected a string');
@@ -48,9 +58,8 @@ export function createReplacerTransformFn(opts: {
   const findAnyReplacementRegex = new RegExp(`(?:${keys.map(escapeStringRegexp).join('|')})`, 'g');
 
   return function transform(
-    rollupPluginCtx: {
-      parse: TransformPluginContext['parse'];
-      warn: TransformPluginContext['warn']
+    parserCtx: {
+      parse: AstParseFn;
     },
     code: string,
     id: string,
@@ -62,9 +71,9 @@ export function createReplacerTransformFn(opts: {
 
     if (code.search(findAnyReplacementRegex) === -1) return null;
 
-    const parse = (codeToParse: string, source = code): ReturnType<PluginContext['parse']> => {
+    const parse = (codeToParse: string, source = code): any => {
       try {
-        return rollupPluginCtx.parse(codeToParse, undefined);
+        return parserCtx.parse(codeToParse, undefined);
       } catch (error) {
         (error as Error).message += ` in ${source}`;
         throw error;


### PR DESCRIPTION
## What

The turbopack loader's static replacement of non-sensitive `ENV.KEY` references was a plain regex `String.replace` over the whole source, so matches inside string literals, comments, and template literal text got spliced with the quoted value — e.g. `console.log("ENV.PUBLIC_VAR is set")` became invalid JS.

Replacement is now AST-based, reusing the vite integration's replacement machinery:

- `createReplacerTransformFn` moved from `@varlock/vite-integration` into `@env-spec/utils/ast-replacer` (generalized to take any estree-compliant `parse` fn instead of rollup's plugin context); the vite integration now imports it from there — no behavior change on the vite side.
- The nextjs turbopack loader parses each file with `@babel/parser` (plugins picked per file extension) and replaces only real `ENV.KEY` member expressions. String literals, comments, template literal quasis, JSX text, nested members like `foo.ENV.KEY`, and longer identifiers like `ENV.KEY_LONGER` are left untouched; `${ENV.KEY}` interpolations still inline.
- If a file fails to parse (exotic syntax), the loader warns once per file and falls back to the previous regex replacement so values still inline.

Webpack is untouched (it uses DefinePlugin, which was already safe), and the recent turbopack gating is preserved: dev-mode server files still skip inlining in favor of runtime proxy reads, while client components, edge files, and all build-mode files still inline.

## Testing

- New unit tests for the loader (`packages/integrations/nextjs/test/loader.test.ts`) covering strings, comments, template literals, JSX text, member expressions, longer identifiers, sensitive skipping, the parse-failure fallback, and the dev/build/client/edge inlining gate.
- Framework-test fixture coverage: the client-page fixture now renders `ENV.PUBLIC_VAR` inside a string literal, template-literal text, and JSX text, and the build scenarios assert the text survives verbatim into the prerendered HTML (guards both the turbopack AST path and webpack's DefinePlugin path end-to-end).
- Framework tests pass locally: nextjs v14/v15/v16 suites and the full vite suite (since its replacement code moved).