### PR TITLE
fix(codegen): harden typegen icon fetching (ok-check, timeout, negative cache)

### DIFF
--- a/.bumpy/typegen-icon-fetch-hardening.md
+++ b/.bumpy/typegen-icon-fetch-hardening.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+icon fetching during type generation now ignores failed responses, times out after 2s, and doesn't retry failed icons within a run

--- a/packages/varlock/src/env-graph/lib/type-generation/emitters/ts.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation/emitters/ts.ts
@@ -27,9 +27,13 @@ function getItemTsTypeString(coerced: CoercedType): string {
 }
 
 const ICON_SIZE = 20;
+const ICON_FETCH_TIMEOUT_MS = 2000;
 
 let iconCacheFolderInit = false;
 const iconInMemoryCache: Record<string, string> = {};
+// negative cache — icons that failed to fetch (non-200, timeout, network error) are not
+// retried within this process, so an offline/broken iconify doesn't stall every field
+const iconFetchFailedNames = new Set<string>();
 
 async function fetchIconSvg(
   iconifyName: string,
@@ -50,14 +54,21 @@ async function fetchIconSvg(
     const svgFileBuffer = await fs.promises.readFile(iconPath, 'utf-8');
     svgSrc = svgFileBuffer.toString();
     iconInMemoryCache[iconPath] = svgSrc;
+  } else if (iconFetchFailedNames.has(iconifyName)) {
+    return;
   } else {
     try {
-      const iconSvg = await fetch(`https://api.iconify.design/${iconifyName.replace(':', '/')}.svg?height=${ICON_SIZE}`);
+      const iconSvg = await fetch(`https://api.iconify.design/${iconifyName.replace(':', '/')}.svg?height=${ICON_SIZE}`, {
+        signal: AbortSignal.timeout(ICON_FETCH_TIMEOUT_MS),
+      });
+      // an error body (e.g. the literal text "404") must never be cached or embedded
+      if (!iconSvg.ok) throw new Error(`icon fetch failed: ${iconSvg.status}`);
       svgSrc = await iconSvg.text();
+      if (!svgSrc) throw new Error('icon fetch returned empty body');
     } catch {
+      iconFetchFailedNames.add(iconifyName);
       return;
     }
-    if (!svgSrc) return;
     await fs.promises.writeFile(iconPath, svgSrc, 'utf-8');
     iconInMemoryCache[iconPath] = svgSrc;
   }

--- a/packages/varlock/src/env-graph/test/type-generation.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation.test.ts
@@ -1,5 +1,5 @@
 import {
-  describe, expect, test, vi,
+  afterEach, describe, expect, test, vi,
 } from 'vitest';
 import outdent from 'outdent';
 import path from 'node:path';
@@ -10,6 +10,7 @@ import {
   generateTsTypesSrc,
   resolveFieldType,
   resolveFieldTypes,
+  type ResolvedFieldType,
   type TypeGenItemInfo,
 } from '../index';
 import { getTypeGenInfoMap, loadFixtureFields, loadGraph } from './type-generation/helpers';
@@ -1048,6 +1049,85 @@ describe('type generation', () => {
         expect(statAfter.mtimeMs).toBeLessThan(statBefore.mtimeMs); // ...but the file was not rewritten
       } finally {
         await fs.promises.rm(outputPath, { force: true });
+      }
+    });
+  });
+
+  describe('@icon fetching', () => {
+    const ICON_CACHE_FOLDER = '/tmp/varlock-icon-cache';
+    // unique per-run icon names so stale disk-cache entries / the module-level caches
+    // from other tests can't interfere
+    const uniqueIconName = (label: string) => `fake-test:${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const iconCachePath = (iconName: string) => path.join(ICON_CACHE_FOLDER, `${iconName}-20.svg`);
+
+    function iconField(icon: string): ResolvedFieldType {
+      return {
+        key: 'ICON_ITEM',
+        coerced: 'string',
+        isRequired: true,
+        isSensitive: false,
+        docs: { isDeprecated: false, docsLinks: [], icon },
+      };
+    }
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    test('non-200 responses are not embedded or cached, and are not retried within the process', async () => {
+      const iconName = uniqueIconName('non-200');
+      const fetchMock = vi.fn(async () => new Response('404', { status: 404 }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const src = await generateTsTypesSrc([iconField(iconName)]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      // the error body must not end up in the generated jsdoc...
+      expect(src).not.toContain('![icon]');
+      // ...nor be written to the (expiry-less) disk cache
+      const fs = await import('node:fs');
+      expect(fs.existsSync(iconCachePath(iconName))).toBe(false);
+
+      // negative cache: even if iconify recovers, the same failed icon is not refetched this run
+      fetchMock.mockResolvedValue(new Response('<svg>ok currentColor</svg>', { status: 200 }));
+      const src2 = await generateTsTypesSrc([iconField(iconName)]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(src2).not.toContain('![icon]');
+    });
+
+    test('network failures (incl. timeout aborts) are swallowed and negative-cached', async () => {
+      const iconName = uniqueIconName('net-fail');
+      const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+        throw new DOMException('The operation timed out.', 'TimeoutError');
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const src = await generateTsTypesSrc([iconField(iconName)]);
+      expect(src).not.toContain('![icon]');
+      expect(src).toContain('ICON_ITEM: string;'); // generation itself is unaffected
+      // fetch is given an abort signal so a hung request can't stall the load forever
+      expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+
+      await generateTsTypesSrc([iconField(iconName)]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('successful fetches are embedded and disk-cached', async () => {
+      const iconName = uniqueIconName('success');
+      const fetchMock = vi.fn(async () => new Response('<svg fill="currentColor"></svg>', { status: 200 }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const fs = await import('node:fs');
+      try {
+        const src = await generateTsTypesSrc([iconField(iconName)]);
+        expect(src).toContain('![icon](data:image/svg+xml;utf-8,');
+        expect(src).toContain(encodeURIComponent('#808080')); // currentColor replaced
+        expect(fs.existsSync(iconCachePath(iconName))).toBe(true);
+
+        // second generation hits the in-memory cache — no refetch
+        await generateTsTypesSrc([iconField(iconName)]);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      } finally {
+        await fs.promises.rm(iconCachePath(iconName), { force: true });
       }
     });
   });


### PR DESCRIPTION
`@icon` fetching from api.iconify.design happens during type generation, which runs on every `varlock load`/`run`. The fetch helper had three defects (pre-existing, carried over from the old `type-generation.ts`):

- **No `response.ok` check** — a 404/5xx body (e.g. the literal text `404`) passed the empty-string guard, got written to the expiry-less `/tmp/varlock-icon-cache` disk cache, and was embedded as a broken data: URI in generated jsdoc *permanently* (until the cache dir was manually deleted). Now a non-200 bails out before any caching.
- **No fetch timeout** — a hung iconify request stalled every load indefinitely. Now aborts after 2s (`AbortSignal.timeout`), treated like any other fetch failure.
- **No negative caching** — offline/DNS failures were retried per icon, sequentially, on every load. Failed icon names are now negative-cached in memory for the life of the process, so one load never retries the same failing icon.

Positive disk/memory caching behavior is unchanged. Added unit coverage for the non-200 path (nothing cached or embedded, no retry), network-failure/timeout handling, and the success path (embed + disk cache + in-memory hit).
