### PR TITLE
nextjs framework tests: pages router + middleware coverage (fixes 3 integration bugs)

### DIFF
--- a/.bumpy/nextjs-pages-router-middleware-fixes.md
+++ b/.bumpy/nextjs-pages-router-middleware-fixes.md
@@ -1,6 +1,5 @@
 ---
-varlock: patch
 "@varlock/nextjs-integration": patch
 ---
 
-Fix Next.js pages router and middleware support: webpack builds no longer fail on pages-router files, pages-router SSR picks up reloaded env values in turbopack dev, middleware no longer crashes the dev server with a `Native module not found: crypto` error, and on Next 15.5+ the turbopack loader rule is scoped away from edge files so middleware no longer breaks dev page rendering
+Fix pages router and middleware support: webpack builds no longer fail on pages-router files, middleware no longer crashes the dev server, and on Next 15.5+ the turbopack loader rule is scoped away from edge files so middleware doesn't break dev page rendering

--- a/.bumpy/nextjs-pages-router-middleware-fixes.md
+++ b/.bumpy/nextjs-pages-router-middleware-fixes.md
@@ -1,0 +1,6 @@
+---
+varlock: patch
+"@varlock/nextjs-integration": patch
+---
+
+Fix Next.js pages router and middleware support: webpack builds no longer fail on pages-router files, pages-router SSR picks up reloaded env values in turbopack dev, and middleware no longer crashes the dev server with a `Native module not found: crypto` error

--- a/.bumpy/nextjs-pages-router-middleware-fixes.md
+++ b/.bumpy/nextjs-pages-router-middleware-fixes.md
@@ -3,4 +3,4 @@ varlock: patch
 "@varlock/nextjs-integration": patch
 ---
 
-Fix Next.js pages router and middleware support: webpack builds no longer fail on pages-router files, pages-router SSR picks up reloaded env values in turbopack dev, and middleware no longer crashes the dev server with a `Native module not found: crypto` error
+Fix Next.js pages router and middleware support: webpack builds no longer fail on pages-router files, pages-router SSR picks up reloaded env values in turbopack dev, middleware no longer crashes the dev server with a `Native module not found: crypto` error, and on Next 15.5+ the turbopack loader rule is scoped away from edge files so middleware no longer breaks dev page rendering

--- a/.bumpy/runtime-leak-scan-gzip.md
+++ b/.bumpy/runtime-leak-scan-gzip.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Runtime leak detection now catches secrets in compressed responses: gzipped responses that fit in a single chunk (i.e. most pages) were never scanned, so browsers — which always send `Accept-Encoding: gzip` — could receive leaked sensitive values the scanner should have blocked. Compressed chunks that can't be scrubbed now fail closed instead of passing through

--- a/.bumpy/runtime-shared-state-lazy-crypto.md
+++ b/.bumpy/runtime-shared-state-lazy-crypto.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Runtime fixes: env state is now shared across bundled copies of `varlock/env` (fixes stale values after env reloads when a bundler duplicates the module), and `node:crypto` is loaded lazily so the init bundles can be evaluated in edge sandboxes that lack node builtins

--- a/framework-tests/frameworks/nextjs/files/middleware/middleware.ts
+++ b/framework-tests/frameworks/nextjs/files/middleware/middleware.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { ENV } from 'varlock/env';
+
+// only run for a dedicated test path so other routes are unaffected
+export const config = { matcher: '/middleware-test' };
+
+// middleware always runs in the edge runtime
+export function middleware() {
+  return NextResponse.json({
+    title: 'varlock-middleware-response',
+    nextPrefixedVar: ENV.NEXT_PUBLIC_VAR,
+    publicVar: ENV.PUBLIC_VAR,
+    envSpecificVar: ENV.ENV_SPECIFIC_VAR,
+    hasSensitive: ENV.SENSITIVE_VAR ? 'middleware-sensitive-available' : 'X - not available',
+  });
+}

--- a/framework-tests/frameworks/nextjs/files/pages-router/leaky-page.tsx
+++ b/framework-tests/frameworks/nextjs/files/pages-router/leaky-page.tsx
@@ -1,0 +1,18 @@
+import { ENV } from 'varlock/env';
+
+// Deliberately pass a sensitive value through getStaticProps — it ends up in
+// both the rendered HTML and the __NEXT_DATA__ payload, so the build must fail
+export function getStaticProps() {
+  return {
+    props: { leakedSecret: ENV.SENSITIVE_VAR },
+  };
+}
+
+export default function LeakyPagesRouterPage(props: { leakedSecret: string }) {
+  return (
+    <main>
+      <h1>Leaky Pages Router Page</h1>
+      <p>Sensitive: {props.leakedSecret}</p>
+    </main>
+  );
+}

--- a/framework-tests/frameworks/nextjs/files/pages-router/leaky-ssr-page.tsx
+++ b/framework-tests/frameworks/nextjs/files/pages-router/leaky-ssr-page.tsx
@@ -1,0 +1,21 @@
+import { ENV } from 'varlock/env';
+
+// Deliberately leak a sensitive value at REQUEST time — getServerSideProps never
+// runs during the build, so build-output scanning can't catch this. The runtime
+// response scanner must prevent the secret from reaching the client, and the
+// runtime console.log must come out redacted in the server logs.
+export function getServerSideProps() {
+  console.log('runtime-secret-log-test:', ENV.SENSITIVE_VAR);
+  return {
+    props: { leaked: ENV.SENSITIVE_VAR },
+  };
+}
+
+export default function LeakySsrPage(props: { leaked: string }) {
+  return (
+    <main>
+      <h1>Leaky SSR Page</h1>
+      <p>Sensitive: {props.leaked}</p>
+    </main>
+  );
+}

--- a/framework-tests/frameworks/nextjs/files/pages-router/ssr-page.tsx
+++ b/framework-tests/frameworks/nextjs/files/pages-router/ssr-page.tsx
@@ -1,0 +1,25 @@
+import { ENV } from 'varlock/env';
+
+// pages-router request-time data fetching — runs on the server for every request
+export function getServerSideProps() {
+  return {
+    props: {
+      envSpecificVar: ENV.ENV_SPECIFIC_VAR,
+      hasSensitive: !!ENV.SENSITIVE_VAR,
+    },
+  };
+}
+
+export default function PagesRouterSsrPage(
+  props: { envSpecificVar: string, hasSensitive: boolean },
+) {
+  return (
+    <main>
+      <h1>Varlock Pages Router SSR Page</h1>
+      <p>Next prefixed var: {ENV.NEXT_PUBLIC_VAR}</p>
+      <p>Unprefixed var: {ENV.PUBLIC_VAR}</p>
+      <p>Env specific var (via getServerSideProps): {props.envSpecificVar}</p>
+      <p>Has sensitive: {props.hasSensitive ? 'pages-ssr-sensitive-available' : 'X - not available'}</p>
+    </main>
+  );
+}

--- a/framework-tests/frameworks/nextjs/files/pages-router/static-page.tsx
+++ b/framework-tests/frameworks/nextjs/files/pages-router/static-page.tsx
@@ -1,0 +1,27 @@
+import { ENV } from 'varlock/env';
+
+// pages-router build-time data fetching — runs in the prerender worker
+export function getStaticProps() {
+  // we'll check that the sensitive var is redacted
+  console.log('pages-static-secret-log-test:', ENV.SENSITIVE_VAR);
+  return {
+    props: {
+      envSpecificVar: ENV.ENV_SPECIFIC_VAR,
+      hasSensitive: !!ENV.SENSITIVE_VAR,
+    },
+  };
+}
+
+export default function PagesRouterStaticPage(
+  props: { envSpecificVar: string, hasSensitive: boolean },
+) {
+  return (
+    <main>
+      <h1>Varlock Pages Router Static Page</h1>
+      <p>Next prefixed var: {ENV.NEXT_PUBLIC_VAR}</p>
+      <p>Unprefixed var: {ENV.PUBLIC_VAR}</p>
+      <p>Env specific var (via getStaticProps): {props.envSpecificVar}</p>
+      <p>Has sensitive: {props.hasSensitive ? 'pages-static-sensitive-available' : 'X - not available'}</p>
+    </main>
+  );
+}

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -130,12 +130,25 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
         // One dev-server session covers both env file watching behaviors:
         // rewriting the file with identical content must not churn the server,
         // and actually changing the content must reload env and serve the new value.
+        // The same session also covers the pages-router SSR path (getServerSideProps)
+        // and edge middleware, which read env through different code paths.
+        // KNOWN ISSUE: on Next 15 + turbopack, applying the integration's JS loader rule
+        // to edge-context files (middleware) generates a fatal analysis issue in
+        // turbopack's own loader-runner (process.cwd/path.sep are unavailable in the edge
+        // environment), which 500s every page render in dev. Fixed upstream in Next 16.
+        // Until the integration works around it, skip middleware for that combo.
+        const middlewareBreaksDev = nextVersion === 15 && webpackOrTurbo === 'turbopack';
+
         nextEnv.describeDevScenario('dev: extra env file watching', {
           command: devCommand,
           readyPattern: /Ready in|Starting\.\.\./,
           readyTimeout: 40_000,
           templateFiles: {
             'app/page.tsx': 'pages/basic-page.tsx',
+            'pages/pages-ssr.tsx': 'pages-router/ssr-page.tsx',
+            ...!middlewareBreaksDev && {
+              'middleware.ts': 'middleware/middleware.ts',
+            },
           },
           requests: [
             {
@@ -145,6 +158,36 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
                 shouldContain: ['Varlock Framework Test - Next.js', 'env-specific-var--dev'],
               },
             },
+            {
+              label: 'pages-router getServerSideProps reads env at request time',
+              path: '/pages-ssr',
+              bodyAssertions: {
+                shouldContain: [
+                  'Varlock Pages Router SSR Page',
+                  'next-prefixed-public-var',
+                  'unprefixed-public-var',
+                  'env-specific-var--dev',
+                  'pages-ssr-sensitive-available',
+                ],
+                shouldNotContain: ['super-secret-var'],
+              },
+            },
+            ...!middlewareBreaksDev ? [
+              {
+                label: 'edge middleware reads env',
+                path: '/middleware-test',
+                bodyAssertions: {
+                  shouldContain: [
+                    'varlock-middleware-response',
+                    'next-prefixed-public-var',
+                    'unprefixed-public-var',
+                    'env-specific-var--dev',
+                    'middleware-sensitive-available',
+                  ],
+                  shouldNotContain: ['super-secret-var'],
+                },
+              },
+            ] : [],
             {
               label: 'rewrite with unchanged content: does not reload, same value served',
               path: '/',
@@ -168,17 +211,29 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
                 shouldContain: ['Varlock Framework Test - Next.js', 'env-specific-var--dev-updated'],
               },
             },
+            {
+              label: 'pages-router getServerSideProps serves reloaded env value',
+              path: '/pages-ssr',
+              bodyAssertions: {
+                shouldContain: ['Varlock Pages Router SSR Page', 'env-specific-var--dev-updated'],
+              },
+            },
           ],
         });
 
         describe.skipIf(!runBuildScenarios)('output=export', () => {
-          // One build with two routes: a server component page and a client
-          // component page, each asserted against its own output file.
-          nextEnv.describeScenario('static pages (server + client component)', {
+          // One build with three routes: a server component page, a client
+          // component page, and a pages-router page (getStaticProps), each
+          // asserted against its own output file.
+          // NOTE: middleware is not supported with output=export, so it is
+          // only covered in the default output mode scenario below.
+          nextEnv.describeScenario('static pages (server + client component + pages router)', {
             command: buildCommand,
+            expectSuccess: true,
             templateFiles: {
               'app/page.tsx': 'pages/basic-page.tsx',
               'app/client-page/page.tsx': 'pages/client-page.tsx',
+              'pages/pages-static.tsx': 'pages-router/static-page.tsx',
               'next.config.mjs': EXPORT_CONFIG,
             },
             fileAssertions: [
@@ -202,6 +257,16 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
                 ],
               },
               {
+                description: 'pages-router page: env vars are injected via getStaticProps',
+                filePath: 'out/pages-static.html',
+                shouldContain: [
+                  'next-prefixed-public-var',
+                  'unprefixed-public-var',
+                  'env-specific-var--dev',
+                  'pages-static-sensitive-available',
+                ],
+              },
+              {
                 description: 'no secrets or wrong-env values in any static output',
                 fileGlob: 'out/**/*.html',
                 shouldNotContain: [
@@ -213,7 +278,7 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
             outputAssertions: [
               {
                 description: 'secret is redacted from stdout',
-                shouldContain: ['secret-log-test:'],
+                shouldContain: ['secret-log-test:', 'pages-static-secret-log-test:'],
                 shouldNotContain: ['super-secret-var'],
               },
             ],
@@ -254,13 +319,22 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
         });
 
         describe.skipIf(!runBuildScenarios)('default output mode', () => {
-          // One build with two routes: a server component page and a client
-          // component page, each asserted against its own pre-rendered output.
-          nextEnv.describeScenario('static pages (server + client component)', {
+          // Middleware compiles into its own edge bundle; output layout differs by bundler
+          const middlewareOutputGlob = webpackOrTurbo === 'turbopack'
+            ? '.next/server/edge/**/*.js'
+            : '.next/server/middleware.js';
+
+          // One build covering the app router (server + client component),
+          // the pages router (getStaticProps), and edge middleware — each
+          // asserted against its own output file.
+          nextEnv.describeScenario('static pages (server + client component + pages router + middleware)', {
             command: buildCommand,
+            expectSuccess: true,
             templateFiles: {
               'app/page.tsx': 'pages/basic-page.tsx',
               'app/client-page/page.tsx': 'pages/client-page.tsx',
+              'pages/pages-static.tsx': 'pages-router/static-page.tsx',
+              'middleware.ts': 'middleware/middleware.ts',
             },
             fileAssertions: [
               {
@@ -283,6 +357,24 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
                 ],
               },
               {
+                description: 'pages-router page: env vars are injected via getStaticProps',
+                filePath: '.next/server/pages/pages-static.html',
+                shouldContain: [
+                  'next-prefixed-public-var',
+                  'unprefixed-public-var',
+                  'env-specific-var--dev',
+                  'pages-static-sensitive-available',
+                ],
+              },
+              {
+                description: 'middleware bundle: public env vars are inlined',
+                fileGlob: middlewareOutputGlob,
+                shouldContain: [
+                  'varlock-middleware-response',
+                  'unprefixed-public-var',
+                ],
+              },
+              {
                 description: 'no secrets or wrong-env values in any pre-rendered output',
                 fileGlob: '.next/**/*.html',
                 shouldNotContain: [
@@ -299,7 +391,7 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
             outputAssertions: [
               {
                 description: 'secret is redacted from stdout',
-                shouldContain: ['secret-log-test:'],
+                shouldContain: ['secret-log-test:', 'pages-static-secret-log-test:'],
                 shouldNotContain: ['super-secret-var'],
               },
             ],
@@ -326,6 +418,25 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
                 path: 'pages/leaky-page.tsx',
                 prepend: "'use client';",
               },
+            },
+            expectSuccess: false,
+            outputAssertions: [
+              {
+                description: 'output contains leak detection message',
+                shouldContain: ['DETECTED LEAKED SENSITIVE CONFIG'],
+              },
+            ],
+          });
+
+          // A sensitive value passed through getStaticProps leaks into both the
+          // rendered HTML and the __NEXT_DATA__ payload. Needs its own build, so
+          // only run on the newest major to keep the older version jobs fast.
+          nextEnv.describeScenario('leaky pages-router page', {
+            skip: nextVersion < 16,
+            command: buildCommand,
+            templateFiles: {
+              'app/page.tsx': 'pages/basic-page.tsx',
+              'pages/pages-leaky.tsx': 'pages-router/leaky-page.tsx',
             },
             expectSuccess: false,
             outputAssertions: [

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -132,13 +132,8 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
         // and actually changing the content must reload env and serve the new value.
         // The same session also covers the pages-router SSR path (getServerSideProps)
         // and edge middleware, which read env through different code paths.
-        // KNOWN ISSUE: on Next 15 + turbopack, applying the integration's JS loader rule
-        // to edge-context files (middleware) generates a fatal analysis issue in
-        // turbopack's own loader-runner (process.cwd/path.sep are unavailable in the edge
-        // environment), which 500s every page render in dev. Fixed upstream in Next 16.
-        // Until the integration works around it, skip middleware for that combo.
-        const middlewareBreaksDev = nextVersion === 15 && webpackOrTurbo === 'turbopack';
-
+        // NOTE: on Next 15.5 + turbopack this exercises the plugin's conditioned loader
+        // rule (edge files excluded) — middleware env comes through the runtime proxy.
         nextEnv.describeDevScenario('dev: extra env file watching', {
           command: devCommand,
           readyPattern: /Ready in|Starting\.\.\./,
@@ -146,9 +141,7 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
           templateFiles: {
             'app/page.tsx': 'pages/basic-page.tsx',
             'pages/pages-ssr.tsx': 'pages-router/ssr-page.tsx',
-            ...!middlewareBreaksDev && {
-              'middleware.ts': 'middleware/middleware.ts',
-            },
+            'middleware.ts': 'middleware/middleware.ts',
           },
           requests: [
             {
@@ -172,22 +165,20 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
                 shouldNotContain: ['super-secret-var'],
               },
             },
-            ...!middlewareBreaksDev ? [
-              {
-                label: 'edge middleware reads env',
-                path: '/middleware-test',
-                bodyAssertions: {
-                  shouldContain: [
-                    'varlock-middleware-response',
-                    'next-prefixed-public-var',
-                    'unprefixed-public-var',
-                    'env-specific-var--dev',
-                    'middleware-sensitive-available',
-                  ],
-                  shouldNotContain: ['super-secret-var'],
-                },
+            {
+              label: 'edge middleware reads env',
+              path: '/middleware-test',
+              bodyAssertions: {
+                shouldContain: [
+                  'varlock-middleware-response',
+                  'next-prefixed-public-var',
+                  'unprefixed-public-var',
+                  'env-specific-var--dev',
+                  'middleware-sensitive-available',
+                ],
+                shouldNotContain: ['super-secret-var'],
               },
-            ] : [],
+            },
             {
               label: 'rewrite with unchanged content: does not reload, same value served',
               path: '/',

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -141,6 +141,7 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
           templateFiles: {
             'app/page.tsx': 'pages/basic-page.tsx',
             'pages/pages-ssr.tsx': 'pages-router/ssr-page.tsx',
+            'pages/leaky-ssr.tsx': 'pages-router/leaky-ssr-page.tsx',
             'middleware.ts': 'middleware/middleware.ts',
           },
           requests: [
@@ -208,6 +209,24 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
               bodyAssertions: {
                 shouldContain: ['Varlock Pages Router SSR Page', 'env-specific-var--dev-updated'],
               },
+            },
+            {
+              // Runtime leak detection: getServerSideProps leaks a secret at request
+              // time (invisible to build scans). The response scanner fails closed —
+              // the connection is killed mid-stream, so no bytes reach the client.
+              label: 'runtime leak detection blocks secret in SSR response',
+              path: '/leaky-ssr',
+              allowRequestFailure: true,
+              bodyAssertions: {
+                shouldNotContain: ['super-secret-var'],
+              },
+            },
+          ],
+          outputAssertions: [
+            {
+              description: 'runtime secret logs are redacted, leak detection fires, no raw secret in dev logs',
+              shouldContain: ['runtime-secret-log-test:', 'DETECTED LEAKED SENSITIVE CONFIG'],
+              shouldNotContain: ['super-secret-var'],
             },
           ],
         });

--- a/framework-tests/harness/dev-server.ts
+++ b/framework-tests/harness/dev-server.ts
@@ -330,6 +330,13 @@ export async function runDevServer(
         log(`Response: status=${result.status}, body=${result.body.length} bytes`);
         responses.push(result);
       } catch (err) {
+        if (req.allowRequestFailure) {
+          // e.g. runtime leak detection kills the response mid-stream — record a
+          // synthetic result so scenario/log assertions can still run
+          log(`Request failed (allowed): ${(err as Error).message}`);
+          responses.push({ status: 0, body: '' });
+          continue;
+        }
         logError(`Request failed: ${(err as Error).message}`);
         dumpOutput();
         throw err;

--- a/framework-tests/harness/test-fixture.ts
+++ b/framework-tests/harness/test-fixture.ts
@@ -412,8 +412,11 @@ export class FrameworkTestEnv {
         test(testLabel, () => {
           const resp = ctx.result!.responses[i];
           expect(resp, `No response for request ${i} (GET ${req.path})`).toBeDefined();
-          const expectedStatus = req.expectedStatus ?? 200;
-          expect(resp.status, `Expected status ${expectedStatus} for GET ${req.path}, got ${resp.status}`).toBe(expectedStatus);
+          // requests marked allowRequestFailure only assert status when explicitly set
+          if (req.expectedStatus !== undefined || !req.allowRequestFailure) {
+            const expectedStatus = req.expectedStatus ?? 200;
+            expect(resp.status, `Expected status ${expectedStatus} for GET ${req.path}, got ${resp.status}`).toBe(expectedStatus);
+          }
           for (const str of req.bodyAssertions?.shouldContain ?? []) {
             expect(resp.body, `Response body should contain "${str}"`).toContain(str);
           }

--- a/framework-tests/harness/types.ts
+++ b/framework-tests/harness/types.ts
@@ -153,6 +153,13 @@ export interface DevServerRequest {
    * config file dependency changes) or HMR updates where the server doesn't restart.
    */
   fileEditDelay?: number;
+  /**
+   * Tolerate a network-level request failure (e.g. the server killing the response
+   * mid-stream when runtime leak detection fires). Records status 0 with an empty
+   * body instead of failing the scenario. When set, the status assertion is skipped
+   * unless `expectedStatus` is set explicitly.
+   */
+  allowRequestFailure?: boolean;
 }
 
 /** Result of a single HTTP request to the dev server */

--- a/packages/integrations/nextjs/src/loader.ts
+++ b/packages/integrations/nextjs/src/loader.ts
@@ -39,6 +39,10 @@ const MIDDLEWARE_FILE_RE = /(?:^|[\\/])middleware\.(?:ts|js|mts|mjs)$/;
 // captures the directive block so we can inject code after it
 const DIRECTIVE_PROLOGUE_RE = /^((?:[^\S\n]*\/\/[^\n]*\n|[^\S\n]*\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/[^\S\n]*\n|[^\S\n]*\n)*[^\S\n]*['"]use (?:server|client|strict)['"][^\S\n]*;?[^\S\n]*\n?)/;
 
+// rough check for ES module syntax (a line starting with import/export) — used to decide
+// whether the injected init guard can use import statements instead of require()
+const ESM_SYNTAX_RE = /^[^\S\n]*(?:import|export)\b/m;
+
 // the loader runs for every project file, so cache the env graph parse
 // (keyed on the raw string — env reloads produce a new string)
 let cachedRawEnv: string | undefined;
@@ -120,17 +124,33 @@ function webpackLoader(this: LoaderContext, source: string) {
       // which the init-edge bundle exposes. The init guard is skipped since edge init
       // is handled by the runtime file injection (processAssets hook).
       initGuard = 'if(globalThis.__varlockPatchConsole)globalThis.__varlockPatchConsole();';
+      result = prependAfterDirectives(result, initGuard);
+    } else if (isWebpack && ESM_SYNTAX_RE.test(source)) {
+      // Webpack compiles pages-router files in the "pages layer", which keeps
+      // node_modules external — and since varlock is ESM-only, an injected
+      // require() of it is a webpack build error (import-esm-externals).
+      // For ES modules we inject import statements instead: imports hoist, so
+      // evaluation order is the same as the require() version (user imports
+      // still evaluate first, guard runs before any module statements).
+      initGuard = [
+        'import {initVarlockEnv as __varlock$init} from \'varlock/env\';',
+        'import {patchGlobalConsole as __varlock$patchConsole} from \'varlock/patch-console\';',
+        'if(!globalThis.__varlockBuildInit){globalThis.__varlockBuildInit=true;__varlock$init();__varlock$patchConsole();}',
+        // React wraps console for RSC dev replay AFTER our initial patch in the
+        // runtime file. Re-patching outside the once-guard ensures our redaction
+        // wraps React's wrapper so secrets are redacted before React captures them.
+        // patchGlobalConsole() no-ops if console.log still has _varlockPatchedFn.
+        '__varlock$patchConsole();',
+      ].join('');
+      result = prependAfterDirectives(result, initGuard);
     } else {
       initGuard = 'if(!globalThis.__varlockBuildInit){globalThis.__varlockBuildInit=true;require(\'varlock/env\').initVarlockEnv();require(\'varlock/patch-console\').patchGlobalConsole();}';
-      // When used from webpack, React wraps console for RSC dev replay AFTER our initial
-      // patch in the runtime file. Re-patching outside the once-guard ensures our redaction
-      // wraps React's wrapper so secrets are redacted before React captures them.
-      // patchGlobalConsole() no-ops if console.log still has _varlockPatchedFn.
+      // (see comment above about re-patching console for webpack RSC dev replay)
       if (isWebpack) {
         initGuard += 'require(\'varlock/patch-console\').patchGlobalConsole();';
       }
+      result = prependAfterDirectives(result, initGuard);
     }
-    result = prependAfterDirectives(result, initGuard);
   }
 
   // static replacements for non-sensitive env vars

--- a/packages/integrations/nextjs/src/plugin.ts
+++ b/packages/integrations/nextjs/src/plugin.ts
@@ -52,6 +52,22 @@ if (IS_TURBOPACK && varlockSettings.preventLeaks) {
   });
 }
 
+function getNextVersion(): [number, number] {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const version: string = require('next/package.json').version;
+    const [major, minor] = version.split('.').map((part) => parseInt(part, 10));
+    return [major || 0, minor || 0];
+  } catch {
+    return [0, 0];
+  }
+}
+
+function hasMiddlewareFile(): boolean {
+  return ['middleware.ts', 'middleware.js', 'src/middleware.ts', 'src/middleware.js']
+    .some((f) => fs.existsSync(path.resolve(process.cwd(), f)));
+}
+
 const IS_WORKER = !!process.env.NEXT_PRIVATE_WORKER;
 function debug(...args: Array<any>) {
   if (!process.env.DEBUG_VARLOCK_NEXT_INTEGRATION) return;
@@ -326,7 +342,27 @@ export function varlockNextConfigPlugin(_pluginOptions?: VarlockPluginOptions) {
           ],
         };
         turbopackConfig.rules ||= {};
-        turbopackConfig.rules['*.{js,jsx,ts,tsx,mjs,mts}'] = loaderRule;
+
+        // On Next 15, applying JS loaders to edge-context files (middleware, edge routes)
+        // triggers a fatal analysis issue in turbopack's own loader-runner (it uses
+        // process.cwd/path.sep, which don't exist in the edge environment), and every dev
+        // page render 500s. Next 15.5 added per-condition rules, so we scope the loader to
+        // node + browser contexts there — edge files read env through the runtime ENV
+        // proxy instead (env is available in the edge sandbox), they just lose static
+        // inlining. Next 16 fixed the underlying analysis, so it keeps the flat rule
+        // (edge files still need the loader for inlining during turbopack builds).
+        const [nextMajor, nextMinor] = getNextVersion();
+        if (nextMajor === 15 && nextMinor >= 5) {
+          turbopackConfig.rules['*.{js,jsx,ts,tsx,mjs,mts}'] = { node: loaderRule, browser: loaderRule };
+        } else {
+          turbopackConfig.rules['*.{js,jsx,ts,tsx,mjs,mts}'] = loaderRule;
+          if (nextMajor === 15 && hasMiddlewareFile()) {
+            console.warn(
+              '[varlock] ⚠️ middleware + `next dev --turbopack` breaks page rendering on Next 15.0-15.4 '
+              + '(turbopack cannot apply JS loaders to edge files). Upgrade to next@^15.5, or run dev without --turbopack.',
+            );
+          }
+        }
 
         // Turbopack can't resolve symlinked packages (e.g. link: or workspace: installs).
         // If varlock is symlinked, we copy dist files into node_modules/.varlock/ as real

--- a/packages/varlock-website/src/content/docs/integrations/nextjs.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/nextjs.mdx
@@ -375,8 +375,8 @@ Almost all setup issues come down to the `@next/env` override not being applied.
   - Re-run your package manager's install command, then re-verify the banner.
 - ❌ `Error [ERR_REQUIRE_ESM]: require() of ES Module ...`
   <br/>💡 Varlock requires node v22 or higher - which has better CJS/ESM interoperability
-- ❌ Every page 500s in dev with a `[turbopack-node]/transforms/transforms.ts ... lint TP1006` error, but only when the project has a `middleware.ts` file (Next 15 + Turbopack only)
-  <br/>💡 Next 15's Turbopack cannot apply JS loaders (which varlock uses) to edge-context files like middleware without breaking dev page rendering. This is fixed upstream in Next 16 — upgrade to Next 16, or run `next dev` without `--turbopack`.
+- ❌ Every page 500s in dev with a `[turbopack-node]/transforms/transforms.ts ... lint TP1006` error, but only when the project has a `middleware.ts` file (Next 15.0–15.4 + Turbopack)
+  <br/>💡 Turbopack on those versions cannot apply JS loaders (which varlock uses) to edge-context files like middleware without breaking dev page rendering. Upgrade to `next@^15.5` (where varlock scopes its loader away from edge files automatically) or Next 16 (which fixed the underlying issue), or run `next dev` without `--turbopack`.
 - ❌ `Property 'SOMEVAR' does not exist on type 'TypedEnvSchema'`
   <br/>💡 If the item does exist in your schema, then the generated types are not being loaded properly by TypeScript
   - make sure the [`@generateTypes` root decorator](/reference/root-decorators/#generatetypes) is enabled

--- a/packages/varlock-website/src/content/docs/integrations/nextjs.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/nextjs.mdx
@@ -375,6 +375,8 @@ Almost all setup issues come down to the `@next/env` override not being applied.
   - Re-run your package manager's install command, then re-verify the banner.
 - ❌ `Error [ERR_REQUIRE_ESM]: require() of ES Module ...`
   <br/>💡 Varlock requires node v22 or higher - which has better CJS/ESM interoperability
+- ❌ Every page 500s in dev with a `[turbopack-node]/transforms/transforms.ts ... lint TP1006` error, but only when the project has a `middleware.ts` file (Next 15 + Turbopack only)
+  <br/>💡 Next 15's Turbopack cannot apply JS loaders (which varlock uses) to edge-context files like middleware without breaking dev page rendering. This is fixed upstream in Next 16 — upgrade to Next 16, or run `next dev` without `--turbopack`.
 - ❌ `Property 'SOMEVAR' does not exist on type 'TypedEnvSchema'`
   <br/>💡 If the item does exist in your schema, then the generated types are not being loaded properly by TypeScript
   - make sure the [`@generateTypes` root decorator](/reference/root-decorators/#generatetypes) is enabled

--- a/packages/varlock/src/runtime/crypto.ts
+++ b/packages/varlock/src/runtime/crypto.ts
@@ -17,10 +17,17 @@ import type * as NodeCrypto from 'node:crypto';
 let cachedNodeCrypto: typeof NodeCrypto | undefined;
 function getNodeCrypto(): typeof NodeCrypto {
   if (!cachedNodeCrypto) {
-    cachedNodeCrypto = (globalThis as any).process?.getBuiltinModule?.('node:crypto')
-      // fallback for CJS bundles running on node < 22.3 (no process.getBuiltinModule)
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      ?? (typeof require === 'function' ? require('node:crypto') : undefined);
+    cachedNodeCrypto = (globalThis as any).process?.getBuiltinModule?.('node:crypto');
+    if (!cachedNodeCrypto) {
+      try {
+        // fallback for CJS bundles running on node < 22.3 (no process.getBuiltinModule)
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        cachedNodeCrypto = typeof require === 'function' ? require('node:crypto') : undefined;
+      } catch {
+        // bundlers may replace require with a shim that throws instead of resolving —
+        // swallow so the clear error below is what surfaces
+      }
+    }
     if (!cachedNodeCrypto) {
       throw new Error('[varlock] node:crypto is not available in this runtime — use decryptEnvBlobAsync instead');
     }

--- a/packages/varlock/src/runtime/crypto.ts
+++ b/packages/varlock/src/runtime/crypto.ts
@@ -4,11 +4,29 @@
  * Uses AES-256-GCM with a 12-byte random IV.
  * Encrypted format: "varlock:v1:" + base64(iv[12] + ciphertext + authTag[16])
  *
- * Sync versions use Node.js `node:crypto` (build-time + init-server).
- * Async version uses Web Crypto API (init-edge, where node:crypto is unavailable).
+ * Sync versions use Node.js `node:crypto` (loaded lazily — see getNodeCrypto below).
+ * Async version uses Web Crypto API, for runtimes without node:crypto.
  */
 
-import crypto from 'node:crypto';
+import type * as NodeCrypto from 'node:crypto';
+
+// node:crypto is loaded lazily so that merely evaluating this module doesn't touch node
+// builtins — the self-contained init bundles (init-server/init-edge) include this file and
+// can get evaluated inside edge sandboxes (e.g. Next.js dev middleware) where an eager
+// require('crypto') throws, even when nothing ever gets encrypted/decrypted
+let cachedNodeCrypto: typeof NodeCrypto | undefined;
+function getNodeCrypto(): typeof NodeCrypto {
+  if (!cachedNodeCrypto) {
+    cachedNodeCrypto = (globalThis as any).process?.getBuiltinModule?.('node:crypto')
+      // fallback for CJS bundles running on node < 22.3 (no process.getBuiltinModule)
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      ?? (typeof require === 'function' ? require('node:crypto') : undefined);
+    if (!cachedNodeCrypto) {
+      throw new Error('[varlock] node:crypto is not available in this runtime — use decryptEnvBlobAsync instead');
+    }
+  }
+  return cachedNodeCrypto;
+}
 
 const ENCRYPTED_PREFIX = 'varlock:v1:';
 const IV_LENGTH = 12;
@@ -36,6 +54,7 @@ function hexToBytes(hex: string): Uint8Array {
 // -- Sync (Node.js node:crypto) ------------------------------------------
 
 export function encryptEnvBlobSync(json: string, hexKey: string): string {
+  const crypto = getNodeCrypto();
   validateHexKey(hexKey);
   const keyBytes = hexToBytes(hexKey);
   const iv = crypto.randomBytes(IV_LENGTH);
@@ -47,6 +66,7 @@ export function encryptEnvBlobSync(json: string, hexKey: string): string {
 }
 
 export function decryptEnvBlobSync(encrypted: string, hexKey: string): string {
+  const crypto = getNodeCrypto();
   validateHexKey(hexKey);
   if (!isEncryptedBlob(encrypted)) {
     throw new Error('[varlock] expected encrypted blob with varlock:v1: prefix');
@@ -97,5 +117,5 @@ export async function decryptEnvBlobAsync(encrypted: string, hexKey: string): Pr
 // -- Key generation -------------------------------------------------------
 
 export function generateEncryptionKeyHex(): string {
-  return (crypto.randomBytes(32) as Buffer).toString('hex');
+  return (getNodeCrypto().randomBytes(32) as Buffer).toString('hex');
 }

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -256,10 +256,35 @@ export function scanForLeaks(
 
 // --------------
 
-let initializedEnv = false;
-let configHasErrors = false;
-const envValues = {} as Record<string, any>;
-export const varlockSettings = {} as Record<string, any>;
+// Like the redaction state above, env state lives on globalThis so all module instances
+// share it. Bundlers can create multiple copies of this module in one process (e.g. Next.js
+// bundles it into the app-router server code AND the pages-router code, while @next/env
+// uses the node_modules copy) — env loads/reloads happen via one instance and ENV reads
+// via another, so instance-local state would go stale or appear uninitialized.
+type EnvState = {
+  initialized: boolean,
+  configHasErrors: boolean,
+  // NOTE: these objects are mutated in place, never replaced — module instances
+  // capture references to them at load time
+  values: Record<string, any>,
+  settings: Record<string, any>,
+};
+const ENV_STATE_KEY = '__varlockEnvState';
+function getEnvState(): EnvState {
+  if (!(globalThis as any)[ENV_STATE_KEY]) {
+    (globalThis as any)[ENV_STATE_KEY] = {
+      initialized: false,
+      configHasErrors: false,
+      values: {},
+      settings: {},
+    } satisfies EnvState;
+  }
+  return (globalThis as any)[ENV_STATE_KEY];
+}
+
+const envState = getEnvState();
+const envValues = envState.values;
+export const varlockSettings = envState.settings;
 
 const processExists = !!globalThis.process;
 const originalProcessEnv = { ...processExists && process.env };
@@ -268,13 +293,13 @@ let varlockInjectedProcessEnvKeys: Array<string> | undefined;
 export function initVarlockEnv(opts?: {
   allowFail?: boolean,
 }) {
-  debug('⚡️ INIT VARLOCK ENV!', initializedEnv, !!(globalThis as any).__varlockLoadedEnv, !!globalThis.process?.env.__VARLOCK_ENV);
+  debug('⚡️ INIT VARLOCK ENV!', envState.initialized, !!(globalThis as any).__varlockLoadedEnv, !!globalThis.process?.env.__VARLOCK_ENV);
 
   // normally we can just bail if we detect we are in the browser
   // however when front-end related tests, it may appear that we are in the browser but it is not
   // also some frameworks inject a process polyfill, others do not
   if (isBrowser && !globalThis.process?.env.__VARLOCK_ENV) {
-    initializedEnv = true;
+    envState.initialized = true;
     return;
   }
 
@@ -300,7 +325,7 @@ export function initVarlockEnv(opts?: {
     throw new Error('initVarlockEnv failed');
   }
   Object.assign(varlockSettings, serializedEnvData.settings);
-  configHasErrors = !!(serializedEnvData as any).errors;
+  envState.configHasErrors = !!(serializedEnvData as any).errors;
   resetRedactionMap(serializedEnvData);
 
   const setProcessEnv = processExists && !serializedEnvData.settings?.disableProcessEnvInjection;
@@ -324,13 +349,13 @@ export function initVarlockEnv(opts?: {
       process.env[itemKey] = itemValue === undefined ? '' : String(itemValue);
     }
   }
-  initializedEnv = true;
+  envState.initialized = true;
 }
 
 // we will attempt to call initVarlockEnv automatically, but in most cases it should be called explicitly
 // note that if this is being imported in the browser, process.env may not exist, so we do this in a try/catch
 try {
-  if (!initializedEnv) {
+  if (!envState.initialized) {
     // if we are automatically loading because __VARLOCK_ENV is already set
     // then we assume process.env vars have also already been set (although might not harm anything?)
     initVarlockEnv({ allowFail: true });
@@ -366,14 +391,14 @@ const EnvProxy = new Proxy<TypedEnvSchema>({}, {
     // special cases to avoid throwing on invalid keys
     if (IGNORED_PROXY_KEYS.includes(prop)) return;
 
-    if (!initializedEnv) {
+    if (!envState.initialized) {
       throw new Error(
         'varlock ENV not initialized — make sure varlock is set up correctly.\n'
         + 'See https://varlock.dev/docs/get-started for setup instructions.',
       );
     }
 
-    if (configHasErrors) {
+    if (envState.configHasErrors) {
       // eslint-disable-next-line no-console
       console.error(`[varlock] ⚠️ ENV.${prop} accessed but config has errors — values may be missing or incorrect`);
       return undefined;

--- a/packages/varlock/src/runtime/patch-server-response.ts
+++ b/packages/varlock/src/runtime/patch-server-response.ts
@@ -69,26 +69,25 @@ export function patchGlobalServerResponse(opts?: {
       chunkType = 'encoded';
       const decoder = new TextDecoder();
       chunkStr = decoder.decode(rawChunk);
-    } else if (compressionType === 'gzip') {
+    } else if (compressionType === 'gzip' || compressionType === 'deflate') {
       chunkType = 'gzip';
-      // first chunk of data contains only compression headers
-      if (!(this as any)._zlibChunks) {
-        // (this as any)._zlibHeadersChunk = rawChunk;
-        (this as any)._zlibChunks = [rawChunk];
-      } else {
-        // TODO: figure out how we can unzip one chunk at a time instead of storing everything
-        (this as any)._zlibChunks?.push(rawChunk);
-        try {
-          const unzippedChunk = zlib.unzipSync(Buffer.concat((this as any)._zlibChunks || []), {
-            flush: zlib.constants.Z_SYNC_FLUSH,
-            finishFlush: zlib.constants.Z_SYNC_FLUSH,
-          });
-          const fullUnzippedData = unzippedChunk.toString('utf-8');
-          chunkStr = fullUnzippedData.substring((this as any)._lastChunkEndIndex || 0);
-          (this as any)._lastChunkEndIndex = fullUnzippedData.length;
-        } catch (err) {
-          // console.log('error unzipping chunk', err);
-        }
+      // TODO: figure out how we can unzip one chunk at a time instead of storing everything
+      (this as any)._zlibChunks ||= [];
+      (this as any)._zlibChunks.push(rawChunk);
+      // NOTE - we must attempt to decode from the very FIRST chunk: small responses
+      // arrive as a single complete gzip chunk, so skipping it means never scanning
+      // at all (and browsers always send Accept-Encoding: gzip). A genuinely partial
+      // stream fails to decode here and gets scanned once more chunks arrive.
+      try {
+        const unzippedChunk = zlib.unzipSync(Buffer.concat((this as any)._zlibChunks || []), {
+          flush: zlib.constants.Z_SYNC_FLUSH,
+          finishFlush: zlib.constants.Z_SYNC_FLUSH,
+        });
+        const fullUnzippedData = unzippedChunk.toString('utf-8');
+        chunkStr = fullUnzippedData.substring((this as any)._lastChunkEndIndex || 0);
+        (this as any)._lastChunkEndIndex = fullUnzippedData.length;
+      } catch (err) {
+        // partial gzip data that doesn't decode yet — scanned when more chunks arrive
       }
     }
     // TODO: we may want to support other compression schemes? but currently only used in nextjs which is using gzip
@@ -109,13 +108,11 @@ export function patchGlobalServerResponse(opts?: {
             const encoder = new TextEncoder();
             args[0] = encoder.encode(chunkStr);
           } else if (chunkType === 'gzip') {
-            // currently unable to scrub gzip chunks
-            // this works sometimes, but othertimes causes decoding error
-            // we'll need to pass through chunks from a new gzip stream, because we don't have access to the underlying one
-            // args[0] = zlib.gzipSync(chunkStr, {
-            //   flush: zlib.constants.Z_SYNC_FLUSH,
-            //   finishFlush: zlib.constants.Z_SYNC_FLUSH,
-            // });
+            // we can't reliably scrub inside a compressed stream (re-gzipping a single
+            // chunk corrupts the stream state), so fail closed — killing the response
+            // beats serving the secret, even in dev
+            // TODO: pass chunks through our own gzip stream so we can scrub + re-encode
+            throw err;
           } else {
             throw new Error(`unable to scrub - unknown chunk type ${chunkType}`);
           }


### PR DESCRIPTION
Adds pages-router, middleware, and runtime leak-detection coverage to the Next.js framework test suite. The new coverage exposed five real bugs, all fixed here.

## New coverage

- **Pages router (`getStaticProps`)** page added to the existing merged "static pages" build scenarios (default + export output modes), with per-route file assertions (`.next/server/pages/*.html` / `out/*.html`) and stdout redaction of a secret logged during pre-render — no extra builds
- **Edge middleware** added to the default-output build scenario, asserting public env vars are inlined into the middleware bundle (per-bundler output paths)
- **Dev scenario** now also exercises pages-router SSR (`getServerSideProps`), middleware, env values after a reload, and **runtime leak detection**: a page leaks `ENV.SENSITIVE_VAR` via `getServerSideProps` at request time (invisible to build scans) and the tests assert the response is blocked, runtime console logs come out redacted, and no raw secret appears in dev output
- One new expected-failure build: a sensitive value passed through `getStaticProps` leaks into HTML/`__NEXT_DATA__` (v16+ only)
- Harness: `allowRequestFailure` for requests that die mid-stream when leak detection kills the response

Suite runtime stays in budget (~110s / ~87s / ~55s for v16/v15/v14 locally). Also verified against next@canary, `next start` prod runtime (both bundlers + encrypted env), and a real Vercel deployment (remote build + build-log redaction).

## Bugs exposed & fixed

1. **Runtime leak detection was bypassed by gzip** (`patch-server-response.ts`) — the response scanner skipped the first gzip chunk assuming it only held compression headers, but small responses arrive as a single complete chunk, so gzipped responses were never scanned at all. Browsers always send `Accept-Encoding: gzip`, meaning request-time leaks reached real clients unscanned (plain-text clients like curl were correctly blocked, which is how this stayed hidden). Scanning now starts at the first chunk, and compressed chunks that can't be scrubbed fail closed. Found because the harness's undici requests send `Accept-Encoding: gzip`.
2. **webpack + pages router builds failed outright** (`loader.ts`) — the injected init guard uses `require('varlock/env')`, but webpack's pages layer keeps node_modules external and varlock is ESM-only. ES modules now get an import-based guard (imports hoist, so evaluation order is unchanged).
3. **Stale env after reload in turbopack dev pages-router SSR** (`env.ts`) — the pages-router bundle carries its own copy of `varlock/env` whose values never refreshed. Env runtime state now lives on `globalThis`, shared across module instances (same pattern as the existing redaction state).
4. **Middleware crashed webpack dev with `Native module not found: crypto`** (`crypto.ts`) — the injected `init-edge` bundle eagerly required node crypto. Now loaded lazily via `process.getBuiltinModule` (guarded `require` fallback for CJS bundles on node < 22.3). Real-deployment testing (#862) showed this fix matters even more than dev: **Vercel's edge bundle analyzer hard-rejects the published package's eager require, so middleware apps currently cannot deploy to Vercel at all** (`Edge Function "_middleware" is referencing unsupported modules: crypto`); with the lazy load, deploys pass and middleware works on their Edge runtime.
5. **Middleware broke every dev page render on Next 15 + turbopack** (`plugin.ts`) — turbopack's analysis of its own loader-runner fails under the edge environment. On Next 15.5+ the loader rule uses per-condition scoping (`{ node, browser }`) so edge files are excluded — pages render, middleware gets full env via the runtime proxy, client-component inlining is preserved. Next 16 fixed the underlying analysis and keeps the flat rule; 15.0–15.4 get an actionable warning plus a docs troubleshooting entry.
