### PR TITLE
feat(codegen): first-class coercedType hint on data type defs

### DIFF
--- a/.bumpy/datatype-coerced-type.md
+++ b/.bumpy/datatype-coerced-type.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+plugin-registered data types can now declare `coercedType` so generated env modules type their fields correctly (previously they always emitted as strings)

--- a/packages/varlock-website/src/content/docs/guides/code-generation.mdx
+++ b/packages/varlock-website/src/content/docs/guides/code-generation.mdx
@@ -82,3 +82,15 @@ Once registered, users trigger it from their schema like any other generator:
 ```
 
 The `decoratorName` must start with `generate` (e.g. `generateZodSchema`) — a shared convention that keeps code-generation decorators recognizable and separate from behavior decorators. Generators also get the common `path`, `auto`, and `executeWhenImported` args automatically — your `generate` function only handles turning the schema into code.
+
+Plugins that register custom data types can also declare `coercedType` — what their `coerce()` function outputs (`'string'`, `'int'`, `'number'`, `'boolean'`, `'object'`, or `{ enum: [...] }`) — so generated code types those fields correctly in every language:
+
+```ts title="my-plugin.ts"
+plugin.registerDataType({
+  name: 'retryCount',
+  coercedType: 'int',
+  coerce: (val) => parseInt(val, 10),
+});
+```
+
+Data types that don't declare a `coercedType` are treated as strings.

--- a/packages/varlock-website/src/content/docs/reference/data-types.mdx
+++ b/packages/varlock-website/src/content/docs/reference/data-types.mdx
@@ -57,7 +57,7 @@ In any slightly ambiguous situation, it is better to explicitly add a `@type` de
 
 ## Built-in data types
 
-These are the built-in data types. [Plugins](/guides/plugins/) may register additional data types.
+These are the built-in data types. [Plugins](/guides/plugins/) may register additional data types, which appear in [generated code](/guides/code-generation/#extending-with-plugins) according to the coerced type they declare (as strings if they don't declare one).
 
 <div class="reference-docs">
 <div>

--- a/packages/varlock/src/env-graph/lib/data-types.ts
+++ b/packages/varlock/src/env-graph/lib/data-types.ts
@@ -8,6 +8,19 @@ import {
 
 type MaybePromise<T> = T | Promise<T>;
 
+/**
+ * The runtime shape a data type's `coerce()` produces — consumed by code generation to type the
+ * generated fields in each target language. `'int'` vs `'number'` matters for languages that
+ * distinguish them (Go/Rust/PHP; JS/TS just uses `number`); an enum carries its member values so
+ * emitters can build literal-union types. Types that don't declare one are treated as strings.
+ */
+export type CoercedType = | 'string'
+  | 'int' // integer number
+  | 'number' // general (possibly fractional) number
+  | 'boolean'
+  | 'object'
+  | { enum: Array<string | number | boolean> };
+
 type EnvGraphDataTypeDef<CoerceReturnType, ValidateInputType = FallbackIfUnknown<CoerceReturnType, string>> = {
   /** this will be the name of the type, used to reference it when using it in a schema */
   name: string;
@@ -30,6 +43,12 @@ type EnvGraphDataTypeDef<CoerceReturnType, ValidateInputType = FallbackIfUnknown
    * - if validation fails, should return a ValidationError or array of errors - or throw an error
    * */
   validate?: (value: ValidateInputType) => MaybePromise<(true | undefined | void | Error | Array<Error>)>;
+
+  /**
+   * what shape `coerce` outputs — lets code generation emit properly typed fields
+   * (e.g. `int` in Go) instead of assuming `string`. Omit for string-valued types.
+   */
+  coercedType?: CoercedType;
 
   // asyncValidate? - async validation function, meant to be called more sparingly
   // for example, when could validate an API key is currently valid
@@ -70,9 +89,7 @@ export class EnvGraphDataType {
   get isSensitive() { return this.def.sensitive; }
   get isInternal() { return this.def.internal; }
   get docsEntries() { return this.def.docs; }
-
-  /** @internal */
-  get _rawDef() { return this.def; }
+  get coercedType() { return this.def.coercedType; }
 
   coerce(val: any) {
     if (this.def.coerce) return this.def.coerce(val);
@@ -245,8 +262,8 @@ const NumberDataType = createEnvGraphDataType(
   )) => ({
     name: 'number',
     icon: 'carbon:string-integer',
-    // exposed for type generation — whether this coerces to an integer
-    _isInt: settings?.isInt === true || settings?.precision === 0,
+    // an integer only when constrained (isInt / precision=0) — coerce() rounds in that case
+    coercedType: (settings?.isInt === true || settings?.precision === 0) ? 'int' : 'number',
     coerce(rawVal) {
       let numVal = coerceToNumber(rawVal);
       if (settings?.coerceToMinMaxRange) {
@@ -284,6 +301,7 @@ const NumberDataType = createEnvGraphDataType(
 const BooleanDataType = createEnvGraphDataType({
   name: 'boolean',
   icon: 'carbon:boolean',
+  coercedType: 'boolean',
   // probably want allow some settings
   // - more strict about coercion or adding additional true/false values
   // - coercing to other values - like 0,1
@@ -364,6 +382,7 @@ const UrlDataType = createEnvGraphDataType(
 const SimpleObjectDataType = createEnvGraphDataType({
   name: 'simple-object',
   icon: 'tabler:code-dots', // curly brackets with nothing inside
+  coercedType: 'object',
   coerce(val) {
     if (_.isPlainObject(val)) return val;
     // if value is a string, we'll try to JSON.parse and see if that is an object
@@ -395,6 +414,7 @@ const EnumDataType = createEnvGraphDataType(
   (...enumOptions: Array<PossibleEnumValues>) => ({
     name: 'enum',
     icon: 'material-symbols-light:category', // a few shapes... not sure about this one
+    coercedType: { enum: enumOptions },
     coerce(val) {
       if (_.isString(val) || _.isNumber(val) || _.isBoolean(val)) return val;
       return new CoercionError('Value must be a string, number, or boolean');
@@ -407,7 +427,6 @@ const EnumDataType = createEnvGraphDataType(
         });
       }
     },
-    _rawEnumOptions: enumOptions,
   }),
 );
 
@@ -466,6 +485,7 @@ const PortDataType = createEnvGraphDataType(
     name: 'port',
     icon: 'material-symbols:captive-portal', //! globe with arrow - not sure about this one
     typeDescription: 'valid port number between 0 and 65535',
+    coercedType: 'int',
     coerce(rawVal) {
       if (_.isString(rawVal)) {
         if (rawVal.includes('.')) throw new CoercionError('Port number must be an integer');
@@ -565,6 +585,8 @@ const DurationDataType = createEnvGraphDataType(
     name: 'duration',
     icon: 'mdi:timer-outline',
     typeDescription: 'flexible duration (accepts "1h", "30m", "500ms", "2days", etc. — outputs ms by default)',
+    // can be fractional after unit conversion (e.g. "90s" output in minutes), so a general number
+    coercedType: 'number',
     coerce(rawVal) {
       if (rawVal === undefined || rawVal === null) return undefined;
       const output = settings?.output ?? 'ms';

--- a/packages/varlock/src/env-graph/lib/type-generation/shared.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation/shared.ts
@@ -1,12 +1,8 @@
 import { ENCRYPTED_PREFIX } from '../../../runtime/crypto';
 import type { TypeGenItemInfo } from '../config-item';
+import type { CoercedType } from '../data-types';
 
-export type CoercedType = | 'string'
-  | 'int' // integer number — languages that distinguish can emit int; JS/TS just uses number
-  | 'number' // general (possibly fractional) number
-  | 'boolean'
-  | 'object'
-  | { enum: Array<string | number | boolean> };
+export type { CoercedType };
 
 export type FieldDocs = {
   description?: string;
@@ -24,39 +20,10 @@ export type ResolvedFieldType = {
   docs: FieldDocs;
 };
 
-function getEnumOptions(info: TypeGenItemInfo): Array<string | number | boolean> {
-  type EnumDef = { _rawEnumOptions?: Array<string | number | boolean> };
-  const rawEnumOptions = (info.dataType?._rawDef as EnumDef | undefined)?._rawEnumOptions;
-  return rawEnumOptions ?? [];
-}
-
-function isIntegerNumber(info: TypeGenItemInfo): boolean {
-  type NumberDef = { _isInt?: boolean };
-  return !!(info.dataType?._rawDef as NumberDef | undefined)?._isInt;
-}
-
-function resolveCoercedType(info: TypeGenItemInfo): CoercedType {
-  const dataTypeName = info.dataType?.name;
-
-  if (info.dataType) {
-    // ports are always integers; `number` is an integer only when constrained (isInt / precision=0);
-    // `duration` can be fractional (unit conversion), so it stays a general number
-    if (dataTypeName === 'port') return 'int';
-    if (dataTypeName === 'number') return isIntegerNumber(info) ? 'int' : 'number';
-    if (dataTypeName === 'duration') return 'number';
-    if (dataTypeName === 'boolean') return 'boolean';
-    if (dataTypeName === 'simple-object') return 'object';
-    if (dataTypeName === 'enum') {
-      const enumOptions = getEnumOptions(info);
-      if (!enumOptions.length) return { enum: [] };
-      return { enum: enumOptions };
-    }
-  }
-  return 'string';
-}
-
 export function resolveFieldType(info: TypeGenItemInfo): ResolvedFieldType {
-  const coerced = resolveCoercedType(info);
+  // each data type declares what its coerce() outputs; types that don't (including
+  // plugin-registered ones) coerce to strings
+  const coerced = info.dataType?.coercedType ?? 'string';
   return {
     key: info.key,
     coerced,

--- a/packages/varlock/src/env-graph/test/type-generation/custom-data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation/custom-data-types.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest';
+import outdent from 'outdent';
+
+import { generateGoEnvSrc, generateTsTypesSrc } from '../../index';
+import { createEnvGraphDataType } from '../../lib/data-types';
+import { loadFixtureFields } from './helpers';
+
+// mimics what a plugin registers via registerDataType — a type whose coerce() outputs
+// a non-string value, declared via `coercedType`
+const RetryCountDataType = createEnvGraphDataType({
+  name: 'retry-count',
+  coercedType: 'int',
+  coerce: (val) => parseInt(String(val), 10),
+});
+
+// no coercedType declared — coerces to string by default
+const CustomTokenDataType = createEnvGraphDataType({
+  name: 'custom-token',
+});
+
+const CUSTOM_TYPE_FIXTURE = outdent`
+  # @defaultSensitive=false
+  # ---
+  # @type=retry-count
+  RETRIES=3        # @required @public
+  # @type=custom-token
+  TOKEN=abc        # @required @public
+`;
+
+describe('plugin-registered data types', () => {
+  test('coercedType declared on the type def drives generated field types', async () => {
+    const { fields } = await loadFixtureFields(CUSTOM_TYPE_FIXTURE, {
+      dataTypes: [RetryCountDataType, CustomTokenDataType],
+    });
+    const byKey = Object.fromEntries(fields.map((f) => [f.key, f]));
+    expect(byKey.RETRIES.coerced).toBe('int');
+    // a type that declares no coercedType stays a string
+    expect(byKey.TOKEN.coerced).toBe('string');
+
+    // the generated Go loader json.Unmarshals the coerced blob value — a numeric value
+    // into a string field fails at runtime, so the field must be numeric
+    const goSrc = generateGoEnvSrc(fields);
+    expect(goSrc).toMatch(/Retries +int64/);
+    expect(goSrc).toMatch(/Token +string/);
+
+    const tsSrc = await generateTsTypesSrc(fields);
+    expect(tsSrc).toContain('RETRIES: number;');
+    expect(tsSrc).toContain('TOKEN: string;');
+  });
+});

--- a/packages/varlock/src/env-graph/test/type-generation/helpers.ts
+++ b/packages/varlock/src/env-graph/test/type-generation/helpers.ts
@@ -7,6 +7,7 @@ import {
   resolveFieldTypes,
   type TypeGenItemInfo,
 } from '../../index';
+import type { EnvGraphDataTypeFactory } from '../../lib/data-types';
 
 /** Schema fixture covering string, number, boolean, enum, and object types. */
 export const NON_STRING_TYPE_FIXTURE = outdent`
@@ -29,11 +30,14 @@ export async function loadGraph(spec: {
   files?: Record<string, string>;
   overrideValues?: Record<string, string>;
   fallbackEnv?: string;
+  /** extra data types to register, as a plugin's registerDataType would */
+  dataTypes?: Array<EnvGraphDataTypeFactory>;
 }) {
   const currentDir = path.dirname(expect.getState().testPath!);
   vi.spyOn(process, 'cwd').mockReturnValue(currentDir);
 
   const g = new EnvGraph();
+  for (const dataType of spec.dataTypes ?? []) g.registerDataType(dataType);
   if (spec.overrideValues) g.overrideValues = spec.overrideValues;
   if (spec.fallbackEnv) g.envFlagFallback = spec.fallbackEnv;
 
@@ -55,8 +59,11 @@ export async function getTypeGenInfoMap(g: EnvGraph) {
   return infos;
 }
 
-export async function loadFixtureFields(envFile = NON_STRING_TYPE_FIXTURE) {
-  const g = await loadGraph({ envFile });
+export async function loadFixtureFields(
+  envFile = NON_STRING_TYPE_FIXTURE,
+  opts?: { dataTypes?: Array<EnvGraphDataTypeFactory> },
+) {
+  const g = await loadGraph({ envFile, dataTypes: opts?.dataTypes });
   const items: Array<TypeGenItemInfo> = [];
   for (const key of g.sortedConfigKeys) {
     items.push(await g.configSchema[key].getTypeGenInfo());


### PR DESCRIPTION
Follow-up to #849.

`resolveCoercedType` hardcoded built-in type names and read private back-channels (`_isInt`, `_rawEnumOptions` via `_rawDef`), so plugin-registered data types always emitted as `string` in every generated language — silently wrong TS types, and a runtime `json.Unmarshal` failure in the generated Go loader when the coerced blob value is numeric.

- Add a first-class `coercedType` field (`'string' | 'int' | 'number' | 'boolean' | 'object' | { enum: [...] }`) to data type defs; built-ins declare it, and field resolution consumes it generically (`info.dataType?.coercedType ?? 'string'`). The `_isInt` / `_rawEnumOptions` / `_rawDef` side channels are gone.
- Plugin data types get this for free through `registerDataType` — no API change. Types that declare nothing still fall back to `string`.
- New test registers a custom type the way a plugin would and asserts declared hints drive Go/TS emission.
- Docs: `coercedType` documented in the code-generation guide's plugin section, plus a pointer on the data-types reference page.