### PR TITLE
runtime hardening before release: br/zstd leak scanning, shared process.env bookkeeping, lazy-crypto fixes

### DIFF
--- a/.bumpy/runtime-leak-scan-gzip.md
+++ b/.bumpy/runtime-leak-scan-gzip.md
@@ -2,4 +2,6 @@
 varlock: patch
 ---
 
-Runtime leak detection now catches secrets in compressed responses: gzipped responses that fit in a single chunk (i.e. most pages) were never scanned, so browsers — which always send `Accept-Encoding: gzip` — could receive leaked sensitive values the scanner should have blocked. Compressed chunks that can't be scrubbed now fail closed instead of passing through
+Runtime leak detection now catches secrets in compressed responses: gzipped responses that fit in a single chunk (i.e. most pages) were never scanned, so browsers — which always send `Accept-Encoding: gzip` — could receive leaked sensitive values the scanner should have blocked. Brotli and zstd responses are now scanned too, and compressed chunks containing a leak fail closed (the response is killed) instead of passing through.
+
+Note: since most browser traffic previously bypassed the scanner, an app with an existing undetected leak will start seeing those responses blocked after upgrading — look for `DETECTED LEAKED SENSITIVE CONFIG` in server logs, which names the offending config key.

--- a/.bumpy/runtime-shared-state-lazy-crypto.md
+++ b/.bumpy/runtime-shared-state-lazy-crypto.md
@@ -2,4 +2,4 @@
 varlock: patch
 ---
 
-Runtime fixes: env state is now shared across bundled copies of `varlock/env` (fixes stale values after env reloads when a bundler duplicates the module), and `node:crypto` is loaded lazily — with encrypted env blobs decrypting via WebCrypto on edge runtimes that lack it entirely (e.g. Vercel Edge)
+Runtime fixes: env state is now shared across bundled copies of `varlock/env` (fixes stale values after env reloads when a bundler duplicates the module, including cleanup of `process.env` keys removed between reloads), and `node:crypto` is loaded lazily — with encrypted env blobs decrypting via WebCrypto on edge runtimes that lack it entirely (e.g. Vercel Edge). Minimum supported Node version is now 22.3.

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -221,6 +221,19 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
                 shouldNotContain: ['super-secret-var'],
               },
             },
+            {
+              // The fail-closed kill must only affect that one response — the dev
+              // server has to keep serving afterwards. The gzip header assertion
+              // pins that responses actually flow through the compressed scan path
+              // (the leak scanner decodes gzip; if dev ever stopped compressing,
+              // the leak scenario above would silently degrade to the plaintext path).
+              label: 'dev server still serves (gzipped) after leak detection kills a response',
+              path: '/pages-ssr',
+              headerAssertions: { 'content-encoding': 'gzip' },
+              bodyAssertions: {
+                shouldContain: ['Varlock Pages Router SSR Page'],
+              },
+            },
           ],
           outputAssertions: [
             {

--- a/framework-tests/harness/dev-server.ts
+++ b/framework-tests/harness/dev-server.ts
@@ -58,7 +58,7 @@ async function fetchWithRetry(
     try {
       const resp = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
       const body = await resp.text();
-      return { status: resp.status, body };
+      return { status: resp.status, body, headers: Object.fromEntries(resp.headers.entries()) };
     } catch {
       if (i < retries - 1) {
         await new Promise<void>((r) => {
@@ -70,7 +70,7 @@ async function fetchWithRetry(
   // final attempt — let it throw
   const resp = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
   const body = await resp.text();
-  return { status: resp.status, body };
+  return { status: resp.status, body, headers: Object.fromEntries(resp.headers.entries()) };
 }
 
 /**
@@ -334,7 +334,7 @@ export async function runDevServer(
           // e.g. runtime leak detection kills the response mid-stream — record a
           // synthetic result so scenario/log assertions can still run
           log(`Request failed (allowed): ${(err as Error).message}`);
-          responses.push({ status: 0, body: '' });
+          responses.push({ status: 0, body: '', headers: {} });
           continue;
         }
         logError(`Request failed: ${(err as Error).message}`);

--- a/framework-tests/harness/test-fixture.ts
+++ b/framework-tests/harness/test-fixture.ts
@@ -423,6 +423,14 @@ export class FrameworkTestEnv {
           for (const str of req.bodyAssertions?.shouldNotContain ?? []) {
             expect(resp.body, `Response body should NOT contain "${str}"`).not.toContain(str);
           }
+          for (const [headerName, expected] of Object.entries(req.headerAssertions ?? {})) {
+            const actual = resp.headers[headerName];
+            if (expected instanceof RegExp) {
+              expect(actual, `Header "${headerName}" should match ${expected}`).toMatch(expected);
+            } else {
+              expect(actual, `Header "${headerName}" should be "${expected}"`).toBe(expected);
+            }
+          }
         });
       }
 

--- a/framework-tests/harness/types.ts
+++ b/framework-tests/harness/types.ts
@@ -141,6 +141,11 @@ export interface DevServerRequest {
     shouldNotContain?: Array<string>;
   };
   /**
+   * Assertions on response headers (keys are lowercase header names).
+   * String values assert an exact match, RegExp values a pattern match.
+   */
+  headerAssertions?: Record<string, string | RegExp>;
+  /**
    * Files to write before this request (triggers env reload / server restart).
    * Keys are paths relative to project root, values are file content.
    * After writing, waits for the server's readyPattern to appear again before making the request.
@@ -166,6 +171,8 @@ export interface DevServerRequest {
 export interface DevServerRequestResult {
   status: number;
   body: string;
+  /** response headers, lowercase keys */
+  headers: Record<string, string>;
 }
 
 /** Configuration for a dev server scenario */

--- a/packages/varlock/package.json
+++ b/packages/varlock/package.json
@@ -60,7 +60,7 @@
     "varlock": "./bin/cli.js"
   },
   "engines": {
-    "node": ">=22",
+    "node": ">=22.3.0",
     "bun": ">=1.3.3"
   },
   "dependencies": {},

--- a/packages/varlock/src/runtime/crypto.ts
+++ b/packages/varlock/src/runtime/crypto.ts
@@ -88,9 +88,8 @@ export function decryptEnvBlobSync(encrypted: string, hexKey: string): string {
 }
 
 // -- Async (Web Crypto API, edge-compatible) ------------------------------
-// Currently unused — all init paths use the sync version since every major edge
-// runtime now supports node:crypto (Vercel Edge, Cloudflare with nodejs_compat, Deno).
-// Kept as a public export in case consumers need to decrypt in a pure Web Crypto context.
+// Used by init-edge as the fallback on runtimes with no node:crypto at all
+// (e.g. Vercel Edge). Also a public export for pure Web Crypto contexts.
 
 export async function decryptEnvBlobAsync(encrypted: string, hexKey: string): Promise<string> {
   validateHexKey(hexKey);

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -268,7 +268,14 @@ type EnvState = {
   // capture references to them at load time
   values: Record<string, any>,
   settings: Record<string, any>,
+  /** snapshot of process.env before any varlock injection (captured by the first instance to load) */
+  originalProcessEnv: Record<string, string | undefined>,
+  /** keys injected into process.env by the last init/reload (undefined = never injected) */
+  injectedProcessEnvKeys: Array<string> | undefined,
 };
+
+const processExists = !!globalThis.process;
+
 const ENV_STATE_KEY = '__varlockEnvState';
 function getEnvState(): EnvState {
   if (!(globalThis as any)[ENV_STATE_KEY]) {
@@ -277,18 +284,20 @@ function getEnvState(): EnvState {
       configHasErrors: false,
       values: {},
       settings: {},
+      originalProcessEnv: { ...processExists && process.env },
+      injectedProcessEnvKeys: undefined,
     } satisfies EnvState;
   }
-  return (globalThis as any)[ENV_STATE_KEY];
+  const state: EnvState = (globalThis as any)[ENV_STATE_KEY];
+  // the state object may have been created by an older copy of this module that
+  // didn't track process.env injection — fill in what we can
+  state.originalProcessEnv ||= { ...processExists && process.env };
+  return state;
 }
 
 const envState = getEnvState();
 const envValues = envState.values;
 export const varlockSettings = envState.settings;
-
-const processExists = !!globalThis.process;
-const originalProcessEnv = { ...processExists && process.env };
-let varlockInjectedProcessEnvKeys: Array<string> | undefined;
 
 export function initVarlockEnv(opts?: {
   allowFail?: boolean,
@@ -335,22 +344,30 @@ export function initVarlockEnv(opts?: {
   envState.configHasErrors = !!(serializedEnvData as any).errors;
   resetRedactionMap(serializedEnvData);
 
+  // on reload, drop values for keys no longer in the config (deleted in place —
+  // module instances hold references to the values object)
+  for (const staleKey of Object.keys(envValues)) {
+    if (!(staleKey in serializedEnvData.config)) delete envValues[staleKey];
+  }
+
   const setProcessEnv = processExists && !serializedEnvData.settings?.disableProcessEnvInjection;
 
   // if we've already injected process.env vars in the past, we'll reset those now
+  // (injection bookkeeping lives on the shared state so a reload flowing through a
+  // different module instance than the one that injected still cleans up removed keys)
   if (setProcessEnv) {
-    if (varlockInjectedProcessEnvKeys) {
-      for (const key of varlockInjectedProcessEnvKeys) delete process.env[key];
-      for (const key of Object.keys(originalProcessEnv)) process.env[key] = originalProcessEnv[key];
+    if (envState.injectedProcessEnvKeys) {
+      for (const key of envState.injectedProcessEnvKeys) delete process.env[key];
+      for (const key of Object.keys(envState.originalProcessEnv)) process.env[key] = envState.originalProcessEnv[key];
     }
-    varlockInjectedProcessEnvKeys = [];
+    envState.injectedProcessEnvKeys = [];
   }
 
   for (const itemKey in serializedEnvData.config) {
     const itemValue = serializedEnvData.config[itemKey].value;
     envValues[itemKey] = itemValue;
     if (setProcessEnv) {
-      varlockInjectedProcessEnvKeys?.push(itemKey);
+      envState.injectedProcessEnvKeys?.push(itemKey);
       // when re-injecting into process.env, we treat undefined as empty string
       // this more closely matches expected behaviour from other .env loaders
       process.env[itemKey] = itemValue === undefined ? '' : String(itemValue);

--- a/packages/varlock/src/runtime/init-edge.ts
+++ b/packages/varlock/src/runtime/init-edge.ts
@@ -100,6 +100,11 @@ if (rawEnvBlob && isEncryptedBlob(rawEnvBlob)) {
       } catch { /* frozen process.env — the globalThis channel covers init */ }
       initNow();
     });
+    // mark rejections handled so a bad key / corrupt blob doesn't surface as an
+    // unhandled rejection (fatal on some edge runtimes) before any request runs —
+    // gated handlers still await `ready` and surface the real error per-request
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    ready.catch(() => {});
     (globalThis as any).__varlockEnvReady = ready;
     gateEdgeEntriesUntilReady(ready);
   }

--- a/packages/varlock/src/runtime/patch-server-response.ts
+++ b/packages/varlock/src/runtime/patch-server-response.ts
@@ -9,6 +9,32 @@ import { debug } from './lib/debug';
 
 // NOTE - previously was using a symbol but got weird because of multiple builds and contexts...
 const patchedKey = '_patchedByVarlock';
+
+/**
+ * Returns a sync decompressor for a Content-Encoding value, or undefined if unsupported.
+ * Each decompressor must tolerate truncated input (returning whatever prefix is decodable,
+ * or throwing) so responses can be scanned incrementally as chunks arrive.
+ */
+function getDecompressor(encoding: string): ((buf: Buffer) => Buffer) | undefined {
+  if (encoding === 'gzip' || encoding === 'deflate') {
+    return (buf) => zlib.unzipSync(buf, {
+      flush: zlib.constants.Z_SYNC_FLUSH,
+      finishFlush: zlib.constants.Z_SYNC_FLUSH,
+    });
+  }
+  if (encoding === 'br') {
+    return (buf) => zlib.brotliDecompressSync(buf, {
+      flush: zlib.constants.BROTLI_OPERATION_FLUSH,
+      finishFlush: zlib.constants.BROTLI_OPERATION_FLUSH,
+    });
+  }
+  // zstd support requires node >= 22.15 — truncated input yields partial
+  // (usually empty) output rather than throwing, which the delta tracking handles
+  if (encoding === 'zstd' && typeof (zlib as any).zstdDecompressSync === 'function') {
+    return (buf) => (zlib as any).zstdDecompressSync(buf);
+  }
+  return undefined;
+}
 export function patchGlobalServerResponse(opts?: {
   ignoreUrlPatterns?: Array<RegExp>,
   redactInsteadOfThrow?: boolean,
@@ -61,7 +87,7 @@ export function patchGlobalServerResponse(opts?: {
     // have to deal with compressed data, which is awkward but possible
     const compressionType = this.getHeader('Content-Encoding');
     let chunkStr;
-    let chunkType: 'string' | 'encoded' | 'gzip' | null = null;
+    let chunkType: 'string' | 'encoded' | 'compressed' | null = null;
     if (typeof rawChunk === 'string') {
       chunkType = 'string';
       chunkStr = rawChunk;
@@ -69,28 +95,30 @@ export function patchGlobalServerResponse(opts?: {
       chunkType = 'encoded';
       const decoder = new TextDecoder();
       chunkStr = decoder.decode(rawChunk);
-    } else if (compressionType === 'gzip' || compressionType === 'deflate') {
-      chunkType = 'gzip';
-      // TODO: figure out how we can unzip one chunk at a time instead of storing everything
-      (this as any)._zlibChunks ||= [];
-      (this as any)._zlibChunks.push(rawChunk);
-      // NOTE - we must attempt to decode from the very FIRST chunk: small responses
-      // arrive as a single complete gzip chunk, so skipping it means never scanning
-      // at all (and browsers always send Accept-Encoding: gzip). A genuinely partial
-      // stream fails to decode here and gets scanned once more chunks arrive.
-      try {
-        const unzippedChunk = zlib.unzipSync(Buffer.concat((this as any)._zlibChunks || []), {
-          flush: zlib.constants.Z_SYNC_FLUSH,
-          finishFlush: zlib.constants.Z_SYNC_FLUSH,
-        });
-        const fullUnzippedData = unzippedChunk.toString('utf-8');
-        chunkStr = fullUnzippedData.substring((this as any)._lastChunkEndIndex || 0);
-        (this as any)._lastChunkEndIndex = fullUnzippedData.length;
-      } catch (err) {
-        // partial gzip data that doesn't decode yet — scanned when more chunks arrive
+    } else {
+      const decompress = getDecompressor(String(compressionType).toLowerCase());
+      if (decompress) {
+        chunkType = 'compressed';
+        // TODO: figure out how we can decompress one chunk at a time instead of storing everything
+        (this as any)._zlibChunks ||= [];
+        (this as any)._zlibChunks.push(rawChunk);
+        // NOTE - we must attempt to decode from the very FIRST chunk: small responses
+        // arrive as a single complete compressed chunk, so skipping it means never
+        // scanning at all (and browsers always send Accept-Encoding: gzip). A genuinely
+        // partial stream fails to decode here and gets scanned once more chunks arrive.
+        try {
+          const decompressedChunk = decompress(Buffer.concat((this as any)._zlibChunks || []));
+          const fullDecompressedData = decompressedChunk.toString('utf-8');
+          chunkStr = fullDecompressedData.substring((this as any)._lastChunkEndIndex || 0);
+          (this as any)._lastChunkEndIndex = fullDecompressedData.length;
+        } catch (err) {
+          // partial compressed data that doesn't decode yet — scanned when more chunks arrive
+        }
+      } else {
+        // no decompressor for this encoding — response cannot be scanned (fails open)
+        debug(`⚠️ leak scan skipped - unsupported content-encoding: ${compressionType}`);
       }
     }
-    // TODO: we may want to support other compression schemes? but currently only used in nextjs which is using gzip
     if (chunkStr) {
       // console.log('scanning!', chunkStr.substring(0, 1000));
 
@@ -107,11 +135,11 @@ export function patchGlobalServerResponse(opts?: {
           } else if (chunkType === 'encoded') {
             const encoder = new TextEncoder();
             args[0] = encoder.encode(chunkStr);
-          } else if (chunkType === 'gzip') {
-            // we can't reliably scrub inside a compressed stream (re-gzipping a single
+          } else if (chunkType === 'compressed') {
+            // we can't reliably scrub inside a compressed stream (re-compressing a single
             // chunk corrupts the stream state), so fail closed — killing the response
             // beats serving the secret, even in dev
-            // TODO: pass chunks through our own gzip stream so we can scrub + re-encode
+            // TODO: pass chunks through our own compression stream so we can scrub + re-encode
             throw err;
           } else {
             throw new Error(`unable to scrub - unknown chunk type ${chunkType}`);

--- a/packages/varlock/src/runtime/test/env-state.test.ts
+++ b/packages/varlock/src/runtime/test/env-state.test.ts
@@ -1,0 +1,99 @@
+/*
+  Tests for the shared-on-globalThis env runtime state — specifically that env
+  loads/reloads behave correctly when a bundler creates MULTIPLE copies of the
+  varlock/env module in one process (e.g. Next.js bundling it into app-router and
+  pages-router server code while @next/env uses the node_modules copy).
+
+  Each "module copy" is simulated with vi.resetModules() + a fresh dynamic import.
+*/
+import {
+  describe, it, expect, beforeEach, afterEach, vi,
+} from 'vitest';
+
+const ENV_STATE_KEY = '__varlockEnvState';
+const REDACTION_STATE_KEY = '__varlockRedactionState';
+
+const TEST_KEYS = ['EST_FOO', 'EST_BAR'];
+
+function makeEnvBlob(config: Record<string, string | undefined>) {
+  return JSON.stringify({
+    sources: [],
+    settings: {},
+    config: Object.fromEntries(
+      Object.entries(config).map(([key, value]) => [key, { value, isSensitive: false }]),
+    ),
+  });
+}
+
+async function importFreshEnvModuleCopy() {
+  vi.resetModules();
+  return import('../env');
+}
+
+function cleanup() {
+  delete (globalThis as any)[ENV_STATE_KEY];
+  delete (globalThis as any)[REDACTION_STATE_KEY];
+  delete (globalThis as any).__varlockLoadedEnv;
+  delete process.env.__VARLOCK_ENV;
+  for (const key of TEST_KEYS) delete process.env[key];
+}
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+describe('env state shared across module copies', () => {
+  it('a second module copy sees env already initialized and reads the same values', async () => {
+    process.env.__VARLOCK_ENV = makeEnvBlob({ EST_FOO: 'foo-1' });
+    const copyA = await importFreshEnvModuleCopy();
+    copyA.initVarlockEnv();
+    expect((copyA.ENV as any).EST_FOO).toBe('foo-1');
+
+    const copyB = await importFreshEnvModuleCopy();
+    expect(copyB).not.toBe(copyA);
+    // no explicit init on copyB — it must pick up the shared initialized state
+    expect((copyB.ENV as any).EST_FOO).toBe('foo-1');
+  });
+
+  it('a reload through a second module copy updates values seen by the first copy', async () => {
+    process.env.__VARLOCK_ENV = makeEnvBlob({ EST_FOO: 'foo-1' });
+    const copyA = await importFreshEnvModuleCopy();
+    copyA.initVarlockEnv();
+
+    const copyB = await importFreshEnvModuleCopy();
+    process.env.__VARLOCK_ENV = makeEnvBlob({ EST_FOO: 'foo-2' });
+    copyB.initVarlockEnv();
+
+    expect((copyA.ENV as any).EST_FOO).toBe('foo-2');
+    expect(process.env.EST_FOO).toBe('foo-2');
+  });
+
+  it('a reload through a second module copy cleans up keys removed from config', async () => {
+    process.env.__VARLOCK_ENV = makeEnvBlob({ EST_FOO: 'foo-1', EST_BAR: 'bar-1' });
+    const copyA = await importFreshEnvModuleCopy();
+    copyA.initVarlockEnv();
+    expect(process.env.EST_FOO).toBe('foo-1');
+    expect(process.env.EST_BAR).toBe('bar-1');
+
+    // reload flows through a DIFFERENT module copy, with EST_BAR removed
+    const copyB = await importFreshEnvModuleCopy();
+    process.env.__VARLOCK_ENV = makeEnvBlob({ EST_FOO: 'foo-2' });
+    copyB.initVarlockEnv();
+
+    expect(process.env.EST_FOO).toBe('foo-2');
+    // injection bookkeeping is shared, so the removed key is cleaned up
+    expect(process.env.EST_BAR).toBeUndefined();
+    // and the removed key is also dropped from the ENV values (read via either copy)
+    expect((copyB.ENV as any).EST_BAR).toBeUndefined();
+    expect((copyA.ENV as any).EST_BAR).toBeUndefined();
+  });
+
+  it('treats a still-encrypted blob as not yet available', async () => {
+    process.env.__VARLOCK_ENV = 'varlock:v1:bm90LXJlYWwtZGF0YQ==';
+    // module-load auto-init uses allowFail and must not explode
+    const envModule = await importFreshEnvModuleCopy();
+    // explicit init without allowFail should throw a clear error
+    expect(() => envModule.initVarlockEnv()).toThrow(/still encrypted/);
+    // and env should not be marked initialized
+    expect(() => (envModule.ENV as any).ANYTHING).toThrow(/not initialized/);
+  });
+});

--- a/packages/varlock/src/runtime/test/patch-server-response-redact.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response-redact.test.ts
@@ -1,0 +1,106 @@
+/*
+  Tests for the patched ServerResponse leak scanner in redactInsteadOfThrow mode
+  (how the nextjs integration applies it in dev), exercised through a real HTTP
+  server so pass-through integrity is verified end-to-end.
+
+  Kept separate from patch-server-response.test.ts because the prototype patch
+  captures its options once per process (vitest isolates files into separate workers).
+*/
+import http from 'node:http';
+import zlib from 'node:zlib';
+import {
+  describe, it, expect, beforeAll, afterAll,
+} from 'vitest';
+
+import { patchGlobalServerResponse } from '../patch-server-response';
+import { resetRedactionMap } from '../env';
+
+const SECRET = 'redact-mode-secret-xyz789';
+
+const FAKE_GRAPH = {
+  sources: [],
+  settings: {},
+  config: {
+    SECRET_KEY: { value: SECRET, isSensitive: true },
+  },
+} as any;
+
+const htmlClean = `<html><body>${'filler '.repeat(100)}no secrets here</body></html>`;
+const htmlWithSecret = `<html><body>leak: ${SECRET}</body></html>`;
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  resetRedactionMap(FAKE_GRAPH);
+  patchGlobalServerResponse({ redactInsteadOfThrow: true });
+
+  server = http.createServer((req, res) => {
+    res.setHeader('content-type', 'text/html');
+    if (req.url === '/string-leak') {
+      res.write(htmlWithSecret);
+      res.end();
+    } else if (req.url === '/gzip-clean') {
+      res.setHeader('content-encoding', 'gzip');
+      const gz = zlib.gzipSync(htmlClean);
+      // write in two chunks to exercise incremental decode + pass-through
+      res.write(gz.subarray(0, 15));
+      res.write(gz.subarray(15));
+      res.end();
+    } else if (req.url === '/gzip-leak') {
+      res.setHeader('content-encoding', 'gzip');
+      try {
+        res.write(zlib.gzipSync(htmlWithSecret));
+        res.end();
+      } catch (err) {
+        // compressed chunks can't be scrubbed, so the patched write fails closed —
+        // kill the connection like a framework's error handling would
+        res.destroy();
+      }
+    } else {
+      res.end('not found');
+    }
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('expected address info');
+  }
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => {
+    server.close(resolve);
+  });
+});
+
+describe('patchGlobalServerResponse with redactInsteadOfThrow', () => {
+  it('redacts a leaked secret in an uncompressed response', async () => {
+    const resp = await fetch(`${baseUrl}/string-leak`);
+    const body = await resp.text();
+    expect(body).not.toContain(SECRET);
+    expect(body).toContain('▒'); // redaction marker in place of the secret
+  });
+
+  it('passes a clean gzip response through intact', async () => {
+    const resp = await fetch(`${baseUrl}/gzip-clean`);
+    const body = await resp.text(); // fetch auto-decompresses
+    expect(body).toBe(htmlClean);
+  });
+
+  it('fails closed on a leak in a gzip response (cannot scrub compressed chunks)', async () => {
+    let failed = false;
+    let body = '';
+    try {
+      const resp = await fetch(`${baseUrl}/gzip-leak`);
+      body = await resp.text();
+    } catch {
+      failed = true;
+    }
+    expect(failed).toBe(true);
+    expect(body).not.toContain(SECRET);
+  });
+});

--- a/packages/varlock/src/runtime/test/patch-server-response.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response.test.ts
@@ -1,0 +1,132 @@
+/*
+  Tests for the patched ServerResponse leak scanner in its default mode (throw on leak),
+  which is how auto-load, init-server, and the vite integration apply it.
+
+  NOTE: patchGlobalServerResponse patches ServerResponse.prototype once per process and
+  captures its options at patch time, so redactInsteadOfThrow mode is covered in a
+  separate test file (vitest isolates files into separate workers).
+*/
+import zlib from 'node:zlib';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { Socket } from 'node:net';
+import {
+  describe, it, expect, beforeAll,
+} from 'vitest';
+
+import { patchGlobalServerResponse } from '../patch-server-response';
+import { resetRedactionMap } from '../env';
+
+const SECRET = 'super-secret-value-abc123';
+
+const FAKE_GRAPH = {
+  sources: [],
+  settings: {},
+  config: {
+    SECRET_KEY: { value: SECRET, isSensitive: true },
+    PUBLIC_KEY: { value: 'public-value', isSensitive: false },
+  },
+} as any;
+
+// filler makes the payload look like a real page (and compress into multiple
+// flush blocks); the secret sits at the END so truncated prefixes decode clean
+const htmlWithSecret = `<html><body>${'filler '.repeat(100)}leaked: ${SECRET}</body></html>`;
+const htmlClean = `<html><body>${'filler '.repeat(100)}no secrets here</body></html>`;
+
+function makeRes(headers: Record<string, string> = {}) {
+  const req = new IncomingMessage(new Socket());
+  req.url = '/test-url';
+  const res = new ServerResponse(req);
+  res.setHeader('content-type', 'text/html');
+  for (const [key, value] of Object.entries(headers)) res.setHeader(key, value);
+  return res;
+}
+
+beforeAll(() => {
+  resetRedactionMap(FAKE_GRAPH);
+  patchGlobalServerResponse();
+});
+
+describe('patched ServerResponse.write - uncompressed', () => {
+  it('throws when a sensitive value appears in a string chunk', () => {
+    const res = makeRes();
+    expect(() => res.write(htmlWithSecret)).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('passes clean string chunks through', () => {
+    const res = makeRes();
+    expect(() => res.write(htmlClean)).not.toThrow();
+  });
+
+  it('throws when a sensitive value appears in a Buffer chunk', () => {
+    const res = makeRes();
+    expect(() => res.write(Buffer.from(htmlWithSecret))).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('does not scan non-text content types', () => {
+    const res = makeRes({ 'content-type': 'image/png' });
+    expect(() => res.write(Buffer.from(htmlWithSecret))).not.toThrow();
+  });
+});
+
+describe('patched ServerResponse.write - compressed', () => {
+  it('detects a leak in a single complete gzip chunk', () => {
+    const res = makeRes({ 'content-encoding': 'gzip' });
+    expect(() => res.write(zlib.gzipSync(htmlWithSecret))).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('passes a clean gzip response through', () => {
+    const res = makeRes({ 'content-encoding': 'gzip' });
+    expect(() => res.write(zlib.gzipSync(htmlClean))).not.toThrow();
+  });
+
+  it('detects a leak split across multiple gzip chunks', () => {
+    const gz = zlib.gzipSync(htmlWithSecret);
+    const res = makeRes({ 'content-encoding': 'gzip' });
+    // truncated prefix decodes (partially or not at all) without the secret
+    expect(() => res.write(gz.subarray(0, 20))).not.toThrow();
+    expect(() => res.write(gz.subarray(20))).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('tolerates a header-only first chunk', () => {
+    const gz = zlib.gzipSync(htmlClean);
+    const res = makeRes({ 'content-encoding': 'gzip' });
+    expect(() => res.write(gz.subarray(0, 10))).not.toThrow(); // 10-byte gzip header only
+    expect(() => res.write(gz.subarray(10))).not.toThrow();
+  });
+
+  it('detects a leak in a deflate response', () => {
+    const res = makeRes({ 'content-encoding': 'deflate' });
+    expect(() => res.write(zlib.deflateSync(htmlWithSecret))).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('detects a leak in a brotli response', () => {
+    const res = makeRes({ 'content-encoding': 'br' });
+    expect(() => res.write(zlib.brotliCompressSync(htmlWithSecret))).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('detects a leak split across multiple brotli chunks', () => {
+    const br = zlib.brotliCompressSync(htmlWithSecret);
+    const res = makeRes({ 'content-encoding': 'br' });
+    expect(() => res.write(br.subarray(0, 20))).not.toThrow();
+    expect(() => res.write(br.subarray(20))).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  const hasZstd = typeof (zlib as any).zstdCompressSync === 'function';
+  it.skipIf(!hasZstd)('detects a leak in a zstd response', () => {
+    const res = makeRes({ 'content-encoding': 'zstd' });
+    const compressed = (zlib as any).zstdCompressSync(Buffer.from(htmlWithSecret));
+    expect(() => res.write(compressed)).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('does not scan unsupported encodings (documented fail-open)', () => {
+    const res = makeRes({ 'content-encoding': 'x-unknown' });
+    expect(() => res.write(Buffer.from(htmlWithSecret))).not.toThrow();
+  });
+});
+
+describe('patched ServerResponse.end', () => {
+  it('throws when a sensitive value appears in a string end chunk', () => {
+    const res = makeRes({ 'content-type': 'application/json' });
+    expect(() => res.end(JSON.stringify({ leaked: SECRET }))).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+});


### PR DESCRIPTION
Follow-ups from a pre-publish review of the runtime changes in #861/#862, since those ship to all varlock users.

## Changes

**Leak scanner** ([patch-server-response.ts](https://github.com/dmno-dev/varlock/blob/runtime-prepublish-hardening/packages/varlock/src/runtime/patch-server-response.ts))
- now decodes **brotli and zstd** responses (zstd where node >= 22.15), not just gzip/deflate — same accumulate/flush pattern; unsupported encodings log via debug instead of silently skipping

**Shared env state** ([env.ts](https://github.com/dmno-dev/varlock/blob/runtime-prepublish-hardening/packages/varlock/src/runtime/env.ts))
- `originalProcessEnv` + injected-key bookkeeping moved into the shared globalThis state (`#861` moved values/settings but left these module-local), so a reload flowing through a *different bundled copy* of `varlock/env` still cleans up keys removed from config
- removed keys are also dropped from the shared values object, so `ENV.REMOVED_KEY` no longer serves a stale value after reload

**Edge init** ([init-edge.ts](https://github.com/dmno-dev/varlock/blob/runtime-prepublish-hardening/packages/varlock/src/runtime/init-edge.ts))
- async-decrypt promise is marked handled, so a wrong key surfaces as a clean per-request error instead of a pre-request unhandled rejection (fatal on some edge runtimes)

**Engines**: node floor raised to `>=22.3.0` — `process.getBuiltinModule` (which the lazy `node:crypto` loading relies on in ESM contexts) doesn't exist before 22.3.

## Tests
- new unit coverage for the previously untested response scanner: throw mode (single/multi-chunk gzip, header-only chunk, deflate/br/zstd, unknown-encoding fail-open) and redact mode through a real HTTP server (redaction, byte-identical gzip pass-through, compressed leaks failing closed)
- new multi-module-copy env state tests (cross-copy init/reload, removed-key cleanup, still-encrypted blob handling)
- framework harness gains `headerAssertions`; the nextjs dev scenario now asserts the dev server **survives** a leak-killed response and that responses actually flow through the gzip scan path — verified locally against next 14/15/16 (webpack + turbopack)

Changeset texts updated accordingly (including a heads-up that apps with existing undetected leaks will start seeing those responses blocked, since most browser traffic previously bypassed the scanner).