### PR TITLE
docs: tone cleanup pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,16 @@ This is a monorepo managed with bun workspaces and Turborepo:
 - When pushing new commits to an open PR, update the PR description if the changes alter what it says
 - If a change affects user-facing behavior, update the docs in `packages/varlock-website/src/content/docs/` (guides and/or reference) in the same PR
 
+## Documentation
+
+Docs content lives in `packages/varlock-website/src/content/docs/` (`.mdx`). When writing or editing docs prose, keep the tone plain and direct, like an engineer wrote it:
+
+- No em dashes (`—`). Rewrite into separate sentences, commas, colons, or parentheses instead. Do not swap in a spaced hyphen (` - `). (En dashes for genuine numeric ranges like `15.0–15.4` are fine.)
+- Avoid marketing and AI-flavored filler: `seamless`, `comprehensive`, `powerful`, `robust`, `leverage`, `out of the box`, `by design`, `effortless`, `unlock` (metaphorical), "whether you need X, Y, or Z", "instead of wrestling with", and similar. Say what the thing does plainly.
+- Be concise, but never at the cost of completeness. Keep every flag, command, caveat, and link a user or their agent needs to stay unblocked.
+- Never edit code fences, `ansi`/`diff` blocks, generated fixtures, frontmatter structure, or MDX component markup for tone. Prose only.
+- Run `bun run --filter varlock-website astro build` to confirm the docs still build after non-trivial edits.
+
 ## Linting
 
 - Run **`bun run lint:fix`** from the repo root after completing a significant chunk of work (new feature, refactor, bug fix, etc.)

--- a/packages/varlock-website/src/content/docs/env-spec/reference.mdx
+++ b/packages/varlock-website/src/content/docs/env-spec/reference.mdx
@@ -61,7 +61,7 @@ Decorators are used within comments to attach structured data to specific config
 
 - Each decorator has a name and optional value (`@name=value`) or is a bare function call `@func()`
 - The two forms carry a meaning: **bare function calls `@func(...)` may be used multiple times** (their args accumulate, e.g. multiple `@docs(...)` links), while **decorators with a value `@name=value` are single-use**
-- A decorator value may itself be a function call (`@name=func(args)`), an object literal (`@name={key=value}`), or an array literal (`@name=[a, b, c]`) — these are all single-use values, not bare function calls
+- A decorator value may itself be a function call (`@name=func(args)`), an object literal (`@name={key=value}`), or an array literal (`@name=[a, b, c]`). These are all single-use values, not bare function calls
 - Using the name only is equivalent to setting the value to true -- `@required` === `@required=true`
 - Multiple decorators may be specified on the same line
 - Decorator values will be parsed using the common value-handling rules (see below)
@@ -175,7 +175,7 @@ Values are interpreted similarly for config item values, decorator values, and v
 
 ### Regex literals
 
-Regex literals use JavaScript-style `/pattern/flags` syntax and can be used anywhere a value is expected — for example, as function arguments or decorator option values.
+Regex literals use JavaScript-style `/pattern/flags` syntax and can be used anywhere a value is expected, for example as function arguments or decorator option values.
 
 - The pattern is delimited by `/` characters
 - Forward slashes within the pattern must be escaped as `\/`
@@ -211,11 +211,11 @@ NOT_FN_CALL="fn()" # treated as string
 
 Standalone objects and arrays use distinct brackets, keeping them unambiguous from function calls (which use `()`):
 
-- `{ key=value, ... }` is an **object** — keys use `=` (as elsewhere in the spec), not `:`
+- `{ key=value, ... }` is an **object**, where keys use `=` (as elsewhere in the spec), not `:`
 - `[ value, ... ]` is an **array**
 - they may be nested, and used as decorator values or as function-call arguments
 - they are parsed using the common value-handling rules, and may span multiple lines (see [Multi-line literals](#multi-line-literals) below)
-- they are **not yet supported as standalone config item values** (e.g. `ITEM={...}`) — for now an item value that starts with `{`/`[` is still treated as a string
+- they are **not yet supported as standalone config item values** (e.g. `ITEM={...}`). For now an item value that starts with `{`/`[` is still treated as a string
 
 ```env-spec
 # @dec={ key1=v1, key2="v2", nested={ a=1 } }
@@ -224,16 +224,16 @@ Standalone objects and arrays use distinct brackets, keeping them unambiguous fr
 ITEM=
 ```
 
-This is why per-item options are written `@sensitive={preventLeaks=false}` rather than `@sensitive(...)` — the latter (a bare function call) is reserved for repeatable decorators.
+This is why per-item options are written `@sensitive={preventLeaks=false}` rather than `@sensitive(...)`. The latter (a bare function call) is reserved for repeatable decorators.
 
 #### When to reach for a literal (and when not to)
 
 Object/array literals earn their place only where there is **no function-call `()` already carrying the structure**. In practice that means two situations:
 
-1. **The value of a non-function decorator** — e.g. `@sensitive={preventLeaks=false}`. These decorators can't take bare `()` args (that syntax is reserved for repeatable decorators), so an object value is the only way to attach options.
-2. **A single argument that is itself a nested object or list**, sitting alongside other args — e.g. `fn(retry={count=3, backoff=2})`.
+1. **The value of a non-function decorator**, e.g. `@sensitive={preventLeaks=false}`. These decorators can't take bare `()` args (that syntax is reserved for repeatable decorators), so an object value is the only way to attach options.
+2. **A single argument that is itself a nested object or list**, sitting alongside other args, e.g. `fn(retry={count=3, backoff=2})`.
 
-Do **not** wrap a function's (or function-decorator's) own named arguments in a literal — the parentheses already _are_ the options bag. The following are correct as written, and the literal-wrapped versions are redundant:
+Do **not** wrap a function's (or function-decorator's) own named arguments in a literal. The parentheses already _are_ the options bag. The following are correct as written, and the literal-wrapped versions are redundant:
 
 | Prefer | Avoid |
 | --- | --- |
@@ -243,8 +243,8 @@ Do **not** wrap a function's (or function-decorator's) own named arguments in a 
 
 Also prefer the existing positional/comma forms for:
 
-- **ordered pairs** — `ifs(cond1, val1, cond2, val2, default)` and `remap($VAR, match1, result1, ...)` read like a spreadsheet `IFS()`/lookup and stay flat. Crucially, `remap` match keys may be **regexes or non-identifier strings**, which cannot be object keys (keys must match `/[a-zA-Z][a-zA-Z0-9_]*/`), so an object would be strictly less expressive.
-- **value lists** — `@type=enum(dev, staging, prod)` already reads as a list; `enum([...])` only adds brackets.
+- **ordered pairs**: `ifs(cond1, val1, cond2, val2, default)` and `remap($VAR, match1, result1, ...)` read like a spreadsheet `IFS()`/lookup and stay flat. Crucially, `remap` match keys may be **regexes or non-identifier strings**, which cannot be object keys (keys must match `/[a-zA-Z][a-zA-Z0-9_]*/`), so an object would be strictly less expressive.
+- **value lists**: `@type=enum(dev, staging, prod)` already reads as a list; `enum([...])` only adds brackets.
 
 #### Multi-line literals
 
@@ -284,7 +284,7 @@ and depends on where the literal lives:
 
 A trailing comma is allowed. If a `#`-prefixed continuation is omitted in a decorator,
 the bracket simply falls back to a plain string value and the following lines remain
-independent config items — they are never silently absorbed into the literal.
+independent config items. They are never silently absorbed into the literal.
 
 Within a multi-line literal (or function call), `#` introduces a comment that runs to the
 end of the line, so entries can be commented out or annotated. This applies the same way

--- a/packages/varlock-website/src/content/docs/getting-started/installation.mdx
+++ b/packages/varlock-website/src/content/docs/getting-started/installation.mdx
@@ -58,7 +58,7 @@ varlock init
 ```
 
 :::note[Windows Defender]
-If Windows flags `varlock-local-encrypt.exe`, see the [local encryption guide — Windows Defender false positives](/guides/local-encryption/#windows-defender-false-positives) for verification and recovery steps.
+If Windows flags `varlock-local-encrypt.exe`, see the [local encryption guide, Windows Defender false positives](/guides/local-encryption/#windows-defender-false-positives) for verification and recovery steps.
 :::
 
 ## Varlock skill

--- a/packages/varlock-website/src/content/docs/getting-started/introduction.mdx
+++ b/packages/varlock-website/src/content/docs/getting-started/introduction.mdx
@@ -1,19 +1,19 @@
 ---
 title: Introduction
-description: Introduction to Varlock - the AI-safe env var toolkit for validating, securing, and sharing your environment variables
+description: Introduction to Varlock, the AI-safe env var toolkit for validating, securing, and sharing your environment variables
 ---
 
 import { LinkButton } from "@astrojs/starlight/components";
 
-Varlock is a universal configuration/secrets/environment variable management tool built on top of the [@env-spec](/env-spec/overview/) specification. It provides a comprehensive set of features out of the box that simplify managing, validating, and securing your environment configuration. Whether you need type-safe environment variables, multi-environment management, secure secret handling, or leak prevention, Varlock lets you focus on building your application instead of wrestling with configuration. While it is written in TypeScript, it is language and framework agnostic, and meant to be used in any project that needs configuration at build or boot time, usually passed in via environment variables.
+Varlock is a universal configuration/secrets/environment variable management tool built on top of the [@env-spec](/env-spec/overview/) specification. It helps you manage, validate, and secure your environment configuration, with type-safe environment variables, multi-environment management, secure secret handling, and leak prevention. While it is written in TypeScript, it is language and framework agnostic, and meant to be used in any project that needs configuration at build or boot time, usually passed in via environment variables.
 
 ## Features
 
-Varlock aims to be the most comprehensive environment variable management tool. It provides a wide range of features out of the box:
+Varlock provides:
 
-- **[AI-Safe Config](/guides/ai-tools/)** - Your `.env.schema` gives AI agents full context on your config without ever exposing secret values. Prevent leaks to AI servers by design, and scan for leaked secrets with `varlock scan`
+- **[AI-Safe Config](/guides/ai-tools/)** - Your `.env.schema` gives AI agents full context on your config without ever exposing secret values. Prevent leaks to AI servers, and scan for leaked secrets with `varlock scan`
 - **[Security](/guides/secrets/)** - Automatic log redaction for sensitive values, leak detection in bundled code and server responses, and proactive scanning via `varlock scan`
-- **[Validation & Type Safety](/reference/data-types/)** - Powerful validation capabilities with clear error messages, plus automatic type generation for IntelliSense support
+- **[Validation & Type Safety](/reference/data-types/)** - Validation with clear error messages, plus automatic type generation for IntelliSense support
 - **[Secure Secrets](/guides/secrets/)** - Built-in [device-local encryption](/guides/local-encryption/) with hardware-backed security (Secure Enclave, TPM), plus provider [plugins](/plugins/overview/) (e.g., [1Password](/plugins/1password/), [AWS](/plugins/aws-secrets/), [HashiCorp Vault](/plugins/hashicorp-vault/)) or any CLI tool using [exec()](/reference/functions/#exec)
 - **[Multi-Environment Management](/guides/environments/)** - Flexible environment handling with support for environment-specific files, local overrides, and value composition
 - **[Value Composition](/reference/functions/)** - Compose values together using functions, references, and external data sources

--- a/packages/varlock-website/src/content/docs/getting-started/migration.mdx
+++ b/packages/varlock-website/src/content/docs/getting-started/migration.mdx
@@ -20,7 +20,7 @@ In some cases where `dotenv` is being called deep under the hood by another depe
 
 ### Within a framework
 
-We must replace the framework's existing `.env` logic with Varlock. Our [framework integrations](/integrations/overview/) handle most of the work for you. After [installation](/getting-started/installation/), simply follow the instructions in the relevant integration guide to set up Varlock in your project. Usually this involves adding a new plugin to the existing build system or the framework config file.
+We must replace the framework's existing `.env` logic with Varlock. Our [framework integrations](/integrations/overview/) handle most of the work for you. After [installation](/getting-started/installation/), follow the instructions in the relevant integration guide to set up Varlock in your project. Usually this involves adding a new plugin to the existing build system or the framework config file.
 
 ### Minimal setup
 

--- a/packages/varlock-website/src/content/docs/getting-started/usage.mdx
+++ b/packages/varlock-website/src/content/docs/getting-started/usage.mdx
@@ -43,10 +43,10 @@ By default, `varlock load` prints a human-readable summary to **stdout**. Schema
   packages/varlock-website/examples/load-output/ and contain raw ANSI escape
   bytes, so don't hand-edit them. To regenerate (run inside that fixture dir):
 
-    # success block — warm the cache first so the cached hint shows:
+    # success block, warm the cache first so the cached hint shows:
     APP_ENV=production FORCE_COLOR=1 varlock load >/dev/null 2>&1
     APP_ENV=production FORCE_COLOR=1 varlock load
-    # error block — key genuinely unset:
+    # error block, key genuinely unset:
     mv .env .env.bak; APP_ENV=production FORCE_COLOR=1 varlock load; mv .env.bak .env
 
   Paste each capture into the matching block, then normalize the volatile
@@ -102,7 +102,7 @@ Each item line shows:
 
 - A status icon (`✅` valid, or an error/warning icon if something failed)
 - The key name, with `*` if [`@required`](/reference/item-decorators/#required)
-- `🔐 sensitive` when the item is marked [`@sensitive`](/reference/item-decorators/#sensitive) — values are redacted in the summary
+- `🔐 sensitive` when the item is marked [`@sensitive`](/reference/item-decorators/#sensitive); values are redacted in the summary
 - The resolved value (quoted strings, colored booleans/numbers)
 - Inline hints such as `📦` (cached), `🟡 process.env` (overridden by the shell), or `< coerced from ...` when a value was coerced
 

--- a/packages/varlock-website/src/content/docs/guides/ai-tools.mdx
+++ b/packages/varlock-website/src/content/docs/guides/ai-tools.mdx
@@ -1,15 +1,15 @@
 ---
 title: AI Tools
-description: Varlock is purpose-built for the AI era — your schema gives agents full context, your secrets never touch AI servers
+description: Your schema gives AI agents full context, while your secrets never touch AI servers
 ---
 import { TabItem, Tabs } from "@astrojs/starlight/components";
 
-Varlock is purpose-built for the AI era. Your `.env.schema` gives AI agents full context on your configuration — variable names, types, validation rules, descriptions — while your secret values never leave your machine or touch AI servers.
+Your `.env.schema` gives AI agents full context on your configuration (variable names, types, validation rules, descriptions), while your secret values never leave your machine or touch AI servers.
 
-This solves two critical problems with AI-assisted development:
+This solves two problems with AI-assisted development:
 
-1. **Secret exposure** — AI tools read your project files, including `.env` files. With varlock, secrets are never stored in plain text — they're fetched at runtime from secure providers.
-2. **AI-generated leaks** — AI agents may hardcode secrets or log sensitive values in generated code. `varlock scan` catches these leaks before they're committed, and runtime protection redacts secrets from logs and responses.
+1. **Secret exposure**: AI tools read your project files, including `.env` files. With varlock, secrets are never stored in plain text. They're fetched at runtime from secure providers.
+2. **AI-generated leaks**: AI agents may hardcode secrets or log sensitive values in generated code. `varlock scan` catches these leaks before they're committed, and runtime protection redacts secrets from logs and responses.
 
 ## Securely inject secrets into AI CLI tools
 
@@ -40,7 +40,7 @@ GOOGLE_API_KEY=op(op://api-local/google/api-key)
 Store the actual secret values in your preferred [secret provider](/plugins/overview/). The examples above use the [1Password plugin](/plugins/1password/)'s `op()` resolver, but any provider plugin works the same way ([AWS Secrets Manager](/plugins/aws-secrets/), [and more](/plugins/overview/)). If you'd rather not depend on an external provider, keep encrypted values in a gitignored `.env.local` using [device-local encryption](/guides/local-encryption/). See also the [Secrets guide](/guides/secrets/#loading-secrets-from-external-sources).
 
 :::tip
-You can use any secrets provider you want, but we like 1Password since it uses biometric authentication for local access. All the examples in this guide use the [1Password plugin](/plugins/1password/) (`op()`) as a means of showing more real world examples — see that page for plugin setup and auth options.
+You can use any secrets provider you want, but we like 1Password since it uses biometric authentication for local access. All the examples in this guide use the [1Password plugin](/plugins/1password/) (`op()`) to show more real world examples. See that page for plugin setup and auth options.
 :::
 
 ### 3. Run your tool via `varlock run`
@@ -57,8 +57,8 @@ See [AI CLI tool examples](#ai-cli-tool-examples) below for tool-specific setup.
 
 Popular AI coding CLIs differ in which env vars they need and how they authenticate. Varlock supports two patterns:
 
-- **Project setup** — define secrets in the repo's `.env.schema` (steps 1-2 above) and run `varlock run -- <tool>` from the project directory.
-- **Personal setup** — keep a schema in your home directory (for example `~/.env.claude`) and pass it with [`-p`](/reference/cli-commands/#run) when launching a tool from any directory (usually using an alias).
+- **Project setup**: define secrets in the repo's `.env.schema` (steps 1-2 above) and run `varlock run -- <tool>` from the project directory.
+- **Personal setup**: keep a schema in your home directory (for example `~/.env.claude`) and pass it with [`-p`](/reference/cli-commands/#run) when launching a tool from any directory (usually using an alias).
 
 Varlock does not auto-load a global schema (that would make two developers' machines behave differently for the same repo).
 
@@ -66,9 +66,9 @@ Varlock does not auto-load a global schema (that would make two developers' mach
   <TabItem label="Claude">
     [Claude Code](https://docs.claude.com/en/docs/claude-code/overview) is Anthropic's CLI tool for AI-assisted coding.
 
-    **Environment variable:** `ANTHROPIC_API_KEY` — see [supported env variables](https://docs.claude.com/en/docs/claude-code/settings#environment-variables).
+    **Environment variable:** `ANTHROPIC_API_KEY`. See [supported env variables](https://docs.claude.com/en/docs/claude-code/settings#environment-variables).
 
-    **In a project** — add to `.env.schema`:
+    **In a project**, add to `.env.schema`:
 
     ```env-spec
     # @sensitive @required
@@ -79,7 +79,7 @@ Varlock does not auto-load a global schema (that would make two developers' mach
     varlock run -- claude
     ```
 
-    **From any directory** — personal schema at `~/.env.claude`:
+    **From any directory**, personal schema at `~/.env.claude`:
 
     ```env-spec title="~/.env.claude"
     # @sensitive @required
@@ -103,11 +103,11 @@ Varlock does not auto-load a global schema (that would make two developers' mach
     [Opencode](https://opencode.ai/) is a provider-agnostic AI coding assistant that works in your terminal.
 
     **Environment variables:**
-    - `ANTHROPIC_API_KEY` — for Claude models
-    - `OPENAI_API_KEY` — for OpenAI models
-    - `OPENCODE_CONFIG` — path to custom config file (optional)
+    - `ANTHROPIC_API_KEY` for Claude models
+    - `OPENAI_API_KEY` for OpenAI models
+    - `OPENCODE_CONFIG` path to custom config file (optional)
 
-    **Auth configuration** — run `opencode auth login` once. When prompted for an API key, paste an env reference instead:
+    **Auth configuration:** run `opencode auth login` once. When prompted for an API key, paste an env reference instead:
 
     `{"env:ANTHROPIC_API_KEY"}`
 
@@ -122,7 +122,7 @@ Varlock does not auto-load a global schema (that would make two developers' mach
     }
     ```
 
-    **In a project** — add to `.env.schema`:
+    **In a project**, add to `.env.schema`:
 
     ```env-spec
     # @sensitive @required
@@ -139,7 +139,7 @@ Varlock does not auto-load a global schema (that would make two developers' mach
     varlock run -- opencode --model claude-3-5-sonnet
     ```
 
-    **From any directory** — personal schema at `~/.env.opencode`:
+    **From any directory**, personal schema at `~/.env.opencode`:
 
     ```env-spec title="~/.env.opencode"
     # @sensitive @required
@@ -166,7 +166,7 @@ Varlock does not auto-load a global schema (that would make two developers' mach
   </TabItem>
 
   <TabItem label="Antigravity">
-    [Antigravity CLI](https://antigravity.google/docs/cli-getting-started) is Google's agent-first terminal experience — the successor to [Gemini CLI](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/), which has been phased out.
+    [Antigravity CLI](https://antigravity.google/docs/cli-getting-started) is Google's agent-first terminal experience, the successor to [Gemini CLI](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/), which has been phased out.
 
     **Launch command:** `agy`
 
@@ -176,7 +176,7 @@ Varlock does not auto-load a global schema (that would make two developers' mach
     varlock run -- agy
     ```
 
-    **From any directory** — personal schema at `~/.env.antigravity` for project-agnostic defaults:
+    **From any directory**, personal schema at `~/.env.antigravity` for project-agnostic defaults:
 
     ```env-spec title="~/.env.antigravity"
     # @type=enum(development, staging, production)
@@ -201,7 +201,7 @@ Varlock does not auto-load a global schema (that would make two developers' mach
 
 ## Install the Varlock skill
 
-Give your AI agent project-scoped instructions for working with Varlock — security rules, schema checklists, and CLI guidance. Install using one of:
+Give your AI agent project-scoped instructions for working with Varlock: security rules, schema checklists, and CLI guidance. Install using one of:
 
 <Tabs>
   <TabItem label="skills">
@@ -279,10 +279,10 @@ Drop the `--agent` flag when you need human-readable output to show the user dir
 
 When an agent needs to consume varlock output rather than show it to a user, prefer machine-readable formats and branch on exit codes:
 
-- **`varlock load --agent`** — flat `{ "KEY": value }` JSON on stdout with `@sensitive` values redacted. Safe to keep in a transcript.
-- **`varlock load --agent --format json-full`** — the full serialized graph (sources, per-item validation state, sensitivity) with sensitive values redacted, for when you need to reason about *why* something is invalid, not just the values. Always keep `--agent` here: plain `--format json-full` emits **raw secret values** and must not go into an agent transcript.
-- **Exit codes** — `varlock load` exits non-zero when config is invalid, `varlock run` forwards the child command's exit code, and `varlock scan` exits `1` when it finds a leaked secret. Check the code instead of parsing prose.
-- **stdout vs stderr** — pass `--summary-stderr` (or `--summary-file`) so the redacted human summary goes to stderr while stdout stays clean JSON for parsing.
+- **`varlock load --agent`**: flat `{ "KEY": value }` JSON on stdout with `@sensitive` values redacted. Safe to keep in a transcript.
+- **`varlock load --agent --format json-full`**: the full serialized graph (sources, per-item validation state, sensitivity) with sensitive values redacted, for when you need to reason about *why* something is invalid, not just the values. Always keep `--agent` here: plain `--format json-full` emits **raw secret values** and must not go into an agent transcript.
+- **Exit codes**: `varlock load` exits non-zero when config is invalid, `varlock run` forwards the child command's exit code, and `varlock scan` exits `1` when it finds a leaked secret. Check the code instead of parsing prose.
+- **stdout vs stderr**: pass `--summary-stderr` (or `--summary-file`) so the redacted human summary goes to stderr while stdout stays clean JSON for parsing.
 
 See the [CLI commands reference](/reference/cli-commands/#load) for the full output-format and exit-code details.
 
@@ -310,7 +310,7 @@ If your tool supports custom rules, you can use our own varlock [Cursor rule fil
 
 ## Scan for leaked secrets
 
-AI agents can sometimes hardcode secret values or leak them into generated code. Use `varlock scan` to proactively detect leaked secrets in your codebase:
+AI agents can sometimes hardcode secret values or leak them into generated code. Use `varlock scan` to detect leaked secrets in your codebase:
 
 ```bash
 # Scan the current directory for leaked secret values
@@ -327,7 +327,7 @@ You can also set up `varlock scan` as a git pre-commit hook to automatically cat
 varlock scan --staged
 ```
 
-This is especially valuable when working with AI coding tools — the scan command compares your resolved secret values against your codebase to find any that may have been accidentally included in plain text.
+This is especially useful when working with AI coding tools. The scan command compares your resolved secret values against your codebase to find any that may have been accidentally included in plain text.
 
 ## Varlock Docs MCP
 

--- a/packages/varlock-website/src/content/docs/guides/caching.mdx
+++ b/packages/varlock-website/src/content/docs/guides/caching.mdx
@@ -11,7 +11,7 @@ Rather than caching environment variable values, it is a general key-value store
 
 Plugins have access to cache helpers that can be used to avoid repeated network round trips, or to hold short-lived tokens. They will usually expose params (like `cacheTtl`) to let the user opt into caching. This still respects global cache mode and CLI flags. Each plugin can decide how to cache things and it will often depend on the shape of the external API.
 
-`cacheTtl` can be set dynamically — for example `cacheTtl=forEnv(dev, "1h")` to cache only in development. Setting it to `false` (or an empty string) disables caching for that plugin instance.
+`cacheTtl` can be set dynamically, for example `cacheTtl=forEnv(dev, "1h")` to cache only in development. Setting it to `false` (or an empty string) disables caching for that plugin instance.
 
 ## Common `cache()` use case: stable generated values
 

--- a/packages/varlock-website/src/content/docs/guides/code-generation.mdx
+++ b/packages/varlock-website/src/content/docs/guides/code-generation.mdx
@@ -3,7 +3,7 @@ title: Code generation
 description: Generate types and other code from your env schema, and extend it with plugins
 ---
 
-Your `.env.schema` is the single source of truth for your environment variables — their names, types, and metadata. Varlock can turn that schema into **generated code**: strongly-typed definitions for your language, and, via plugins, anything else you can derive from a schema.
+Your `.env.schema` is the single source of truth for your environment variables: their names, types, and metadata. Varlock can turn that schema into **generated code**: strongly-typed definitions for your language, and, via plugins, anything else you can derive from a schema.
 
 Generation is driven by per-language root decorators in your schema. Each one writes its own output file:
 
@@ -20,7 +20,7 @@ Output is regenerated automatically on [`varlock load`](/reference/cli-commands/
 
 ## TypeScript
 
-[`@generateTsTypes`](/reference/root-decorators/#generatetstypes) is the default for JavaScript/TypeScript projects. Out of the box it makes `import { ENV } from 'varlock/env'` fully typed, and augments `process.env` / `import.meta.env`:
+[`@generateTsTypes`](/reference/root-decorators/#generatetstypes) is the default for JavaScript/TypeScript projects. It makes `import { ENV } from 'varlock/env'` fully typed, and augments `process.env` / `import.meta.env`:
 
 ```env-spec title=".env.schema"
 # @generateTsTypes(path=./env.d.ts)
@@ -28,14 +28,14 @@ Output is regenerated automatically on [`varlock load`](/reference/cli-commands/
 
 You can control what it emits:
 
-- **`exposeEnv`** — where the coerced `ENV` object lives: `global` (default, augments `varlock/env`), `local` (export a package-local `ENV` from the generated file, ideal for monorepos), or `none`.
-- **`processEnv`** / **`importMetaEnv`** — `strict` (only defined keys), `loose` (also allow extra keys), or `none` (don't augment).
+- **`exposeEnv`**: where the coerced `ENV` object lives: `global` (default, augments `varlock/env`), `local` (export a package-local `ENV` from the generated file, ideal for monorepos), or `none`.
+- **`processEnv`** / **`importMetaEnv`**: `strict` (only defined keys), `loose` (also allow extra keys), or `none` (don't augment).
 
-See the [`@generateTsTypes` reference](/reference/root-decorators/#generatetstypes) for details. In monorepos where multiple packages have different schemas, prefer `exposeEnv=local` to avoid global augmentation clashes — see [Typed `ENV` across packages](/guides/monorepos/#typed-env-across-packages).
+See the [`@generateTsTypes` reference](/reference/root-decorators/#generatetstypes) for details. In monorepos where multiple packages have different schemas, prefer `exposeEnv=local` to avoid global augmentation clashes. See [Typed `ENV` across packages](/guides/monorepos/#typed-env-across-packages).
 
 ## Other languages
 
-Varlock ships generators for several languages. Each emits a **self-contained, idiomatic module** — a typed value object, a loader that reads the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob, and a `SENSITIVE_KEYS` constant (so you can build your own redaction or leak-scanning) — usable out of the box, no hand-rolled parsing:
+Varlock ships generators for several languages. Each emits a **self-contained, idiomatic module**: a typed value object, a loader that reads the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob, and a `SENSITIVE_KEYS` constant (so you can build your own redaction or leak-scanning). No hand-rolled parsing required:
 
 | Language | Decorator | Loader | Guide |
 | --- | --- | --- | --- |
@@ -48,7 +48,7 @@ For a language without a generated module, see [Other languages](/integrations/o
 
 ## Disabling automatic generation
 
-Set `auto=false` on any generator to skip it during `load`/`run`, then regenerate on demand with [`varlock codegen`](/reference/cli-commands/#codegen) — useful for CI or a dedicated build step:
+Set `auto=false` on any generator to skip it during `load`/`run`, then regenerate on demand with [`varlock codegen`](/reference/cli-commands/#codegen), useful for CI or a dedicated build step:
 
 ```env-spec title=".env.schema"
 # @generateTsTypes(path=./env.d.ts, auto=false)
@@ -81,9 +81,9 @@ Once registered, users trigger it from their schema like any other generator:
 # @generateZodSchema(path=./env.schema.ts)
 ```
 
-The `decoratorName` must start with `generate` (e.g. `generateZodSchema`) — a shared convention that keeps code-generation decorators recognizable and separate from behavior decorators. Generators also get the common `path`, `auto`, and `executeWhenImported` args automatically — your `generate` function only handles turning the schema into code.
+The `decoratorName` must start with `generate` (e.g. `generateZodSchema`), a shared convention that keeps code-generation decorators recognizable and separate from behavior decorators. Generators also get the common `path`, `auto`, and `executeWhenImported` args automatically, so your `generate` function only handles turning the schema into code.
 
-Plugins that register custom data types can also declare `coercedType` — what their `coerce()` function outputs (`'string'`, `'int'`, `'number'`, `'boolean'`, `'object'`, or `{ enum: [...] }`) — so generated code types those fields correctly in every language:
+Plugins that register custom data types can also declare `coercedType` (what their `coerce()` function outputs: `'string'`, `'int'`, `'number'`, `'boolean'`, `'object'`, or `{ enum: [...] }`) so generated code types those fields correctly in every language:
 
 ```ts title="my-plugin.ts"
 plugin.registerDataType({

--- a/packages/varlock-website/src/content/docs/guides/docker.mdx
+++ b/packages/varlock-website/src/content/docs/guides/docker.mdx
@@ -1,6 +1,6 @@
 ---
 title: Docker
-description: Using varlock with Docker containers — CI validation, runtime injection, multi-stage builds, and monorepo workarounds
+description: Using varlock with Docker containers for CI validation, runtime injection, multi-stage builds, and monorepo workarounds
 ---
 
 import { TabItem, Tabs } from "@astrojs/starlight/components";
@@ -13,14 +13,14 @@ Before adding varlock to a Dockerfile, decide which role it plays:
 
 | Approach | When to use | varlock in production image? |
 | --- | --- | --- |
-| **CI-only validation** | Validate schema and config in pipelines; runtime env comes from the platform | No — run `varlock load` in CI only |
-| **Runtime injection** | Long-running containers (APIs, workers) that resolve secrets at boot via [plugins](/guides/plugins/) | Yes — use `varlock run` as the entrypoint |
-| **Build-time** | SSR apps where a [framework integration](/integrations/overview/) injects resolved env into build output | Sometimes — only in a **builder** stage, not the final runtime image |
+| **CI-only validation** | Validate schema and config in pipelines; runtime env comes from the platform | No. Run `varlock load` in CI only |
+| **Runtime injection** | Long-running containers (APIs, workers) that resolve secrets at boot via [plugins](/guides/plugins/) | Yes. Use `varlock run` as the entrypoint |
+| **Build-time** | SSR apps where a [framework integration](/integrations/overview/) injects resolved env into build output | Sometimes. Only in a **builder** stage, not the final runtime image |
 
 <Tabs>
   <TabItem label="CI-only validation">
 
-Use varlock in your pipeline to catch schema errors before deploy. Your production container does not need the CLI — the hosting platform (or orchestrator) injects env vars, and varlock has already validated the config graph in CI.
+Use varlock in your pipeline to catch schema errors before deploy. Your production container does not need the CLI. The hosting platform (or orchestrator) injects env vars, and varlock has already validated the config graph in CI.
 
 ```yaml title=".github/workflows/ci.yml"
 - name: Validate environment schema
@@ -37,7 +37,7 @@ See also the [GitHub Action](/integrations/github-action/) for a native Actions 
   </TabItem>
   <TabItem label="Runtime injection">
 
-Use when your container must resolve secrets at boot — for example via a [1Password service account token](/plugins/1password/), AWS IAM, or [OIDC workload identity](/guides/oidc/). The final image runs your app through `varlock run`:
+Use when your container must resolve secrets at boot, for example via a [1Password service account token](/plugins/1password/), AWS IAM, or [OIDC workload identity](/guides/oidc/). The final image runs your app through `varlock run`:
 
 ```dockerfile title="Dockerfile (runtime stage excerpt)"
 ENTRYPOINT ["varlock", "run", "--"]
@@ -49,7 +49,7 @@ Secrets are fetched when the container starts, not when the image is built.
   </TabItem>
   <TabItem label="Build-time">
 
-Use when a [framework integration](/integrations/overview/) (Next.js, Vite SSR, Cloudflare Workers, etc.) resolves and injects env during `build`. Varlock belongs in the **builder** stage; the runtime image receives env via the platform or an encrypted blob — not via the CLI.
+Use when a [framework integration](/integrations/overview/) (Next.js, Vite SSR, Cloudflare Workers, etc.) resolves and injects env during `build`. Varlock belongs in the **builder** stage; the runtime image receives env via the platform or an encrypted blob, not via the CLI.
 
 For serverless SSR, prefer [encrypted deployments](/guides/encrypted-deployments/) over baking resolved values into image layers.
 
@@ -61,9 +61,9 @@ For serverless SSR, prefer [encrypted deployments](/guides/encrypted-deployments
 :::caution[Don't ship the CLI unless you need it at runtime]
 Skip varlock in the final production image when:
 
-- **Serverless / edge** — integrations inject env at build or deploy time; the runtime has no filesystem or CLI access anyway
-- **Platform-managed env** — your host already injects env vars and you only want schema validation in CI
-- **Build-time-only resolution** — secrets are resolved during `docker build` and would end up in a layer (see [best practices](#best-practices) below)
+- **Serverless / edge**: integrations inject env at build or deploy time; the runtime has no filesystem or CLI access anyway
+- **Platform-managed env**: your host already injects env vars and you only want schema validation in CI
+- **Build-time-only resolution**: secrets are resolved during `docker build` and would end up in a layer (see [best practices](#best-practices) below)
 
 Adding varlock to every production image increases size and attack surface without benefit if secrets are already handled elsewhere.
 :::
@@ -94,8 +94,8 @@ docker run --rm \
 
 ### Available tags
 
-- `ghcr.io/dmno-dev/varlock:latest` — latest stable release
-- `ghcr.io/dmno-dev/varlock:1.6.0` — specific version (replace with the version you pin in CI/production)
+- `ghcr.io/dmno-dev/varlock:latest`: latest stable release
+- `ghcr.io/dmno-dev/varlock:1.6.0`: specific version (replace with the version you pin in CI/production)
 
 :::tip[Pin image tags]
 Use an explicit version tag in CI and production Dockerfiles. `latest` is convenient for local experiments but can change without notice.
@@ -107,7 +107,7 @@ Use an explicit version tag in CI and production Dockerfiles. `latest` is conven
 
 Anything written during `RUN` is persisted in the image history. Avoid:
 
-```dockerfile title="Anti-pattern — secrets in layers"
+```dockerfile title="Anti-pattern: secrets in layers"
 # BAD: resolved values become part of the image
 RUN varlock load > /app/.env.production
 RUN varlock run -- node scripts/build.js   # if build embeds secrets in output
@@ -122,7 +122,7 @@ Instead:
 
 ### Use the `/work` mount and `PWD=/work` pattern
 
-The official image sets `WORKDIR /work`. When bind-mounting your project, mirror that layout and set `PWD` explicitly — varlock uses the process working directory to resolve relative `@import()` paths and `.env` files:
+The official image sets `WORKDIR /work`. When bind-mounting your project, mirror that layout and set `PWD` explicitly. Varlock uses the process working directory to resolve relative `@import()` paths and `.env` files:
 
 ```bash
 docker run --rm \
@@ -140,7 +140,7 @@ Pin the GHCR image tag **and** any plugin versions in `.env.schema` when using t
 
 ## Multi-stage builds
 
-Copy the varlock binary from the official image into your application image — no need to install Node or curl in the final stage:
+Copy the varlock binary from the official image into your application image. No need to install Node or curl in the final stage:
 
 ```dockerfile title="Dockerfile"
 FROM ghcr.io/dmno-dev/varlock:1.6.0 AS varlock
@@ -192,7 +192,7 @@ ENTRYPOINT ["varlock", "run", "--"]
 CMD ["node", "dist/server.js"]
 ```
 
-Inject the environment flag and secret-zero credentials via your orchestrator — not via `docker build`:
+Inject the environment flag and secret-zero credentials via your orchestrator, not via `docker build`:
 
 ```bash
 docker run --rm \
@@ -226,20 +226,20 @@ Use [Docker Compose secrets](https://docs.docker.com/compose/how-tos/use-secrets
 
 ## Monorepos and partial build context
 
-In a monorepo, `.env.schema` often uses [`@import()`](/guides/import/) to pull shared config from other packages. For Docker builds, prefer importing **specific files** (optionally with `pick`) over whole directories — a [directory import](/guides/import/#directory) also pulls sibling `.env.local` / `.env.[currentEnv]` files, which you generally don't want baked into an image and may not have copied into the build context:
+In a monorepo, `.env.schema` often uses [`@import()`](/guides/import/) to pull shared config from other packages. For Docker builds, prefer importing **specific files** (optionally with `pick`) over whole directories. A [directory import](/guides/import/#directory) also pulls sibling `.env.local` / `.env.[currentEnv]` files, which you generally don't want baked into an image and may not have copied into the build context:
 
 ```env-spec title="apps/web/.env.schema"
 # @import(../../shared/.env.common)
 # @import(../api/.env.schema, pick=[DATABASE_URL, REDIS_URL])
 ```
 
-When Docker's build context is limited to `apps/web/`, those imported files are **not** in the context — `varlock load` fails with missing file errors.
+When Docker's build context is limited to `apps/web/`, those imported files are **not** in the context, so `varlock load` fails with missing file errors.
 
 ### Workaround: copy imported files explicitly
 
 Until a dedicated **`varlock flatten`** command ships (to inline the import graph into a local directory for Docker builds), copy every file the import graph needs:
 
-```dockerfile title="Dockerfile — monorepo env files"
+```dockerfile title="Dockerfile: monorepo env files"
 # Build from repo root: docker build -f apps/web/Dockerfile .
 ARG SERVICE_DIR=web
 
@@ -252,7 +252,7 @@ WORKDIR /app/apps/${SERVICE_DIR}
 RUN varlock load
 ```
 
-Alternatively, set the build context to the **monorepo root** and use `docker build -f apps/web/Dockerfile .` so all import paths resolve naturally — at the cost of a larger context and slower builds.
+Alternatively, set the build context to the **monorepo root** and use `docker build -f apps/web/Dockerfile .` so all import paths resolve naturally, at the cost of a larger context and slower builds.
 
 :::note[Coming soon]
 A planned `varlock flatten` command will automate inlining imported env files for Docker builds. Until then, explicit `COPY` lines or a root build context are the supported approaches.
@@ -262,12 +262,12 @@ A planned `varlock flatten` command will automate inlining imported env files fo
 
 Containers commonly authenticate to secret providers in two ways:
 
-1. **Service account tokens** — pass a long-lived token (e.g. `OP_SERVICE_ACCOUNT_TOKEN`) as a runtime environment variable
-2. **OIDC workload identity** — exchange a short-lived platform token for temporary credentials; no secret-zero in the image
+1. **Service account tokens**: pass a long-lived token (e.g. `OP_SERVICE_ACCOUNT_TOKEN`) as a runtime environment variable
+2. **OIDC workload identity**: exchange a short-lived platform token for temporary credentials; no secret-zero in the image
 
 For OIDC on Fly.io, GCP Cloud Run, GitHub Actions, and other platforms, see the [OIDC workload identity guide](/guides/oidc/).
 
-When using the **standalone binary** (copied from GHCR or a release tarball), plugins must specify a **fixed version** in `@plugin()` — semver ranges require a local `node_modules` install:
+When using the **standalone binary** (copied from GHCR or a release tarball), plugins must specify a **fixed version** in `@plugin()`. Semver ranges require a local `node_modules` install:
 
 ```env-spec title=".env.schema"
 # @plugin(@varlock/1password-plugin@1.2.3)
@@ -304,7 +304,7 @@ RUN pnpm exec varlock load
 RUN pnpm build
 ```
 
-Install `varlock` and any plugins in `package.json` — the npm package includes the CLI.
+Install `varlock` and any plugins in `package.json`. The npm package includes the CLI.
 
   </TabItem>
   <TabItem label="install.sh">
@@ -320,12 +320,12 @@ WORKDIR /work
 ENTRYPOINT ["/usr/local/bin/varlock"]
 ```
 
-Pass `--version=x.y.z` for reproducible builds. For multi-arch images, prefer the release tarball tab — `install.sh` picks the host architecture at install time.
+Pass `--version=x.y.z` for reproducible builds. For multi-arch images, prefer the release tarball tab, since `install.sh` picks the host architecture at install time.
 
   </TabItem>
   <TabItem label="Release tarball">
 
-Matches how the [official Dockerfile](https://github.com/dmno-dev/varlock/blob/main/Dockerfile) is built — download a versioned binary from GitHub releases:
+Matches how the [official Dockerfile](https://github.com/dmno-dev/varlock/blob/main/Dockerfile) is built. Download a versioned binary from GitHub releases:
 
 ```dockerfile title="Dockerfile"
 FROM alpine:3.19 AS varlock-builder
@@ -385,11 +385,11 @@ Or adjust host file permissions so the container user can read your env files.
 Plugins that call external APIs (1Password, AWS, Azure, Vault, etc.) need outbound network access from the container. If fetches fail with connection errors:
 
 - Confirm the container has DNS and egress to the provider's endpoints
-- For local CLI tools (e.g. 1Password desktop app), use `--network host` only in local dev — not in production
+- For local CLI tools (e.g. 1Password desktop app), use `--network host` only in local dev, not in production
 - Check that secret-zero tokens are passed at **runtime**, not only at build time
 
 ```bash
-# Local dev only — host network for desktop CLI integrations
+# Local dev only: host network for desktop CLI integrations
 docker run --rm --network host \
   -v "$(pwd):/work" \
   -w /work \
@@ -401,7 +401,7 @@ For cloud deployments, prefer [service account tokens](/guides/plugins/) or [OID
 
 ### Missing `@import` files
 
-See [Monorepos and partial build context](#monorepos-and-partial-build-context). The error usually lists a path outside your Docker build context — add explicit `COPY` instructions or widen the context to the monorepo root.
+See [Monorepos and partial build context](#monorepos-and-partial-build-context). The error usually lists a path outside your Docker build context. Add explicit `COPY` instructions or widen the context to the monorepo root.
 
 ### Wrong environment loaded
 

--- a/packages/varlock-website/src/content/docs/guides/encrypted-deployments.mdx
+++ b/packages/varlock-website/src/content/docs/guides/encrypted-deployments.mdx
@@ -7,7 +7,7 @@ import ExecCommandWidget from '@/components/ExecCommandWidget.astro';
 
 When deploying SSR applications to **serverless platforms** (like Vercel, Netlify, or Cloudflare Workers), varlock injects the fully resolved env data into your server-side build output so it's available at runtime without needing the CLI or filesystem access. This is necessary because serverless environments don't give you control over how the application boots.
 
-By default, this blob is **plaintext JSON**. Since it only appears in server-side code, it's generally safe — your secrets are not exposed to the client. However, encrypting the blob provides an extra layer of protection, particularly against secrets leaking via **sourcemaps** that may be uploaded to error tracking services.
+By default, this blob is **plaintext JSON**. Since it only appears in server-side code, it's generally safe: your secrets are not exposed to the client. However, encrypting the blob adds protection against secrets leaking via **sourcemaps** that may be uploaded to error tracking services.
 
 ## Enabling encryption
 
@@ -30,9 +30,9 @@ SECRET_KEY= # @sensitive
 ## How it works
 
 1. At **build time**, varlock encrypts the serialized env graph with **AES-256-GCM** before injecting it
-2. The encrypted blob is prefixed with `varlock:v1:` — you can verify encryption by inspecting your build output
+2. The encrypted blob is prefixed with `varlock:v1:`, so you can verify encryption by inspecting your build output
 3. At **runtime**, `initVarlockEnv()` detects the encrypted prefix and decrypts using `_VARLOCK_ENV_KEY` from the runtime environment
-4. The key is **never baked into the build** — it must always come from the runtime environment
+4. The key is **never baked into the build**. It must always come from the runtime environment
 
 Decryption uses `node:crypto` where available; edge runtimes without it (e.g. Vercel Edge middleware) automatically fall back to asynchronous Web Crypto, with request handling gated until the env is ready.
 
@@ -42,11 +42,11 @@ The encryption key (`_VARLOCK_ENV_KEY`) is managed differently depending on your
 
 ### Local development
 
-No setup needed — varlock **auto-generates a temporary key** when running dev servers. The key exists only in memory for the duration of the dev session.
+No setup needed. Varlock **auto-generates a temporary key** when running dev servers. The key exists only in memory for the duration of the dev session.
 
 ### Cloudflare Workers
 
-No setup needed — `varlock-wrangler deploy` **auto-generates a key** and uploads it alongside your encrypted env as a Cloudflare secret binding. The key persists across deploys.
+No setup needed. `varlock-wrangler deploy` **auto-generates a key** and uploads it alongside your encrypted env as a Cloudflare secret binding. The key persists across deploys.
 
 ### Vercel, Netlify, and other platforms
 
@@ -91,9 +91,9 @@ You must set `_VARLOCK_ENV_KEY` as an environment variable on your platform. The
 |---|---|
 | **[Next.js](/integrations/nextjs/)** | Encrypts the env blob injected into the webpack/turbopack build output |
 | **[Vite](/integrations/vite/)** | Encrypts the env blob when using `ssrInjectMode: 'resolved-env'` |
-| **[Astro](/integrations/astro/)** | Uses the Vite integration — encryption applies to SSR adapter builds |
-| **[SvelteKit](/integrations/sveltekit/)** | Uses the Vite integration — encryption applies to SSR builds |
-| **[TanStack Start](/integrations/tanstack-start/)** | Uses the Vite integration — encryption applies to SSR builds |
+| **[Astro](/integrations/astro/)** | Uses the Vite integration; encryption applies to SSR adapter builds |
+| **[SvelteKit](/integrations/sveltekit/)** | Uses the Vite integration; encryption applies to SSR builds |
+| **[TanStack Start](/integrations/tanstack-start/)** | Uses the Vite integration; encryption applies to SSR builds |
 | **[Cloudflare Workers](/integrations/cloudflare/)** | Encrypts the `__VARLOCK_ENV` secret binding uploaded at deploy time |
 | **[Expo](/integrations/expo/)** | Encrypts the env blob used by the Metro bundler for server routes |
 
@@ -110,4 +110,4 @@ If encryption is working, you'll see `varlock:v1:` followed by a base64-encoded 
 
 ## Alternative: manual key without the decorator
 
-You can also enable encryption without the `@encryptInjectedEnv` decorator by simply setting `_VARLOCK_ENV_KEY` in your environment. When present, varlock will encrypt the blob — but it won't enforce the key's presence or auto-generate it.
+You can also enable encryption without the `@encryptInjectedEnv` decorator by setting `_VARLOCK_ENV_KEY` in your environment. When present, varlock will encrypt the blob, but it won't enforce the key's presence or auto-generate it.

--- a/packages/varlock-website/src/content/docs/guides/import.mdx
+++ b/packages/varlock-website/src/content/docs/guides/import.mdx
@@ -48,8 +48,8 @@ You can import files from your home directory using the `~/` prefix. This is use
 # @import(../shared-config-dir/)
 ```
 
-:::tip[File vs directory — which should I import?]
-- **Import a single file** when you want exactly that file's contents — a shared `.env.common`, or specific keys from another schema via `pick`.
+:::tip[File vs directory: which should I import?]
+- **Import a single file** when you want exactly that file's contents: a shared `.env.common`, or specific keys from another schema via `pick`.
 - **Import a directory** (trailing `/`) when you want everything that directory would load on its own: its `.env.schema` **plus** sibling `.env`, `.env.local`, and environment-specific files, resolved by the current environment flag.
 
 This distinction matters when pulling in a root or sibling package. Importing its `.env.schema` file alone brings only the schema; importing the package's **directory** also brings its values (including `.env.local` and `.env.[currentEnv]`). For the common "import the repo root" case in a monorepo, use the directory form (`# @import(../../)`).
@@ -91,7 +91,7 @@ By default, all items will be imported, but you can restrict which keys are brou
 ```
 
 :::caution[Positional keys are deprecated]
-Older docs and configs list keys as positional args (`@import(./.env.imported, KEY1, KEY2)`). This still works but is deprecated and will warn — use `pick=[KEY1, KEY2]` instead.
+Older docs and configs list keys as positional args (`@import(./.env.imported, KEY1, KEY2)`). This still works but is deprecated and will warn. Use `pick=[KEY1, KEY2]` instead.
 :::
 
 ## Conditional imports
@@ -154,13 +154,13 @@ Meaning if there was a value for `ITEM` in all 4 files, the final value used wou
 - Root decorators that affect individual items (e.g., `@defaultRequired`) affect only the items that are defined in the file, not those in imported files
 - An item with no value at all (e.g., `ITEM=`) will be skipped when looking for a value / function to use, but its presence can be used to add other decorators/description to the item
 - If an imported file is marked with [`@disable`](/reference/root-decorators/#disable), it and any files it imports are skipped entirely
-- Importing the same source from multiple places (a "diamond") is fine — it is loaded once and reused
+- Importing the same source from multiple places (a "diamond") is fine: it is loaded once and reused
 
 ## When things go wrong
 
 ### `environment flag "..." must be defined within this schema`
 
-If you use [`@currentEnv`](/reference/root-decorators/#currentenv) to point at a variable (e.g. `# @currentEnv=$DEPLOY_ENV`) and that variable is only brought in via a **partial** `@import()`, varlock validates the env flag during schema initialization — before imported values are merged. The flag must be **defined in the same `.env.schema` file** that declares `@currentEnv`, not only in an imported file.
+If you use [`@currentEnv`](/reference/root-decorators/#currentenv) to point at a variable (e.g. `# @currentEnv=$DEPLOY_ENV`) and that variable is only brought in via a **partial** `@import()`, varlock validates the env flag during schema initialization, before imported values are merged. The flag must be **defined in the same `.env.schema` file** that declares `@currentEnv`, not only in an imported file.
 
 This commonly appears in monorepos when a sub-package imports shared keys from a parent schema:
 

--- a/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
+++ b/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
@@ -94,22 +94,22 @@ If native capabilities are unavailable, varlock falls back to file-based local e
 
 ## Unattended decryption (headless servers & CI)
 
-Local encryption isn't just for laptops. On a headless host with a TPM — a home server, a CI runner, a container host — varlock seals the key to the machine's TPM and decrypts automatically at load with **no prompt**. That makes it a good way to store a "secret-zero" (like a 1Password service account token) that bootstraps the rest of your secrets:
+Local encryption isn't just for laptops. On a headless host with a TPM (a home server, a CI runner, a container host), varlock seals the key to the machine's TPM and decrypts automatically at load with **no prompt**. That makes it a good way to store a "secret-zero" (like a 1Password service account token) that bootstraps the rest of your secrets:
 
 ```env-spec title=".env.schema"
 # @type=opServiceAccountToken @sensitive @internal
 OP_TOKEN=varlock("local:...")
 ```
 
-On Linux this requires `tpm2-tools` and a TPM (see [Linux setup](#linux) below). The sealed value survives reboots and is bound to that specific machine — it can't be copied to another host.
+On Linux this requires `tpm2-tools` and a TPM (see [Linux setup](#linux) below). The sealed value survives reboots and is bound to that specific machine. It can't be copied to another host.
 
-This unattended path applies to backends whose key is unsealed to the host — Linux (TPM2) and Windows (NCrypt/TPM). **macOS is different:** Secure Enclave keys never leave the enclave, and every decrypt requires user presence (Touch ID or password), so there is no unattended decrypt on macOS. A headless Mac or CI runner falls back to file-based encryption instead.
+This unattended path applies to backends whose key is unsealed to the host: Linux (TPM2) and Windows (NCrypt/TPM). **macOS is different:** Secure Enclave keys never leave the enclave, and every decrypt requires user presence (Touch ID or password), so there is no unattended decrypt on macOS. A headless Mac or CI runner falls back to file-based encryption instead.
 
 ### What this protects (and what it doesn't)
 
 Hardware-backed encryption protects your secrets **at rest**: a stolen disk, a leaked backup, or an env file committed by mistake can't be decrypted off the machine.
 
-It does **not** protect against an attacker who is already running code as your user on that machine — they can ask the TPM to unseal the value exactly like varlock does. This is the same trade-off as tools like [`systemd-creds`](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html), and it's inherent to unattended decryption: if no human is present to approve, anything running as you can decrypt.
+It does **not** protect against an attacker who is already running code as your user on that machine. They can ask the TPM to unseal the value exactly like varlock does. This is the same trade-off as tools like [`systemd-creds`](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html), and it's inherent to unattended decryption: if no human is present to approve, anything running as you can decrypt.
 
 If you want a presence gate (fingerprint / password / YubiKey via polkit + PAM) on every decrypt, register the policy:
 
@@ -117,9 +117,9 @@ If you want a presence gate (fingerprint / password / YubiKey via polkit + PAM) 
 sudo varlock-local-encrypt setup --linux-biometrics
 ```
 
-Once configured, varlock's normal decrypt flow requires user presence, so everyday loads are no longer unattended — enable this only on interactive machines, not headless servers.
+Once configured, varlock's normal decrypt flow requires user presence, so everyday loads are no longer unattended. Enable this only on interactive machines, not headless servers.
 
-Treat this gate as a **consent prompt**, not an at-rest boundary. On Linux the TPM unseal isn't bound to polkit, so — as noted above — other code already running as your user can still unseal directly. It means "a human approved this load," not "only a human can ever decrypt."
+Treat this gate as a **consent prompt**, not an at-rest boundary. On Linux the TPM unseal isn't bound to polkit, so (as noted above) other code already running as your user can still unseal directly. It means "a human approved this load," not "only a human can ever decrypt."
 
 ## Platform details & setup
 
@@ -136,7 +136,7 @@ Treat this gate as a **consent prompt**, not an at-rest boundary. On Linux the T
 
 - Native helper with **TPM-sealed** key protection when a TPM 2.0 chip is available (via NCrypt / Platform Crypto Provider)
 - Falls back to **DPAPI** (user-session-scoped) when TPM sealing is unavailable
-- **Windows Hello** gates interactive decrypts (fingerprint/face/PIN) — separate from at-rest protection, same as before
+- **Windows Hello** gates interactive decrypts (fingerprint/face/PIN), separate from at-rest protection, same as before
 - Windows native and **WSL** workflows are both supported (WSL uses the Windows `.exe` via `--via-daemon`; Hello + TPM behavior is identical)
 - Automated daemon startup/installation behavior is built in for biometric session flows
 - WSL decrypt flows use a native bridge to the Windows daemon path
@@ -145,16 +145,16 @@ Treat this gate as a **consent prompt**, not an at-rest boundary. On Linux the T
 
 #### Upgrading existing keys to TPM
 
-New keys automatically use TPM sealing when available. Existing **DPAPI** keys are **auto-upgraded to TPM sealing on the next successful decrypt** (public key unchanged — no re-encryption of `.env` values). To upgrade without decrypting, use `varlock-local-encrypt rewrap-key --key-id varlock-default`.
+New keys automatically use TPM sealing when available. Existing **DPAPI** keys are **auto-upgraded to TPM sealing on the next successful decrypt** (public key unchanged, no re-encryption of `.env` values). To upgrade without decrypting, use `varlock-local-encrypt rewrap-key --key-id varlock-default`.
 
 #### Windows Defender false positives
 
-`varlock-local-encrypt.exe` is Varlock's official local-encryption helper (bundled with the npm package and standalone CLI). Windows Defender may flag it as `Trojan:Win32/Wacatac.C!ml` or similar — a common machine-learning false positive on new, unsigned executables. The binary is safe when obtained from official Varlock releases.
+`varlock-local-encrypt.exe` is Varlock's official local-encryption helper (bundled with the npm package and standalone CLI). Windows Defender may flag it as `Trojan:Win32/Wacatac.C!ml` or similar, a common machine-learning false positive on new, unsigned executables. The binary is safe when obtained from official Varlock releases.
 
 **Verify the download:** each [GitHub release](https://github.com/dmno-dev/varlock/releases) includes `SHA256SUMS.txt` with hashes for all native helpers. After installing, compare your file:
 
 ```powershell
-# PowerShell — run from the directory containing the .exe
+# PowerShell: run from the directory containing the .exe
 Get-FileHash varlock-local-encrypt.exe -Algorithm SHA256
 ```
 

--- a/packages/varlock-website/src/content/docs/guides/migrate-from-dotenv.mdx
+++ b/packages/varlock-website/src/content/docs/guides/migrate-from-dotenv.mdx
@@ -62,7 +62,7 @@ Finally, you can remove `dotenv` from your dependencies:
 
 ## Using overrides
 
-If `dotenv` is being used under the hood of one of your dependencies, you can use `overrides` to seamlessly swap in `varlock` instead.
+If `dotenv` is being used under the hood of one of your dependencies, you can use `overrides` to swap in `varlock` instead.
 
 
 <Tabs syncKey='package-manager'>

--- a/packages/varlock-website/src/content/docs/guides/monorepos.mdx
+++ b/packages/varlock-website/src/content/docs/guides/monorepos.mdx
@@ -9,7 +9,7 @@ Monorepos often mix shared platform config with app-specific settings. Varlock s
 
 ## Schema layout
 
-The recommended pattern is **one `.env.schema` per project** — each app or service owns a schema next to its code and imports whatever shared config it needs from the repo root or sibling packages. Avoid funneling every variable into a single central env directory; keep each project's config with the project.
+The recommended pattern is **one `.env.schema` per project**. Each app or service owns a schema next to its code and imports whatever shared config it needs from the repo root or sibling packages. Avoid funneling every variable into a single central env directory; keep each project's config with the project.
 
 ### One schema per project (recommended)
 
@@ -22,7 +22,7 @@ packages/
   api/.env.schema
 ```
 
-Varlock resolves env files from each package's **current working directory** — it does not walk up to a parent directory automatically. Use [`@import()`](/guides/import/) when a package needs config defined elsewhere.
+Varlock resolves env files from each package's **current working directory**. It does not walk up to a parent directory automatically. Use [`@import()`](/guides/import/) when a package needs config defined elsewhere.
 
 :::tip[Packages with no env vars]
 A library or utility package that doesn't read any environment variables doesn't need a `.env.schema` at all. Only add one where a package actually loads config.
@@ -30,7 +30,7 @@ A library or utility package that doesn't read any environment variables doesn't
 
 ### Sharing config from the root or siblings
 
-Put cross-cutting config — database URLs used by many services, shared feature flags, platform identifiers — in a schema at the repo root, then **import the root directory** from each project that needs it:
+Put cross-cutting config (database URLs used by many services, shared feature flags, platform identifiers) in a schema at the repo root, then **import the root directory** from each project that needs it:
 
 ```env-spec title="packages/web/.env.schema"
 # Import only the shared keys this app needs
@@ -42,16 +42,16 @@ Put cross-cutting config — database URLs used by many services, shared feature
 PUBLIC_SITE_URL=
 ```
 
-By default every key in the imported source is brought in, but importing only the keys an app actually needs is usually the cleaner default — use `pick=[...]` (allowlist) or `omit=[...]` (denylist) so each schema declares exactly what it depends on.
+By default every key in the imported source is brought in, but importing only the keys an app actually needs is usually the cleaner default. Use `pick=[...]` (allowlist) or `omit=[...]` (denylist) so each schema declares exactly what it depends on.
 
-Importing the **directory** (`../../`) rather than the schema file (`../../.env.schema`) means all files like `.env.local` and [environment-specific](/guides/environments/) are loaded too — not just the schema — following the same precedence as the current directory. Imported definitions merge with the importing schema, and the importing file wins. See the [Imports guide](/guides/import/) for partial imports, precedence, and conditional loading.
+Importing the **directory** (`../../`) rather than the schema file (`../../.env.schema`) means all files like `.env.local` and [environment-specific](/guides/environments/) are loaded too, not just the schema, following the same precedence as the current directory. Imported definitions merge with the importing schema, and the importing file wins. See the [Imports guide](/guides/import/) for partial imports, precedence, and conditional loading.
 
 Use `@import()` to pull in a root or shared schema without copying keys, to split a large schema into focused files (e.g. `.env.database`, `.env.features`), or to share a directory of common env files across services (`# @import(../../shared-config/)`).
 
-You can also **import directly from a sibling package**, which lets you keep a config item with its logical owner instead of hoisting everything to the root. Define the item once in the package that owns it, then `pick` just what you need — like the `../api/` import in the example above.
+You can also **import directly from a sibling package**, which lets you keep a config item with its logical owner instead of hoisting everything to the root. Define the item once in the package that owns it, then `pick` just what you need, like the `../api/` import in the example above.
 
 :::caution[Avoid circular imports]
-Imports must flow in one direction — if `web` imports `api` and `api` also imports `web` (directly or through a chain), varlock detects the cycle and loading fails with an explicit error naming the chain (e.g. `Circular import detected: web/.env.schema -> api/.env.schema -> web/.env.schema`). Keep each shared item with a single owner and import one way; if two packages genuinely need each other's values, hoist those keys into a common file (e.g. the repo root) that both import.
+Imports must flow in one direction. If `web` imports `api` and `api` also imports `web` (directly or through a chain), varlock detects the cycle and loading fails with an explicit error naming the chain (e.g. `Circular import detected: web/.env.schema -> api/.env.schema -> web/.env.schema`). Keep each shared item with a single owner and import one way; if two packages genuinely need each other's values, hoist those keys into a common file (e.g. the repo root) that both import.
 :::
 
 :::note[Shared environment flag]
@@ -60,7 +60,7 @@ If several projects share an environment flag like `APP_ENV`, define it in the s
 
 ### Pointing varlock at the right directory
 
-In most cases you don't need anything here — a `.env.schema` in each package, loaded from its working directory, is the right default. Reach for the options below only when a package's env files live somewhere other than its cwd.
+In most cases you don't need anything here. A `.env.schema` in each package, loaded from its working directory, is the right default. Reach for the options below only when a package's env files live somewhere other than its cwd.
 
 When an app's env files live outside its default cwd (or you need multiple roots), set `varlock.loadPath` in that package's `package.json`:
 
@@ -72,7 +72,7 @@ When an app's env files live outside its default cwd (or you need multiple roots
 }
 ```
 
-You can also pass an explicit path on the CLI with `--path` (or `-p`) — useful in CI or scripts that run from the monorepo root:
+You can also pass an explicit path on the CLI with `--path` (or `-p`), useful in CI or scripts that run from the monorepo root:
 
 <ExecCommandWidget command="varlock load --path apps/web/" showBinary={false} />
 
@@ -80,11 +80,11 @@ For loading from multiple directories in one package, see [Loading from multiple
 
 ## Next.js apps
 
-Next.js requires a workspace-root `@next/env` override and has extra footguns when only some apps use varlock. See [Next.js in a monorepo](/integrations/nextjs/#monorepos) for package-manager overrides, incremental adoption, and troubleshooting — then return here for shared schema layout and CI patterns.
+Next.js requires a workspace-root `@next/env` override and has extra footguns when only some apps use varlock. See [Next.js in a monorepo](/integrations/nextjs/#monorepos) for package-manager overrides, incremental adoption, and troubleshooting, then return here for shared schema layout and CI patterns.
 
 ## Turborepo and strict env mode
 
-Turborepo v2+ enables **Strict Environment Mode** by default. Tasks only receive env vars that are listed in `turbo.json`, so any var varlock reads from the ambient environment — not just your `@currentEnv` flag — must be declared there, or it won't reach the task. This includes:
+Turborepo v2+ enables **Strict Environment Mode** by default. Tasks only receive env vars that are listed in `turbo.json`, so any var varlock reads from the ambient environment (not just your `@currentEnv` flag) must be declared there, or it won't reach the task. This includes:
 
 - your environment flag (e.g. `APP_ENV`), or varlock may load the wrong `.env.[currentEnv]` file
 - the **CI-detection vars** that built-ins like [`VARLOCK_ENV`](/reference/builtin-variables/#varlock_env) rely on (`CI`, `VERCEL`, `WORKERS_CI_BRANCH`, etc.)
@@ -96,10 +96,10 @@ Declare these in `globalEnv` (or per-task `env`) in `turbo.json`. Full explanati
 
 You do not need to migrate every package at once. A practical order:
 
-1. **Pick one app** — run `varlock init` in that package and commit its `.env.schema`.
+1. **Pick one app**: run `varlock init` in that package and commit its `.env.schema`.
 2. **Wire the integration** for that stack only (Next.js plugin, Vite plugin, or `varlock run` for scripts).
-3. **Expand shared config** — extract common keys to a root or shared schema and `@import()` them from apps as you go.
-4. **Leave untouched apps alone** — packages without a `.env.schema` should keep using their existing env loading until you migrate them.
+3. **Expand shared config**: extract common keys to a root or shared schema and `@import()` them from apps as you go.
+4. **Leave untouched apps alone**: packages without a `.env.schema` should keep using their existing env loading until you migrate them.
 
 :::tip[CLI-only services]
 Services that do not need a framework integration can start with [`varlock run`](/reference/cli-commands/#run) and a local `.env.schema` without changing root dependency overrides.
@@ -107,9 +107,9 @@ Services that do not need a framework integration can start with [`varlock run`]
 
 ## Typed `ENV` across packages
 
-By default, [`@generateTsTypes`](/reference/root-decorators/#generatetstypes) globally augments the `varlock/env` module so `import { ENV } from 'varlock/env'` is typed. There is only one `varlock/env` module in a TypeScript program, so when several packages each generate types with **different** schemas, their augmentations merge — a package can end up seeing keys it never declared, or hit conflicting types.
+By default, [`@generateTsTypes`](/reference/root-decorators/#generatetstypes) globally augments the `varlock/env` module so `import { ENV } from 'varlock/env'` is typed. There is only one `varlock/env` module in a TypeScript program, so when several packages each generate types with **different** schemas, their augmentations merge, so a package can end up seeing keys it never declared, or hit conflicting types.
 
-To keep each package's `ENV` isolated, set `exposeEnv=local`. It emits a package-local file that re-exports the runtime `ENV` typed to *that* package's schema, with no global augmentation — the `process.env` / `import.meta.env` augmentations default off too, so nothing from this package merges into the global type scope:
+To keep each package's `ENV` isolated, set `exposeEnv=local`. It emits a package-local file that re-exports the runtime `ENV` typed to *that* package's schema, with no global augmentation. The `process.env` / `import.meta.env` augmentations default off too, so nothing from this package merges into the global type scope:
 
 ```env-spec title="packages/api/.env.schema"
 # @generateTsTypes(path=./env.ts, exposeEnv=local)
@@ -133,8 +133,8 @@ Run the command from the service directory (or pass `--path` to its env folder).
 
 ## Container builds
 
-Container images often copy a single app directory, not the whole monorepo. If your schema uses `@import()` to pull files from sibling packages or the repo root, those paths must exist in the build context — otherwise the load graph fails at build time.
+Container images often copy a single app directory, not the whole monorepo. If your schema uses `@import()` to pull files from sibling packages or the repo root, those paths must exist in the build context, otherwise the load graph fails at build time.
 
 The [Docker guide](/guides/docker/) covers the official image, multi-stage copies of the varlock binary, and running `varlock run` as your container entrypoint.
 
-Today you may need to copy imported env files explicitly in your Dockerfile (mirroring the import tree). A planned **`varlock flatten`** command will collapse an import graph into local files for slim Docker contexts — see the [Docker guide](/guides/docker/#monorepos-and-partial-build-context).
+Today you may need to copy imported env files explicitly in your Dockerfile (mirroring the import tree). A planned **`varlock flatten`** command will collapse an import graph into local files for slim Docker contexts. See the [Docker guide](/guides/docker/#monorepos-and-partial-build-context).

--- a/packages/varlock-website/src/content/docs/guides/oidc.mdx
+++ b/packages/varlock-website/src/content/docs/guides/oidc.mdx
@@ -1,9 +1,9 @@
 ---
 title: OIDC Workload Identity
-description: Authenticate with secret providers using OIDC tokens from your deployment platform — no long-lived credentials needed
+description: Authenticate with secret providers using OIDC tokens from your deployment platform, with no long-lived credentials
 ---
 
-Many deployment platforms issue short-lived [OIDC](https://openid.net/developers/how-connect-works/) tokens that your application can exchange for temporary credentials with secret providers. This eliminates the need to store long-lived API keys or service account credentials in your deployment environment — no "secret zero" needed to fetch the rest of your secrets.
+Many deployment platforms issue short-lived [OIDC](https://openid.net/developers/how-connect-works/) tokens that your application can exchange for temporary credentials with secret providers. This eliminates the need to store long-lived API keys or service account credentials in your deployment environment: no "secret zero" needed to fetch the rest of your secrets.
 
 Varlock supports OIDC workload identity federation across multiple plugins and platforms. In most cases, the OIDC token is **auto-detected** from your deployment platform, so you just need to configure the provider side.
 

--- a/packages/varlock-website/src/content/docs/guides/plugins.mdx
+++ b/packages/varlock-website/src/content/docs/guides/plugins.mdx
@@ -15,7 +15,7 @@ OP_TOKEN=
 XYZ_API_KEY=op(op://api-prod/xyz/api-key) # custom resolver function
 ```
 
-This unlocks use cases like:
+This enables use cases like:
 - loading values from cloud providers or locally running services
 - adding domain-specific validation/coercion logic via custom data types
 - generating values dynamically via custom resolver functions
@@ -35,7 +35,7 @@ In a JavaScript project (where a `package.json` file is present), you must insta
 # @plugin(@varlock/a-plugin) # uses the locally installed version
 ```
 
-You can optionally add a version specifier to validate that the installed version satisfies a [semver range](https://devhints.io/semver) — but the local version is always what gets loaded. If the installed version doesn't match the specified range, an error will be thrown.
+You can optionally add a version specifier to validate that the installed version satisfies a [semver range](https://devhints.io/semver), but the local version is always what gets loaded. If the installed version doesn't match the specified range, an error will be thrown.
 
 ```env-spec title=".env.schema"
 # @plugin(@varlock/a-plugin@^2.3.4) # validates installed version is >=2.3.4 <3.0.0

--- a/packages/varlock-website/src/content/docs/guides/schema.mdx
+++ b/packages/varlock-website/src/content/docs/guides/schema.mdx
@@ -2,7 +2,7 @@
 title: Schema
 description: Using the schema to manage your environment variables
 ---
-One of the core features of Varlock is its schema-driven approach to environment variables — which is best when shared with your team and committed to version control. We recommend creating a new `.env.schema` file to hold schema info set by [config item decorators](/reference/item-decorators/), non-sensitive default values, and [root decorators](/reference/root-decorators/) to specify global settings that affect the `varlock` CLI itself.
+One of the core features of Varlock is its schema-driven approach to environment variables, which is best when shared with your team and committed to version control. We recommend creating a new `.env.schema` file to hold schema info set by [config item decorators](/reference/item-decorators/), non-sensitive default values, and [root decorators](/reference/root-decorators/) to specify global settings that affect the `varlock` CLI itself.
 
 This schema should include all of the environment variables that your application depends on, along with comments and documentation about them, and decorators which affect coercion, validation, and generated types / documentation.
 
@@ -35,7 +35,7 @@ More details:
 
 Config items are the environment variables that your application depends on. Like normal `.env` syntax, each item is a key-value pair of the form `KEY=value`. The key is the name of the environment variable, and a value may be specified or not.
 
-While simply enumerating all of them in your `.env.schema` is useful (like a `.env.example` file), [@env-spec](/env-spec/overview/) allows us to attach additional comments and [item decorators](/reference/item-decorators/), making our schema much more powerful.
+While simply enumerating all of them in your `.env.schema` is useful (like a `.env.example` file), [@env-spec](/env-spec/overview/) allows us to attach additional comments and [item decorators](/reference/item-decorators/), making our schema much more capable.
 
 
 ### Item Values

--- a/packages/varlock-website/src/content/docs/guides/secrets.mdx
+++ b/packages/varlock-website/src/content/docs/guides/secrets.mdx
@@ -23,7 +23,7 @@ NON_SECRET_FOO=
 SECRET_FOO=
 ```
 
-These decorators are typically used only in your `.env.schema` file, but may be used in any file — which can be useful to override sensitivity in a specific environment.
+These decorators are typically used only in your `.env.schema` file, but may be used in any file, which can be useful to override sensitivity in a specific environment.
 
 ## Local encryption via `varlock()` ||local-encryption||
 
@@ -46,7 +46,7 @@ On macOS, you can also use the built-in [keychain()](/plugins/macos-keychain/) p
 
 ### Using plugins (recommended)
 
-`varlock` provides official plugins for popular secret management platforms, offering a seamless and type-safe way to fetch secrets directly in your `.env` files.
+`varlock` provides official plugins for popular secret management platforms, giving you a type-safe way to fetch secrets directly in your `.env` files.
 
 Available plugins include:
 - [1Password](/plugins/1password/)
@@ -91,7 +91,7 @@ For cases where a plugin doesn't exist or you need custom logic, `varlock` suppo
 MY_SECRET=exec(`./scripts/fetch-secret.sh prod/api-credential`)
 ```
 
-This approach works with any CLI tool, ensuring no secrets are left in plaintext on your system, even if they are gitignored. If a [plugin](/plugins/overview/) already exists for your provider (1Password, AWS, Vault, …), prefer it over `exec()` — plugin resolvers like `op()` handle auth and caching for you.
+This approach works with any CLI tool, ensuring no secrets are left in plaintext on your system, even if they are gitignored. If a [plugin](/plugins/overview/) already exists for your provider (1Password, AWS, Vault, …), prefer it over `exec()`. Plugin resolvers like `op()` handle auth and caching for you.
 
 ### Bulk injection with `@setValuesBulk()`
 
@@ -123,7 +123,7 @@ For example, using 1Password, you could store a .env style blob within a text fi
 # @setValuesBulk(infisicalBulk(), omit=[LEGACY_TOKEN])
 ```
 
-The bulk values are injected at the precedence level of the file containing the decorator — so `.env.local` and `process.env` will still override them as expected. See the [reference docs](/reference/root-decorators/#setvaluesbulk) for full details.
+The bulk values are injected at the precedence level of the file containing the decorator, so `.env.local` and `process.env` will still override them as expected. See the [reference docs](/reference/root-decorators/#setvaluesbulk) for full details.
 
 ## Security enhancements
 Unlike other tools where you have to rely on pattern matching to detect _sensitive-looking_ data, `varlock` knows exactly which values are sensitive, and can take extra precautions to protect them.
@@ -140,26 +140,26 @@ varlock reveal MY_SECRET    # reveal a specific variable
 varlock reveal MY_SECRET --copy  # copy to clipboard (auto-clears after 10s)
 ```
 
-The `reveal` command displays values in an **alternate screen buffer** — when you press any key to dismiss, the value disappears from your terminal entirely and won't be visible in scrollback history. With `--copy`, the value is copied to your clipboard and automatically cleared after 10 seconds.
+The `reveal` command displays values in an **alternate screen buffer**. When you press any key to dismiss, the value disappears from your terminal entirely and won't be visible in scrollback history. With `--copy`, the value is copied to your clipboard and automatically cleared after 10 seconds.
 
 #### Redaction in `varlock run`
 
 When the output of [`varlock run`](/reference/cli-commands/#run) is piped or redirected (CI logs, files, `| tee`, etc.), the child process's stdout/stderr is piped through the same redaction engine, so any sensitive values that end up in your application's output will be masked automatically before they persist anywhere.
 
-When output is attached to an interactive terminal, it passes straight through instead — piping would break interactive tools (e.g., `psql`, `claude`) that rely on TTY detection, and a human at the terminal already has access to the secrets. Use `--no-redact-stdout` to force-disable redaction for piped output, or `--redact-stdout` to force it (e.g., to override `@redactLogs=false`; errors if output is attached to an interactive terminal, where redaction is not possible without breaking TTY behavior):
+When output is attached to an interactive terminal, it passes straight through instead. Piping would break interactive tools (e.g., `psql`, `claude`) that rely on TTY detection, and a human at the terminal already has access to the secrets. Use `--no-redact-stdout` to force-disable redaction for piped output, or `--redact-stdout` to force it (e.g., to override `@redactLogs=false`; errors if output is attached to an interactive terminal, where redaction is not possible without breaking TTY behavior):
 
 ```bash
 varlock run --no-redact-stdout -- node app.js | tee log.txt  # force-disable redaction for piped output
 varlock run --redact-stdout -- node app.js > log.txt         # force redaction despite @redactLogs=false
 ```
 
-The same override can be set with the [`_VARLOCK_REDACT_STDOUT`](/reference/reserved-variables/#_varlock_redact_stdout) environment variable (`true`/`1` or `false`/`0`) when you can't easily change the command — e.g. in a wrapper script or CI config. The CLI flag takes precedence over the env var.
+The same override can be set with the [`_VARLOCK_REDACT_STDOUT`](/reference/reserved-variables/#_varlock_redact_stdout) environment variable (`true`/`1` or `false`/`0`) when you can't easily change the command, e.g. in a wrapper script or CI config. The CLI flag takes precedence over the env var.
 
 ### Runtime log redaction
 
 _Only available in JavaScript/Node.js projects using varlock's runtime integrations._
 
-When using `varlock/auto-load` or a [framework integration](/integrations/overview/), varlock automatically patches global `console` methods (`log`, `warn`, `error`, `debug`, `info`, `trace`) to redact any sensitive values before they reach stdout/stderr. Sensitive values are replaced with a partially masked string using the `▒` character — for example, `my-secret-value` becomes `my▒▒▒▒▒`.
+When using `varlock/auto-load` or a [framework integration](/integrations/overview/), varlock automatically patches global `console` methods (`log`, `warn`, `error`, `debug`, `info`, `trace`) to redact any sensitive values before they reach stdout/stderr. Sensitive values are replaced with a partially masked string using the `▒` character. For example, `my-secret-value` becomes `my▒▒▒▒▒`.
 
 ```js
 console.log(process.env.SECRET_KEY);
@@ -185,8 +185,8 @@ _Only available in JavaScript/Node.js projects using varlock's runtime integrati
 Varlock scans outgoing HTTP responses at runtime to detect if any sensitive values are being accidentally sent to clients. If a leak is detected, varlock throws an error with a detailed diagnostic message including the config item key and where the leak was detected.
 
 This works by patching:
-- **Node.js `ServerResponse`** — intercepts `write()` and `end()` calls, scanning text and JSON response bodies (including gzip-compressed responses)
-- **Global `Response` constructor** — intercepts the `Response` class used in edge runtimes (e.g., Cloudflare Workers), scanning bodies passed to the constructor and `Response.json()`
+- **Node.js `ServerResponse`**: intercepts `write()` and `end()` calls, scanning text and JSON response bodies (including gzip-compressed responses)
+- **Global `Response` constructor**: intercepts the `Response` class used in edge runtimes (e.g., Cloudflare Workers), scanning bodies passed to the constructor and `Response.json()`
 
 Our [framework integrations](/integrations/overview/) automatically apply the appropriate patches for your environment. For example, a Next.js integration will scan both server-rendered pages and API route responses.
 

--- a/packages/varlock-website/src/content/docs/guides/shell-completion.mdx
+++ b/packages/varlock-website/src/content/docs/guides/shell-completion.mdx
@@ -8,12 +8,12 @@ import ExecCommandWidget from "@/components/ExecCommandWidget.astro";
 
 The varlock CLI supports tab completion for subcommands and flags. There are two ways to get it, depending on how varlock is installed:
 
-- **`varlock` on your PATH** (standalone binary or global npm install) — install varlock's own completion script. See [Setup](#setup) below.
-- **varlock as a local project dependency** (run via `pnpm exec`, `npm exec`, `bun x`, scripts, etc.) — completion comes from your package manager's completion instead. See [Local project installs](#local-project-installs).
+- **`varlock` on your PATH** (standalone binary or global npm install): install varlock's own completion script. See [Setup](#setup) below.
+- **varlock as a local project dependency** (run via `pnpm exec`, `npm exec`, `bun x`, scripts, etc.): completion comes from your package manager's completion instead. See [Local project installs](#local-project-installs).
 
 ## Setup
 
-Use this when `varlock` is on your PATH — installed via the [standalone binary](/getting-started/installation/#as-a-standalone-binary) (Homebrew or cURL) or a global npm install (`npm install -g varlock`).
+Use this when `varlock` is on your PATH, installed via the [standalone binary](/getting-started/installation/#as-a-standalone-binary) (Homebrew or cURL) or a global npm install (`npm install -g varlock`).
 
 Generate a completion script with `varlock complete <shell>`, then install it using the instructions below for your shell.
 
@@ -44,7 +44,7 @@ After upgrading varlock, re-run `varlock complete <shell>` if new commands or fl
     varlock complete fish > ~/.config/fish/completions/varlock.fish
     ```
 
-    Fish loads completions automatically — restart your shell or open a new terminal to pick them up.
+    Fish loads completions automatically. Restart your shell or open a new terminal to pick them up.
   </TabItem>
   <TabItem label="PowerShell">
     ```powershell
@@ -56,7 +56,7 @@ After upgrading varlock, re-run `varlock complete <shell>` if new commands or fl
 
 ## Local project installs
 
-When varlock is only a local dependency (not on your PATH), you run it through your package manager — `pnpm exec varlock …`, `npm exec varlock …`, `bun x varlock …`, or a `package.json` script. In that case completion comes from **your package manager's** completion, which delegates to varlock automatically. You don't install anything varlock-specific — varlock already speaks the completion protocol that package-manager completion uses.
+When varlock is only a local dependency (not on your PATH), you run it through your package manager: `pnpm exec varlock …`, `npm exec varlock …`, `bun x varlock …`, or a `package.json` script. In that case completion comes from **your package manager's** completion, which delegates to varlock automatically. You don't install anything varlock-specific; varlock already speaks the completion protocol that package-manager completion uses.
 
 Set up completion for your package manager once, using [`@bomb.sh/tab`](https://bomb.sh/docs/tab/#package-manager-completions):
 
@@ -78,7 +78,7 @@ Completion is registered against the package-manager binary (`npm`, `pnpm`, `yar
 
 Tab completion covers varlock **subcommands** and **static flags** (including enum choices like `load --format`).
 
-Dynamic values — such as env var names from your schema — are not completed yet.
+Dynamic values, such as env var names from your schema, are not completed yet.
 
 ## Troubleshooting
 

--- a/packages/varlock-website/src/content/docs/guides/telemetry.mdx
+++ b/packages/varlock-website/src/content/docs/guides/telemetry.mdx
@@ -11,13 +11,13 @@ The `varlock` CLI collects **anonymous telemetry data** about usage to help us u
 
 We track general usage information, and the environment in which `varlock` is being used. Specifically we collect _anonymous_ information about:
 - Which varlock command is being invoked
-- Which framework integration invoked the CLI (if any), such as Vite, Next.js, or Astro — official `@varlock/*` package name and version only
-- Which plugins are installed in the project — `@varlock/*` plugin names and versions are sent as-is; third-party plugin names are hashed (SHA-256) and versions are omitted
-- Anonymous, non-sensitive usage attributes that official `@varlock/*` plugins report about how they are used (for example which authentication mode is active, or whether a feature is enabled) — booleans, short enum strings, and counts only; collected for official plugins only and strictly sanitized (never secret values, item references, hostnames, or paths)
-- Anonymous schema feature signals when a project is loaded — for example root settings like `@redactLogs`, cache mode, safe resolver/decorator identifiers in use, and data source type counts (not config keys, values, file paths, or error messages)
-- Whether the env graph was loaded (`graph_loaded`) and a coarse error category when the run failed (`error_code`: e.g. `parse_error`, `plugin_error`, `schema_error`, `validation_error`, `resolution_error`, `load_error`) — no error messages or file paths
+- Which framework integration invoked the CLI (if any), such as Vite, Next.js, or Astro: official `@varlock/*` package name and version only
+- Which plugins are installed in the project: `@varlock/*` plugin names and versions are sent as-is; third-party plugin names are hashed (SHA-256) and versions are omitted
+- Anonymous, non-sensitive usage attributes that official `@varlock/*` plugins report about how they are used (for example which authentication mode is active, or whether a feature is enabled): booleans, short enum strings, and counts only; collected for official plugins only and strictly sanitized (never secret values, item references, hostnames, or paths)
+- Anonymous schema feature signals when a project is loaded: for example root settings like `@redactLogs`, cache mode, safe resolver/decorator identifiers in use, and data source type counts (not config keys, values, file paths, or error messages)
+- Whether the env graph was loaded (`graph_loaded`) and a coarse error category when the run failed (`error_code`: e.g. `parse_error`, `plugin_error`, `schema_error`, `validation_error`, `resolution_error`, `load_error`): no error messages or file paths
 - Version information for varlock and Node.js
-- JavaScript package manager in use (if detectable from lockfiles or runtime env) — `npm`, `pnpm`, `yarn`, `bun`, or `deno` only
+- JavaScript package manager in use (if detectable from lockfiles or runtime env): `npm`, `pnpm`, `yarn`, `bun`, or `deno` only
 - General system/machine information
 - Anonymous user + project ID
 

--- a/packages/varlock-website/src/content/docs/integrations/astro.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/astro.mdx
@@ -76,7 +76,7 @@ console.log(ENV.SOMEVAR);             // ✨ recommended
 - Enables future DX improvements and tighter control over what is bundled
 
 ### Within `astro.config.*`
-It's often useful to be able to access env vars in your Astro config. Without varlock, it's a bit awkward, but varlock makes it dead simple - in fact it's already available! Just import varlock's `ENV` object and reference env vars via `ENV.SOME_ITEM` like you do everywhere else.
+It's often useful to be able to access env vars in your Astro config. Without varlock, it's a bit awkward, but varlock makes it easy. In fact it's already available: import varlock's `ENV` object and reference env vars via `ENV.SOME_ITEM` like you do everywhere else.
 
 ```diff lang="ts" title="astro.config.ts"
 import { defineConfig } from 'astro/config';
@@ -171,7 +171,7 @@ When deploying SSR Astro apps to serverless platforms, varlock injects the resol
 
 ## Deploying to Cloudflare Workers
 
-If you deploy your SSR Astro app to Cloudflare Workers via [`@astrojs/cloudflare`](https://docs.astro.build/en/guides/integrations-guide/cloudflare/), install [`@varlock/cloudflare-integration`](/integrations/cloudflare/) alongside the Astro integration. The Astro integration **auto-detects** the Cloudflare adapter and wires up env injection into the worker — there's no extra Vite or adapter config to write, and you keep using `astro dev` as normal.
+If you deploy your SSR Astro app to Cloudflare Workers via [`@astrojs/cloudflare`](https://docs.astro.build/en/guides/integrations-guide/cloudflare/), install [`@varlock/cloudflare-integration`](/integrations/cloudflare/) alongside the Astro integration. The Astro integration **auto-detects** the Cloudflare adapter and wires up env injection into the worker. There's no extra Vite or adapter config to write, and you keep using `astro dev` as normal.
 
 <Steps>
 
@@ -181,7 +181,7 @@ If you deploy your SSR Astro app to Cloudflare Workers via [`@astrojs/cloudflare
 
 1. **Use the Cloudflare adapter as usual**
 
-    No varlock-specific Cloudflare setup is needed — just the standard adapter alongside `varlockAstroIntegration()`:
+    No varlock-specific Cloudflare setup is needed. Use the standard adapter alongside `varlockAstroIntegration()`:
 
     ```ts title="astro.config.ts"
     import { defineConfig } from 'astro/config';
@@ -216,7 +216,7 @@ Varlock relies on a handful of `node:*` built-ins at runtime, so your worker mus
 :::
 
 :::caution[Remove `.dev.vars`]
-Varlock manages env injection automatically — delete any `.dev.vars` file in your project root, or the dev server will error.
+Varlock manages env injection automatically. Delete any `.dev.vars` file in your project root, or the dev server will error.
 :::
 
 See the [Cloudflare Workers integration docs](/integrations/cloudflare/) for full details on how dev injection, deployment, CI/CD, and `varlock-wrangler` work.

--- a/packages/varlock-website/src/content/docs/integrations/cloudflare.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/cloudflare.mdx
@@ -11,12 +11,12 @@ import InstallJsDepsWidget from '@/components/InstallJsDepsWidget.astro';
   <Badge npmPackage="@varlock/cloudflare-integration" />
 </div>
 
-Varlock provides a robust solution for managing environment variables in Cloudflare Workers, offering validation, type safety, and security features that go beyond Cloudflare's built-in environment variable and secrets handling.
+Varlock manages environment variables in Cloudflare Workers with validation, type safety, and security features that go beyond Cloudflare's built-in environment variable and secrets handling.
 
-Our integration relies on using `varlock-wrangler` — a thin wrapper around `wrangler` that automatically resolves and uploads your env vars as Cloudflare secrets and vars during deployment, and injects them into miniflare during local dev.
+Our integration relies on using `varlock-wrangler`, a thin wrapper around `wrangler` that automatically resolves and uploads your env vars as Cloudflare secrets and vars during deployment, and injects them into miniflare during local dev.
 
 :::caution[Requires `nodejs_compat`]
-Varlock relies on a handful of `node:*` built-ins at runtime, so your worker must opt into Cloudflare's Node.js compatibility layer. Add `nodejs_compat` to your `compatibility_flags` in `wrangler.toml` / `wrangler.json` — without it, the worker will fail to start with "Cannot resolve 'node:...'" errors.
+Varlock relies on a handful of `node:*` built-ins at runtime, so your worker must opt into Cloudflare's Node.js compatibility layer. Add `nodejs_compat` to your `compatibility_flags` in `wrangler.toml` / `wrangler.json`. Without it, the worker will fail to start with "Cannot resolve 'node:...'" errors.
 
 ```json title="wrangler.json"
 {
@@ -27,7 +27,7 @@ Varlock relies on a handful of `node:*` built-ins at runtime, so your worker mus
 
 ## Choosing an approach
 
-All paths use the same `.env.schema` and `varlock-wrangler deploy` for production uploads — the difference is how env reaches your worker during **local dev** and **build**:
+All paths use the same `.env.schema` and `varlock-wrangler deploy` for production uploads. The difference is how env reaches your worker during **local dev** and **build**:
 
 | Approach | Best when | Dev / build |
 |----------|-----------|-------------|
@@ -37,12 +37,12 @@ All paths use the same `.env.schema` and `varlock-wrangler deploy` for productio
 | **[SvelteKit](/integrations/sveltekit/#setup-for-cloudflare-workers)** | SvelteKit with [`@sveltejs/adapter-cloudflare`](https://svelte.dev/docs/kit/adapter-cloudflare) | `@varlock/vite-integration` auto-detects the adapter; `vite dev` via an SSR entry loader; `vite build` + `varlock-wrangler deploy` |
 
 :::caution[Using SvelteKit? Follow the SvelteKit guide instead]
-This page covers plain Workers and the `@cloudflare/vite-plugin` flow, which **does not support SvelteKit** ([workers-sdk#8922](https://github.com/cloudflare/workers-sdk/issues/8922)). For SvelteKit with `@sveltejs/adapter-cloudflare`, set up varlock using the **[SvelteKit → Cloudflare Workers guide](/integrations/sveltekit/#setup-for-cloudflare-workers)** — you use the standard `varlockVitePlugin` (which auto-detects the adapter), **not** `varlockCloudflareVitePlugin`. You'll still install `@varlock/cloudflare-integration` (for `varlock-wrangler`) and deploy the same way described below.
+This page covers plain Workers and the `@cloudflare/vite-plugin` flow, which **does not support SvelteKit** ([workers-sdk#8922](https://github.com/cloudflare/workers-sdk/issues/8922)). For SvelteKit with `@sveltejs/adapter-cloudflare`, set up varlock using the **[SvelteKit → Cloudflare Workers guide](/integrations/sveltekit/#setup-for-cloudflare-workers)**. You use the standard `varlockVitePlugin` (which auto-detects the adapter), **not** `varlockCloudflareVitePlugin`. You'll still install `@varlock/cloudflare-integration` (for `varlock-wrangler`) and deploy the same way described below.
 :::
 
 ## Approach 1: Using `varlock-wrangler`
 
-Replace your `wrangler` commands with `varlock-wrangler` and initialize varlock in your worker code with a single import. It's a thin wrapper that wires up your env vars correctly, and passes everything else through unchanged.
+Replace your `wrangler` commands with `varlock-wrangler` and initialize varlock in your worker code with a single import. It's a thin wrapper that wires up your env vars correctly and passes everything else through unchanged.
 
 ### Setup
 
@@ -89,22 +89,22 @@ Replace your `wrangler` commands with `varlock-wrangler` and initialize varlock 
     }
     ```
 
-    If you deploy via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) instead of a local/CI script, override the deploy command in your Cloudflare dashboard under **Settings → Build → Deploy command** — see [Workers Builds](#cloudflare-workers-builds-cicd) below.
+    If you deploy via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) instead of a local/CI script, override the deploy command in your Cloudflare dashboard under **Settings → Build → Deploy command** (see [Workers Builds](#cloudflare-workers-builds-cicd) below).
 
 </Steps>
 
 ### How it works
 
-- **In dev**: `varlock-wrangler dev` resolves your env and injects it into `wrangler` using `--env-file` with a named pipe (unix/mac) or temp file (windows). It also watches your `.env` files and automatically restarts wrangler when they change - something `wrangler dev` doesn't do.
+- **In dev**: `varlock-wrangler dev` resolves your env and injects it into `wrangler` using `--env-file` with a named pipe (unix/mac) or temp file (windows). It also watches your `.env` files and automatically restarts wrangler when they change, something `wrangler dev` doesn't do.
 - **In production**: `varlock-wrangler deploy` (and `varlock-wrangler versions upload`) attaches non-sensitive values as Cloudflare vars (via `--var`) and sensitive values as Cloudflare secrets via `--secrets-file`. The worker reads them at runtime via `import { env } from 'cloudflare:workers'`.
 
 ----
 
 ## Approach 2: With the Vite plugin
 
-If you're building with Vite, `varlockCloudflareVitePlugin` wraps the [Cloudflare Workers Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/) and adds env var + varlock init injection — no extra init import needed, and both `ENV.MY_VAR` and native `env.MY_VAR` work in dev and production.
+If you're building with Vite, `varlockCloudflareVitePlugin` wraps the [Cloudflare Workers Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/) and adds env var + varlock init injection. No extra init import needed, and both `ENV.MY_VAR` and native `env.MY_VAR` work in dev and production.
 
-For SvelteKit on Cloudflare, use the standard [`varlockVitePlugin`](/integrations/sveltekit/#setup-for-cloudflare-workers) instead — it auto-detects the Cloudflare adapter and wires up the SSR entry loader.
+For SvelteKit on Cloudflare, use the standard [`varlockVitePlugin`](/integrations/sveltekit/#setup-for-cloudflare-workers) instead. It auto-detects the Cloudflare adapter and wires up the SSR entry loader.
 
 ### Setup
 
@@ -113,7 +113,7 @@ For SvelteKit on Cloudflare, use the standard [`varlockVitePlugin`](/integration
 1. **Install packages**
     <InstallJsDepsWidget packages="@varlock/cloudflare-integration @cloudflare/vite-plugin varlock" />
 
-    `@cloudflare/vite-plugin` is an (optional) peer dependency — this plugin wraps it, so you need it installed in the same project. SvelteKit users should omit it (see the [SvelteKit callout](#choosing-an-approach) at the top of this page).
+    `@cloudflare/vite-plugin` is an (optional) peer dependency. This plugin wraps it, so you need it installed in the same project. SvelteKit users should omit it (see the [SvelteKit callout](#choosing-an-approach) at the top of this page).
 
 1. **Run `varlock init` to set up your `.env.schema` file**
 
@@ -121,7 +121,7 @@ For SvelteKit on Cloudflare, use the standard [`varlockVitePlugin`](/integration
 
 1. **Update your Vite config**
 
-    Replace the `cloudflare()` plugin with `varlockCloudflareVitePlugin()` — it is a thin wrapper of the Cloudflare vite plugin and passes through all config:
+    Replace the `cloudflare()` plugin with `varlockCloudflareVitePlugin()`. It is a thin wrapper of the Cloudflare vite plugin and passes through all config:
 
     ```diff lang="ts" title="vite.config.ts"
     import { defineConfig } from 'vite';
@@ -153,12 +153,12 @@ For SvelteKit on Cloudflare, use the standard [`varlockVitePlugin`](/integration
     }
     ```
 
-    If you deploy via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) instead of a local/CI script, override the deploy command in your Cloudflare dashboard under **Settings → Build → Deploy command** — see [Workers Builds](#cloudflare-workers-builds-cicd) below.
+    If you deploy via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) instead of a local/CI script, override the deploy command in your Cloudflare dashboard under **Settings → Build → Deploy command** (see [Workers Builds](#cloudflare-workers-builds-cicd) below).
 
 </Steps>
 
 :::caution[Remove `.dev.vars`]
-If you have a `.dev.vars` file in your project root, **delete it**. Varlock manages env injection automatically — a `.dev.vars` file will conflict and the plugin will throw an error. This also applies to `.dev.vars.<environment>` files.
+If you have a `.dev.vars` file in your project root, **delete it**. Varlock manages env injection automatically. A `.dev.vars` file will conflict and the plugin will throw an error. This also applies to `.dev.vars.<environment>` files.
 :::
 
 ### How it works
@@ -170,7 +170,7 @@ If you have a `.dev.vars` file in your project root, **delete it**. Varlock mana
 
 If you were previously using `varlockVitePlugin()` from `@varlock/vite-integration` with Cloudflare Workers:
 
-1. Install `@varlock/cloudflare-integration` (you can remove `@varlock/vite-integration` — it's included)
+1. Install `@varlock/cloudflare-integration` (you can remove `@varlock/vite-integration`, it's included)
 2. In `vite.config.ts`, replace both `varlockVitePlugin()` and `cloudflare()` with `varlockCloudflareVitePlugin()`
 3. Replace `wrangler deploy` with `varlock-wrangler deploy` in your deploy script
 
@@ -188,7 +188,7 @@ export default defineConfig({
 });
 ```
 
-Your secrets will no longer be bundled into the JS artifact — they'll be stored in Cloudflare's secret management instead.
+Your secrets will no longer be bundled into the JS artifact. They'll be stored in Cloudflare's secret management instead.
 
 ----
 
@@ -213,7 +213,7 @@ On Unix, secrets are passed to wrangler commands via a named pipe (FIFO) and nev
 :::
 
 :::caution[Varlock owns your env vars]
-`varlock-wrangler deploy` replaces **all** Cloudflare vars and secrets with the ones defined in your `.env.schema`. Any vars or secrets set manually via the Cloudflare dashboard or `wrangler secret put` that aren't in your schema will be removed on the next deploy. If you need additional bindings (KV, D1, etc.), configure them in your `wrangler.toml` as usual — only plain vars/secrets are affected.
+`varlock-wrangler deploy` replaces **all** Cloudflare vars and secrets with the ones defined in your `.env.schema`. Any vars or secrets set manually via the Cloudflare dashboard or `wrangler secret put` that aren't in your schema will be removed on the next deploy. If you need additional bindings (KV, D1, etc.), configure them in your `wrangler.toml` as usual. Only plain vars/secrets are affected.
 :::
 </div>
 
@@ -243,14 +243,14 @@ For more details, see the [root decorators reference](/reference/root-decorators
 
 Varlock can load multiple _environment-specific_ `.env` files (e.g., `.env.development`, `.env.preview`, `.env.production`) by using the [`@currentEnv` root decorator](/reference/root-decorators/#currentenv).
 
-The simplest approach is to use the built-in [`VARLOCK_ENV`](/reference/builtin-variables/#varlock_env) variable, which auto-detects the deployment environment on most CI platforms — including [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) (via `WORKERS_CI_BRANCH`), Vercel, Netlify, and others. Locally it resolves to `development`, and during tests to `test`.
+The simplest approach is to use the built-in [`VARLOCK_ENV`](/reference/builtin-variables/#varlock_env) variable, which auto-detects the deployment environment on most CI platforms, including [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) (via `WORKERS_CI_BRANCH`), Vercel, Netlify, and others. Locally it resolves to `development`, and during tests to `test`.
 
 ```env-spec title=".env.schema"
 # @currentEnv=$VARLOCK_ENV
 # ---
 ```
 
-If you need more control — for example mapping specific branches to specific environments — you can define your own env-selection var instead:
+If you need more control, for example mapping specific branches to specific environments, you can define your own env-selection var instead:
 
 ```env-spec title=".env.schema"
 # @currentEnv=$APP_ENV
@@ -266,7 +266,7 @@ For more information, see the [environments guide](/guides/environments).
 
 ## Cloudflare Workers Builds (CI/CD)
 
-If you deploy via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/), two pieces of setup are required in the dashboard — neither can be configured from a file in the repo:
+If you deploy via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/), two pieces of setup are required in the dashboard, and neither can be configured from a file in the repo:
 
 <Steps>
 
@@ -282,9 +282,9 @@ If you deploy via [Cloudflare Workers Builds](https://developers.cloudflare.com/
 
 1. **Set any _secret-zero_ vars under Build variables**
 
-    Any env vars that varlock itself needs _during load_ — for example a 1Password service account token, a GCP key — must be set under **Settings → Build → Variables and Secrets**. These are made available to the build step, where `varlock-wrangler deploy` resolves your full env graph and uploads the result to the worker runtime as regular vars/secrets.
+    Any env vars that varlock itself needs _during load_ (for example a 1Password service account token or a GCP key) must be set under **Settings → Build → Variables and Secrets**. These are made available to the build step, where `varlock-wrangler deploy` resolves your full env graph and uploads the result to the worker runtime as regular vars/secrets.
 
-    Vars that only your worker needs at runtime (not varlock itself) don't need to be set here — they'll be resolved by varlock and set  automatically by `varlock-wrangler deploy`.
+    Vars that only your worker needs at runtime (not varlock itself) don't need to be set here. They'll be resolved by varlock and set automatically by `varlock-wrangler deploy`.
 
 </Steps>
 
@@ -292,7 +292,7 @@ If you deploy via [Cloudflare Workers Builds](https://developers.cloudflare.com/
 
 ## Deploying from your own CI
 
-Deploying from **your own CI** (GitHub Actions, GitLab CI, a self-hosted runner) instead of [Cloudflare Workers Builds](#cloudflare-workers-builds-cicd) works the same way — and isn't really Cloudflare-specific. The same _secret-zero_ rule applies: any var varlock needs to resolve your secrets (a 1Password service account token, a GCP key, etc.) must be present in the job environment before `varlock-wrangler deploy` runs.
+Deploying from **your own CI** (GitHub Actions, GitLab CI, a self-hosted runner) instead of [Cloudflare Workers Builds](#cloudflare-workers-builds-cicd) works the same way, and isn't really Cloudflare-specific. The same _secret-zero_ rule applies: any var varlock needs to resolve your secrets (a 1Password service account token, a GCP key, etc.) must be present in the job environment before `varlock-wrangler deploy` runs.
 
 ```yaml title=".github/workflows/deploy-worker.yml"
 jobs:
@@ -306,20 +306,20 @@ jobs:
       - run: npm run build
       - run: npx varlock-wrangler deploy
         env:
-          # Only vars varlock needs to *resolve* secrets — not every worker var
+          # Only vars varlock needs to *resolve* secrets, not every worker var
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 ```
 
-For supported providers, varlock can authenticate with **short-lived OIDC tokens** from your CI instead of long-lived keys — see the [OIDC workload identity guide](/guides/oidc/). Run `varlock load` in an earlier step to fail fast on schema errors without exposing values.
+For supported providers, varlock can authenticate with **short-lived OIDC tokens** from your CI instead of long-lived keys. See the [OIDC workload identity guide](/guides/oidc/). Run `varlock load` in an earlier step to fail fast on schema errors without exposing values.
 
 ----
 
 ## Multi-worker and auxiliary Workers
 
-Cloudflare supports running [multiple Workers in one dev session](https://developers.cloudflare.com/workers/development-testing/multi-workers/) — a primary Worker plus **auxiliary Workers** reachable via service bindings. The Vite plugin exposes this through [`auxiliaryWorkers`](https://developers.cloudflare.com/workers/development-testing/multi-workers/#vite-plugin-with-auxiliary-workers) in `vite.config.ts`.
+Cloudflare supports running [multiple Workers in one dev session](https://developers.cloudflare.com/workers/development-testing/multi-workers/): a primary Worker plus **auxiliary Workers** reachable via service bindings. The Vite plugin exposes this through [`auxiliaryWorkers`](https://developers.cloudflare.com/workers/development-testing/multi-workers/#vite-plugin-with-auxiliary-workers) in `vite.config.ts`.
 
 :::caution[Single-worker env injection today]
-Varlock currently resolves and uploads env vars for **one Wrangler config per deploy**. `varlock-wrangler deploy` injects vars/secrets into the worker named by the target `wrangler.toml` / `wrangler.json` — it does not automatically propagate env to auxiliary Workers or sibling configs passed to `wrangler dev -c ./a.json -c ./b.json`.
+Varlock currently resolves and uploads env vars for **one Wrangler config per deploy**. `varlock-wrangler deploy` injects vars/secrets into the worker named by the target `wrangler.toml` / `wrangler.json`. It does not automatically propagate env to auxiliary Workers or sibling configs passed to `wrangler dev -c ./a.json -c ./b.json`.
 
 For multi-worker repos today:
 
@@ -336,7 +336,7 @@ First-class multi-worker / auxiliary-worker support is not implemented yet. If t
 
 ### `Cannot resolve 'node:...'` at worker startup
 
-Your worker is missing the Node.js compatibility layer. Add `nodejs_compat` to `compatibility_flags` — see the **`nodejs_compat` caution** near the top of this page.
+Your worker is missing the Node.js compatibility layer. Add `nodejs_compat` to `compatibility_flags`; see the **`nodejs_compat` caution** near the top of this page.
 
 ### `.dev.vars` conflicts with the Vite plugin
 
@@ -344,15 +344,15 @@ Delete `.dev.vars` and `.dev.vars.<environment>` files when using the Vite plugi
 
 ### Vars or secrets missing after deploy
 
-- Confirm you deploy with `varlock-wrangler deploy`, not stock `wrangler deploy` — especially on [Workers Builds](#cloudflare-workers-builds-cicd)
+- Confirm you deploy with `varlock-wrangler deploy`, not stock `wrangler deploy`, especially on [Workers Builds](#cloudflare-workers-builds-cicd)
 - Check that secret-zero CI vars are set for any plugin-backed items varlock must resolve at deploy time
-- Remember that `varlock-wrangler deploy` **replaces all** Cloudflare vars and secrets with schema-defined ones — manually added dashboard secrets not in your schema are removed
+- Remember that `varlock-wrangler deploy` **replaces all** Cloudflare vars and secrets with schema-defined ones. Manually added dashboard secrets not in your schema are removed
 
 ### Non-wrangler deploy tools (Alchemy, SST, Pulumi)
 
-If you deploy Workers with **IaC tools other than wrangler** — [Alchemy](https://alchemy.run/), SST, Pulumi, Terraform, etc. — you can still use varlock for **fail-fast validation and secret resolution** via [`varlock run`](/reference/cli-commands/#run), which injects resolved values into `process.env` for the deploy tool to read.
+If you deploy Workers with **IaC tools other than wrangler** ([Alchemy](https://alchemy.run/), SST, Pulumi, Terraform, etc.), you can still use varlock for **fail-fast validation and secret resolution** via [`varlock run`](/reference/cli-commands/#run), which injects resolved values into `process.env` for the deploy tool to read.
 
-What you **cannot** get today without `varlock-wrangler`: the in-worker runtime layer (`@varlock/cloudflare-integration/init`) that provides console redaction and response leak detection. That layer reads a `__VARLOCK_ENV` binding that only `varlock-wrangler` produces today.
+What you **cannot** get today without `varlock-wrangler`: the in-worker runtime layer (`@varlock/cloudflare-integration/init`) that provides console redaction and response leak detection. That layer reads a `__VARLOCK_ENV` binding that only `varlock-wrangler` produces.
 
 A public API to build `__VARLOCK_ENV` bindings for non-wrangler deploy tools is planned but not available yet. Until then, teams on Alchemy/SST/Pulumi typically rely on varlock for validation + env injection at deploy time and skip the in-worker runtime protections.
 
@@ -362,10 +362,10 @@ A public API to build `__VARLOCK_ENV` bindings for non-wrangler deploy tools is 
 
 Cloudflare Workers have built-in support for [vars](https://developers.cloudflare.com/workers/configuration/environment-variables/) and [secrets](https://developers.cloudflare.com/workers/configuration/secrets/), but managing them across environments quickly becomes painful. Here's what Varlock adds:
 
-- **Single source of truth** — Instead of scattering config across the Cloudflare dashboard, `wrangler.toml`, `.dev.vars`, and your code, everything is defined in one `.env.schema` file that works across local dev, preview, and production.
-- **Validation before deploy** — Cloudflare only has basic required var validation. Varlock catches missing vars, wrong types, and invalid values _before_ your worker starts — not when it crashes at runtime.
-- **Pull secrets from vaults** — Instead of manually running `wrangler secret put` or copy-pasting values in the dashboard, pull secrets directly from [1Password](/plugins/1password/), [AWS Secrets Manager](/plugins/aws-secrets/), [HashiCorp Vault](/plugins/hashicorp-vault/), and [more](/plugins/overview/).
-- **Log redaction & leak prevention** — Cloudflare doesn't prevent you from accidentally `console.log`-ing a secret or including one in a response body. Varlock automatically redacts sensitive values in logs and scans outgoing responses for leaked secrets.
-- **Simpler multi-environment setup** — Wrangler's `[env.staging]` / `[env.production]` blocks duplicate config and don't support `.env` file overrides. Varlock uses familiar `.env.production` / `.env.preview` files with a single schema, and auto-detects the current environment in CI.
-- **Local dev that matches production** — `.dev.vars` is completely disconnected from your production secrets. With Varlock, local dev resolves from the same schema and same secret sources, so there's no drift between environments.
-- **AI-safe by design** — Your `.env.schema` gives AI coding tools full context on your config (names, types, descriptions) without ever exposing secret values.
+- **Single source of truth**: Instead of scattering config across the Cloudflare dashboard, `wrangler.toml`, `.dev.vars`, and your code, everything is defined in one `.env.schema` file that works across local dev, preview, and production.
+- **Validation before deploy**: Cloudflare only has basic required var validation. Varlock catches missing vars, wrong types, and invalid values _before_ your worker starts, not when it crashes at runtime.
+- **Pull secrets from vaults**: Instead of manually running `wrangler secret put` or copy-pasting values in the dashboard, pull secrets directly from [1Password](/plugins/1password/), [AWS Secrets Manager](/plugins/aws-secrets/), [HashiCorp Vault](/plugins/hashicorp-vault/), and [more](/plugins/overview/).
+- **Log redaction & leak prevention**: Cloudflare doesn't prevent you from accidentally `console.log`-ing a secret or including one in a response body. Varlock automatically redacts sensitive values in logs and scans outgoing responses for leaked secrets.
+- **Simpler multi-environment setup**: Wrangler's `[env.staging]` / `[env.production]` blocks duplicate config and don't support `.env` file overrides. Varlock uses familiar `.env.production` / `.env.preview` files with a single schema, and auto-detects the current environment in CI.
+- **Local dev that matches production**: `.dev.vars` is completely disconnected from your production secrets. With Varlock, local dev resolves from the same schema and same secret sources, so there's no drift between environments.
+- **AI-safe**: Your `.env.schema` gives AI coding tools full context on your config (names, types, descriptions) without ever exposing secret values.

--- a/packages/varlock-website/src/content/docs/integrations/direnv.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/direnv.mdx
@@ -8,7 +8,7 @@ import { Steps } from "@astrojs/starlight/components";
 [direnv](https://direnv.net/) is a shell extension that automatically loads and unloads environment variables when you enter and leave a directory. By combining it with varlock, you can get validated, schema-driven environment variables loaded directly into your shell session.
 
 :::tip[Consider a deeper integration]
-For projects where you control the codebase, using one of varlock's [framework integrations](/integrations/overview/) or the [JavaScript / Node.js integration](/integrations/javascript/) is usually a better fit than direnv. Those integrations wire validation, type safety, and leak protection directly into your build and runtime — rather than relying on shell-level injection. You can also use [`varlock run`](/reference/cli-commands/#run) to inject env vars into any process without needing direnv. direnv is most useful when you need env vars available in your shell session itself, or when working with tools that cannot be launched via `varlock run`.
+For projects where you control the codebase, using one of varlock's [framework integrations](/integrations/overview/) or the [JavaScript / Node.js integration](/integrations/javascript/) is usually a better fit than direnv. Those integrations wire validation, type safety, and leak protection directly into your build and runtime, rather than relying on shell-level injection. You can also use [`varlock run`](/reference/cli-commands/#run) to inject env vars into any process without needing direnv. direnv is most useful when you need env vars available in your shell session itself, or when working with tools that cannot be launched via `varlock run`.
 :::
 
 ## How it works
@@ -41,7 +41,7 @@ When you `cd` into your project, direnv runs this command and exports all your v
    eval "$(varlock load --format shell)"
    ```
 
-   The `watch_file` line tells direnv to re-evaluate whenever any of your `.env` files change. Note that **new files added after the initial load will not be watched until you run `direnv reload`** — but this is rarely a concern since adding new env files is uncommon.
+   The `watch_file` line tells direnv to re-evaluate whenever any of your `.env` files change. Note that **new files added after the initial load will not be watched until you run `direnv reload`**, but this is rarely a concern since adding new env files is uncommon.
 
    :::caution[Imported files outside the project directory]
    If your `.env` files [import](/guides/import/) other files from outside the current directory, those external files will **not** be watched automatically. You would need to add additional `watch_file` entries for them, or run `direnv reload` manually after changing them.
@@ -79,7 +79,7 @@ eval "$(varlock load --format shell --compact)"
 ## Troubleshooting
 
 :::caution[direnv strict mode]
-Some shells or direnv configurations run `.envrc` files in strict mode (`set -euo pipefail`). If `varlock load` exits with a non-zero code (e.g. due to a validation error), direnv will halt and show an error. This is intentional — it prevents your shell from loading a broken environment.
+Some shells or direnv configurations run `.envrc` files in strict mode (`set -euo pipefail`). If `varlock load` exits with a non-zero code (e.g. due to a validation error), direnv will halt and show an error. This is intentional: it prevents your shell from loading a broken environment.
 :::
 
 :::tip[Loading errors]

--- a/packages/varlock-website/src/content/docs/integrations/expo.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/expo.mdx
@@ -14,15 +14,15 @@ import InstallJsDepsWidget from '@/components/InstallJsDepsWidget.astro';
 
 Expo and [React Native CLI](https://github.com/react-native-community/cli) projects both use the [Metro bundler](https://metrobundler.dev/), which has its own approach to environment variables. Varlock integrates via a **Babel plugin** that replaces `ENV.xxx` references with their resolved values at compile time, and a **Metro config wrapper** that initializes the `ENV` proxy at runtime.
 
-Both stacks use the same [`@varlock/expo-integration`](https://www.npmjs.com/package/@varlock/expo-integration) package — only the Babel preset and Metro base config differ between Expo and React Native CLI projects.
+Both stacks use the same [`@varlock/expo-integration`](https://www.npmjs.com/package/@varlock/expo-integration) package. Only the Babel preset and Metro base config differ between Expo and React Native CLI projects.
 
 This integration does a few things:
 - Loads and validates your `.env` files using varlock at bundle time
 - Replaces `ENV.xxx` references to non-sensitive config items with their literal values at compile time
-- Sensitive values are **never** inlined into your bundle — in Expo projects they are accessible at runtime only in [Expo Router API routes](https://docs.expo.dev/router/reference/api-routes/) (`+api` files)
+- Sensitive values are **never** inlined into your bundle. In Expo projects they are accessible at runtime only in [Expo Router API routes](https://docs.expo.dev/router/reference/api-routes/) (`+api` files)
 - Patches the global console to redact sensitive values from logs
 
-No CLI command wrapping is needed — env loads when Metro/Babel start. Run `expo start`, `npx react-native start`, or your usual build commands as normal.
+No CLI command wrapping is needed. Env loads when Metro/Babel start. Run `expo start`, `npx react-native start`, or your usual build commands as normal.
 
 ## Setup
 
@@ -123,7 +123,7 @@ Rather than using `process.env.SOMEVAR` directly, use varlock's `ENV` object for
 import { ENV } from 'varlock/env';
 
 // Non-sensitive values are inlined at bundle time:
-const apiUrl = ENV.API_URL;   // ✨ recommended — replaced at compile time
+const apiUrl = ENV.API_URL;   // ✨ recommended, replaced at compile time
 
 // process.env still works, but loses type-safety and compile-time replacement:
 const legacyUrl = process.env.API_URL; // 🆗 still works
@@ -152,7 +152,7 @@ const port = 3000;
 const debug = false;
 ```
 
-Sensitive items (marked with `@sensitive` in your `.env.schema`) are **never** replaced — they remain as `ENV.xxx` references. In Expo Router `+api` server routes they resolve at runtime via the proxy; in all other code they throw at runtime.
+Sensitive items (marked with `@sensitive` in your `.env.schema`) are **never** replaced. They remain as `ENV.xxx` references. In Expo Router `+api` server routes they resolve at runtime via the proxy; in all other code they throw at runtime.
 
 ### Type-safety and IntelliSense
 
@@ -210,7 +210,7 @@ See the [environments guide](/guides/environments) for more information.
 
 ## Managing sensitive config values
 
-Sensitive values (marked with `@sensitive`) are **never** statically inlined into your bundle — regardless of any prefix conventions. You control this with the [`@defaultSensitive`](/reference/root-decorators/#defaultsensitive) root decorator and the [`@sensitive`](/reference/item-decorators/#sensitive) item decorator. See the [secrets guide](/guides/secrets) for more information.
+Sensitive values (marked with `@sensitive`) are **never** statically inlined into your bundle, regardless of any prefix conventions. You control this with the [`@defaultSensitive`](/reference/root-decorators/#defaultsensitive) root decorator and the [`@sensitive`](/reference/item-decorators/#sensitive) item decorator. See the [secrets guide](/guides/secrets) for more information.
 
 Set a default and explicitly mark items:
 
@@ -229,7 +229,7 @@ Non-sensitive items are inlined into your JavaScript bundle. Anyone who extracts
 ### Sensitive values in server routes (Expo only)
 
 :::note[Expo Router only]
-[Expo Router API routes](https://docs.expo.dev/router/reference/api-routes/) (`+api` files) are an **Expo-only** feature. React Native CLI apps have no server-side JS runtime — skip to the next section.
+[Expo Router API routes](https://docs.expo.dev/router/reference/api-routes/) (`+api` files) are an **Expo-only** feature. React Native CLI apps have no server-side JS runtime, so skip to the next section.
 :::
 
 If you use Expo Router API routes (`+api` files), sensitive values **are** accessible at runtime via the `ENV` proxy. These files run server-side in the Metro process where `withVarlockMetroConfig` has initialized the environment.
@@ -246,19 +246,19 @@ export function GET() {
 
 ### Sensitive values in native code
 
-In native app code (anything that isn't an Expo Router `+api` server route), sensitive values are **not available**. React Native apps run entirely on the device — there is no server to keep secrets safe. Accessing a sensitive value in native code will **throw at runtime**.
+In native app code (anything that isn't an Expo Router `+api` server route), sensitive values are **not available**. React Native apps run entirely on the device, so there is no server to keep secrets safe. Accessing a sensitive value in native code will **throw at runtime**.
 
 The Babel plugin also emits a **build-time warning** when it detects a sensitive `ENV.xxx` reference in a non-server file, helping you catch these issues early. This applies to **all** React Native code, including React Native CLI projects where every screen and component is client-side.
 
 ```ts title="src/screens/Home.tsx"
 import { ENV } from 'varlock/env';
 
-const url = ENV.API_URL;     // ✅ non-sensitive — inlined at build time
+const url = ENV.API_URL;     // ✅ non-sensitive, inlined at build time
 const key = ENV.SECRET_KEY;  // ❌ throws at runtime, build-time warning
 ```
 
 :::note[Expo pages are universal]
-Unlike Next.js Server Components, Expo Router page components run on **both** the server (SSR) and the client (hydration). This means you cannot safely access sensitive values in page components — use `+api` server routes instead.
+Unlike Next.js Server Components, Expo Router page components run on **both** the server (SSR) and the client (hydration). This means you cannot safely access sensitive values in page components. Use `+api` server routes instead.
 :::
 
 ---

--- a/packages/varlock-website/src/content/docs/integrations/github-action.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/github-action.mdx
@@ -10,7 +10,7 @@ import InstallJsDepsWidget from '@/components/InstallJsDepsWidget.astro';
 
 [![GitHub Actions Marketplace](https://img.shields.io/badge/GitHub%20Actions-Marketplace-blue?logo=github)](https://github.com/marketplace/actions/varlock-environment-loader)
 
-The Varlock GitHub Action provides a secure way to load and validate environment variables in your GitHub Actions workflows. It automatically detects and loads your `.env.schema` file and all relevant `.env.*` files, validates all environment variables against your schema, and exports them as either environment variables or a JSON blob for use in subsequent steps.
+The Varlock GitHub Action loads and validates environment variables in your GitHub Actions workflows. It automatically detects and loads your `.env.schema` file and all relevant `.env.*` files, validates all environment variables against your schema, and exports them as either environment variables or a JSON blob for use in subsequent steps.
 
 ## Features
 
@@ -239,7 +239,7 @@ jobs:
 
 ## Error Handling
 
-The action provides comprehensive error handling and reporting:
+The action provides error handling and reporting:
 
 ### Validation Errors
 

--- a/packages/varlock-website/src/content/docs/integrations/go.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/go.mdx
@@ -3,9 +3,9 @@ title: Go
 description: Use varlock with Go via a generated env package
 ---
 
-To use varlock with Go, [install the standalone binary](/getting-started/installation/#as-a-binary) and run your app under [`varlock run`](/reference/cli-commands/#run) — it loads and validates your env, then injects it into the process.
+To use varlock with Go, [install the standalone binary](/getting-started/installation/#as-a-binary) and run your app under [`varlock run`](/reference/cli-commands/#run). It loads and validates your env, then injects it into the process.
 
-Add [`@generateGoEnv`](/reference/root-decorators/#generategoenv) to your schema to generate a small, self-contained package — an `Env` struct, a `Load()` function that parses the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob, and a `SensitiveKeys` map.
+Add [`@generateGoEnv`](/reference/root-decorators/#generategoenv) to your schema to generate a small, self-contained package: an `Env` struct, a `Load()` function that parses the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob, and a `SensitiveKeys` map.
 
 ```env-spec title=".env.schema"
 # @generateGoEnv(path=env/env.go)
@@ -15,7 +15,7 @@ The package name follows the output directory (`env/env.go` → `package env`); 
 
 ## Reading values
 
-Call `Load()` once, then read fields off the struct — required fields are the plain type, optional ones are pointers (deref when set):
+Call `Load()` once, then read fields off the struct. Required fields are the plain type, optional ones are pointers (deref when set):
 
 ```go
 package main
@@ -32,7 +32,7 @@ func main() {
         log.Fatal(err)
     }
     host := e.DbHost       // string (required field)
-    if e.DbPort != nil {   // *int64 (optional field — deref when set)
+    if e.DbPort != nil {   // *int64 (optional field, deref when set)
         log.Printf("%s:%d", host, *e.DbPort)
     }
 }
@@ -73,5 +73,5 @@ port := config.Env.DbPort   // *int64
 ```
 
 :::note
-Every key is also injected as a plain environment variable, so you can read any of them with `os.Getenv` (raw strings) if you don't need the typed module. Enums become plain `string` (Go has no enum type), and keys whose names aren't valid identifiers (they contain `.` or `-`) can't be struct fields — read those from the env var directly. See [Other languages](/integrations/other-languages/) for the shared details on the injected blob, raw env vars, and encryption.
+Every key is also injected as a plain environment variable, so you can read any of them with `os.Getenv` (raw strings) if you don't need the typed module. Enums become plain `string` (Go has no enum type), and keys whose names aren't valid identifiers (they contain `.` or `-`) can't be struct fields, so read those from the env var directly. See [Other languages](/integrations/other-languages/) for the shared details on the injected blob, raw env vars, and encryption.
 :::

--- a/packages/varlock-website/src/content/docs/integrations/javascript.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/javascript.mdx
@@ -28,7 +28,7 @@ const FROM_PROCESS_ENV = process.env.MY_CONFIG_ITEM; // 🆗 still works
 ```
 
 :::note[dotenv drop-in replacement]
-If you are using [`dotenv`](https://www.npmjs.com/package/dotenv), or a package you are using is using it under the hood - you can seamlessly swap in varlock using your package manager's override feature. See the [migrate from dotenv](/guides/migrate-from-dotenv) guide for more information.
+If you are using [`dotenv`](https://www.npmjs.com/package/dotenv), or a package you are using is using it under the hood, you can swap in varlock using your package manager's override feature. See the [migrate from dotenv](/guides/migrate-from-dotenv) guide for more information.
 :::
 
 

--- a/packages/varlock-website/src/content/docs/integrations/mise.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/mise.mdx
@@ -8,9 +8,9 @@ import { Steps, Tabs, TabItem } from "@astrojs/starlight/components";
 [mise](https://mise.jdx.dev/) (mise-en-place) is a polyglot tool manager, environment manager, and task runner. You can use it to install the `varlock` CLI itself, and to wire varlock into the commands you run during development.
 
 :::tip[Inject into commands, not your shell]
-mise can load environment variables into your shell session (via `[env]`), but we **don't recommend** loading your varlock-managed env — especially secrets — that way. Once values live in your shell, every process inherits them, they show up in `env`, and varlock's [log redaction](/guides/secrets/#redaction-in-varlock-run) is bypassed.
+mise can load environment variables into your shell session (via `[env]`), but we **don't recommend** loading your varlock-managed env (especially secrets) that way. Once values live in your shell, every process inherits them, they show up in `env`, and varlock's [log redaction](/guides/secrets/#redaction-in-varlock-run) is bypassed.
 
-Instead, integrate varlock at the point where each program runs — either by wrapping the command with [`varlock run`](/reference/cli-commands/#run) (works for anything), or with one of varlock's [framework/runtime integrations](/integrations/overview/) (for JS/TS apps). Both approaches let you load env vars in different configurations per context — a different [environment](/guides/environments/) per command, build-time vs. runtime resolution, redacted output, leak protection — rather than forcing one global set into the shell where everything sees the same thing.
+Instead, integrate varlock at the point where each program runs: either by wrapping the command with [`varlock run`](/reference/cli-commands/#run) (works for anything), or with one of varlock's [framework/runtime integrations](/integrations/overview/) (for JS/TS apps). Both approaches let you load env vars in different configurations per context (a different [environment](/guides/environments/) per command, build-time vs. runtime resolution, redacted output, leak protection) rather than forcing one global set into the shell where everything sees the same thing.
 
 See [Loading into your shell](#loading-env-vars-into-your-shell-advanced) for the narrow cases where shell injection still makes sense.
 :::
@@ -20,7 +20,7 @@ See [Loading into your shell](#loading-env-vars-into-your-shell-advanced) for th
 mise can install and version-manage the `varlock` CLI alongside the rest of your toolchain.
 
 :::note[Already using varlock in a JS project?]
-If varlock is already a dependency of your JavaScript/TypeScript project, you **don't need any mise integration to install it** — keep installing it with your package manager (`npm`/`pnpm`/`yarn`/`bun`) and run it via `npx varlock` / `bun run varlock` as usual. mise's job there is just managing your runtime (e.g. `node` or `bun`) and, optionally, [running your scripts as tasks](#running-your-commands-as-tasks). The backends below are for installing the standalone `varlock` CLI itself — useful for non-JS projects, or for sharing one varlock version across a team's machines.
+If varlock is already a dependency of your JavaScript/TypeScript project, you **don't need any mise integration to install it**. Keep installing it with your package manager (`npm`/`pnpm`/`yarn`/`bun`) and run it via `npx varlock` / `bun run varlock` as usual. mise's job there is managing your runtime (e.g. `node` or `bun`) and, optionally, [running your scripts as tasks](#running-your-commands-as-tasks). The backends below are for installing the standalone `varlock` CLI itself, useful for non-JS projects, or for sharing one varlock version across a team's machines.
 :::
 
 <Tabs>
@@ -56,7 +56,7 @@ mise applies a default 24-hour `minimum_release_age` delay to releases as a supp
 </TabItem>
 <TabItem label="npm package">
 
-The `npm` backend installs varlock from npm. This **requires a Node.js runtime** — mise uses Node's `npm` under the hood, so declare `node` in the same `[tools]` table (mise will not provide it automatically):
+The `npm` backend installs varlock from npm. This **requires a Node.js runtime**, since mise uses Node's `npm` under the hood, so declare `node` in the same `[tools]` table (mise will not provide it automatically):
 
 ```toml title="mise.toml"
 [tools]
@@ -69,10 +69,10 @@ mise install
 varlock --version
 ```
 
-Prefer the standalone binary above when you only need the CLI — it avoids the Node dependency and starts faster.
+Prefer the standalone binary above when you only need the CLI. It avoids the Node dependency and starts faster.
 
 :::note[Using Bun?]
-mise's `npm` backend can't be driven by Bun alone (it still needs Node for `npm`). If your project uses Bun or Node already, you typically wouldn't install varlock as a mise *tool* at all — add it as a project dependency and run it through [tasks](#running-your-commands-as-tasks) with your project's runtime. See the [Bun](/integrations/bun/) and [JavaScript / Node.js](/integrations/javascript/) integrations.
+mise's `npm` backend can't be driven by Bun alone (it still needs Node for `npm`). If your project uses Bun or Node already, you typically wouldn't install varlock as a mise *tool* at all. Add it as a project dependency and run it through [tasks](#running-your-commands-as-tasks) with your project's runtime. See the [Bun](/integrations/bun/) and [JavaScript / Node.js](/integrations/javascript/) integrations.
 :::
 
 </TabItem>
@@ -84,7 +84,7 @@ mise's `npm` backend can't be driven by Bun alone (it still needs Node for `npm`
 
 ### When varlock is already wired into the command
 
-Often it is. A `package.json` script may already call [`varlock run`](/reference/cli-commands/#run), or your app may use a [framework/runtime integration](/integrations/overview/) (Next.js, Vite, Astro, Node, etc.) that loads and validates env on startup. In that case the mise task just runs the command as-is — nothing varlock-specific belongs here:
+Often it is. A `package.json` script may already call [`varlock run`](/reference/cli-commands/#run), or your app may use a [framework/runtime integration](/integrations/overview/) (Next.js, Vite, Astro, Node, etc.) that loads and validates env on startup. In that case the mise task just runs the command as-is, and nothing varlock-specific belongs here:
 
 ```toml title="mise.toml"
 [tasks.dev]
@@ -97,7 +97,7 @@ mise run dev
 
 ### When the command doesn't load varlock on its own
 
-For a raw binary, a shell script, or a one-off command that isn't already varlock-aware, wrap it with `varlock run` so it gets a resolved, validated environment with redacted output — scoped to that one subprocess, never your shell:
+For a raw binary, a shell script, or a one-off command that isn't already varlock-aware, wrap it with `varlock run` so it gets a resolved, validated environment with redacted output, scoped to that one subprocess, never your shell:
 
 ```toml title="mise.toml"
 [tools]
@@ -110,11 +110,11 @@ run = "varlock run -- ./scripts/migrate.sh"
 run = "varlock run -- psql"
 ```
 
-Declaring varlock in `[tools]` lets mise install it and put it on `PATH` before the task runs. If varlock is instead a dependency of your JS project, call the project-local version through your package manager and drop it from `[tools]` — e.g. `run = "npx varlock run -- ./scripts/migrate.sh"` or `run = "bun run varlock run -- ./scripts/migrate.sh"`.
+Declaring varlock in `[tools]` lets mise install it and put it on `PATH` before the task runs. If varlock is instead a dependency of your JS project, call the project-local version through your package manager and drop it from `[tools]`, e.g. `run = "npx varlock run -- ./scripts/migrate.sh"` or `run = "bun run varlock run -- ./scripts/migrate.sh"`.
 
 ## Loading env vars into your shell (advanced)
 
-Sometimes you genuinely want a value available to any command you type in the terminal — typically **non-secret** config like `NODE_ENV` or a public base URL. You can do this without a plugin using mise's `env._.source`, which captures variables exported by a script.
+Sometimes you genuinely want a value available to any command you type in the terminal, typically **non-secret** config like `NODE_ENV` or a public base URL. You can do this without a plugin using mise's `env._.source`, which captures variables exported by a script.
 
 Create a small script that emits varlock's resolved env in shell format:
 
@@ -132,16 +132,16 @@ _.source = "./.mise/load-env.sh"
 `varlock load --format shell` outputs `export KEY='value'` lines; `--compact` skips undefined optional values.
 
 :::caution[This puts values in your shell]
-Anything loaded this way lives in your shell session and is inherited by every process you launch — and varlock's [log redaction](/guides/secrets/#redaction-in-varlock-run) does **not** apply, since it only protects the output of `varlock run`. Scope a dedicated file to just the non-secret values you want ambient (and keep secrets in [tasks](#running-your-commands-as-tasks)), or use [direnv](/integrations/direnv/) if you specifically want enter/leave shell loading.
+Anything loaded this way lives in your shell session and is inherited by every process you launch, and varlock's [log redaction](/guides/secrets/#redaction-in-varlock-run) does **not** apply, since it only protects the output of `varlock run`. Scope a dedicated file to just the non-secret values you want ambient (and keep secrets in [tasks](#running-your-commands-as-tasks)), or use [direnv](/integrations/direnv/) if you specifically want enter/leave shell loading.
 :::
 
 :::note[mise's `redact` isn't a substitute for `varlock run`]
-mise has its own [redactions](https://mise.jdx.dev/environments/#redactions) (`redact = true`, or a `redactions` list) that hide values from `mise run` task logs. But mise can only redact a value it manages as an env var, and — by its own docs — redaction "does not prevent the values from being exported to child processes." So it's log hygiene, not isolation: the value still flows to everything. For real secrets, prefer [`varlock run`](#running-your-commands-as-tasks), which both scopes the value to a single subprocess **and** redacts its output before mise (or anything else) ever sees it.
+mise has its own [redactions](https://mise.jdx.dev/environments/#redactions) (`redact = true`, or a `redactions` list) that hide values from `mise run` task logs. But mise can only redact a value it manages as an env var, and by its own docs, redaction "does not prevent the values from being exported to child processes." So it's log hygiene, not isolation: the value still flows to everything. For real secrets, prefer [`varlock run`](#running-your-commands-as-tasks), which both scopes the value to a single subprocess **and** redacts its output before mise (or anything else) ever sees it.
 :::
 
 ## Validate when entering a project
 
-If you just want a fast failure when a project's environment is missing or invalid — without injecting anything into your shell — use a [hook](https://mise.jdx.dev/hooks.html) instead of `[env]`:
+If you just want a fast failure when a project's environment is missing or invalid, without injecting anything into your shell, use a [hook](https://mise.jdx.dev/hooks.html) instead of `[env]`:
 
 ```toml title="mise.toml"
 [hooks]

--- a/packages/varlock-website/src/content/docs/integrations/nextjs.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/nextjs.mdx
@@ -12,9 +12,9 @@ import InstallJsDepsWidget from '@/components/InstallJsDepsWidget.astro';
   <Badge npmPackage="@varlock/nextjs-integration" />
 </div>
 
-Varlock provides a huge upgrade over the [default Next.js environment variable tooling](https://nextjs.org/docs/pages/guides/environment-variables) - adding validation, type safety, flexible multi-environment management, log redaction, leak detection, and more.
+Varlock is a big upgrade over the [default Next.js environment variable tooling](https://nextjs.org/docs/pages/guides/environment-variables), adding validation, type safety, multi-environment management, log redaction, leak detection, and more.
 
-To integrate varlock into a Next.js application, you must use our [`@varlock/nextjs-integration`](https://www.npmjs.com/package/@varlock/nextjs-integration) package. This package provides a drop-in replacement for [`@next/env`](https://www.npmjs.com/package/@next/env), the internal package that handles .env loading, plus a small config plugin which injects our additional security features.
+To integrate varlock into a Next.js application, use our [`@varlock/nextjs-integration`](https://www.npmjs.com/package/@varlock/nextjs-integration) package. It provides a drop-in replacement for [`@next/env`](https://www.npmjs.com/package/@next/env), the internal package that handles .env loading, plus a small config plugin that injects our additional security features.
 
 ## Setup
 
@@ -54,7 +54,7 @@ To integrate varlock into a Next.js application, you must use our [`@varlock/nex
         ```
 
         :::caution[npm may not apply the override on a plain `npm install`]
-        npm can be inconsistent about applying `overrides` for nested scoped packages like `@next/env`, especially when an existing `package-lock.json` has it pinned to a stale location. If after installing you hit `Cannot find module '@next/env'` or don't see the varlock banner, you'll need to delete both `node_modules` and `package-lock.json` and reinstall — see [Troubleshooting](#troubleshooting).
+        npm can be inconsistent about applying `overrides` for nested scoped packages like `@next/env`, especially when an existing `package-lock.json` has it pinned to a stale location. If after installing you hit `Cannot find module '@next/env'` or don't see the varlock banner, delete both `node_modules` and `package-lock.json` and reinstall. See [Troubleshooting](#troubleshooting).
         :::
       </TabItem>
 
@@ -168,10 +168,10 @@ To integrate varlock into a Next.js application, you must use our [`@varlock/nex
                        ✨ loaded by varlock ✨
     ```
 
-    If you **don't** see `✨ loaded by varlock ✨` — or you get `Cannot find module '@next/env'` or `__VARLOCK_ENV is not set` — the override didn't take effect. See [Troubleshooting](#troubleshooting) below.
+    If you **don't** see `✨ loaded by varlock ✨`, or you get `Cannot find module '@next/env'` or `__VARLOCK_ENV is not set`, the override didn't take effect. See [Troubleshooting](#troubleshooting) below.
 
     :::note[The override only needs to apply at build/dev time]
-    On serverless platforms (e.g. Vercel, Cloudflare), the fully-resolved env is baked into your build output by the config plugin, so the production server does not re-load `.env` files. This means you only need the `@next/env` override to be active when you run `next dev` and `next build` — there is no separate runtime config to set on the platform.
+    On serverless platforms (e.g. Vercel, Cloudflare), the fully-resolved env is baked into your build output by the config plugin, so the production server does not re-load `.env` files. This means you only need the `@next/env` override to be active when you run `next dev` and `next build`. There is no separate runtime config to set on the platform.
     :::
 
 </Steps>
@@ -180,7 +180,7 @@ To integrate varlock into a Next.js application, you must use our [`@varlock/nex
 
 ## Monorepos
 
-In a [monorepo](/guides/monorepos/), the `@next/env` override from setup step 3 must live at the **workspace root** so every Next.js app resolves the same replacement. Package-manager overrides apply to **all** Next.js packages in the workspace — only add the override once each app you run has its own `.env.schema` and `varlockNextConfigPlugin`.
+In a [monorepo](/guides/monorepos/), the `@next/env` override from setup step 3 must live at the **workspace root** so every Next.js app resolves the same replacement. Package-manager overrides apply to **all** Next.js packages in the workspace, so only add the override once each app you run has its own `.env.schema` and `varlockNextConfigPlugin`.
 
 ---
 
@@ -235,7 +235,7 @@ Instead, we recommend explicitly setting your own environment flag using the [`@
 :::note[Loading `.env.local` in `test` environment]
 Next.js makes [a special exception](https://nextjs.org/docs/pages/guides/environment-variables#test-environment-variables) to skip loading `.env.local` if the current environment is `test`.
 
-Varlock does not (following Vite's lead) - but you may explicitly recreate that behavior:
+Varlock does not (following Vite's lead), but you may explicitly recreate that behavior:
 
 ```env-spec title=".env.local"
 # @disable=forEnv(test)
@@ -352,17 +352,17 @@ varlock run -- node .next/standalone/server.js
 ---
 
 :::note[Encrypting the env blob]
-When deploying to serverless platforms like Vercel, Varlock injects the fully resolved env data into your server-side build output. By default, this blob is plaintext JSON — meaning anyone with access to the build artifact can read your secrets. You can encrypt it for extra protection (e.g., against sourcemap leaks). See the [encrypted deployments guide](/guides/encrypted-deployments/) for setup instructions.
+When deploying to serverless platforms like Vercel, Varlock injects the fully resolved env data into your server-side build output. By default, this blob is plaintext JSON, meaning anyone with access to the build artifact can read your secrets. You can encrypt it for extra protection (e.g., against sourcemap leaks). See the [encrypted deployments guide](/guides/encrypted-deployments/) for setup instructions.
 :::
 
 ---
 ## Troubleshooting
 
-Almost all setup issues come down to the `@next/env` override not being applied. The fixes below are ordered by the symptom you see — work top to bottom.
+Almost all setup issues come down to the `@next/env` override not being applied. The fixes below are ordered by the symptom you see. Work top to bottom.
 
 - ❌ `Error: Cannot find module '@next/env'` (or no `✨ loaded by varlock ✨` banner)
-  <br/>💡 The override was recorded in your lockfile but your package manager didn't materialize it correctly. This is a known package-manager issue with `overrides`/`resolutions` for nested scoped packages — npm in particular can create a dangling symlink under `node_modules/next/node_modules/@next/env`, or skip it entirely, when installing against a stale lockfile.
-  - Delete **both** `node_modules` **and** your lockfile, then reinstall — deleting the lockfile alone is not enough:
+  <br/>💡 The override was recorded in your lockfile but your package manager didn't materialize it correctly. This is a known package-manager issue with `overrides`/`resolutions` for nested scoped packages. npm in particular can create a dangling symlink under `node_modules/next/node_modules/@next/env`, or skip it entirely, when installing against a stale lockfile.
+  - Delete **both** `node_modules` **and** your lockfile, then reinstall. Deleting the lockfile alone is not enough:
     - npm: `rm -rf node_modules package-lock.json && npm install`
     - pnpm: `rm -rf node_modules pnpm-lock.yaml && pnpm install`
     - yarn: `rm -rf node_modules yarn.lock && yarn install`
@@ -370,11 +370,11 @@ Almost all setup issues come down to the `@next/env` override not being applied.
   - Commit the regenerated lockfile.
   - Re-verify with the banner above, or directly: `cat node_modules/@next/env/package.json` should show `"name": "@varlock/nextjs-integration"`.
 - ❌ `process.env.__VARLOCK_ENV is not set`
-  <br/>💡 The override is missing or in the wrong place — Next loaded its own `@next/env` instead of ours.
-  - Confirm the override config is present and in the **correct file** for your package manager (see [step 3](#setup)) — for pnpm it must be in `pnpm-workspace.yaml` (v10) or `package.json#pnpm.overrides` (v9), and in a monorepo it must be at the repo root.
+  <br/>💡 The override is missing or in the wrong place, so Next loaded its own `@next/env` instead of ours.
+  - Confirm the override config is present and in the **correct file** for your package manager (see [step 3](#setup)). For pnpm it must be in `pnpm-workspace.yaml` (v10) or `package.json#pnpm.overrides` (v9), and in a monorepo it must be at the repo root.
   - Re-run your package manager's install command, then re-verify the banner.
 - ❌ `Error [ERR_REQUIRE_ESM]: require() of ES Module ...`
-  <br/>💡 Varlock requires node v22 or higher - which has better CJS/ESM interoperability
+  <br/>💡 Varlock requires node v22 or higher, which has better CJS/ESM interoperability
 - ❌ Every page 500s in dev with a `[turbopack-node]/transforms/transforms.ts ... lint TP1006` error, but only when the project has a `middleware.ts` file (Next 15.0–15.4 + Turbopack)
   <br/>💡 Turbopack on those versions cannot apply JS loaders (which varlock uses) to edge-context files like middleware without breaking dev page rendering. Upgrade to `next@^15.5` (where varlock scopes its loader away from edge files automatically) or Next 16 (which fixed the underlying issue), or run `next dev` without `--turbopack`.
 - ❌ `Property 'SOMEVAR' does not exist on type 'TypedEnvSchema'`

--- a/packages/varlock-website/src/content/docs/integrations/other-languages.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/other-languages.mdx
@@ -3,7 +3,7 @@ title: Other languages
 description: Integrating varlock into other languages
 ---
 
-To use varlock with other languages, [install the standalone binary](/getting-started/installation/#as-a-binary) rather than a JS package manager, and run your app under [`varlock run`](/reference/cli-commands/#run) — it loads and validates your environment, then runs your command with the resolved values injected into the process.
+To use varlock with other languages, [install the standalone binary](/getting-started/installation/#as-a-binary) rather than a JS package manager, and run your app under [`varlock run`](/reference/cli-commands/#run). It loads and validates your environment, then runs your command with the resolved values injected into the process.
 
 ```bash
 varlock run -- <your-command>
@@ -11,13 +11,13 @@ varlock run -- <your-command>
 
 ## Generated env modules
 
-Varlock can generate a ready-to-use, typed env module from your schema for several languages via per-language [`@generate*Env`](/reference/root-decorators/#code-generation) root decorators (see the [Code generation guide](/guides/code-generation/) for the full picture). Each generated file is a small, self-contained module — no hand-rolled JSON parsing — containing:
+Varlock can generate a typed env module from your schema for several languages via per-language [`@generate*Env`](/reference/root-decorators/#code-generation) root decorators (see the [Code generation guide](/guides/code-generation/) for the full picture). Each generated file is a small, self-contained module with no hand-rolled JSON parsing, containing:
 
-- a **typed, coerced env** object/type (numbers, booleans, parsed objects — not raw strings)
+- a **typed, coerced env** object/type (numbers, booleans, parsed objects, not raw strings)
 - a **loader** that reads the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob and returns those typed values
 - a **`SENSITIVE_KEYS`** constant listing which keys hold sensitive values, so you can build your own redaction or leak-scanning
 
-It exposes just these primitives — no global singleton or imposed caching — so it stays idiomatic in each language. Pick your language for setup and usage:
+It exposes only these primitives (no global singleton or imposed caching), so it stays idiomatic in each language. Pick your language for setup and usage:
 
 | Language | Decorator | Guide |
 | --- | --- | --- |
@@ -26,17 +26,17 @@ It exposes just these primitives — no global singleton or imposed caching — 
 | Go | `@generateGoEnv` | [Go](/integrations/go/) |
 | PHP | `@generatePhpEnv` | [PHP](/integrations/php/) |
 
-Files are generated automatically on [`varlock load`](/reference/cli-commands/#load) and [`varlock run`](/reference/cli-commands/#run), or explicitly via [`varlock codegen`](/reference/cli-commands/#codegen). The loaders read `__VARLOCK_ENV`, so run your program under [`varlock run`](/reference/cli-commands/#run) — which always injects a **plaintext** blob. The generated loaders don't decrypt, so they don't support [`@encryptInjectedEnv`](/reference/root-decorators/#encryptinjectedenv) (a JS/SSR build-output feature); if a loader is handed an encrypted blob it fails with a clear message rather than a raw parse error.
+Files are generated automatically on [`varlock load`](/reference/cli-commands/#load) and [`varlock run`](/reference/cli-commands/#run), or explicitly via [`varlock codegen`](/reference/cli-commands/#codegen). The loaders read `__VARLOCK_ENV`, so run your program under [`varlock run`](/reference/cli-commands/#run), which always injects a **plaintext** blob. The generated loaders don't decrypt, so they don't support [`@encryptInjectedEnv`](/reference/root-decorators/#encryptinjectedenv) (a JS/SSR build-output feature); if a loader is handed an encrypted blob it fails with a clear message rather than a raw parse error.
 
-Note that `varlock run --inject vars` strips the `__VARLOCK_ENV` blob from the child process, so the generated loaders can't work under it — use the default injection mode (or `--inject blob`) when your program loads a generated module.
+Note that `varlock run --inject vars` strips the `__VARLOCK_ENV` blob from the child process, so the generated loaders can't work under it. Use the default injection mode (or `--inject blob`) when your program loads a generated module.
 
 ## Languages without a generated module
 
-For a language that doesn't have a `@generate*Env` decorator yet, you have two options — both work under `varlock run`:
+For a language that doesn't have a `@generate*Env` decorator yet, you have two options, both of which work under `varlock run`:
 
 **Read individual env vars.** Every config key is injected as a plain environment variable, so read them the way you normally would (`os.environ`, `getenv`, etc.). These values are always **strings** (uncoerced), so parse numbers/booleans yourself.
 
-**Parse the blob yourself.** For coerced values and metadata, read the [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) environment variable — a JSON object with a `config` map keyed by env var name. Skip entries with no `value` (unset optionals), and use `isSensitive` to build redaction:
+**Parse the blob yourself.** For coerced values and metadata, read the [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) environment variable, a JSON object with a `config` map keyed by env var name. Skip entries with no `value` (unset optionals), and use `isSensitive` to build redaction:
 
 ```jsonc
 // shape of __VARLOCK_ENV
@@ -48,16 +48,16 @@ For a language that doesn't have a `@generate*Env` decorator yet, you have two o
 }
 ```
 
-The generated modules above do exactly this — they're the fastest path if your language is supported. We're planning first-class helper libraries and more generated languages.
+The generated modules above do exactly this, and they're the fastest path if your language is supported. We're planning first-class helper libraries and more generated languages.
 
 :::note[Raw string env vars]
 Individual config keys are also injected as plain environment variables, but those values are always strings (uncoerced). Prefer the generated loader / `__VARLOCK_ENV` when you want coerced types.
 
-Keys whose names aren't valid identifiers (they contain `.` or `-`) are **omitted from the typed value** in Python, Rust, Go, and PHP — they can't be a struct field / property — so read them from the raw environment variable instead (they're still injected, and still listed in `SENSITIVE_KEYS`). TypeScript keeps them, accessible as `ENV['MY-KEY']`.
+Keys whose names aren't valid identifiers (they contain `.` or `-`) are **omitted from the typed value** in Python, Rust, Go, and PHP, since they can't be a struct field / property. Read them from the raw environment variable instead (they're still injected, and still listed in `SENSITIVE_KEYS`). TypeScript keeps them, accessible as `ENV['MY-KEY']`.
 :::
 
 :::caution[Sensitive values in the blob]
-`__VARLOCK_ENV` includes resolved sensitive values and metadata used by varlock integrations. For interactive shells or workflows where subprocesses inspect the environment, use [`--inject vars`](/reference/cli-commands/#run) and read individual vars (as strings) instead — but note this also disables the generated loaders, which need the blob.
+`__VARLOCK_ENV` includes resolved sensitive values and metadata used by varlock integrations. For interactive shells or workflows where subprocesses inspect the environment, use [`--inject vars`](/reference/cli-commands/#run) and read individual vars (as strings) instead. Note that this also disables the generated loaders, which need the blob.
 :::
 
 **We are planning deeper integrations with other languages. Want to help us build these? Join our <a href={process.env.PUBLIC_DISCORD_URL}>Discord</a>.**

--- a/packages/varlock-website/src/content/docs/integrations/overview.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/overview.mdx
@@ -7,36 +7,36 @@ Varlock ships with official integrations that wire the CLI, runtime helpers, and
 
 If you are working in a monorepo, start with the [Monorepos guide](/guides/monorepos/) for schema layout, root-level dependency overrides, and CI patterns before picking per-framework integrations below.
 
-Integrations allow you to:
+Integrations let you:
 - load and validate `.env` files automatically during dev and use them in CI/CD and production
 - inject config into your code at build or request time
 - enable runtime protections such as leak prevention, and log redaction
 
 ## Official integrations
-- [JavaScript / Node.js](/integrations/javascript/) — use `varlock` in custom toolchains, scripts, and servers
-- [Bun](/integrations/bun/) — instructions to set up Varlock with Bun
-- [Next.js](/integrations/nextjs/) — drop-in replacement for `@next/env`
-- [Vite](/integrations/vite/) — Vite plugin that validates and replaces at build time
-- [Qwik](/integrations/vite/) — use the Vite integration
-- [React Router](/integrations/vite/) — use the Vite integration
-- [Cloudflare Workers](/integrations/cloudflare/) — use the Vite integration or Wrangler vars/secrets directly
-- [Astro](/integrations/astro/) — Astro integration built on top of our Vite plugin
-- [SvelteKit](/integrations/sveltekit/) — use the Vite integration, or the Cloudflare integration's SvelteKit plugin when deploying to Workers
-- [TanStack Start](/integrations/tanstack-start/) — use the Vite integration, or the Cloudflare integration when deploying to Workers
-- [Expo / React Native](/integrations/expo/) — Expo and React Native CLI: Babel plugin + Metro config wrapper with compile-time replacements and server route support (Expo only)
-- [GitHub Actions](/integrations/github-action/) — validate your `.env.schema` in GitHub Actions workflows
-- [Python](/integrations/python/) — `varlock run` + a generated typed env module (also Pydantic Settings / environs)
-- [Rust](/integrations/rust/) — a generated, serde-derived env module
-- [Go](/integrations/go/) — a generated env package
-- [PHP](/integrations/php/) — a generated, typed env class
-- [Other languages](/integrations/other-languages/) — generated-module overview + guidance for any other non-JS runtime
-- [Docker](/guides/docker/) — a Docker wrapper around the varlock CLI including examples
-- [mise](/integrations/mise/) — install varlock and wire validated env vars into your tasks
-- [direnv](/integrations/direnv/) — load validated env vars directly into your shell session
+- [JavaScript / Node.js](/integrations/javascript/): use `varlock` in custom toolchains, scripts, and servers
+- [Bun](/integrations/bun/): instructions to set up Varlock with Bun
+- [Next.js](/integrations/nextjs/): drop-in replacement for `@next/env`
+- [Vite](/integrations/vite/): Vite plugin that validates and replaces at build time
+- [Qwik](/integrations/vite/): use the Vite integration
+- [React Router](/integrations/vite/): use the Vite integration
+- [Cloudflare Workers](/integrations/cloudflare/): use the Vite integration or Wrangler vars/secrets directly
+- [Astro](/integrations/astro/): Astro integration built on top of our Vite plugin
+- [SvelteKit](/integrations/sveltekit/): use the Vite integration, or the Cloudflare integration's SvelteKit plugin when deploying to Workers
+- [TanStack Start](/integrations/tanstack-start/): use the Vite integration, or the Cloudflare integration when deploying to Workers
+- [Expo / React Native](/integrations/expo/): Expo and React Native CLI: Babel plugin + Metro config wrapper with compile-time replacements and server route support (Expo only)
+- [GitHub Actions](/integrations/github-action/): validate your `.env.schema` in GitHub Actions workflows
+- [Python](/integrations/python/): `varlock run` + a generated typed env module (also Pydantic Settings / environs)
+- [Rust](/integrations/rust/): a generated, serde-derived env module
+- [Go](/integrations/go/): a generated env package
+- [PHP](/integrations/php/): a generated, typed env class
+- [Other languages](/integrations/other-languages/): generated-module overview + guidance for any other non-JS runtime
+- [Docker](/guides/docker/): a Docker wrapper around the varlock CLI including examples
+- [mise](/integrations/mise/): install varlock and wire validated env vars into your tasks
+- [direnv](/integrations/direnv/): load validated env vars directly into your shell session
 
 
 ## Coming soon
-We’re actively working on additional first-party integrations for popular runtimes, frameworks and hosting platforms. If yours isn’t listed yet, let us know!
+We’re working on more first-party integrations for popular runtimes, frameworks and hosting platforms. If yours isn’t listed yet, let us know!
 
 :::note[Request an integration]
 Join us on [Discord](https://chat.dmno.dev) or open a GitHub issue describing your use case so we can prioritize it.

--- a/packages/varlock-website/src/content/docs/integrations/php.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/php.mdx
@@ -3,9 +3,9 @@ title: PHP
 description: Use varlock with PHP via a generated, typed env class
 ---
 
-To use varlock with PHP, [install the standalone binary](/getting-started/installation/#as-a-binary) and run your app under [`varlock run`](/reference/cli-commands/#run) — it loads and validates your env, then injects it into the process.
+To use varlock with PHP, [install the standalone binary](/getting-started/installation/#as-a-binary) and run your app under [`varlock run`](/reference/cli-commands/#run). It loads and validates your env, then injects it into the process.
 
-Add [`@generatePhpEnv`](/reference/root-decorators/#generatephpenv) to your schema to generate a small, self-contained class — a readonly `Env` with typed promoted properties, a static `load()` that parses the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob, and a `SENSITIVE_KEYS` constant.
+Add [`@generatePhpEnv`](/reference/root-decorators/#generatephpenv) to your schema to generate a small, self-contained class: a readonly `Env` with typed promoted properties, a static `load()` that parses the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob, and a `SENSITIVE_KEYS` constant.
 
 ```env-spec title=".env.schema"
 # @generatePhpEnv(path=Env.php)
@@ -15,11 +15,11 @@ The file is regenerated automatically on [`varlock load`](/reference/cli-command
 
 ## Reading values
 
-Call `load()` once, then read fields off the object — required fields are the plain type, optional ones are nullable (`?type`):
+Call `load()` once, then read fields off the object. Required fields are the plain type, optional ones are nullable (`?type`):
 
 ```php
 <?php
-require_once 'Env.php';   // require_once — a second require would fatal
+require_once 'Env.php';   // require_once, since a second require would fatal
 
 $env = Env::load();       // call once, hold or inject $env
 $port = $env->DB_PORT;    // ?int
@@ -37,7 +37,7 @@ varlock run -- php main.php
 
 ## Sharing one instance
 
-Every `load()` call re-parses the blob. To avoid reloading, bind the loaded instance wherever your app keeps shared services — e.g. your DI container:
+Every `load()` call re-parses the blob. To avoid reloading, bind the loaded instance wherever your app keeps shared services, e.g. your DI container:
 
 ```php
 // bootstrap.php
@@ -70,5 +70,5 @@ By default the class is a global `final class Env` loaded via `require_once`. Fo
 Under PHP-FPM, make sure the pool passes `__VARLOCK_ENV` through (`clear_env = no`).
 
 :::note
-Every key is also injected as a plain environment variable, so you can read any of them with `getenv()` (raw strings) if you don't need the typed module. Keys whose names aren't valid identifiers (they contain `.` or `-`) can't be properties — read those from the env var directly. See [Other languages](/integrations/other-languages/) for the shared details on the injected blob, raw env vars, and encryption.
+Every key is also injected as a plain environment variable, so you can read any of them with `getenv()` (raw strings) if you don't need the typed module. Keys whose names aren't valid identifiers (they contain `.` or `-`) can't be properties, so read those from the env var directly. See [Other languages](/integrations/other-languages/) for the shared details on the injected blob, raw env vars, and encryption.
 :::

--- a/packages/varlock-website/src/content/docs/integrations/python.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/python.mdx
@@ -3,9 +3,9 @@ title: Python
 description: Use varlock with Python via a generated typed env module, Pydantic Settings, or environs
 ---
 
-To use varlock with Python, [install the standalone binary](/getting-started/installation/#as-a-binary) and run your app under [`varlock run`](/reference/cli-commands/#run) — it loads and validates your env, then injects it into the process.
+To use varlock with Python, [install the standalone binary](/getting-started/installation/#as-a-binary) and run your app under [`varlock run`](/reference/cli-commands/#run). It loads and validates your env, then injects it into the process.
 
-Add [`@generatePythonEnv`](/reference/root-decorators/#generatepythonenv) to your schema to generate a small, self-contained module — a coerced `Env` [`TypedDict`](https://docs.python.org/3/library/typing.html#typing.TypedDict), a `load_env()` function that parses the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob, and a `SENSITIVE_KEYS` constant.
+Add [`@generatePythonEnv`](/reference/root-decorators/#generatepythonenv) to your schema to generate a small, self-contained module: a coerced `Env` [`TypedDict`](https://docs.python.org/3/library/typing.html#typing.TypedDict), a `load_env()` function that parses the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob, and a `SENSITIVE_KEYS` constant.
 
 ```env-spec title=".env.schema"
 # @generatePythonEnv(path=env.py)
@@ -15,7 +15,7 @@ The file is regenerated automatically on [`varlock load`](/reference/cli-command
 
 ## Reading values
 
-Call `load_env()` once, then read keys off the dict — values are coerced (`int`/`bool`/etc.), not raw strings:
+Call `load_env()` once, then read keys off the dict. Values are coerced (`int`/`bool`/etc.), not raw strings:
 
 ```python
 from env import load_env, SENSITIVE_KEYS
@@ -36,7 +36,7 @@ varlock run -- python main.py
 
 ## Sharing one instance
 
-Every `load_env()` call re-parses the blob. To avoid reloading, load once in a config module and share it — the idiomatic "settings module" pattern:
+Every `load_env()` call re-parses the blob. To avoid reloading, load once in a config module and share it, the idiomatic "settings module" pattern:
 
 ```python
 # config.py
@@ -54,7 +54,7 @@ port = env["DB_PORT"]   # int
 
 ## Running your server
 
-[`varlock run`](/reference/cli-commands/#run) wraps any command, so boot your ASGI server, task runner, or scripts through it — local dev, CI, and production all use the same schema:
+[`varlock run`](/reference/cli-commands/#run) wraps any command, so boot your ASGI server, task runner, or scripts through it. Local dev, CI, and production all use the same schema:
 
 ```bash
 varlock run -- uvicorn main:app --reload
@@ -68,7 +68,7 @@ Environment variables in the command itself are expanded by your shell **before*
 
 ## Using a settings library
 
-If you'd rather keep the settings library you already use, every key is also injected as a plain environment variable — so [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/), [environs](https://github.com/sloria/environs), and friends work unchanged. They read the **raw string** values (e.g. `"5432"`, `"true"`), so your settings class is what coerces them:
+If you'd rather keep the settings library you already use, every key is also injected as a plain environment variable, so [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/), [environs](https://github.com/sloria/environs), and friends work unchanged. They read the **raw string** values (e.g. `"5432"`, `"true"`), so your settings class is what coerces them:
 
 ```python title="settings.py"
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -89,16 +89,16 @@ settings = Settings()
 from environs import Env
 
 env = Env()
-# Do not call env.read_env() — varlock run already populated os.environ
+# Do not call env.read_env(); varlock run already populated os.environ
 
 DATABASE_URL = env.str("DATABASE_URL")
 DEBUG = env.bool("DEBUG", default=False)
 ```
 
 :::note[Skip `.env` file loading in Python]
-When using varlock, don't also load `.env` from Python (`python-dotenv`, Pydantic's `env_file=`, etc.) unless you intentionally want a second source of truth. Varlock is the single resolver — your schema, plugins, and environment files all flow through it before Python starts.
+When using varlock, don't also load `.env` from Python (`python-dotenv`, Pydantic's `env_file=`, etc.) unless you intentionally want a second source of truth. Varlock is the single resolver: your schema, plugins, and environment files all flow through it before Python starts.
 :::
 
 :::note
-Every key is also injected as a plain environment variable, so you can read any of them with `os.environ` (raw strings) if you don't need the typed module. Keys whose names aren't valid identifiers (they contain `.` or `-`) can't be `TypedDict` fields — read those from the env var directly. See [Other languages](/integrations/other-languages/) for the shared details on the injected blob, raw env vars, and encryption.
+Every key is also injected as a plain environment variable, so you can read any of them with `os.environ` (raw strings) if you don't need the typed module. Keys whose names aren't valid identifiers (they contain `.` or `-`) can't be `TypedDict` fields, so read those from the env var directly. See [Other languages](/integrations/other-languages/) for the shared details on the injected blob, raw env vars, and encryption.
 :::

--- a/packages/varlock-website/src/content/docs/integrations/rust.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/rust.mdx
@@ -3,9 +3,9 @@ title: Rust
 description: Use varlock with Rust via a generated, serde-derived env module
 ---
 
-To use varlock with Rust, [install the standalone binary](/getting-started/installation/#as-a-binary) and run your app under [`varlock run`](/reference/cli-commands/#run) — it loads and validates your env, then injects it into the process.
+To use varlock with Rust, [install the standalone binary](/getting-started/installation/#as-a-binary) and run your app under [`varlock run`](/reference/cli-commands/#run). It loads and validates your env, then injects it into the process.
 
-Add [`@generateRustEnv`](/reference/root-decorators/#generaterustenv) to your schema to generate a small, self-contained module — a serde-derived `Env` struct, a `load()` function that parses the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob, and a `SENSITIVE_KEYS` constant.
+Add [`@generateRustEnv`](/reference/root-decorators/#generaterustenv) to your schema to generate a small, self-contained module: a serde-derived `Env` struct, a `load()` function that parses the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob, and a `SENSITIVE_KEYS` constant.
 
 ```env-spec title=".env.schema"
 # @generateRustEnv(path=src/env.rs)
@@ -20,7 +20,7 @@ cargo add serde_json
 
 ## Reading values
 
-Call `load()` once, then read fields off the struct — required fields are the plain type, optional ones are `Option<T>`:
+Call `load()` once, then read fields off the struct. Required fields are the plain type, optional ones are `Option<T>`:
 
 ```rust
 mod env;
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 varlock run -- cargo run
 ```
 
-`load()` returns a clear error if `__VARLOCK_ENV` is missing (e.g. you forgot `varlock run`) or if a required key is absent. The struct derives a **redacting `Debug`** — sensitive fields print as `<redacted>`, so `{:?}` won't leak secrets.
+`load()` returns a clear error if `__VARLOCK_ENV` is missing (e.g. you forgot `varlock run`) or if a required key is absent. The struct derives a **redacting `Debug`**: sensitive fields print as `<redacted>`, so `{:?}` won't leak secrets.
 
 ## Sharing one instance
 
@@ -61,8 +61,8 @@ use crate::config::ENV;
 let port = ENV.db_port;   // Option<i64>
 ```
 
-Prefer no globals? Call `env::load()?` once in `main` and pass `&Env` through your app state — the type comes along either way.
+Prefer no globals? Call `env::load()?` once in `main` and pass `&Env` through your app state. The type comes along either way.
 
 :::note
-Every key is also injected as a plain environment variable, so you can read any of them with `std::env::var` (raw strings) if you don't need the typed module. Enums become plain `String` (Rust has no string-literal type), and keys whose names aren't valid identifiers (they contain `.` or `-`) can't be struct fields — read those from the env var directly. See [Other languages](/integrations/other-languages/) for the shared details on the injected blob, raw env vars, and encryption.
+Every key is also injected as a plain environment variable, so you can read any of them with `std::env::var` (raw strings) if you don't need the typed module. Enums become plain `String` (Rust has no string-literal type), and keys whose names aren't valid identifiers (they contain `.` or `-`) can't be struct fields, so read those from the env var directly. See [Other languages](/integrations/other-languages/) for the shared details on the injected blob, raw env vars, and encryption.
 :::

--- a/packages/varlock-website/src/content/docs/integrations/sveltekit.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/sveltekit.mdx
@@ -7,9 +7,9 @@ import Badge from '@/components/Badge.astro';
 import ExecCommandWidget from '@/components/ExecCommandWidget.astro';
 import InstallJsDepsWidget from '@/components/InstallJsDepsWidget.astro';
 
-[SvelteKit](https://svelte.dev/docs/kit) is built on [Vite](https://vite.dev), so there's no dedicated SvelteKit package — you use the [Vite integration](/integrations/vite/) the same way regardless of where you deploy.
+[SvelteKit](https://svelte.dev/docs/kit) is built on [Vite](https://vite.dev), so there's no dedicated SvelteKit package. You use the [Vite integration](/integrations/vite/) the same way regardless of where you deploy.
 
-Add `varlockVitePlugin()` to your Vite config ([setup below](#setup)) and it works across deploy targets. If you deploy to **Cloudflare Workers** (via [`@sveltejs/adapter-cloudflare`](https://svelte.dev/docs/kit/adapter-cloudflare)), the plugin detects the adapter and automatically wires up the runtime env-loader — you just need `@varlock/cloudflare-integration` installed as well (it ships `varlock-wrangler`). See [Cloudflare Workers setup](#setup-for-cloudflare-workers).
+Add `varlockVitePlugin()` to your Vite config ([setup below](#setup)) and it works across deploy targets. If you deploy to **Cloudflare Workers** (via [`@sveltejs/adapter-cloudflare`](https://svelte.dev/docs/kit/adapter-cloudflare)), the plugin detects the adapter and automatically wires up the runtime env-loader. You just need `@varlock/cloudflare-integration` installed as well (it ships `varlock-wrangler`). See [Cloudflare Workers setup](#setup-for-cloudflare-workers).
 
 Check out the [SvelteKit example project](https://github.com/dmno-dev/varlock-examples/tree/main/examples/sveltekit) for a working reference.
 
@@ -21,7 +21,7 @@ Check out the [SvelteKit example project](https://github.com/dmno-dev/varlock-ex
   <Badge npmPackage="@varlock/vite-integration" />
 </div>
 
-Use `varlockVitePlugin` exactly as you would in any Vite project. This is the setup for every deploy target — see [Cloudflare Workers](#setup-for-cloudflare-workers) below for the one extra package CF deployments need.
+Use `varlockVitePlugin` exactly as you would in any Vite project. This is the setup for every deploy target. See [Cloudflare Workers](#setup-for-cloudflare-workers) below for the one extra package CF deployments need.
 
 <Steps>
 
@@ -32,7 +32,7 @@ Use `varlockVitePlugin` exactly as you would in any Vite project. This is the se
 
     <ExecCommandWidget command="varlock init" showBinary={false} />
 
-1. **Add the plugin to your Vite config** — it should come **before** `sveltekit()`:
+1. **Add the plugin to your Vite config.** It should come **before** `sveltekit()`:
 
     ```diff lang="ts" title="vite.config.ts"
     import { sveltekit } from '@sveltejs/kit/vite';
@@ -61,12 +61,12 @@ See the [**Vite integration page**](/integrations/vite/) for configuration optio
   <Badge npmPackage="@varlock/cloudflare-integration" />
 </div>
 
-For SvelteKit projects deploying to Cloudflare Workers via [`@sveltejs/adapter-cloudflare`](https://svelte.dev/docs/kit/adapter-cloudflare), use the same `varlockVitePlugin()` from the [setup above](#setup). When it detects the Cloudflare adapter, it automatically injects the runtime env-loader into SvelteKit's SSR entry so the resolved env is available inside the worker. You just need to additionally install `@varlock/cloudflare-integration` — it provides `varlock-wrangler` and the Cloudflare-specific loader the plugin pulls in. (The standard `varlockCloudflareVitePlugin` isn't used here because `@cloudflare/vite-plugin` doesn't currently support SvelteKit — see [cloudflare/workers-sdk#8922](https://github.com/cloudflare/workers-sdk/issues/8922).)
+For SvelteKit projects deploying to Cloudflare Workers via [`@sveltejs/adapter-cloudflare`](https://svelte.dev/docs/kit/adapter-cloudflare), use the same `varlockVitePlugin()` from the [setup above](#setup). When it detects the Cloudflare adapter, it automatically injects the runtime env-loader into SvelteKit's SSR entry so the resolved env is available inside the worker. You just need to additionally install `@varlock/cloudflare-integration`, which provides `varlock-wrangler` and the Cloudflare-specific loader the plugin pulls in. (The standard `varlockCloudflareVitePlugin` isn't used here because `@cloudflare/vite-plugin` doesn't currently support SvelteKit. See [cloudflare/workers-sdk#8922](https://github.com/cloudflare/workers-sdk/issues/8922).)
 
 The adapter is detected whether you configure it in `svelte.config.js` or inline in your Vite config (SvelteKit ≥ 2.62), so no extra setup is needed either way.
 
 :::note[Static-only SvelteKit sites]
-If your SvelteKit app is fully static (no SSR — typically using `@sveltejs/adapter-static` and deployed to Cloudflare Pages or any CDN), you don't need `@varlock/cloudflare-integration` at all. The [base setup](#setup) is enough — there's no server bundle for us to inject into.
+If your SvelteKit app is fully static (no SSR, typically using `@sveltejs/adapter-static` and deployed to Cloudflare Pages or any CDN), you don't need `@varlock/cloudflare-integration` at all. The [base setup](#setup) is enough, since there's no server bundle for us to inject into.
 :::
 
 ### Setup
@@ -80,7 +80,7 @@ If your SvelteKit app is fully static (no SSR — typically using `@sveltejs/ada
 
     <ExecCommandWidget command="varlock init" showBinary={false} />
 
-1. **Add the plugin to your Vite config** — the same as the base setup; it auto-detects the Cloudflare adapter:
+1. **Add the plugin to your Vite config.** This is the same as the base setup; it auto-detects the Cloudflare adapter:
 
     ```diff lang="ts" title="vite.config.ts"
     import { sveltekit } from '@sveltejs/kit/vite';
@@ -109,7 +109,7 @@ If your SvelteKit app is fully static (no SSR — typically using `@sveltejs/ada
     }
     ```
 
-    If you deploy via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) instead of a local/CI script, override the deploy command in your Cloudflare dashboard under **Settings → Build → Deploy command** — see [Workers Builds](#deploying-via-cloudflare-workers-builds) below.
+    If you deploy via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) instead of a local/CI script, override the deploy command in your Cloudflare dashboard under **Settings → Build → Deploy command**. See [Workers Builds](#deploying-via-cloudflare-workers-builds) below.
 
 </Steps>
 
@@ -121,10 +121,10 @@ If your SvelteKit app is fully static (no SSR — typically using `@sveltejs/ada
 
 ### Deploying via Cloudflare Workers Builds
 
-If you deploy through [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/), two pieces of configuration must be set in the dashboard — neither can be committed to the repo:
+If you deploy through [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/), two pieces of configuration must be set in the dashboard, and neither can be committed to the repo:
 
-- **Override the Deploy command** — Under **Settings → Build → Deploy command**, replace the default `npx wrangler deploy` with `npx varlock-wrangler deploy`. Without this, Cloudflare runs stock `wrangler deploy`, which skips varlock resolution and leaves your worker without its resolved vars/secrets.
-- **Set any _secret-zero_ vars under Build variables** — Any env vars varlock itself needs _during load_ (e.g. a 1Password service account token, a GCP key) must be set under **Settings → Build → Variables and Secrets** so they're available at build time. `varlock-wrangler deploy` then resolves your full env graph and uploads the result to the worker runtime as regular vars/secrets.
+- **Override the Deploy command.** Under **Settings → Build → Deploy command**, replace the default `npx wrangler deploy` with `npx varlock-wrangler deploy`. Without this, Cloudflare runs stock `wrangler deploy`, which skips varlock resolution and leaves your worker without its resolved vars/secrets.
+- **Set any _secret-zero_ vars under Build variables.** Any env vars varlock itself needs _during load_ (e.g. a 1Password service account token, a GCP key) must be set under **Settings → Build → Variables and Secrets** so they're available at build time. `varlock-wrangler deploy` then resolves your full env graph and uploads the result to the worker runtime as regular vars/secrets.
 
 :::tip[Next steps]
 See the [**Cloudflare integration page**](/integrations/cloudflare/) for more on `varlock-wrangler`, multi-environment setup, and [Workers Builds configuration](/integrations/cloudflare/#cloudflare-workers-builds-cicd).
@@ -134,18 +134,18 @@ See the [**Cloudflare integration page**](/integrations/cloudflare/) for more on
 
 ## Migrating from SvelteKit's `$env/*`
 
-SvelteKit ships [four built-in env modules](https://svelte.dev/docs/kit/$env-static-private) — `$env/static/private`, `$env/static/public`, `$env/dynamic/private`, `$env/dynamic/public` — which split env vars along two axes: _static vs dynamic_ (inlined at build vs looked up at runtime) and _private vs public_ (server-only vs bundled for the browser, gated by the `PUBLIC_` prefix).
+SvelteKit ships [four built-in env modules](https://svelte.dev/docs/kit/$env-static-private) (`$env/static/private`, `$env/static/public`, `$env/dynamic/private`, `$env/dynamic/public`) which split env vars along two axes: _static vs dynamic_ (inlined at build vs looked up at runtime) and _private vs public_ (server-only vs bundled for the browser, gated by the `PUBLIC_` prefix).
 
-The key conceptual shift is that SvelteKit's system is **access-driven**: the same underlying variable behaves differently depending on which module you import it from, and public/private is inferred from the variable's name. Varlock is **schema-driven**: each item is declared once in `.env.schema` with decorators that determine its behavior — sensitivity, type, validation, whether it's inlined or resolved at runtime — and every access site uses the same `ENV` object. You describe the variable once, and that description is authoritative everywhere it's used.
+The key conceptual shift is that SvelteKit's system is **access-driven**: the same underlying variable behaves differently depending on which module you import it from, and public/private is inferred from the variable's name. Varlock is **schema-driven**: each item is declared once in `.env.schema` with decorators that determine its behavior (sensitivity, type, validation, whether it's inlined or resolved at runtime), and every access site uses the same `ENV` object. You describe the variable once, and that description is authoritative everywhere it's used.
 
 Varlock replaces all four `$env/*` modules with a single `ENV` object from `varlock/env`. The same two axes still exist, but they're controlled by the schema rather than the import path:
 
 | SvelteKit concept | Varlock equivalent |
 | :---------------- | :----------------- |
-| `$env/static/public` | `ENV.FOO` where `@sensitive=false` — non-sensitive values are inlined at build time on both client and server |
-| `$env/static/private` | `ENV.FOO` where `@sensitive=true`, referenced from SSR/server code — inlined into the server bundle, build errors if referenced from client code |
-| `$env/dynamic/public` | **Not yet supported** — non-sensitive values are currently always inlined at build time (equivalent to `$env/static/public`). Runtime-resolved public values are on the roadmap. |
-| `$env/dynamic/private` | `ENV.FOO` — in server contexts it's read from the live runtime env (e.g. Cloudflare bindings via `varlockCloudflareVitePlugin`, or Node's `process.env` elsewhere) rather than baked into the bundle |
+| `$env/static/public` | `ENV.FOO` where `@sensitive=false`; non-sensitive values are inlined at build time on both client and server |
+| `$env/static/private` | `ENV.FOO` where `@sensitive=true`, referenced from SSR/server code; inlined into the server bundle, build errors if referenced from client code |
+| `$env/dynamic/public` | **Not yet supported.** Non-sensitive values are currently always inlined at build time (equivalent to `$env/static/public`). Runtime-resolved public values are on the roadmap. |
+| `$env/dynamic/private` | `ENV.FOO`; in server contexts it's read from the live runtime env (e.g. Cloudflare bindings via `varlockCloudflareVitePlugin`, or Node's `process.env` elsewhere) rather than baked into the bundle |
 | `PUBLIC_` prefix requirement | Per-item [`@sensitive`](/reference/item-decorators/#sensitive) decorator, or a schema-wide [`@defaultSensitive`](/reference/root-decorators/#defaultsensitive) rule |
 
 ### Migrating imports
@@ -166,11 +166,11 @@ Everywhere you currently import from `$env/*`, switch to `varlock/env`:
  };
 ```
 
-`ENV` works from both `+page.svelte` (client) and `+page.server.ts`/`+server.ts` (server) — there's no need to import from different paths depending on context. Varlock enforces the public/private boundary with both **build-time** checks (sensitive values are never included in the client bundle, and referencing one from client-reachable code surfaces as a build error) and **runtime** checks (log redaction and leak detection in server responses) so a mistake in either layer is caught rather than silently exposing a secret.
+`ENV` works from both `+page.svelte` (client) and `+page.server.ts`/`+server.ts` (server); there's no need to import from different paths depending on context. Varlock enforces the public/private boundary with both **build-time** checks (sensitive values are never included in the client bundle, and referencing one from client-reachable code surfaces as a build error) and **runtime** checks (log redaction and leak detection in server responses) so a mistake in either layer is caught rather than silently exposing a secret.
 
 ### Managing sensitive values
 
-SvelteKit uses the `PUBLIC_` prefix to determine which vars are safe to bundle for the browser. Varlock uses decorators — either per-item, or schema-wide via [`@defaultSensitive`](/reference/root-decorators/#defaultsensitive).
+SvelteKit uses the `PUBLIC_` prefix to determine which vars are safe to bundle for the browser. Varlock uses decorators, either per-item or schema-wide via [`@defaultSensitive`](/reference/root-decorators/#defaultsensitive).
 
 The simplest setup is to mark items explicitly:
 
@@ -192,7 +192,7 @@ PUBLIC_API_URL=         # non-sensitive (has PUBLIC_ prefix)
 ```
 
 :::caution[Bundling behavior]
-All non-sensitive items are replaced at build time wherever `ENV.FOO` appears. Sensitive items are only available in server contexts — build-time checks block them from client bundles, and runtime log redaction / response leak detection catch any that slip past the build layer.
+All non-sensitive items are replaced at build time wherever `ENV.FOO` appears. Sensitive items are only available in server contexts: build-time checks block them from client bundles, and runtime log redaction / response leak detection catch any that slip past the build layer.
 :::
 
 :::note[Encrypting the env blob]

--- a/packages/varlock-website/src/content/docs/integrations/tanstack-start.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/tanstack-start.mdx
@@ -7,10 +7,10 @@ import Badge from '@/components/Badge.astro';
 import ExecCommandWidget from '@/components/ExecCommandWidget.astro';
 import InstallJsDepsWidget from '@/components/InstallJsDepsWidget.astro';
 
-[TanStack Start](https://tanstack.com/start) is a full-stack React framework built on [Vite](https://vite.dev), so there's no dedicated TanStack Start package — which integration you use depends on where you deploy.
+[TanStack Start](https://tanstack.com/start) is a full-stack React framework built on [Vite](https://vite.dev), so there's no dedicated TanStack Start package. Which integration you use depends on where you deploy.
 
-- **Node / Vercel / Netlify / self-hosted** — use the [**Vite integration**](/integrations/vite/). See [setup below](#setup).
-- **Cloudflare Workers** — use the [**Cloudflare integration**](/integrations/cloudflare/). See [Cloudflare setup below](#deploying-to-cloudflare-workers).
+- **Node / Vercel / Netlify / self-hosted**: use the [**Vite integration**](/integrations/vite/). See [setup below](#setup).
+- **Cloudflare Workers**: use the [**Cloudflare integration**](/integrations/cloudflare/). See [Cloudflare setup below](#deploying-to-cloudflare-workers).
 
 Check out the [TanStack Start example project](https://github.com/dmno-dev/varlock-examples/tree/main/examples/tanstack-start) for a working reference.
 
@@ -111,7 +111,7 @@ If you're deploying your TanStack Start app to Cloudflare Workers, use `varlockC
     }
     ```
 
-    If you deploy via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) instead of a local/CI script, override the deploy command in your Cloudflare dashboard under **Settings → Build → Deploy command** — see [Workers Builds](#deploying-via-cloudflare-workers-builds) below.
+    If you deploy via [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) instead of a local/CI script, override the deploy command in your Cloudflare dashboard under **Settings → Build → Deploy command**. See [Workers Builds](#deploying-via-cloudflare-workers-builds) below.
 
 </Steps>
 
@@ -121,10 +121,10 @@ See the [**Cloudflare integration page**](/integrations/cloudflare/) for more on
 
 ### Deploying via Cloudflare Workers Builds
 
-If you deploy through [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/), two pieces of configuration must be set in the dashboard — neither can be committed to the repo:
+If you deploy through [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/), two pieces of configuration must be set in the dashboard, and neither can be committed to the repo:
 
-- **Override the Deploy command** — Under **Settings → Build → Deploy command**, replace the default `npx wrangler deploy` with `npx varlock-wrangler deploy`. Without this, Cloudflare runs stock `wrangler deploy`, which skips varlock resolution and leaves your worker without its resolved vars/secrets.
-- **Set any _secret-zero_ vars under Build variables** — Any env vars varlock itself needs _during load_ (e.g. a 1Password service account token, a GCP key) must be set under **Settings → Build → Variables and Secrets** so they're available at build time. `varlock-wrangler deploy` then resolves your full env graph and uploads the result to the worker runtime as regular vars/secrets.
+- **Override the Deploy command.** Under **Settings → Build → Deploy command**, replace the default `npx wrangler deploy` with `npx varlock-wrangler deploy`. Without this, Cloudflare runs stock `wrangler deploy`, which skips varlock resolution and leaves your worker without its resolved vars/secrets.
+- **Set any _secret-zero_ vars under Build variables.** Any env vars varlock itself needs _during load_ (e.g. a 1Password service account token, a GCP key) must be set under **Settings → Build → Variables and Secrets** so they're available at build time. `varlock-wrangler deploy` then resolves your full env graph and uploads the result to the worker runtime as regular vars/secrets.
 
 See the [Cloudflare integration page](/integrations/cloudflare/) for more detail on `varlock-wrangler` and [Workers Builds configuration](/integrations/cloudflare/#cloudflare-workers-builds-cicd).
 
@@ -134,7 +134,7 @@ See the [Cloudflare integration page](/integrations/cloudflare/) for more detail
 
 TanStack Start inherits [Vite's env var approach](https://tanstack.com/start/v0/docs/framework/react/guide/environment-variables): `process.env` on the server and `import.meta.env` on the client, with only `VITE_`-prefixed vars exposed client-side. Their docs recommend maintaining a manual `src/env.d.ts` for TypeScript support and separate Zod schemas for runtime validation.
 
-With varlock, your `.env.schema` is the single source of truth — it handles validation, type coercion, TypeScript generation, sensitivity controls, and more, replacing the need for separate type declarations, Zod schemas, and the `VITE_` prefix convention. You also get leak detection (sensitive values are automatically scrubbed from outgoing HTTP responses) and clear error messages when env vars are missing or invalid — no more silent `undefined` values at runtime. See the [Vite integration page](/integrations/vite/) for the full details.
+With varlock, your `.env.schema` is the single source of truth. It handles validation, type coercion, TypeScript generation, sensitivity controls, and more, replacing the need for separate type declarations, Zod schemas, and the `VITE_` prefix convention. You also get leak detection (sensitive values are automatically scrubbed from outgoing HTTP responses) and clear error messages when env vars are missing or invalid, so no more silent `undefined` values at runtime. See the [Vite integration page](/integrations/vite/) for the full details.
 
 :::note[Encrypting the env blob]
 When deploying SSR TanStack Start apps to serverless platforms, varlock injects the resolved env into your server-side build output as plaintext JSON. This is generally safe since it only appears in server code, but you can encrypt it for extra protection (e.g., against sourcemap leaks). See the [encrypted deployments guide](/guides/encrypted-deployments/) for setup instructions.

--- a/packages/varlock-website/src/content/docs/integrations/vite.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/vite.mdx
@@ -25,11 +25,11 @@ For [Astro](https://astro.build) - which is also powered by Vite - you should us
 ::::
 
 :::note[SvelteKit users]
-For [SvelteKit](https://svelte.dev/docs/kit), the plain Vite integration below works for most adapters. If you're deploying to Cloudflare Workers via `@sveltejs/adapter-cloudflare`, see our [SvelteKit guide](/integrations/sveltekit/) — it points you at the Cloudflare-specific plugin.
+For [SvelteKit](https://svelte.dev/docs/kit), the plain Vite integration below works for most adapters. If you're deploying to Cloudflare Workers via `@sveltejs/adapter-cloudflare`, see our [SvelteKit guide](/integrations/sveltekit/), which points you at the Cloudflare-specific plugin.
 ::::
 
 :::caution[Deploying a non-static site to Cloudflare Workers?]
-If your project has an SSR/server component that runs on Cloudflare Workers, the plain Vite integration won't wire up runtime secrets correctly — secrets would end up bundled into the worker instead of being stored as Cloudflare secrets. Use the [Cloudflare integration](/integrations/cloudflare/) (or the [SvelteKit guide](/integrations/sveltekit/) for SvelteKit) instead. This page is fine for **static-only** Vite sites.
+If your project has an SSR/server component that runs on Cloudflare Workers, the plain Vite integration won't wire up runtime secrets correctly: secrets would end up bundled into the worker instead of being stored as Cloudflare secrets. Use the [Cloudflare integration](/integrations/cloudflare/) (or the [SvelteKit guide](/integrations/sveltekit/) for SvelteKit) instead. This page is fine for **static-only** Vite sites.
 :::
 
 ## Frameworks that use Vite ||frameworks||
@@ -82,7 +82,7 @@ By default, varlock loads `.env` files from the current working directory. If yo
 }
 ```
 
-This works for all varlock commands and integrations, not just Vite. The `loadPath` can point to a directory (trailing `/` recommended) or a specific `.env` file. The varlock CLI `--path` flag overrides this setting when provided. Varlock looks for this config in the `package.json` in the current working directory only — it does not walk up to parent directories.
+This works for all varlock commands and integrations, not just Vite. The `loadPath` can point to a directory (trailing `/` recommended) or a specific `.env` file. The varlock CLI `--path` flag overrides this setting when provided. Varlock looks for this config in the `package.json` in the current working directory only; it does not walk up to parent directories.
 
 :::tip[Directory vs file path]
 Point `loadPath` to a **directory** if you want varlock to automatically load all relevant files (`.env.schema`, `.env`, `.env.local`, etc.). Pointing to a specific file will only load that file and anything it explicitly imports via `@import`.
@@ -90,7 +90,7 @@ Point `loadPath` to a **directory** if you want varlock to automatically load al
 
 ### Loading from multiple directories
 
-You can also provide an array of paths to combine env vars from multiple locations — useful in monorepos where different packages each have their own `.env` files:
+You can also provide an array of paths to combine env vars from multiple locations, useful in monorepos where different packages each have their own `.env` files:
 
 ```json title="package.json"
 {
@@ -142,7 +142,7 @@ console.log(ENV.SOMEVAR);             // ✨ recommended
 - Enables future DX improvements and tighter control over what is bundled
 
 ### Within `vite.config.*`
-It's often useful to be able to access env vars in your Vite config. Without varlock, it's a bit awkward, but varlock makes it dead simple - in fact it's already available! Just import varlock's `ENV` object and reference env vars via `ENV.SOME_ITEM` like you do everywhere else.
+It's often useful to be able to access env vars in your Vite config. Without varlock, it's a bit awkward, but with varlock it's already available. Import varlock's `ENV` object and reference env vars via `ENV.SOME_ITEM` like you do everywhere else.
 
 ```diff lang="ts" title="vite.config.ts"
 import { defineConfig } from 'vite';
@@ -244,7 +244,7 @@ All non-sensitive items are bundled at build time via `ENV`, while `import.meta.
 ---
 
 :::note[Encrypting the env blob]
-When using `ssrInjectMode: 'resolved-env'`, Varlock injects the fully resolved env data into your SSR build output. By default, this blob is plaintext JSON — meaning anyone with access to the build artifact can read your secrets. You can encrypt it for extra protection (e.g., against sourcemap leaks). See the [encrypted deployments guide](/guides/encrypted-deployments/) for setup instructions.
+When using `ssrInjectMode: 'resolved-env'`, Varlock injects the fully resolved env data into your SSR build output. By default, this blob is plaintext JSON, meaning anyone with access to the build artifact can read your secrets. You can encrypt it for extra protection (e.g., against sourcemap leaks). See the [encrypted deployments guide](/guides/encrypted-deployments/) for setup instructions.
 :::
 
 ---

--- a/packages/varlock-website/src/content/docs/plugins/1password.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/1password.mdx
@@ -51,7 +51,7 @@ Consider how you want to organize your vaults and service accounts, keeping in m
 
 If you plan on using data from 1Password in deployed environments (CI/CD, production, etc), you will need to create a [service account](https://www.1password.dev/service-accounts/get-started/) to allow machine-to-machine authentication. You could also use a service account for local development, although we recommend using the desktop app auth method described below for convenience.
 
-This service account token will now serve as your _secret-zero_ - which grants access to the rest of your sensitive data stored in 1Password. For local-only workflows, you can secure this value by using [device-local encryption](/guides/local-encryption/).
+This service account token will now serve as your _secret-zero_, granting access to the rest of your sensitive data stored in 1Password. For local-only workflows, you can secure this value by using [device-local encryption](/guides/local-encryption/).
 
 <Steps>
 1. **Create a new service account** and grant access to necessary vault(s). This is a special account used for machine-to-machine communication. This can only be done in the 1Password web interface. Be sure to save the new service account token in another vault so you can find it later. [link](https://www.1password.dev/service-accounts/get-started/)
@@ -69,7 +69,7 @@ This service account token will now serve as your _secret-zero_ - which grants a
     +OP_TOKEN=
     ```
     :::note[Service account tokens are `@internal` by default]
-    The `opServiceAccountToken` type is marked [`@internal`](/reference/item-decorators/#internal), so the token is used by varlock to fetch your other secrets but is **not** injected into your application — keeping this secret-zero out of your app's environment. It still shows (redacted) in `varlock load` output so you can debug it. If your app genuinely needs the token directly, opt out with `@internal=false`.
+    The `opServiceAccountToken` type is marked [`@internal`](/reference/item-decorators/#internal), so the token is used by varlock to fetch your other secrets but is **not** injected into your application, keeping this secret-zero out of your app's environment. It still shows (redacted) in `varlock load` output so you can debug it. If your app genuinely needs the token directly, opt out with `@internal=false`.
     :::
 3. **Set your service account token in deployed environments**. Copy the token value from where you saved it earlier, and set it in deployed environments using your platform's env var management UI. Be sure to use the same name as you defined in your schema (e.g. `OP_TOKEN`).
 </Steps>
@@ -99,7 +99,7 @@ OP_TOKEN=
 1. **Install the `op` CLI**: [Installation guide](https://www.1password.dev/cli/get-started/)
 2. The token referenced by `token=` must resolve to a valid service account token at load time.
 
-The `op` binary is significantly lighter than the WASM SDK. Authentication is handled headlessly via `OP_SERVICE_ACCOUNT_TOKEN` — no desktop app or interactive sign-in is needed. Multiple plugin instances configured with different service account tokens are fully isolated from one another.
+The `op` binary is significantly lighter than the WASM SDK. Authentication is handled headlessly via `OP_SERVICE_ACCOUNT_TOKEN`, with no desktop app or interactive sign-in needed. Multiple plugin instances configured with different service account tokens are fully isolated from one another.
 
 
 ### Desktop app auth (for local dev)
@@ -134,7 +134,7 @@ During local development, you may find it convenient to skip the service account
 {/* 5. **Run `op signin` to test**. Ensure you are logged in to the correct account. You can run `op whoami` to see which account is currently connected to the CLI. */}
 </Steps>
 
-With this option enabled, if the resolved service account token is empty, we will call out to the `op` cli installed on your machine (it must be in your `$PATH`) and use the auth it provides. With the desktop app integration enabled, it will call out and may trigger biometric verification to unlock. It is secure and very convenient!
+With this option enabled, if the resolved service account token is empty, we will call out to the `op` cli installed on your machine (it must be in your `$PATH`) and use the auth it provides. With the desktop app integration enabled, it will call out and may trigger biometric verification to unlock.
 
 :::caution[Connecting as yourself]
 Keep in mind that this method is connecting as _YOU_ who likely has more access than a tightly scoped service account. Consider only enabling this method for a plugin instance that will be handling non-production secrets.
@@ -206,7 +206,7 @@ When using desktop app auth (`allowAppAuth`), the `op environment` command requi
 <div>
 #### `@initOp()`
 
-Initializes an instance of the 1Password plugin - setting up options and authentication. Can be called multiple times to set up different instances.
+Initializes an instance of the 1Password plugin, setting up options and authentication. Can be called multiple times to set up different instances.
 
 **Key/value args:**
 - `id` (optional): identifier for this instance, used when multiple instances are needed
@@ -214,7 +214,7 @@ Initializes an instance of the 1Password plugin - setting up options and authent
 - `allowAppAuth` (optional): boolean flag to enable authenticating using the local desktop app
 - `account` (optional): limits the `op` cli to connect to specific 1Password account (shorthand, sign-in address, account ID, or user ID)
 - `useCliWithServiceAccount` (optional): when `true`, uses the `op` CLI binary instead of the WASM SDK for service account auth. Useful in memory-constrained environments. Requires the `op` CLI to be installed.
-- `cacheTtl` (optional): when set, resolved values from `op()` and `opLoadEnvironment()` are cached for the specified duration. Accepts the same format as the [`cache()` function](/reference/functions/#cache) — e.g., `"5m"`, `"1h"`, `"1d"`, or `forever` to cache until manually cleared. Storage follows global [`@cache`](/reference/root-decorators/#cache) mode (`disk` or `memory`), and is disabled when caching is globally disabled or `--skip-cache` is used. For cache mode strategy and CLI cache controls, see the [Caching guide](/guides/caching/).
+- `cacheTtl` (optional): when set, resolved values from `op()` and `opLoadEnvironment()` are cached for the specified duration. Accepts the same format as the [`cache()` function](/reference/functions/#cache), for example `"5m"`, `"1h"`, `"1d"`, or `forever` to cache until manually cleared. Storage follows global [`@cache`](/reference/root-decorators/#cache) mode (`disk` or `memory`), and is disabled when caching is globally disabled or `--skip-cache` is used. For cache mode strategy and CLI cache controls, see the [Caching guide](/guides/caching/).
 
 ```env-spec "@initOp"
 # @initOp(id=notProd, token=$OP_TOKEN, allowAppAuth=forEnv(dev), account=acmeco, cacheTtl=1h)

--- a/packages/varlock-website/src/content/docs/plugins/akeyless.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/akeyless.mdx
@@ -84,7 +84,7 @@ For deployments on platforms that issue OIDC tokens (Vercel, GitHub Actions, Git
 # @initAkeyless(oidcAccessId="p-your-access-id")
 ```
 
-No `accessKey` is needed — the `oidcAccessId` parameter triggers OIDC authentication. For platforms not auto-detected, pass an explicit token via `oidcToken`.
+No `accessKey` is needed. The `oidcAccessId` parameter triggers OIDC authentication. For platforms not auto-detected, pass an explicit token via `oidcToken`.
 
 ### Using an Akeyless Gateway
 
@@ -158,7 +158,7 @@ DB_USER=akeyless("/MyApp/DynamicDBSecret#user", type=dynamic)
 DB_PASS=akeyless("/MyApp/DynamicDBSecret#password", type=dynamic)
 ```
 
-Multiple items that reference the same dynamic secret path are cached — only one API call is made, and each item extracts its key from the cached response.
+Multiple items that reference the same dynamic secret path are cached: only one API call is made, and each item extracts its key from the cached response.
 
 ### Rotated secrets
 
@@ -231,7 +231,7 @@ Initialize an Akeyless plugin instance.
 - `apiUrl` (optional): Akeyless API URL (defaults to `https://api.akeyless.io`). Use this for self-hosted Akeyless Gateway.
 - `pathPrefix` (optional): Prefix automatically prepended to all secret paths
 - `id` (optional): Instance identifier for multiple instances
-- `cacheTtl` (optional): cache resolved values for the specified duration (e.g. `"5m"`, `"1h"`, `"1d"`, or `forever` to cache until manually cleared). For cache mode behavior and CLI cache controls, see the [Caching guide](/guides/caching/). Only `static` secrets are cached — `dynamic` and `rotated` secrets are designed to change per fetch and are never cached.
+- `cacheTtl` (optional): cache resolved values for the specified duration (e.g. `"5m"`, `"1h"`, `"1d"`, or `forever` to cache until manually cleared). For cache mode behavior and CLI cache controls, see the [Caching guide](/guides/caching/). Only `static` secrets are cached. `dynamic` and `rotated` secrets change per fetch and are never cached.
 
 ```env-spec "@initAkeyless"
 # @initAkeyless(accessId=$AKEYLESS_ACCESS_ID, accessKey=$AKEYLESS_ACCESS_KEY, pathPrefix="/MyApp")
@@ -254,7 +254,7 @@ AKEYLESS_ACCESS_ID=
 <div>
 #### `akeylessAccessKey`
 
-This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+This type is [`@internal`](/reference/item-decorators/#internal) by default: varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly, for example to write secrets back or fetch additional secrets at runtime.
 
 
 Represents an Akeyless Access Key for API Key authentication. This type is marked as `@sensitive`.
@@ -278,13 +278,13 @@ Fetch a secret from Akeyless Platform.
 - `secretName` (optional): full path to the secret, optionally with `#KEY` to extract a JSON key (e.g., `"/MyApp/Secret#username"`). If omitted, uses the item key (variable name) as the secret name.
 
 **Named args:**
-- `type` (optional): secret type — `static` (default), `dynamic`, or `rotated`
+- `type` (optional): secret type, one of `static` (default), `dynamic`, or `rotated`
 - `key` (optional): JSON key to extract from the secret value (overrides `#KEY` syntax)
 
 **Secret types:**
-- `static` — Simple key/value secrets (default). If the value is JSON, use `#KEY` or `key=` to extract individual keys.
-- `dynamic` — On-demand generated credentials (database, cloud, etc.). Returns JSON by default, or extract a specific key with `#KEY` or `key=`.
-- `rotated` — Auto-rotated credentials managed by Akeyless. Returns JSON by default, or extract a specific key with `#KEY` or `key=`.
+- `static`: Simple key/value secrets (default). If the value is JSON, use `#KEY` or `key=` to extract individual keys.
+- `dynamic`: On-demand generated credentials (database, cloud, etc.). Returns JSON by default, or extract a specific key with `#KEY` or `key=`.
+- `rotated`: Auto-rotated credentials managed by Akeyless. Returns JSON by default, or extract a specific key with `#KEY` or `key=`.
 
 **Caching:** Multiple items referencing the same secret path (and type) share a single API call. This is especially useful for dynamic and rotated secrets where you need to extract multiple keys from the same response.
 

--- a/packages/varlock-website/src/content/docs/plugins/aws-secrets.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/aws-secrets.mdx
@@ -18,7 +18,7 @@ The plugin automatically integrates with AWS authentication, including IAM roles
 
 - **Zero-config authentication** - Automatically uses AWS credentials from your environment
 - **IAM role support** - No credentials needed for AWS-hosted apps (EC2, ECS, Lambda, etc.)
-- **AWS CLI authentication** - Works seamlessly with `aws configure` for local development
+- **AWS CLI authentication** - Works with `aws configure` for local development
 - **Auto-infer secret/parameter names** from environment variable names
 - **JSON key extraction** from secrets/parameters using `#` syntax or named `key` parameter
 - **Name prefixing** with `namePrefix` option for organized secret management
@@ -394,7 +394,7 @@ AWS_SECRET_ACCESS_KEY=
 ```
 
 :::tip[Does your app use these credentials too?]
-The examples here mark the credential [`@internal`](/reference/item-decorators/#internal) so it's used by varlock to fetch your secrets but **not** injected into your app — the recommended posture when varlock is the only consumer. Unlike the dedicated secrets-manager tokens, AWS credentials are **not** `@internal` by default (they're commonly read directly by the AWS SDK), so if you need the credential at runtime for other purposes, opt out with `@internal=false` to keep it injected:
+The examples here mark the credential [`@internal`](/reference/item-decorators/#internal) so it's used by varlock to fetch your secrets but **not** injected into your app. This is the recommended posture when varlock is the only consumer. Unlike the dedicated secrets-manager tokens, AWS credentials are **not** `@internal` by default (they're commonly read directly by the AWS SDK), so if you need the credential at runtime for other purposes, opt out with `@internal=false` to keep it injected:
 
 ```env-spec
 # @type=awsSecretKey @internal=false

--- a/packages/varlock-website/src/content/docs/plugins/azure-key-vault.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/azure-key-vault.mdx
@@ -18,7 +18,7 @@ The plugin automatically integrates with Azure authentication, including Managed
 
 - **Zero-config authentication** - Just provide your vault URL, authentication happens automatically
 - **Managed Identity support** - No credentials needed for Azure-hosted apps (App Service, Container Instances, VMs, Functions, AKS)
-- **Azure CLI authentication** - Works seamlessly with `az login` for local development
+- **Azure CLI authentication** - Works with `az login` for local development
 - **Auto-infer secret names** from environment variable names (e.g., `DATABASE_URL` → `database-url`)
 - Support for service principal credentials (for non-Azure environments)
 - Support for versioned secrets
@@ -356,7 +356,7 @@ AZURE_CLIENT_SECRET=
 ```
 
 :::tip[Does your app use these credentials too?]
-The examples here mark the credential [`@internal`](/reference/item-decorators/#internal) so it's used by varlock to fetch your secrets but **not** injected into your app — the recommended posture when varlock is the only consumer. Unlike the dedicated secrets-manager tokens, Azure credentials are **not** `@internal` by default (they're commonly read directly by the Azure SDK), so if you need the credential at runtime for other purposes, opt out with `@internal=false` to keep it injected:
+The examples here mark the credential [`@internal`](/reference/item-decorators/#internal) so it's used by varlock to fetch your secrets but **not** injected into your app. This is the recommended posture when varlock is the only consumer. Unlike the dedicated secrets-manager tokens, Azure credentials are **not** `@internal` by default (they're commonly read directly by the Azure SDK), so if you need the credential at runtime for other purposes, opt out with `@internal=false` to keep it injected:
 
 ```env-spec
 # @type=azureClientSecret @internal=false

--- a/packages/varlock-website/src/content/docs/plugins/bitwarden.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/bitwarden.mdx
@@ -12,8 +12,8 @@ import Badge from '@/components/Badge.astro';
 
 Our Bitwarden plugin enables secure loading of secrets from Bitwarden using declarative instructions within your `.env` files. It supports two distinct Bitwarden products:
 
-- **[Secrets Manager](https://bitwarden.com/products/secrets-manager/)** — programmatic secret storage, accessed via machine account access tokens over the REST API. Best for CI/CD and production. Uses `@initBitwarden()` + `bitwarden()`.
-- **[Password Manager](https://bitwarden.com/products/personal/)** (and self-hosted **[Vaultwarden](https://github.com/dani-garcia/vaultwarden)**) — your personal/team password vault, accessed via the `bw` CLI. Best for local development. Uses `@initBwp()` + `bwp()`.
+- **[Secrets Manager](https://bitwarden.com/products/secrets-manager/)**: programmatic secret storage, accessed via machine account access tokens over the REST API. Best for CI/CD and production. Uses `@initBitwarden()` + `bitwarden()`.
+- **[Password Manager](https://bitwarden.com/products/personal/)** (and self-hosted **[Vaultwarden](https://github.com/dani-garcia/vaultwarden)**): your personal/team password vault, accessed via the `bw` CLI. Best for local development. Uses `@initBwp()` + `bwp()`.
 
 ## Features
 
@@ -21,7 +21,7 @@ Our Bitwarden plugin enables secure loading of secrets from Bitwarden using decl
 - **UUID-based secret access** - Fetch secrets by their unique identifiers
 - **Self-hosted Bitwarden support** - Configure custom API and identity URLs
 - **Multiple instances** - Connect to different organizations or self-hosted instances
-- **Comprehensive error handling** with helpful tips
+- **Helpful error handling** with resolution tips
 - **Lightweight implementation** using REST API (48 KB bundle, no native SDK dependencies)
 
 ## Installation and setup
@@ -205,11 +205,11 @@ This approach makes it easier to manage access to multiple secrets at once.
 
 ## Password Manager / Vaultwarden
 
-Separate from Secrets Manager, you can also load values from your personal or team **Bitwarden Password Manager** vault — or a self-hosted **Vaultwarden** server. This path uses the Bitwarden [`bw` CLI](https://bitwarden.com/help/cli/) rather than the REST API, so it's best suited to local development.
+Separate from Secrets Manager, you can also load values from your personal or team **Bitwarden Password Manager** vault, or a self-hosted **Vaultwarden** server. This path uses the Bitwarden [`bw` CLI](https://bitwarden.com/help/cli/) rather than the REST API, so it's best suited to local development.
 
 varlock acquires and caches a CLI **session token** for you: on first load it runs `bw unlock` (prompting for your master password), then caches the token in varlock's encrypted cache and reuses it on subsequent loads. You no longer need to manually unlock and paste a session token into a `.env` file.
 
-By default the token is cached indefinitely (`sessionTtl="forever"`). This is safe because the cached token is encrypted at rest with varlock's local key — biometric-gated (Touch ID / Windows Hello) on platforms with a secure enclave — so reading it requires *you*. Note the `bw` CLI session does **not** auto-lock on system sleep/lock/restart (those are app-only vault-timeout settings), so by default a fresh master-password unlock is only needed when the session is explicitly invalidated (`bw lock`/`bw logout`, an external `bw unlock`, or an account policy). Set a shorter `sessionTtl` if you want varlock to force periodic master-password re-auth.
+By default the token is cached indefinitely (`sessionTtl="forever"`). This is safe because the cached token is encrypted at rest with varlock's local key (biometric-gated with Touch ID / Windows Hello on platforms with a secure enclave), so reading it requires *you*. Note the `bw` CLI session does **not** auto-lock on system sleep/lock/restart (those are app-only vault-timeout settings), so by default a fresh master-password unlock is only needed when the session is explicitly invalidated (`bw lock`/`bw logout`, an external `bw unlock`, or an account policy). Set a shorter `sessionTtl` if you want varlock to force periodic master-password re-auth.
 
 ### Prerequisites
 
@@ -217,7 +217,7 @@ By default the token is cached indefinitely (`sessionTtl="forever"`). This is sa
 1. **Install the `bw` CLI** from a trusted source.
 
     :::caution[Install from trusted sources only]
-    Install the official CLI via a trusted channel and keep it up to date — supply-chain incidents have affected the broader Bitwarden CLI ecosystem in the past. varlock never installs `bw` for you; it only invokes whatever `bw` is already on your `PATH`.
+    Install the official CLI via a trusted channel and keep it up to date. Supply-chain incidents have affected the broader Bitwarden CLI ecosystem in the past. varlock never installs `bw` for you; it only invokes whatever `bw` is already on your `PATH`.
     :::
 
     ```bash
@@ -239,7 +239,7 @@ By default the token is cached indefinitely (`sessionTtl="forever"`). This is sa
     # bw config server https://vault.yourcompany.com
     ```
 
-    varlock handles unlocking from here on — you don't need to run `bw unlock` yourself.
+    varlock handles unlocking from here on, so you don't need to run `bw unlock` yourself.
 </Steps>
 
 ### Basic usage
@@ -256,12 +256,12 @@ By default the token is cached indefinitely (`sessionTtl="forever"`). This is sa
 DATABASE_PASSWORD=bwp("Production DB")
 ```
 
-On the first `varlock load`, you'll be prompted for your master password once; the resulting session token is cached and reused (`sessionTtl`, default `forever`). The `bw` CLI session does **not** lock on system sleep, lock, or restart — those vault-timeout settings apply to the Bitwarden apps and extension, not the CLI — so in practice you re-enter the master password only when the session is explicitly invalidated (see below) or when you set a shorter `sessionTtl`.
+On the first `varlock load`, you'll be prompted for your master password once; the resulting session token is cached and reused (`sessionTtl`, default `forever`). The `bw` CLI session does **not** lock on system sleep, lock, or restart (those vault-timeout settings apply to the Bitwarden apps and extension, not the CLI), so in practice you re-enter the master password only when the session is explicitly invalidated (see below) or when you set a shorter `sessionTtl`.
 
 :::note[Using `bw` outside varlock can invalidate the cached session]
-Each `bw unlock` (and `bw login`) issues a new session key and **invalidates any previously issued ones**; `bw lock` / `bw logout` invalidate them too. So if you run those commands in your own scripts or shell — or keep a `BW_SESSION` exported elsewhere — varlock's cached token gets invalidated (and vice-versa: varlock unlocking invalidates your shell's `BW_SESSION`). Plain reads (`bw get`, `bw list`, `bw sync`) are fine and don't invalidate anything.
+Each `bw unlock` (and `bw login`) issues a new session key and **invalidates any previously issued ones**; `bw lock` / `bw logout` invalidate them too. So if you run those commands in your own scripts or shell (or keep a `BW_SESSION` exported elsewhere), varlock's cached token gets invalidated (and vice-versa: varlock unlocking invalidates your shell's `BW_SESSION`). Plain reads (`bw get`, `bw list`, `bw sync`) are fine and don't invalidate anything.
 
-This is not fatal: the next `varlock` load detects the stale session and transparently re-unlocks once — the only cost is one extra master-password prompt. If you frequently `bw unlock` outside varlock, consider letting varlock own the unlock (don't re-unlock manually) or pass a shared `sessionToken=$BWP_SESSION` so both sides use the same token.
+This is not fatal: the next `varlock` load detects the stale session and re-unlocks once, at the cost of one extra master-password prompt. If you frequently `bw unlock` outside varlock, consider letting varlock own the unlock (don't re-unlock manually) or pass a shared `sessionToken=$BWP_SESSION` so both sides use the same token.
 :::
 
 ### Selecting a field
@@ -287,16 +287,16 @@ STRIPE_KEY=bwp("Stripe", field="secret-key")
 # @initBwp(sessionTtl="1h", cacheTtl="5m")
 ```
 
-- `sessionTtl` (default `forever`) — how long the unlocked CLI session token is cached before varlock forces a fresh `bw unlock`. `forever` keeps the token until the CLI session is invalidated externally (`bw lock`/`bw logout`, an external `bw unlock`, or account policy), at which point the next load re-unlocks automatically; set e.g. `"1h"` to force periodic master-password re-auth.
-- `cacheTtl` (optional) — additionally cache the **resolved item values**, avoiding a `bw` invocation per value within the window. See the [Caching guide](/guides/caching/).
+- `sessionTtl` (default `forever`): how long the unlocked CLI session token is cached before varlock forces a fresh `bw unlock`. `forever` keeps the token until the CLI session is invalidated externally (`bw lock`/`bw logout`, an external `bw unlock`, or account policy), at which point the next load re-unlocks automatically; set e.g. `"1h"` to force periodic master-password re-auth.
+- `cacheTtl` (optional): additionally cache the **resolved item values**, avoiding a `bw` invocation per value within the window. See the [Caching guide](/guides/caching/).
 
 ### Non-interactive loads
 
 Interactive unlock needs a TTY, so a non-interactive load (a dev server started by a tool that has no TTY, an editor task runner, etc.) can't show the master-password prompt. How you fix it depends on the environment:
 
-**Local dev, using auto-unlock** — if you're letting varlock unlock the vault itself (no `sessionToken` / `masterPassword` configured on `@initBwp()`), run `varlock load` once in a regular terminal (`npx varlock load`, `pnpm exec varlock load`, etc.). That performs the interactive unlock and caches the session token in varlock's encrypted cache, so subsequent non-interactive commands reuse it without prompting (until the session is invalidated — see `sessionTtl` above). This only applies to the auto-unlock flow — if you've configured `sessionToken=` or `masterPassword=`, no interactive `varlock load` is needed.
+**Local dev, using auto-unlock**: if you're letting varlock unlock the vault itself (no `sessionToken` / `masterPassword` configured on `@initBwp()`), run `varlock load` once in a regular terminal (`npx varlock load`, `pnpm exec varlock load`, etc.). That performs the interactive unlock and caches the session token in varlock's encrypted cache, so subsequent non-interactive commands reuse it without prompting (until the session is invalidated, see `sessionTtl` above). This only applies to the auto-unlock flow. If you've configured `sessionToken=` or `masterPassword=`, no interactive `varlock load` is needed.
 
-**CI / truly headless** — there's no terminal to unlock from, so provide credentials explicitly instead:
+**CI / truly headless**: there's no terminal to unlock from, so provide credentials explicitly instead:
 
 ```env-spec title=".env.schema"
 # Option A: pass a pre-obtained session token (from `bw unlock --raw`)
@@ -317,7 +317,7 @@ The `bw` CLI keeps **one logged-in account per data directory**, so to read from
 # @initBwp(id=personal, appDataDir=$BWP_PERSONAL_DIR)
 # @initBwp(id=work, appDataDir=$BWP_WORK_DIR)
 # ---
-# bw data dirs — set per-machine in .env.local (a leading ~ is expanded)
+# bw data dirs, set per-machine in .env.local (a leading ~ is expanded)
 BWP_PERSONAL_DIR=
 BWP_WORK_DIR=
 
@@ -328,11 +328,11 @@ WORK_DB=bwp(work, "Work DB", field=password)
 varlock unlocks and caches a session token **per account** (keyed by `appDataDir`), so the two accounts never share or invalidate each other's sessions.
 
 :::note[`appDataDir` is machine-specific]
-A data-dir path points at a directory on *your* machine, so avoid hardcoding it in a shared `.env.schema`. There's no way to override an already-declared instance's settings from another file, so make the **value** local rather than the instance: reference `appDataDir=$BWP_WORK_DIR` and set that var in your (gitignored) `.env.local`. If the whole multi-account workflow is personal, you can instead declare the entire `@initBwp(...)` in `.env.local` — root decorators are honored there too.
+A data-dir path points at a directory on *your* machine, so avoid hardcoding it in a shared `.env.schema`. There's no way to override an already-declared instance's settings from another file, so make the **value** local rather than the instance: reference `appDataDir=$BWP_WORK_DIR` and set that var in your (gitignored) `.env.local`. If the whole multi-account workflow is personal, you can instead declare the entire `@initBwp(...)` in `.env.local`; root decorators are honored there too.
 :::
 
 :::caution
-Without distinct `appDataDir`s, multiple instances all point at the same global `bw` account — `bwp(personal, …)` and `bwp(work, …)` would read the *same* vault. The `appDataDir` is what makes them separate. (This differs from Secrets Manager, where each instance has its own `accessToken`.)
+Without distinct `appDataDir`s, multiple instances all point at the same global `bw` account, so `bwp(personal, …)` and `bwp(work, …)` would read the *same* vault. The `appDataDir` is what makes them separate. (This differs from Secrets Manager, where each instance has its own `accessToken`.)
 :::
 
 ---
@@ -369,9 +369,9 @@ Initialize a Password Manager / Vaultwarden instance accessed via the `bw` CLI. 
 **Key/value args (all optional):**
 - `sessionToken`: a pre-obtained CLI session token (e.g. `$BWP_SESSION`). When provided and non-empty, it's used as-is instead of auto-unlocking.
 - `masterPassword`: master password used to unlock the vault non-interactively (e.g. in CI). Reference a `@sensitive` config item.
-- `sessionTtl`: how long the auto-unlocked session token is cached before a fresh `bw unlock` (default `forever` — kept until the CLI session is invalidated externally; e.g. `"1h"` to force periodic master-password re-auth).
+- `sessionTtl`: how long the auto-unlocked session token is cached before a fresh `bw unlock` (default `forever`, kept until the CLI session is invalidated externally; e.g. `"1h"` to force periodic master-password re-auth).
 - `cacheTtl`: cache resolved item values for the specified duration. See the [Caching guide](/guides/caching/).
-- `appDataDir`: bw CLI data directory (`BITWARDENCLI_APPDATA_DIR`) for this instance — point separate instances at separate dirs to read from different accounts/servers. A leading `~` is expanded. The dir must be set up independently (`bw config server` + `bw login`).
+- `appDataDir`: bw CLI data directory (`BITWARDENCLI_APPDATA_DIR`) for this instance. Point separate instances at separate dirs to read from different accounts/servers. A leading `~` is expanded. The dir must be set up independently (`bw config server` + `bw login`).
 - `id`: instance identifier for multiple instances.
 
 ```env-spec "@initBwp"
@@ -387,7 +387,7 @@ DB_PASSWORD=bwp("Production DB")
 <div>
 #### `bitwardenAccessToken`
 
-This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+This type is [`@internal`](/reference/item-decorators/#internal) by default: varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly, for example to write secrets back or fetch additional secrets at runtime.
 
 
 Represents a Bitwarden Secrets Manager machine account access token. Validation ensures the token is in the correct format (`0.<client_id>.<client_secret>:<encryption_key>`).
@@ -424,7 +424,7 @@ BITWARDEN_ORG_ID=87654321-4321-4321-4321-cba987654321
 <div>
 #### `bwSessionToken`
 
-This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+This type is [`@internal`](/reference/item-decorators/#internal) by default: varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly, for example to write secrets back or fetch additional secrets at runtime.
 
 Represents a Bitwarden CLI session token (the output of `bw unlock`). Only needed when supplying a token manually for non-interactive use. Marked `@sensitive`.
 
@@ -463,7 +463,7 @@ Fetch a field from a Password Manager / Vaultwarden vault item via the `bw` CLI.
 **Args:**
 - `instanceId` (optional, positional): instance identifier when multiple `@initBwp()` instances are initialized
 - `item` (required, positional): item name or UUID to look up
-- `field` (optional, key/value): which field to return — `password` (default), `username`, `notes`, `totp` (the stored TOTP secret/seed, not a generated code), `uri`, or a custom field name
+- `field` (optional, key/value): which field to return. One of `password` (default), `username`, `notes`, `totp` (the stored TOTP secret/seed, not a generated code), `uri`, or a custom field name
 
 ```env-spec /bwp\\(.*\\)/
 # Default field (password)
@@ -504,10 +504,10 @@ WORK_DB=bwp(work, "Work DB", field=password)
 - UUIDs should contain 32 hexadecimal characters and 4 hyphens
 
 ### Password Manager (`bwp()`)
-- **`bw` not found** — install the CLI from a trusted source and ensure it's on your `PATH`.
-- **Not logged in** — run `bw login` once (for Vaultwarden, also `bw config server <url>` first).
-- **Cannot unlock without an interactive terminal** — you're auto-unlocking (no `sessionToken` / `masterPassword` configured) in a non-TTY context. For local dev, run `varlock load` once in a regular terminal to unlock and cache the session token; for CI / headless, provide `sessionToken=$BWP_SESSION` or `masterPassword=...` to `@initBwp()`. See [Non-interactive loads](#non-interactive-loads).
-- **Item / field not found** — verify the item name or UUID; the error lists the item's available custom fields.
+- **`bw` not found**: install the CLI from a trusted source and ensure it's on your `PATH`.
+- **Not logged in**: run `bw login` once (for Vaultwarden, also `bw config server <url>` first).
+- **Cannot unlock without an interactive terminal**: you're auto-unlocking (no `sessionToken` / `masterPassword` configured) in a non-TTY context. For local dev, run `varlock load` once in a regular terminal to unlock and cache the session token; for CI / headless, provide `sessionToken=$BWP_SESSION` or `masterPassword=...` to `@initBwp()`. See [Non-interactive loads](#non-interactive-loads).
+- **Item / field not found**: verify the item name or UUID; the error lists the item's available custom fields.
 
 ## Resources
 

--- a/packages/varlock-website/src/content/docs/plugins/dashlane.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/dashlane.mdx
@@ -77,7 +77,7 @@ The plugin does not sync the vault by default. To run `dcli sync` once before th
 # @initDashlane(serviceDeviceKeys=$DASHLANE_SERVICE_DEVICE_KEYS, autoSync=true)
 ```
 
-Sync failures are non-blocking -- if the sync fails (e.g. network issues), the plugin still reads from the existing local vault.
+Sync failures are non-blocking. If the sync fails (e.g. network issues), the plugin still reads from the existing local vault.
 
 ### Multiple instances
 
@@ -152,7 +152,7 @@ Initialize a Dashlane plugin instance for `dashlane()` resolver.
 <div>
 #### `dashlaneDeviceKeys`
 
-This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+This type is [`@internal`](/reference/item-decorators/#internal) by default: varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly, for example to write secrets back or fetch additional secrets at runtime.
 
 
 Service device keys for non-interactive Dashlane CLI authentication. Must start with `dls_`.

--- a/packages/varlock-website/src/content/docs/plugins/doppler.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/doppler.mdx
@@ -19,7 +19,7 @@ The plugin uses service tokens for programmatic access to your Doppler secrets, 
 - **Fetch secrets** from Doppler projects and configs
 - **Bulk-load secrets** with `dopplerBulk()` via `@setValuesBulk`
 - **Service token authentication** for secure, scoped API access
-- **Efficient caching** — a single API call is shared across all secret lookups in the same config
+- **Efficient caching**: a single API call is shared across all secret lookups in the same config
 - **Multiple plugin instances** for different projects/configs
 - **Auto-infer secret names** from variable names for convenience
 - **Helpful error messages** with resolution tips
@@ -60,7 +60,7 @@ DOPPLER_TOKEN=
 
 3. **Save the token** (displayed only once!)
 
-    Copy the service token immediately — it will only be displayed once.
+    Copy the service token immediately. It will only be displayed once.
 
     :::caution[Save token securely]
     Store the service token securely. You won't be able to see it again after this step!
@@ -191,7 +191,7 @@ DOPPLER_TOKEN=
 <div>
 #### `dopplerServiceToken`
 
-This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+This type is [`@internal`](/reference/item-decorators/#internal) by default: varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly, for example to write secrets back or fetch additional secrets at runtime.
 
 
 Represents a Doppler service token. This type is marked as `@sensitive`.
@@ -309,7 +309,7 @@ SENDGRID_API_KEY=
 - Check that the service token has access to the requested project/config
 
 ### Access denied
-- Service tokens are scoped to a specific config — ensure you're using the right one
+- Service tokens are scoped to a specific config, so ensure you're using the right one
 - Verify the token hasn't been revoked
 
 ### Wrong config

--- a/packages/varlock-website/src/content/docs/plugins/google-secret-manager.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/google-secret-manager.mdx
@@ -134,7 +134,7 @@ If you are already using GCP Secret Manager, you likely have completed these ste
 
 2. **Create a new service account** in your GCP project. This can be done via the [Google Cloud Console](https://console.cloud.google.com/iam-admin/serviceaccounts) or using the `gcloud` CLI. [docs](https://cloud.google.com/iam/docs/service-accounts-create)
 
-     This service account, whether accessed using ADC or a service account key, will now serve as your _secret-zero_ - which grants access to the rest of your sensitive data stored in Secret Manager. For local-only workflows, you can use [device-local encryption](/guides/local-encryption/) to secure this value.
+     This service account, whether accessed using ADC or a service account key, will now serve as your _secret-zero_, granting access to the rest of your sensitive data stored in Secret Manager. For local-only workflows, you can use [device-local encryption](/guides/local-encryption/) to secure this value.
 
 3. **Grant the service account permissions** to access secrets. The service account needs the `Secret Manager Secret Accessor` role (`roles/secretmanager.secretAccessor`) on the secrets or project level. [docs](https://cloud.google.com/secret-manager/docs/access-control)
 
@@ -265,7 +265,7 @@ GCP_SA_KEY=
 ```
 
 :::tip[Does your app use these credentials too?]
-The examples here mark the credential [`@internal`](/reference/item-decorators/#internal) so it's used by varlock to fetch your secrets but **not** injected into your app — the recommended posture when varlock is the only consumer. Unlike the dedicated secrets-manager tokens, GCP service account keys are **not** `@internal` by default (they're commonly read directly by the Google Cloud SDK), so if you need the credential at runtime for other purposes, opt out with `@internal=false` to keep it injected:
+The examples here mark the credential [`@internal`](/reference/item-decorators/#internal) so it's used by varlock to fetch your secrets but **not** injected into your app. This is the recommended posture when varlock is the only consumer. Unlike the dedicated secrets-manager tokens, GCP service account keys are **not** `@internal` by default (they're commonly read directly by the Google Cloud SDK), so if you need the credential at runtime for other purposes, opt out with `@internal=false` to keep it injected:
 
 ```env-spec
 # @type=gcpServiceAccountJson @internal=false

--- a/packages/varlock-website/src/content/docs/plugins/hashicorp-vault.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/hashicorp-vault.mdx
@@ -18,7 +18,7 @@ The plugin supports multiple authentication methods including explicit tokens, A
 
 - **Zero-config authentication** - Automatically uses Vault token from CLI login
 - **AppRole authentication** - For automated and CI/CD workflows
-- **Vault CLI integration** - Works seamlessly with `vault login` for local development
+- **Vault CLI integration** - Works with `vault login` for local development
 - **OpenBao compatible** - Works with OpenBao (detects `~/.bao-token` automatically)
 - **Auto-infer secret keys** from environment variable names
 - **JSON key extraction** from secrets using `#` syntax or named `key` parameter
@@ -239,7 +239,7 @@ DB_PASSWORD=
 API_KEY=
 ```
 
-This fetches all keys stored at `secret/myapp/config` and maps them to matching item keys. Only items declared in your schema will be populated — any extra keys in the Vault secret are ignored.
+This fetches all keys stored at `secret/myapp/config` and maps them to matching item keys. Only items declared in your schema will be populated; any extra keys in the Vault secret are ignored.
 
 ---
 
@@ -371,7 +371,7 @@ Initialize a HashiCorp Vault / OpenBao plugin instance.
 <div>
 #### `vaultToken`
 
-This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+This type is [`@internal`](/reference/item-decorators/#internal) by default: varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly, for example to write secrets back or fetch additional secrets at runtime.
 
 
 Represents a HashiCorp Vault authentication token. This type is marked as `@sensitive`.

--- a/packages/varlock-website/src/content/docs/plugins/infisical.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/infisical.mdx
@@ -10,7 +10,7 @@ import Badge from '@/components/Badge.astro';
   <Badge npmPackage="@varlock/infisical-plugin" />
 </div>
 
-Our [Infisical](https://infisical.com/) plugin enables secure loading of secrets from Infisical using declarative instructions within your `.env` files.
+Our [Infisical](https://infisical.com/) plugin loads secrets from Infisical using declarative instructions within your `.env` files.
 
 The plugin uses machine identities with Universal Auth or [OIDC workload identity](/guides/oidc/) for programmatic access to your Infisical secrets, making it suitable for both CI/CD and production environments.
 
@@ -19,7 +19,7 @@ The plugin uses machine identities with Universal Auth or [OIDC workload identit
 - **Fetch secrets** from Infisical projects and environments
 - **Bulk-load secrets** with `infisicalBulk()` via `@setValuesBulk`
 - **Universal Auth** with Client ID and Client Secret
-- **[OIDC authentication](/guides/oidc/)** - Authenticate using platform OIDC tokens (Vercel, GitHub Actions, etc.)
+- **[OIDC authentication](/guides/oidc/)**: Authenticate using platform OIDC tokens (Vercel, GitHub Actions, etc.)
 - **Support for self-hosted** Infisical instances
 - **Secret paths** for hierarchical organization
 - **Filter by tag** to load only matching secrets
@@ -128,7 +128,7 @@ For deployments on platforms that issue OIDC tokens (Vercel, GitHub Actions, Git
 # )
 ```
 
-No `clientId` or `clientSecret` is needed — the `identityId` parameter triggers OIDC authentication. For platforms not auto-detected, pass an explicit token via `oidcToken`.
+No `clientId` or `clientSecret` is needed. The `identityId` parameter triggers OIDC authentication. For platforms not auto-detected, pass an explicit token via `oidcToken`.
 
 ### Self-hosted Infisical
 
@@ -145,7 +145,7 @@ For self-hosted Infisical instances, specify the `siteUrl`:
 # )
 ```
 
-`siteUrl` can also be set dynamically — pass a reference like `siteUrl=$INFISICAL_SITE_URL` to point at different Infisical instances per environment.
+`siteUrl` can also be set dynamically. Pass a reference like `siteUrl=$INFISICAL_SITE_URL` to point at different Infisical instances per environment.
 
 ### Multiple instances
 
@@ -177,7 +177,7 @@ API_KEY=infisical()
 STRIPE_SECRET=infisical("STRIPE_SECRET_KEY")
 ```
 
-When called without arguments, `infisical()` automatically uses the config item key as the secret name in Infisical. This provides a convenient convention-over-configuration approach.
+When called without arguments, `infisical()` uses the config item key as the secret name in Infisical.
 
 ### Using secret paths
 
@@ -293,7 +293,7 @@ INFISICAL_CLIENT_ID=
 <div>
 #### `infisicalClientSecret`
 
-This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+This type is [`@internal`](/reference/item-decorators/#internal) by default: varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly, for example to write secrets back or fetch additional secrets at runtime.
 
 
 Represents an Infisical Universal Auth Client Secret. This type is marked as `@sensitive`.

--- a/packages/varlock-website/src/content/docs/plugins/keepass.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/keepass.mdx
@@ -16,12 +16,12 @@ It supports two modes of operation: **file mode** (default) reads `.kdbx` files 
 
 ## Features
 
-- **KDBX 4.0 support** — reads KeePass database files directly via [kdbxweb](https://github.com/keeweb/kdbxweb) with pure WASM argon2
-- **KeePassXC CLI integration** — use `keepassxc-cli` for development workflows
-- **Key file support** — authenticate with password + optional key file
-- **`#attribute` syntax** — read any entry field (Password, UserName, URL, Notes, or custom fields)
+- **KDBX 4.0 support**: reads KeePass database files directly via [kdbxweb](https://github.com/keeweb/kdbxweb) with pure WASM argon2
+- **KeePassXC CLI integration**: use `keepassxc-cli` for development workflows
+- **Key file support**: authenticate with password + optional key file
+- **`#attribute` syntax**: read any entry field (Password, UserName, URL, Notes, or custom fields)
 - **Auto-infer entry paths** from variable names for convenience
-- **Custom attributes object** — load all custom fields from a single entry for `@setValuesBulk`
+- **Custom attributes object**: load all custom fields from a single entry for `@setValuesBulk`
 - **Bulk loading** with `kpBulk()` via `@setValuesBulk` to load all entries in a group
 - **Multiple instances** for accessing different databases
 
@@ -48,9 +48,9 @@ See the [plugins guide](/guides/plugins/#installation) for more instructions on 
 
 ### CLI mode
 
-When `useCli=true`, the plugin uses `keepassxc-cli` to read entries instead of reading the file directly. This is useful during development when you want to leverage KeePassXC's system integration.
+When `useCli=true`, the plugin uses `keepassxc-cli` to read entries instead of reading the file directly. This is useful during development when you want to use KeePassXC's system integration.
 
-The `useCli` option can be dynamic — for example, `useCli=forEnv(dev)` to only use the CLI in development:
+The `useCli` option can be dynamic. For example, `useCli=forEnv(dev)` uses the CLI only in development:
 
 ```env-spec title=".env.schema"
 # @plugin(@varlock/keepass-plugin)
@@ -155,7 +155,7 @@ PORT=
 DB_NAME=
 ```
 
-Standard fields (Title, Password, UserName, URL, Notes) are excluded — only custom fields are included.
+Standard fields (Title, Password, UserName, URL, Notes) are excluded; only custom fields are included.
 
 ### Bulk loading secrets
 
@@ -223,7 +223,7 @@ Initialize a KeePass plugin instance for accessing secrets from a KDBX database.
 <div>
 #### `kdbxPassword`
 
-This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+This type is [`@internal`](/reference/item-decorators/#internal) by default: varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly, for example to write secrets back or fetch additional secrets at runtime.
 
 
 A sensitive string type for KeePass database master passwords. Validates that the value is a non-empty string and is automatically marked as sensitive.
@@ -381,12 +381,12 @@ DB_PASSWORD=kp("Database/production")
 - Ensure `keepassxc-cli` is in your `PATH`
 
 ### Database file not found
-- Check the `dbPath` value — it's resolved relative to the working directory
+- Check the `dbPath` value; it's resolved relative to the working directory
 - Use an absolute path if needed
 
 ## Resources
 
-- [KeePassXC](https://keepassxc.org/) — cross-platform KeePass-compatible password manager
-- [KeePass](https://keepass.info/) — original KeePass Password Safe
-- [KDBX format](https://keepass.info/help/kb/kdbx.html) — KeePass database format specification
-- [kdbxweb](https://github.com/keeweb/kdbxweb) — JavaScript KDBX reader library
+- [KeePassXC](https://keepassxc.org/): cross-platform KeePass-compatible password manager
+- [KeePass](https://keepass.info/): original KeePass Password Safe
+- [KDBX format](https://keepass.info/help/kb/kdbx.html): KeePass database format specification
+- [kdbxweb](https://github.com/keeweb/kdbxweb): JavaScript KDBX reader library

--- a/packages/varlock-website/src/content/docs/plugins/keeper.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/keeper.mdx
@@ -10,18 +10,18 @@ import Badge from '@/components/Badge.astro';
   <Badge npmPackage="@varlock/keeper-plugin" />
 </div>
 
-Our [Keeper Security](https://keepersecurity.com/) plugin enables secure loading of secrets from Keeper vaults via the [Keeper Secrets Manager](https://docs.keeper.io/secrets-manager/) SDK.
+Our [Keeper Security](https://keepersecurity.com/) plugin loads secrets from Keeper vaults via the [Keeper Secrets Manager](https://docs.keeper.io/secrets-manager/) SDK.
 
 The plugin uses base64-encoded configuration tokens for programmatic access to your Keeper secrets, making it suitable for both CI/CD and production environments.
 
 ## Features
 
-- **SDK-based authentication** - Secure access via base64-encoded Secrets Manager config tokens
-- **Flexible secret access** - Fetch by record UID, title, `#field` selector, or [Keeper notation](https://docs.keeper.io/secrets-manager/secrets-manager/developer-sdk-library/javascript-sdk#notation)
-- **Standard and custom fields** - Access any field type including password, login, URL, notes, and custom fields
-- **Multiple instances** - Connect to different Keeper applications or vaults simultaneously
-- **Opt-in secret caching** via `cacheTtl` - see the [Caching guide](/guides/caching/)
-- **Comprehensive error handling** with helpful tips
+- **SDK-based authentication**: access via base64-encoded Secrets Manager config tokens
+- **Secret access** by record UID, title, `#field` selector, or [Keeper notation](https://docs.keeper.io/secrets-manager/secrets-manager/developer-sdk-library/javascript-sdk#notation)
+- **Standard and custom fields**: access any field type including password, login, URL, notes, and custom fields
+- **Multiple instances**: connect to different Keeper applications or vaults at once
+- **Opt-in secret caching** via `cacheTtl`: see the [Caching guide](/guides/caching/)
+- **Error handling** with helpful tips
 
 ## Installation and setup
 
@@ -199,7 +199,7 @@ KSM_CONFIG=
 <div>
 #### `keeperSmToken`
 
-This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+This type is [`@internal`](/reference/item-decorators/#internal) by default: varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly, for example to write secrets back or fetch additional secrets at runtime.
 
 
 Represents a base64-encoded configuration token for the Keeper Secrets Manager SDK. Validation ensures the value is a valid base64-encoded JSON string.
@@ -260,7 +260,7 @@ PROD_SECRET=keeper(prod, "XXXXXXXXXXXXXXXXXXXX")
 ### Access denied
 - Verify the Secrets Manager application has not been revoked
 - Check that the shared folder permissions are still active
-- The one-time token may have expired before being used — generate a new one
+- The one-time token may have expired before being used; generate a new one
 
 ### Record not found
 - Verify the record UID or title is correct
@@ -275,7 +275,7 @@ PROD_SECRET=keeper(prod, "XXXXXXXXXXXXXXXXXXXX")
 ### Config token issues
 - One-time access tokens can only be used once to initialize a device
 - If you need a new config, create a new device in the application settings
-- Config tokens contain encrypted keys — do not modify them manually
+- Config tokens contain encrypted keys; do not modify them manually
 
 ## Resources
 

--- a/packages/varlock-website/src/content/docs/plugins/kubernetes.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/kubernetes.mdx
@@ -14,30 +14,30 @@ Our Kubernetes plugin enables loading values from Kubernetes [Secrets](https://k
 
 ## Scope
 
-This plugin is **read-only**. It performs `get` requests on Secrets and ConfigMaps in a configured namespace and surfaces the values to your `.env` schema — nothing more. It does **not** create, update, or delete cluster resources, generate or template manifests, watch for changes, or manage deployments.
+This plugin is **read-only**. It performs `get` requests on Secrets and ConfigMaps in a configured namespace and surfaces the values to your `.env` schema, nothing more. It does **not** create, update, or delete cluster resources, generate or template manifests, watch for changes, or manage deployments.
 
 **Typical use cases:**
-- **Local development** — pull dev/staging Secrets and ConfigMaps from a cluster into your local app without copying values by hand
-- **In-cluster runtime** — read additional Secrets/ConfigMaps at runtime that aren't already mounted into the pod via `envFrom` / `valueFrom`
-- **CI/CD** — read Secrets/ConfigMaps from a cluster using an explicit service account token
+- **Local development**: pull dev/staging Secrets and ConfigMaps from a cluster into your local app without copying values by hand
+- **In-cluster runtime**: read additional Secrets/ConfigMaps at runtime that aren't already mounted into the pod via `envFrom` / `valueFrom`
+- **CI/CD**: read Secrets/ConfigMaps from a cluster using an explicit service account token
 
 It supports local kubeconfig, in-cluster service account credentials, and explicit API server + token authentication.
 
 :::note[Want deeper Kubernetes integration?]
-We're considering broader Kubernetes support (manifest generation, schema-to-deployment validation, change watching, etc.). If you have a use case this plugin doesn't cover, or feedback from running it in production, come chat on [Discord](https://chat.dmno.dev) — we'd love to hear from you.
+We're considering broader Kubernetes support (manifest generation, schema-to-deployment validation, change watching, etc.). If you have a use case this plugin doesn't cover, or feedback from running it in production, come chat on [Discord](https://chat.dmno.dev). We'd love to hear from you.
 :::
 
 ## Features
 
-- **Zero-config local development** - Automatically uses your default kubeconfig (`~/.kube/config`)
-- **In-cluster authentication** - Auto-detects the mounted service account when running inside a pod
-- **Explicit auth** - Provide a cluster API URL and bearer token directly
+- **Zero-config local development**: automatically uses your default kubeconfig (`~/.kube/config`)
+- **In-cluster authentication**: auto-detects the mounted service account when running inside a pod
+- **Explicit auth**: provide a cluster API URL and bearer token directly
 - **Fetch Secret keys** with `k8sSecret()` (values are automatically base64-decoded)
 - **Fetch ConfigMap keys** with `k8sConfigMap()` (including `binaryData`)
 - **Bulk-load** whole Secrets or ConfigMaps with `k8sSecretBulk()` / `k8sConfigMapBulk()`
 - **Auto-infer keys** from environment variable names
 - **Multiple instances** for different namespaces or clusters
-- **Read-only** — the plugin never mutates cluster state
+- **Read-only**: the plugin never mutates cluster state
 
 ## Installation and setup
 
@@ -83,7 +83,7 @@ If your kubeconfig has multiple contexts, you can select one explicitly:
 
 ### Explicit cluster server and token
 
-If you don't want to rely on a kubeconfig file — for example, in CI/CD or other deployed environments — provide the API server URL and a bearer token directly:
+If you don't want to rely on a kubeconfig file (for example, in CI/CD or other deployed environments), provide the API server URL and a bearer token directly:
 
 <Steps>
 1. **Create a service account and RBAC** in your cluster (see Kubernetes Setup section below)
@@ -110,7 +110,7 @@ For clusters that present self-signed or custom-CA certificates, you can disable
 
 ### Raw kubeconfig
 
-You can also pass an entire kubeconfig as a string (YAML or JSON) — useful when injecting credentials from a secret manager or platform env var:
+You can also pass an entire kubeconfig as a string (YAML or JSON), useful when injecting credentials from a secret manager or platform env var:
 
 ```env-spec title=".env.schema"
 # @initKubernetes(kubeconfig=$KUBECONFIG_DATA)
@@ -155,10 +155,10 @@ data:
 
 So fetching a value is always a two-level lookup: which Secret/ConfigMap (`name`), and which key inside it (`key`). The resolvers reflect this directly:
 
-- `k8sSecret(name, key)` — read `name.data.key`
-- `k8sConfigMap(name, key)` — read `name.data.key` (or `name.binaryData.key`)
+- `k8sSecret(name, key)`: read `name.data.key`
+- `k8sConfigMap(name, key)`: read `name.data.key` (or `name.binaryData.key`)
 
-When `key` is omitted, the plugin uses the config item's name as the key — this works well when your Secret keys already match your env var names.
+When `key` is omitted, the plugin uses the config item's name as the key. This works well when your Secret keys already match your env var names.
 
 ### Secret keys
 
@@ -216,7 +216,7 @@ STRIPE_KEY=k8sSecret(key=stripe_api_key)
 SHARED_TOKEN=k8sSecret(shared-secrets, AUTH_TOKEN)
 ```
 
-You can mix positional and named arguments, but you can't provide the same field twice — e.g., `k8sSecret(app-secrets, name=other-secrets)` is a schema error.
+You can mix positional and named arguments, but you can't provide the same field twice. For example, `k8sSecret(app-secrets, name=other-secrets)` is a schema error.
 
 ### Bulk loading
 
@@ -234,7 +234,7 @@ API_KEY=
 PUBLIC_API_HOST=
 ```
 
-Only items declared in your schema will be populated — any extra keys in the Secret or ConfigMap are ignored.
+Only items declared in your schema will be populated; any extra keys in the Secret or ConfigMap are ignored.
 
 Bulk resolvers also pick up `defaultSecret`/`defaultConfigMap`, so the names can be omitted entirely:
 
@@ -401,7 +401,7 @@ Initialize a Kubernetes plugin instance for `k8sSecret()`, `k8sConfigMap()`, `k8
 <div>
 #### `kubernetesBearerToken`
 
-This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+This type is [`@internal`](/reference/item-decorators/#internal) by default: varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly, for example to write secrets back or fetch additional secrets at runtime.
 
 
 Represents a Kubernetes bearer token used for API server authentication (typically a service account token). This type is marked as `@sensitive`.
@@ -534,7 +534,7 @@ Fetch all keys from a Kubernetes ConfigMap as a JSON object string. Designed to 
 
 ### Secret or ConfigMap not found (404)
 - Verify the resource exists: `kubectl get secret <name> -n <namespace>` or `kubectl get configmap <name> -n <namespace>`
-- Double-check the namespace — the plugin reads only from the configured namespace
+- Double-check the namespace; the plugin reads only from the configured namespace
 - Resource names are case-sensitive and namespace-scoped
 - If the resource is genuinely optional, set `allowMissing=true` on `@initKubernetes()` and `@required=false` on the item
 
@@ -551,7 +551,7 @@ Fetch all keys from a Kubernetes ConfigMap as a JSON object string. Designed to 
 ### Connection refused or TLS errors
 - Verify the cluster API URL is reachable from your machine/pod
 - For clusters with self-signed certificates and explicit auth, set `skipTlsVerify=true` (development only)
-- If using `kubectl` works but the plugin doesn't, your kubeconfig may rely on an [exec credential plugin](https://kubernetes.io/docs/reference/config-api/client-authentication.v1beta1/) (e.g., `aws eks get-token`, `gke-gcloud-auth-plugin`, `kubelogin`) — ensure the helper binary is on your `$PATH`
+- If using `kubectl` works but the plugin doesn't, your kubeconfig may rely on an [exec credential plugin](https://kubernetes.io/docs/reference/config-api/client-authentication.v1beta1/) (e.g., `aws eks get-token`, `gke-gcloud-auth-plugin`, `kubelogin`). Ensure the helper binary is on your `$PATH`
 
 ### Wrong namespace
 - The plugin uses (in order): the explicit `namespace` argument, the current kubeconfig context's namespace, the pod's mounted SA namespace, or `default`

--- a/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/macos-keychain.mdx
@@ -8,24 +8,24 @@ import { Steps, Icon, Aside } from '@astrojs/starlight/components';
 The built-in `keychain()` resolver lets you load secrets directly from the **macOS Keychain** using declarative instructions in your `.env` files. It communicates with the Keychain through Varlock's native Swift daemon, which enforces biometric authentication (Touch ID) and per-session access control.
 
 :::note[Built-in support]
-No plugin installation is required — `keychain()` is built into Varlock and available out of the box on macOS.
+No plugin installation is required. `keychain()` is built into Varlock and available on macOS.
 :::
 
 :::tip[Or use `varlock()`]
-If you don't already have secrets stored in your macOS Keychain, you may want to use the [`varlock()` resolver](/guides/local-encryption) instead. It provides the same biometric-gated, device-local encryption benefits without needing to manage Keychain items — and it works cross-platform.
+If you don't already have secrets stored in your macOS Keychain, you may want to use the [`varlock()` resolver](/guides/local-encryption) instead. It provides the same biometric-gated, device-local encryption benefits without needing to manage Keychain items, and it works cross-platform.
 
 See the [local encryption guide](/guides/local-encryption/) for more details.
 :::
 
 ## Features
 
-- **Built-in** — No plugin or extra dependency needed
-- **Biometric gating** — Access is protected by Touch ID via Varlock's native daemon
-- **Interactive picker** — Use `keychain(prompt)` to browse and select items via a native dialog
-- **Auto-write-back** — Prompt mode writes the resolved reference back to your config file
-- **Named or positional syntax** — Flexible argument styles for quick or precise lookups
-- **Field selection** — Extract specific fields from keychain items
-- **Multiple keychain support** — Access the login, System, or custom keychains
+- **Built-in**: no plugin or extra dependency needed
+- **Biometric gating**: access is protected by Touch ID via Varlock's native daemon
+- **Interactive picker**: use `keychain(prompt)` to browse and select items via a native dialog
+- **Auto-write-back**: prompt mode writes the resolved reference back to your config file
+- **Named or positional syntax** for quick or precise lookups
+- **Field selection**: extract specific fields from keychain items
+- **Multiple keychain support**: access the login, System, or custom keychains
 
 :::caution
 `keychain()` is only supported on **macOS**. It will throw an error on other platforms. If your team includes non-Mac developers, consider wrapping keychain items with a fallback or using a cross-platform secrets source for shared configs.
@@ -47,7 +47,7 @@ If you already have sensitive plaintext values in a local `.env` file, import th
 varlock keychain import .env --profile jb
 ```
 
-By default this **edits the file in place** — each sensitive plaintext value is replaced by its `keychain(...)` ref, so the secret no longer lives on disk. Comments and non-sensitive values are left untouched. To write the refs to a *different* file instead and leave the source as-is, pass `--write-to`:
+By default this **edits the file in place**: each sensitive plaintext value is replaced by its `keychain(...)` ref, so the secret no longer lives on disk. Comments and non-sensitive values are left untouched. To write the refs to a *different* file instead and leave the source as-is, pass `--write-to`:
 
 ```sh
 varlock keychain import .env --profile jb --write-to .env.jb
@@ -55,7 +55,7 @@ varlock keychain import .env --profile jb --write-to .env.jb
 
 Import requires an existing `.env.schema` file for the input env file so Varlock knows which input variables are secrets and which are not. It only imports variables marked `@sensitive` in that schema and never prints secret values. Re-running is safe: values already converted to `keychain(...)` refs are skipped. By default, Varlock refuses to overwrite an existing Keychain item (or, with `--write-to`, an existing ref in the target file); pass `--force` to overwrite.
 
-The file you name must be one Varlock loads as part of your env setup — it resolves your normal env graph (from `package.json` `varlock.loadPath`, or the files in the current directory) to read sensitivity from your schema, the same way `varlock encrypt --file` works. An arbitrary file outside that setup can't be imported. The value stored in Keychain is taken from the file you named specifically; an override of the same variable in another file (such as `.env.local`) does not change what gets imported.
+The file you name must be one Varlock loads as part of your env setup. It resolves your normal env graph (from `package.json` `varlock.loadPath`, or the files in the current directory) to read sensitivity from your schema, the same way `varlock encrypt --file` works. An arbitrary file outside that setup can't be imported. The value stored in Keychain is taken from the file you named specifically; an override of the same variable in another file (such as `.env.local`) does not change what gets imported.
 
 Generated refs use `service="varlock"` and account names like `<project>:<profile>:<ENV_VAR>`. The project defaults to the current directory name and can be overridden:
 

--- a/packages/varlock-website/src/content/docs/plugins/pass.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/pass.mdx
@@ -16,14 +16,14 @@ Pass stores each secret as a GPG-encrypted file in `~/.password-store`, organize
 
 ## Features
 
-- **Zero-config** - Works with your existing pass store out of the box
-- **GPG-backed encryption** - Leverages pass's native GPG security model
-- **Auto-infer entry paths** from variable names for convenience
+- **Zero-config**: works with your existing pass store
+- **GPG-backed encryption**: uses pass's native GPG security model
+- **Auto-infer entry paths** from variable names
 - **Bulk-load secrets** with `passBulk()` via `@setValuesBulk`
 - **Multiple store instances** for accessing different pass stores
 - **Name prefixing** for scoped entry access
-- **`allowMissing`** option for graceful handling of optional secrets
-- **In-session caching** - Each entry is decrypted only once per resolution
+- **`allowMissing`** option for optional secrets
+- **In-session caching**: each entry is decrypted only once per resolution
 - **Helpful error messages** with resolution tips
 
 ## Installation and setup
@@ -122,7 +122,7 @@ STRIPE_KEY=pass("services/stripe/live-key")
 DB_URL=pass("production/database/url")
 ```
 
-When called without arguments, `pass()` automatically uses the config item key as the entry path. This provides a convenient convention-over-configuration approach.
+When called without arguments, `pass()` uses the config item key as the entry path.
 
 ### Handling optional secrets
 

--- a/packages/varlock-website/src/content/docs/plugins/passbolt.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/passbolt.mdx
@@ -10,19 +10,19 @@ import Badge from '@/components/Badge.astro';
   <Badge npmPackage="@varlock/passbolt-plugin" />
 </div>
 
-Our [Passbolt](https://www.passbolt.com/) plugin enables secure loading of secrets from Passbolt password manager using declarative instructions within your `.env` files.
+Our [Passbolt](https://www.passbolt.com/) plugin loads secrets from Passbolt password manager using declarative instructions within your `.env` files.
 
 Passbolt is an open-source, self-hosted password manager built for teams. This plugin connects to your Passbolt instance's API using your account kit and passphrase, decrypting secrets via OpenPGP.
 
 ## Features
 
-- **Account kit authentication** — just provide your account kit and passphrase
-- **UUID-based secret access** — fetch secrets by their resource UUID
-- **`#field` syntax** — read specific fields (username, password, URI, TOTP, custom fields)
+- **Account kit authentication**: provide your account kit and passphrase
+- **UUID-based secret access**: fetch secrets by their resource UUID
+- **`#field` syntax**: read specific fields (username, password, URI, TOTP, custom fields)
 - **Bulk loading** with `passboltBulk()` to load all passwords from a folder
 - **Custom fields object** with `passboltCustomFieldsObj()` for `@setValuesBulk`
-- **Self-hosted support** — API URL is read from your account kit
-- **Multiple instances** — connect to different Passbolt instances
+- **Self-hosted support**: API URL is read from your account kit
+- **Multiple instances**: connect to different Passbolt instances
 
 ## Installation and setup
 
@@ -107,7 +107,7 @@ LOGIN_PASS=passbolt("01234567-0123-4567-890a-bcdef0123456#password")
 TOTP_SECRET=passbolt("01234567-0123-4567-890a-bcdef0123456#totp.secret")
 TOTP_CODE=passbolt("01234567-0123-4567-890a-bcdef0123456#totp.code")
 
-# Custom fields — any unrecognized name is treated as a custom field
+# Custom fields: any unrecognized name is treated as a custom field
 MY_FIELD=passbolt("01234567-0123-4567-890a-bcdef0123456#MyCustomField")
 ```
 
@@ -176,7 +176,7 @@ To find a resource's UUID:
 <div>
 #### `@initPassbolt()`
 
-Initializes an instance of the Passbolt plugin — setting up authentication and options. Can be called multiple times for different instances.
+Initializes an instance of the Passbolt plugin, setting up authentication and options. Can be called multiple times for different instances.
 
 **Key/value args:**
 - `accountKit` **(required)**: Passbolt account kit (base64-encoded). Should be a reference to a config item of type `passboltAccountKit`.
@@ -202,7 +202,7 @@ PB_PASSPHRASE=
 <div>
 #### `passboltAccountKit`
 
-This type is [`@internal`](/reference/item-decorators/#internal) by default — varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly — for example to write secrets back or fetch additional secrets at runtime.
+This type is [`@internal`](/reference/item-decorators/#internal) by default: varlock uses it to fetch your other secrets but does **not** inject it into your application. Override with `@internal=false` if your app uses the credential directly, for example to write secrets back or fetch additional secrets at runtime.
 
 
 Represents a Passbolt account kit (base64-encoded). Validation ensures the value is valid base64. The type is marked as `@sensitive`, so adding an explicit `@sensitive` decorator is optional.
@@ -308,6 +308,6 @@ Fetches all custom fields from a Passbolt resource as a JSON object. Intended fo
 
 ## Resources
 
-- [Passbolt](https://www.passbolt.com/) — open-source password manager for teams
-- [Passbolt Help](https://help.passbolt.com/) — official documentation
-- [Passbolt Community](https://community.passbolt.com/) — community forums
+- [Passbolt](https://www.passbolt.com/): open-source password manager for teams
+- [Passbolt Help](https://help.passbolt.com/): official documentation
+- [Passbolt Community](https://community.passbolt.com/): community forums

--- a/packages/varlock-website/src/content/docs/plugins/proton-pass.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/proton-pass.mdx
@@ -10,14 +10,14 @@ import Badge from '@/components/Badge.astro';
   <Badge npmPackage="@varlock/proton-pass-plugin" />
 </div>
 
-Our [Proton Pass](https://proton.me/pass) plugin enables secure loading of secrets from Proton Pass using declarative instructions within your `.env` files.
+Our [Proton Pass](https://proton.me/pass) plugin loads secrets from Proton Pass using declarative instructions within your `.env` files.
 
 It shells out to the official Proton Pass CLI (`pass-cli`) to resolve secret references in the format `pass://vault/item/field`.
 
 ## Features
 
 - **Secret references via `pass://` URIs** (`pass://vault/item/field`)
-- **Personal access token login** for CI (`PROTON_PASS_PERSONAL_ACCESS_TOKEN`) — non-interactive, scoped, no full account credentials
+- **Personal access token login** for CI (`PROTON_PASS_PERSONAL_ACCESS_TOKEN`): non-interactive, scoped, no full account credentials
 - **Non-interactive password login** using environment variables (`PROTON_PASS_PASSWORD`, `PROTON_PASS_TOTP`, `PROTON_PASS_EXTRA_PASSWORD`)
 - **In-session caching** per resolution run
 - **Helpful error messages** with resolution tips
@@ -42,22 +42,22 @@ See: [Proton Pass CLI overview](https://protonpass.github.io/pass-cli/).
 ### Configure the plugin
 
 In production/CI you typically want a fully non-interactive login. The plugin supports two
-authentication methods — a **personal access token** (recommended) or a **username + password**.
+authentication methods: a **personal access token** (recommended) or a **username + password**.
 
 :::note[Login credentials are `@internal` by default]
-The login credential types (`protonPassPersonalAccessToken`, `protonPassPassword`, `protonPassTotp`, `protonPassExtraPassword`) are marked [`@internal`](/reference/item-decorators/#internal) — varlock uses them to authenticate but does **not** inject them into your application. Override with `@internal=false` if needed.
+The login credential types (`protonPassPersonalAccessToken`, `protonPassPassword`, `protonPassTotp`, `protonPassExtraPassword`) are marked [`@internal`](/reference/item-decorators/#internal): varlock uses them to authenticate but does **not** inject them into your application. Override with `@internal=false` if needed.
 :::
 
 #### Personal access token (recommended)
 
 A [personal access token](https://protonpass.github.io/pass-cli/commands/login/#personal-access-token-login)
-is a scoped, non-interactive credential — it never needs a username, password, or TOTP, which makes it
+is a scoped, non-interactive credential. It never needs a username, password, or TOTP, which makes it
 the cleanest option for CI.
 
 Create one with the Proton Pass CLI, then grant it access to the vaults/items it needs:
 
 ```bash
-# Create a token (the full value is only shown once — save it somewhere safe)
+# Create a token (the full value is only shown once, so save it somewhere safe)
 pass-cli pat create --name "deploy-bot" --expiration 3m
 # PROTON_PASS_PERSONAL_ACCESS_TOKEN=pst_xxxx...xxxx::TOKENKEY
 
@@ -80,13 +80,13 @@ pass-cli pat access grant ...
 PROTON_PASS_PERSONAL_ACCESS_TOKEN=
 ```
 
-When a `personalAccessToken` is provided it takes precedence — the plugin runs `pass-cli login`
+When a `personalAccessToken` is provided it takes precedence: the plugin runs `pass-cli login`
 with the token and ignores `username`/`password`/`totp`/`extraPassword`.
 
 :::note[Token expiration]
 Personal access tokens have a **mandatory expiration** set when you create them (`1d`, `1w`, `1m`, `3m`, `6m`, or `1y`)
 and do **not** auto-renew. When a token expires, mint a new one with `pass-cli pat renew` (or `pat create`) and update
-the value in your config — there is nothing for the plugin to refresh or cache on your behalf.
+the value in your config. There is nothing for the plugin to refresh or cache on your behalf.
 :::
 
 #### Username + password

--- a/packages/varlock-website/src/content/docs/reference/builtin-variables.mdx
+++ b/packages/varlock-website/src/content/docs/reference/builtin-variables.mdx
@@ -3,7 +3,7 @@ title: "Builtin variables"
 description: Auto-detected VARLOCK_* variables for CI platform, branch, commit, and environment info
 ---
 
-Varlock provides a set of **builtin `VARLOCK_*` variables** that are automatically populated with information about the current CI/deploy platform, git branch, commit, and inferred deployment environment. They are entirely **opt-in** — they only exist in your schema when you reference them.
+Varlock provides a set of **builtin `VARLOCK_*` variables** that are automatically populated with information about the current CI/deploy platform, git branch, commit, and inferred deployment environment. They are entirely **opt-in**: they only exist in your schema when you reference them.
 
 ## Usage
 
@@ -20,14 +20,14 @@ DB_URL=if(
 )
 ```
 
-If you want to include a builtin variable in your resolved env without referencing it from another item, just define it with an empty value — varlock will populate it automatically:
+If you want to include a builtin variable in your resolved env without referencing it from another item, define it with an empty value and varlock will populate it automatically:
 
 ```env-spec title=".env.schema"
 VARLOCK_BRANCH=
 VARLOCK_COMMIT_SHA_SHORT=
 ```
 
-You can also use `VARLOCK_ENV` as your environment flag with `@currentEnv`, which means you don't need to create your own `APP_ENV` variable — Varlock will auto-detect the environment for you.
+You can also use `VARLOCK_ENV` as your environment flag with `@currentEnv`, which means you don't need to create your own `APP_ENV` variable. Varlock will auto-detect the environment for you.
 
 :::caution[Verify detection works for your setup]
 Auto-detection is based on environment variables set by each CI/deploy platform. Different platforms expose different information, and detection heuristics (especially branch-to-environment inference) may not match your conventions.
@@ -40,15 +40,15 @@ Auto-detection is based on environment variables set by each CI/deploy platform.
 
 ### `VARLOCK_ENV`
 
-**Type:** `string` — one of `development`, `preview`, `staging`, `production`, `test`
+**Type:** `string`, one of `development`, `preview`, `staging`, `production`, `test`
 
 The inferred deployment environment. Detection follows this priority:
 
-1. **Test environment** — detected from `NODE_ENV=test`, `VITEST`, `JEST_WORKER_ID`, or `VITEST_POOL_ID`
-2. **Platform-provided** — uses the platform's own environment concept (e.g., Vercel's `VERCEL_ENV`, Netlify's `CONTEXT`)
-3. **Branch inference** — in CI, infers from branch name: `main`/`master`/`production`/`prod` &rarr; `production`, `staging`/`stage`/`develop`/`dev` &rarr; `staging`, `qa`/`test` &rarr; `test`, anything else &rarr; `preview`
-4. **CI fallback** — if in CI but no branch info is available, defaults to `preview`
-5. **Local fallback** — if not in CI, defaults to `development`
+1. **Test environment**: detected from `NODE_ENV=test`, `VITEST`, `JEST_WORKER_ID`, or `VITEST_POOL_ID`
+2. **Platform-provided**: uses the platform's own environment concept (e.g., Vercel's `VERCEL_ENV`, Netlify's `CONTEXT`)
+3. **Branch inference**: in CI, infers from branch name: `main`/`master`/`production`/`prod` &rarr; `production`, `staging`/`stage`/`develop`/`dev` &rarr; `staging`, `qa`/`test` &rarr; `test`, anything else &rarr; `preview`
+4. **CI fallback**: if in CI but no branch info is available, defaults to `preview`
+5. **Local fallback**: if not in CI, defaults to `development`
 
 #### Using with `@currentEnv`
 
@@ -63,7 +63,7 @@ DB_URL="postgres://$DB_HOST/$DB_NAME"
 #### Test environment caveat
 
 :::caution[Test runners and `VARLOCK_ENV`]
-Many test runners (Vitest, Jest, etc.) set `NODE_ENV=test` **after** the process has started — often after varlock has already loaded and resolved your env vars. This means `VARLOCK_ENV` may not detect `test` automatically in all setups.
+Many test runners (Vitest, Jest, etc.) set `NODE_ENV=test` **after** the process has started, often after varlock has already loaded and resolved your env vars. This means `VARLOCK_ENV` may not detect `test` automatically in all setups.
 
 If you depend on `VARLOCK_ENV=test` to load `.env.test` or toggle behavior via `forEnv(test)`, **explicitly pass it** when running tests:
 
@@ -73,7 +73,7 @@ VARLOCK_ENV=test bun run test
 VARLOCK_ENV=test varlock run -- vitest
 ```
 
-This is the same pattern recommended for any environment flag — see the [environments guide](/guides/environments/) for more details.
+This is the same pattern recommended for any environment flag. See the [environments guide](/guides/environments/) for more details.
 :::
 
 

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -39,7 +39,7 @@ You can configure varlock's default behavior by adding a `varlock` key to your `
 
 | Option | Description |
 |--------|-------------|
-| `loadPath` | Path (or array of paths) to a directory or specific `.env` file to use as the default entry point. Defaults to the current working directory if not set. Use a **directory path** (with trailing `/`) to automatically load all relevant files (`.env.schema`, `.env`, `.env.local`, etc.); a file path only loads that file and its explicit imports. When an array is provided, all paths are loaded and combined — later entries take higher precedence. Can be overridden by the `--path` CLI flag. Varlock looks for this config in the `package.json` in the current working directory only. |
+| `loadPath` | Path (or array of paths) to a directory or specific `.env` file to use as the default entry point. Defaults to the current working directory if not set. Use a **directory path** (with trailing `/`) to automatically load all relevant files (`.env.schema`, `.env`, `.env.local`, etc.); a file path only loads that file and its explicit imports. When an array is provided, all paths are loaded and combined, with later entries taking higher precedence. Can be overridden by the `--path` CLI flag. Varlock looks for this config in the `package.json` in the current working directory only. |
 
 
 :::note[Plugins]
@@ -50,7 +50,7 @@ While plugins cannot add additional CLI commands, they can extend varlock with a
 
 Several commands share these flags. They behave identically wherever they appear, except where a command's own section calls out a deviation.
 
-- `--path` / `-p` `<path>`: Path to a specific `.env` file or directory to use as the entry point (overrides `varlock.loadPath` in `package.json`). Can be specified multiple times to load from multiple paths — later paths take higher precedence. _(For [`scan`](#scan) and [`audit`](#audit) this is the **schema** entry point used to resolve sensitive values; `audit` accepts a single path only.)_
+- `--path` / `-p` `<path>`: Path to a specific `.env` file or directory to use as the entry point (overrides `varlock.loadPath` in `package.json`). Can be specified multiple times to load from multiple paths, where later paths take higher precedence. _(For [`scan`](#scan) and [`audit`](#audit) this is the **schema** entry point used to resolve sensitive values; `audit` accepts a single path only.)_
 - `--env <env>`: Resolve in the context of a specific environment (e.g., `--env production`). Overridden by `@currentEnv` if it is set in your `.env.schema`.
 - `--clear-cache`: Clear the active cache store before resolving values, then re-resolve all values (when combined with `--skip-cache`, the cache is cleared first, then reads and writes are skipped for the run).
 - `--skip-cache`: Skip cache entirely for this invocation (no reads or writes). This overrides `@cache=disk`/`@cache=memory`.
@@ -98,7 +98,7 @@ varlock load [options]
 
 **Options:**
 - `--format`:     Format of output [pretty|json|env|shell|json-full]
-- `--agent`:      Agent-safe mode — defaults to JSON output and redacts sensitive values. Not compatible with `--format env` or `--format shell`.
+- `--agent`:      Agent-safe mode: defaults to JSON output and redacts sensitive values. Not compatible with `--format env` or `--format shell`.
 - `--compact`:    Compact output (json-full: no indentation, env/shell: skip undefined values)
 - `--show-all`:   Shows all items, not just failing ones, when validation is failing
 - [Common options](#common-options): `--env`, `--path` / `-p`, `--clear-cache`, `--skip-cache`
@@ -144,12 +144,12 @@ varlock load --agent
 - non-zero when validation fails (missing required values, failed coercion, or resolver errors)
 
 **Output formats (for scripts & agents):**
-- `--format json` — a flat `{ "KEY": value }` map of resolved values on stdout
-- `--agent` — the same flat map, but `@sensitive` values are redacted (e.g. `"su▒▒▒▒▒"`), so it is safe to print in logs or agent transcripts. Implies JSON output; not compatible with `--format env`/`shell`. Combine with `--agent --format json-full` to get the redacted full graph.
-- `--format json-full` — the full serialized graph: top-level `basePath`, `sources`, `config` (per-item metadata including resolved value, validation state, and sensitivity), `settings`. Use this when you need per-item validation/error detail rather than just values. ⚠️ This includes **raw resolved secret values** — add `--agent` (`--agent --format json-full`) to redact them before logging or feeding to an agent.
-- `--format env` / `--format shell` — dotenv lines / shell `export` statements with **raw** values. Never pipe these somewhere that gets logged when secrets are involved.
+- `--format json`: a flat `{ "KEY": value }` map of resolved values on stdout
+- `--agent`: the same flat map, but `@sensitive` values are redacted (e.g. `"su▒▒▒▒▒"`), so it is safe to print in logs or agent transcripts. Implies JSON output; not compatible with `--format env`/`shell`. Combine with `--agent --format json-full` to get the redacted full graph.
+- `--format json-full`: the full serialized graph: top-level `basePath`, `sources`, `config` (per-item metadata including resolved value, validation state, and sensitivity), `settings`. Use this when you need per-item validation/error detail rather than just values. ⚠️ This includes **raw resolved secret values**, so add `--agent` (`--agent --format json-full`) to redact them before logging or feeding to an agent.
+- `--format env` / `--format shell`: dotenv lines / shell `export` statements with **raw** values. Never pipe these somewhere that gets logged when secrets are involved.
 
-When emitting machine-readable output, add `--summary-stderr` (or `--summary-file`) to get a human-readable, redacted summary on **stderr** while keeping clean JSON on **stdout** — handy for agents and CI.
+When emitting machine-readable output, add `--summary-stderr` (or `--summary-file`) to get a human-readable, redacted summary on **stderr** while keeping clean JSON on **stdout**. This is handy for agents and CI.
 
 :::caution
 Setting `@currentEnv` in your `.env.schema` will override the `--env` flag.
@@ -170,8 +170,8 @@ varlock run -- <command>
 
 **Options:**
 - `--redact-stdout` / `--no-redact-stdout`: Override automatic stdout/stderr redaction. `--redact-stdout` forces redaction of piped/redirected output (e.g., to override `@redactLogs=false`) and errors if output is attached to an interactive terminal, where redaction is not possible without breaking TTY behavior. `--no-redact-stdout` disables redaction entirely.
-- `--inject <mode>` / `-i`: Control what gets injected into the child process environment — `all` (default: individual vars plus the `__VARLOCK_ENV` serialized config graph blob), `vars` (individual vars only, no blob), or `blob` (only the `__VARLOCK_ENV` blob, no individual vars)
-- `--include-internal`: Pass [`@internal`](/reference/item-decorators/#internal) items through to the child process. By default they are stripped from the child env — even if set in the ambient environment — so a secret-zero token never reaches your app. Use this for a _nested_ `varlock run` whose own resolution needs the internal value.
+- `--inject <mode>` / `-i`: Control what gets injected into the child process environment: `all` (default: individual vars plus the `__VARLOCK_ENV` serialized config graph blob), `vars` (individual vars only, no blob), or `blob` (only the `__VARLOCK_ENV` blob, no individual vars)
+- `--include-internal`: Pass [`@internal`](/reference/item-decorators/#internal) items through to the child process. By default they are stripped from the child env, even if set in the ambient environment, so a secret-zero token never reaches your app. Use this for a _nested_ `varlock run` whose own resolution needs the internal value.
 - [Common options](#common-options): `--path` / `-p`, `--clear-cache`, `--skip-cache`
 
 **Examples:**
@@ -200,10 +200,10 @@ varlock run -- sh -c 'echo $MY_VAR' # ✅ will work
 :::note[Interactive tools and TTY detection]
 `varlock run` automatically detects where each output stream is going:
 
-- **Interactive terminal (TTY)**: output passes straight through, preserving raw TTY behavior — interactive tools like `psql` and `claude` just work, with no flags needed. A human at the terminal already has access to the secrets, so redaction adds little there.
+- **Interactive terminal (TTY)**: output passes straight through, preserving raw TTY behavior. Interactive tools like `psql` and `claude` work with no flags needed. A human at the terminal already has access to the secrets, so redaction adds little there.
 - **Piped or redirected output** (CI logs, files, `| tee`, etc.): output is piped through a redaction filter, since that's where leaked secrets would persist.
 
-Detection is per stream — for example `varlock run -- node app.js | tee log.txt` redacts stdout (piped) while stderr (still attached to your terminal) passes through.
+Detection is per stream. For example `varlock run -- node app.js | tee log.txt` redacts stdout (piped) while stderr (still attached to your terminal) passes through.
 
 To override the auto-detection:
 ```bash
@@ -216,7 +216,7 @@ varlock run --redact-stdout -- node app.js > log.txt
 
 Redacting a TTY-attached stream is not possible without piping it (which would break interactive tools), so `--redact-stdout` errors if output is attached to an interactive terminal rather than silently degrading the experience.
 
-The same override can be set via the [`_VARLOCK_REDACT_STDOUT`](/reference/reserved-variables/#_varlock_redact_stdout) environment variable (`true`/`1` to force on, `false`/`0` to force off), which is handy when you can't easily change the command being run — for example in a wrapper script or CI config. The CLI flag always takes precedence over the env var.
+The same override can be set via the [`_VARLOCK_REDACT_STDOUT`](/reference/reserved-variables/#_varlock_redact_stdout) environment variable (`true`/`1` to force on, `false`/`0` to force off), which is handy when you can't easily change the command being run, for example in a wrapper script or CI config. The CLI flag always takes precedence over the env var.
 :::
 
 :::note[Preventing sensitive value exposure via env inspection]
@@ -239,7 +239,7 @@ Note: When the `__VARLOCK_ENV` blob is omitted, framework integrations that rely
 
 This makes `varlock run` safe to use as a container `ENTRYPOINT` (including PID 1), so `docker stop` / pod termination reaches your app gracefully instead of waiting out the grace period and being `SIGKILL`ed.
 
-By default varlock forwards and then waits indefinitely for the child — it does **not** impose its own kill deadline, leaving that decision to the orchestrator or operator (a forwarded signal isn't always terminal — e.g. many programs use `SIGHUP` to reload). If you want varlock to escalate to `SIGKILL` when the child hasn't exited within a grace period, set the `_VARLOCK_FORCE_KILL_TIMEOUT_MS` environment variable to a number of milliseconds.
+By default varlock forwards and then waits indefinitely for the child. It does **not** impose its own kill deadline, leaving that decision to the orchestrator or operator (a forwarded signal isn't always terminal, since many programs use `SIGHUP` to reload). If you want varlock to escalate to `SIGKILL` when the child hasn't exited within a grace period, set the `_VARLOCK_FORCE_KILL_TIMEOUT_MS` environment variable to a number of milliseconds.
 :::
 
 </div>
@@ -258,7 +258,7 @@ varlock printenv <VAR_NAME> [options]
 ```
 
 **Positional arguments:**
-- `<VAR_NAME>`: The variable to print. Required — printenv errors if omitted.
+- `<VAR_NAME>`: The variable to print. Required; printenv errors if omitted.
 
 **Options:**
 - [Common options](#common-options): `--path` / `-p`, `--clear-cache`, `--skip-cache`
@@ -293,7 +293,7 @@ sh -c 'echo $(varlock printenv MY_VAR)'  # ✅ embed in a larger command
 <div>
 ### `varlock explain` ||explain||
 
-Shows detailed information about how a single config item is resolved — all of its definitions, sources, overrides, and the final resolved value. This is the go-to command for debugging *why* a value is what it is (and an agent-friendly way to inspect resolution without dumping every value).
+Shows detailed information about how a single config item is resolved: all of its definitions, sources, overrides, and the final resolved value. This is the go-to command for debugging *why* a value is what it is (and an agent-friendly way to inspect resolution without dumping every value).
 
 Sensitive values are redacted in the output.
 
@@ -304,7 +304,7 @@ varlock explain <VAR_NAME> [options]
 ```
 
 **Positional arguments:**
-- `<VAR_NAME>`: The config item to explain. Required — explain errors if omitted.
+- `<VAR_NAME>`: The config item to explain. Required; explain errors if omitted.
 
 **Options:**
 - [Common options](#common-options): `--env`, `--path` / `-p`
@@ -334,13 +334,13 @@ varlock scan [paths...] [options]
 ```
 
 **Positional arguments:**
-- `[paths...]`: Optional list of file paths, directories, or glob patterns to scan. When provided, only these targets are scanned — git filtering (`--staged`, `--include-ignored`) is bypassed and build-output directories that are normally skipped (such as `dist`, `.next`, `build`) are included.
+- `[paths...]`: Optional list of file paths, directories, or glob patterns to scan. When provided, only these targets are scanned: git filtering (`--staged`, `--include-ignored`) is bypassed and build-output directories that are normally skipped (such as `dist`, `.next`, `build`) are included.
 
 **Options:**
 - `--staged`:           Only scan staged git files (ignored when explicit paths are provided)
 - `--include-ignored`:  Include git-ignored files in the scan (ignored when explicit paths are provided)
 - `--install-hook`:     Set up `varlock scan` as a git pre-commit hook
-- [Common options](#common-options): `--path` / `-p` — here it sets the **schema** entry point used to resolve sensitive values
+- [Common options](#common-options): `--path` / `-p` (here it sets the **schema** entry point used to resolve sensitive values)
 
 **Examples:**
 ```bash
@@ -381,7 +381,7 @@ This will detect if you are using a hook manager (like husky or lefthook) and pr
 
 If varlock is installed as a project dependency, the hook command will be automatically prefixed with your package manager (e.g., `npx varlock scan`).
 
-You can also set it up manually -- see the [Secrets guide](/guides/secrets/#scanning-for-leaked-secrets) for more details.
+You can also set it up manually. See the [Secrets guide](/guides/secrets/#scanning-for-leaked-secrets) for more details.
 :::
 
 </div>
@@ -400,7 +400,7 @@ varlock encrypt [options]
 ```
 
 **Options:**
-- `--file`:    Path to a `.env` file — encrypts all sensitive plaintext values in-place
+- `--file`:    Path to a `.env` file; encrypts all sensitive plaintext values in-place
 
 **Examples:**
 ```bash
@@ -499,7 +499,7 @@ This command reports two drift categories:
 - **Missing in schema**: key is used in code but not declared in schema
 - **Unused in schema**: key is declared in schema but not referenced in code
 
-Pure execution-environment plumbing — variables that reflect *where/how* the process runs (e.g. `PATH`, `HOME`, `SHELL`, `NODE_OPTIONS`, `npm_*`) — is read from `process.env` in normal code but is never part of your schema, so it is **not** reported as missing. Semantically meaningful variables your app or CI may depend on (e.g. `NODE_ENV`, `CI`, GitHub Actions vars) are still reported, so you can decide whether to declare them or suppress them with [`@auditIgnore`](/reference/item-decorators/#auditignore).
+Pure execution-environment plumbing, meaning variables that reflect *where/how* the process runs (e.g. `PATH`, `HOME`, `SHELL`, `NODE_OPTIONS`, `npm_*`), is read from `process.env` in normal code but is never part of your schema, so it is **not** reported as missing. Semantically meaningful variables your app or CI may depend on (e.g. `NODE_ENV`, `CI`, GitHub Actions vars) are still reported, so you can decide whether to declare them or suppress them with [`@auditIgnore`](/reference/item-decorators/#auditignore).
 
 Exit codes:
 - `0` when schema and code are in sync
@@ -513,7 +513,7 @@ varlock audit [paths...] [options]
 - `[paths...]`: Optional list of directories to scan. When provided, only these directories are scanned instead of the auto-detected scan root.
 
 **Options:**
-- [Common options](#common-options): `--path` / `-p` — here it sets the **schema** entry point (single path only)
+- [Common options](#common-options): `--path` / `-p` (here it sets the **schema** entry point, single path only)
 - `--ignore` / `-i`: Directory to exclude from code scanning (can be specified multiple times)
 
 **Examples:**
@@ -542,7 +542,7 @@ When `--path` points to a directory, code scanning is scoped to that directory t
 :::
 
 :::note[Monorepos]
-Code scanning does not descend into nested projects — any subdirectory that contains its own `package.json` or `.env.schema` is treated as a separate package and skipped. This keeps a parent package's audit from picking up env var references that belong to child packages, and works even in a fresh monorepo where the child packages haven't run `varlock init` yet. Run `varlock audit` inside each package to audit it against its own schema.
+Code scanning does not descend into nested projects. Any subdirectory that contains its own `package.json` or `.env.schema` is treated as a separate package and skipped. This keeps a parent package's audit from picking up env var references that belong to child packages, and works even in a fresh monorepo where the child packages haven't run `varlock init` yet. Run `varlock audit` inside each package to audit it against its own schema.
 :::
 
 :::tip[Suppressing false positives]
@@ -562,8 +562,8 @@ varlock cache [status|clear] [options]
 ```
 
 **Sub-commands:**
-- `status` — print a non-interactive cache status summary (location, file size, entry counts by group)
-- `clear` — remove cache entries. Requires `--yes` for non-interactive use.
+- `status`: print a non-interactive cache status summary (location, file size, entry counts by group)
+- `clear`: remove cache entries. Requires `--yes` for non-interactive use.
 
 **Options:**
 - `--plugin <name>`: When clearing, only remove entries for a specific plugin
@@ -598,14 +598,14 @@ See the [Caching guide](/guides/caching/) for cache mode strategy and troublesho
 <div>
 ### `varlock codegen` ||codegen||
 
-Runs the [code-generation decorators](/reference/root-decorators/#code-generation) in your schema — typed env accessors like `@generateTsTypes` (type declarations) and `@generatePythonEnv` (a loadable module), plus any generators contributed by plugins. Uses only your schema definitions, so output is deterministic regardless of which environment is active. Keys (and decorators) that come only from value files like `.env` or `.env.local` are ignored — only items declared in your `.env.schema` (or imported into it) are included. When run directly, the command reports any keys found only in a plain `.env` so you can move them into your schema if they belong there.
+Runs the [code-generation decorators](/reference/root-decorators/#code-generation) in your schema: typed env accessors like `@generateTsTypes` (type declarations) and `@generatePythonEnv` (a loadable module), plus any generators contributed by plugins. Uses only your schema definitions, so output is deterministic regardless of which environment is active. Keys (and decorators) that come only from value files like `.env` or `.env.local` are ignored. Only items declared in your `.env.schema` (or imported into it) are included. When run directly, the command reports any keys found only in a plain `.env` so you can move them into your schema if they belong there.
 
 Add a per-language decorator for each output file you want: `@generateTsTypes`, `@generatePythonEnv`, `@generateRustEnv`, `@generateGoEnv`, or `@generatePhpEnv`. Each generates its own file.
 
 This command is particularly useful when you have set `auto=false` on a generator decorator to disable automatic generation during `varlock load` or `varlock run`.
 
 :::note
-`varlock typegen` is a deprecated alias for `varlock codegen` — it still works but prints a warning.
+`varlock typegen` is a deprecated alias for `varlock codegen`. It still works but prints a warning.
 :::
 
 ```bash
@@ -660,7 +660,7 @@ See the [Next.js](/integrations/nextjs/#encrypting-the-env-blob) and [Vite](/int
 <div>
 ### `varlock install-plugin` ||install-plugin||
 
-Pre-downloads a plugin from npm into the local varlock plugin cache so it is available without an interactive confirmation prompt. This is mainly for the **standalone binary** in CI or other non-interactive environments — when varlock runs as a package.json dependency, plugins resolve through your normal node_modules instead.
+Pre-downloads a plugin from npm into the local varlock plugin cache so it is available without an interactive confirmation prompt. This is mainly for the **standalone binary** in CI or other non-interactive environments. When varlock runs as a package.json dependency, plugins resolve through your normal node_modules instead.
 
 The plugin must be specified with an exact version (`name@version`).
 

--- a/packages/varlock-website/src/content/docs/reference/data-types.mdx
+++ b/packages/varlock-website/src/content/docs/reference/data-types.mdx
@@ -68,7 +68,7 @@ These are the built-in data types. [Plugins](/guides/plugins/) may register addi
 - `isLength` (number): Exact length required
 - `startsWith` (string): Required starting substring
 - `endsWith` (string): Required ending substring
-- `matches` (string|RegExp): Regular expression pattern to match — use `/pattern/flags` syntax or a quoted string pattern (see [regex-like strings](/reference/functions#regex-like-strings))
+- `matches` (string|RegExp): Regular expression pattern to match. Use `/pattern/flags` syntax or a quoted string pattern (see [regex-like strings](/reference/functions#regex-like-strings))
 - `toUpperCase` (boolean): Convert to uppercase
 - `toLowerCase` (boolean): Convert to lowercase
 - `allowEmpty` (boolean): Allow empty string (default: false)
@@ -121,7 +121,7 @@ MY_BOOL=true
 - `prependHttps` (boolean): Automatically prepend "https://" if no protocol is specified
 - `allowedDomains` (string[]): List of allowed domains
 - `noTrailingSlash` (boolean): Disallow a trailing slash on the URL path (except root `/`)
-- `matches` (string|RegExp): Regular expression pattern the full URL must match — use `/pattern/flags` syntax or a quoted string pattern (see [regex-like strings](/reference/functions#regex-like-strings))
+- `matches` (string|RegExp): Regular expression pattern the full URL must match. Use `/pattern/flags` syntax or a quoted string pattern (see [regex-like strings](/reference/functions#regex-like-strings))
 
 ```env-spec
 # @type=url(prependHttps=true)
@@ -232,18 +232,18 @@ MY_OBJECT={"key": "value"}
 <div>
 ### `duration`
 
-Flexible duration type. Accepts human-readable strings (`"1h"`, `"30m"`, `"500ms"`, `"2days"`) or bare numbers (interpreted as milliseconds — plain decimals only, no hex/exponent/`Infinity` notation), and outputs a number in the unit you specify.
+Flexible duration type. Accepts human-readable strings (`"1h"`, `"30m"`, `"500ms"`, `"2days"`) or bare numbers (interpreted as milliseconds, plain decimals only, no hex/exponent/`Infinity` notation), and outputs a number in the unit you specify.
 
 **Options:**
-- `output` — output unit: `ms` (default), `seconds`, `minutes`, `hours`, `days`, or `weeks`
-- `min` / `max` — bounds in any duration format (e.g. `min="1s"`, `max="1d"`)
+- `output`: output unit: `ms` (default), `seconds`, `minutes`, `hours`, `days`, or `weeks`
+- `min` / `max`: bounds in any duration format (e.g. `min="1s"`, `max="1d"`)
 
 ```env-spec
 # Default: output is milliseconds
 # @type=duration
 REQUEST_TIMEOUT=30s
 
-# Output in seconds — typical for HTTP client configs
+# Output in seconds, typical for HTTP client configs
 # @type=duration(output="seconds")
 HTTP_TIMEOUT=1h
 

--- a/packages/varlock-website/src/content/docs/reference/functions.mdx
+++ b/packages/varlock-website/src/content/docs/reference/functions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Resolver functions
-description: A comprehensive reference of all available function resolvers in varlock
+description: A reference of all available function resolvers in varlock
 ---
 
 You may use _resolver functions_ instead of static values within both config items and decorator values.
@@ -66,7 +66,7 @@ Many CLI tools output an additional newline. `exec()` will trim this automatical
 :::
 
 :::tip[Prefer a plugin when one exists]
-If varlock has a [plugin](/plugins/overview/) for your provider (1Password, AWS, Vault, …), use its resolver (e.g. `op()`) instead of shelling out — plugins handle auth, caching, and validation. Reach for `exec()` only for tools without a plugin, or for custom logic.
+If varlock has a [plugin](/plugins/overview/) for your provider (1Password, AWS, Vault, …), use its resolver (e.g. `op()`) instead of shelling out. Plugins handle auth, caching, and validation. Reach for `exec()` only for tools without a plugin, or for custom logic.
 :::
 
 Expansion equivalent: `exec(command)` === `$(command)`
@@ -113,7 +113,7 @@ APP_ENV=remap($CI_BRANCH, "main", production, /.*/, preview, undefined, developm
 :::caution[Quoting path-like values]
 An unquoted match value that looks like a valid regex (i.e., `/something/` with optional flags) will be treated as a regex pattern. If you need to match a literal string containing slashes (like a file path), wrap it in quotes.
 ```env-spec
-# /usr/local/ looks like a valid regex — use quotes to match it literally
+# /usr/local/ looks like a valid regex, so use quotes to match it literally
 ITEM=remap($PATH_VAR, "/usr/local/", found, default)
 ```
 :::
@@ -156,14 +156,14 @@ API_URL=ifs(
 <div>
 ### Regex-like strings
 
-Certain functions like `remap()` and type options like `matches` support regex pattern matching. You can use JavaScript-style regex syntax (`/pattern/flags`) as an unquoted value — these will be automatically detected and treated as regular expressions.
+Certain functions like `remap()` and type options like `matches` support regex pattern matching. You can use JavaScript-style regex syntax (`/pattern/flags`) as an unquoted value. These will be automatically detected and treated as regular expressions.
 
 A string is treated as a regex when it:
 - Starts and ends with `/` (with optional flags like `i`, `g`, `m`, `s`, `u`, `y` after the closing `/`)
 - Is **not** wrapped in quotes
 
 ```env-spec
-# regex pattern in remap — matches case-insensitively
+# regex pattern in remap, matches case-insensitively
 ENV_TYPE=remap($APP_ENV, /^dev.*/i, dev, "production", prod)
 
 # regex pattern in type options
@@ -177,17 +177,17 @@ API_URL=
 :::caution[Paths vs regex ambiguity]
 Since `/something/` looks like a valid regex, values like `/usr/lib/` will be treated as regex patterns in contexts that support them (like `remap()` match values). To use a literal string containing slashes, wrap it in quotes:
 ```env-spec
-# unquoted — treated as regex pattern matching "usr/lib"
+# unquoted, treated as regex pattern matching "usr/lib"
 ITEM=remap($VAR, /usr/lib/, matched)
 
-# quoted — treated as the literal string "/usr/lib/"
+# quoted, treated as the literal string "/usr/lib/"
 ITEM=remap($VAR, "/usr/lib/", matched)
 ```
 Note that as a top-level config value (e.g., `MY_PATH=/usr/local/bin`), slash-containing strings are always treated as plain strings.
 :::
 
 :::note[`regex()` function]
-The older `regex("pattern")` function wrapper is still supported but the `/pattern/` literal syntax is preferred — it's more concise and supports flags.
+The older `regex("pattern")` function wrapper is still supported but the `/pattern/` literal syntax is preferred, since it's more concise and supports flags.
 
 ```env-spec
 # older style - still works
@@ -327,7 +327,7 @@ SESSION_SECRET=cache(randomHex())
 # @sensitive
 ENCRYPTION_KEY=cache(randomHex(64))
 
-# 32 bytes (= 64 hex chars) — byte-length mode
+# 32 bytes (= 64 hex chars), byte-length mode
 # @sensitive
 HMAC_KEY=cache(randomHex(32, bytes=true))
 
@@ -411,13 +411,13 @@ Plugin authors can also use the cache API via `plugin.cache.getOrSet()` (or `get
 
 Decrypts a locally encrypted value, or prompts for a new secret to encrypt. This is the built-in resolver for varlock's [device-local encryption](/guides/local-encryption/) feature.
 
-**Decrypt mode** — pass an encrypted payload to decrypt at load time:
+**Decrypt mode**: pass an encrypted payload to decrypt at load time:
 ```env-spec "varlock"
 # @sensitive
 API_KEY=varlock("local:<encrypted-payload>")
 ```
 
-**Prompt mode** — prompts the user to enter a secret, encrypts it, and writes the encrypted value back to the source file:
+**Prompt mode**: prompts the user to enter a secret, encrypts it, and writes the encrypted value back to the source file:
 ```env-spec "varlock"
 # @sensitive
 API_KEY=varlock(prompt)
@@ -427,7 +427,7 @@ API_KEY=varlock(prompt=1)
 
 On first run with `prompt` mode, you'll be asked to enter the secret value. Once entered, the file is automatically updated with the encrypted payload. On macOS with Secure Enclave, a native dialog with biometric authentication is used.
 
-Values are encrypted using the best available backend on your platform — see the [Local encryption guide](/guides/local-encryption/) for details.
+Values are encrypted using the best available backend on your platform. See the [Local encryption guide](/guides/local-encryption/) for details.
 
 Encrypted payload lifecycle:
 - Store encrypted payloads (`varlock("local:...")`) in local override files (typically `.env.local`)
@@ -459,7 +459,7 @@ DATABASE_PASSWORD=keychain("com.company.database")
 # Named service with account
 ADMIN_PW=keychain("com.company.db", account="admin")
 
-# Interactive picker mode — writes back resolved reference
+# Interactive picker mode, writes back resolved reference
 NEW_SECRET=keychain(prompt)
 ```
 

--- a/packages/varlock-website/src/content/docs/reference/item-decorators.mdx
+++ b/packages/varlock-website/src/content/docs/reference/item-decorators.mdx
@@ -68,7 +68,7 @@ Sets whether the item should be considered _sensitive_ - meaning it cannot be ex
 
 Default behavior for all items can be set using the [`@defaultSensitive` root decorator](/reference/root-decorators/#defaultsensitive)
 
-Sensitivity may also be implied by the item's [data type](/reference/data-types) — for example plugin "secret-zero" credential types (like a [1Password `opServiceAccountToken`](/plugins/1password/)) are sensitive by default, so you don't need to add `@sensitive` explicitly (use `@public` or `@sensitive=false` to override). An explicit `@sensitive` on the item always wins.
+Sensitivity may also be implied by the item's [data type](/reference/data-types). For example, plugin "secret-zero" credential types (like a [1Password `opServiceAccountToken`](/plugins/1password/)) are sensitive by default, so you don't need to add `@sensitive` explicitly (use `@public` or `@sensitive=false` to override). An explicit `@sensitive` on the item always wins.
 
 📖 See the [secrets management guide](/guides/secrets/) for best practices on handling sensitive values, and how to use plugins to fetch them from secret management platforms.
 
@@ -81,8 +81,8 @@ SERVICE_X_CLIENT_ID=
 
 **Per-item options:** pass an object value to tune protection for a single sensitive item:
 
-- `enabled` (`boolean`, default `true`) — whether the item is sensitive. Lets you keep options while toggling sensitivity, including dynamically via a function (e.g. `enabled=forEnv(production)`). `@sensitive={enabled=false}` is equivalent to `@sensitive=false`.
-- `preventLeaks` (`boolean`, default `true`) — when `false`, this item's value is excluded from [leak detection](/reference/root-decorators/#preventleaks), so it will _not_ trigger an error if it appears in a response. Useful when an endpoint legitimately returns a secret to another system. The value is still redacted in logs.
+- `enabled` (`boolean`, default `true`): whether the item is sensitive. Lets you keep options while toggling sensitivity, including dynamically via a function (e.g. `enabled=forEnv(production)`). `@sensitive={enabled=false}` is equivalent to `@sensitive=false`.
+- `preventLeaks` (`boolean`, default `true`): when `false`, this item's value is excluded from [leak detection](/reference/root-decorators/#preventleaks), so it will _not_ trigger an error if it appears in a response. Useful when an endpoint legitimately returns a secret to another system. The value is still redacted in logs.
 
 ```env-spec
 # @sensitive={preventLeaks=false}
@@ -94,7 +94,7 @@ PARTNER_TOKEN=
 ```
 
 :::caution[Use `preventLeaks=false` sparingly]
-Leak detection is a safety net that stops a secret from accidentally being sent in a response. Setting `preventLeaks=false` removes that net for this item, so only use it when a secret is _deliberately_ meant to leave the system (e.g. an endpoint forwarding a token to another service) — never just to silence a leak-detection error. Prefer disabling it for a single item like this over turning off [`@preventLeaks`](/reference/root-decorators/#preventleaks) globally.
+Leak detection is a safety net that stops a secret from accidentally being sent in a response. Setting `preventLeaks=false` removes that net for this item, so only use it when a secret is _deliberately_ meant to leave the system (e.g. an endpoint forwarding a token to another service), never just to silence a leak-detection error. Prefer disabling it for a single item like this over turning off [`@preventLeaks`](/reference/root-decorators/#preventleaks) globally.
 :::
 </div>
 
@@ -116,9 +116,9 @@ PUBLIC_API_URL=https://api.example.com
 ### `@internal`
 **Value type:** `boolean`
 
-Marks an item as used **only internally by varlock** — not by your application. Internal items are still resolved and can be referenced by other items (e.g. via [`ref()`](/reference/functions/#ref) or string expansion), but they are **excluded** from everything that reaches your app: the injected env vars, the [serialized graph](/reference/reserved-variables/#__varlock_env) blob, and generated types.
+Marks an item as used **only internally by varlock**, not by your application. Internal items are still resolved and can be referenced by other items (e.g. via [`ref()`](/reference/functions/#ref) or string expansion), but they are **excluded** from everything that reaches your app: the injected env vars, the [serialized graph](/reference/reserved-variables/#__varlock_env) blob, and generated types.
 
-The most common use is a "secret zero" — a credential used only to fetch _other_ secrets (for example a vault/secrets-manager token). Your application never needs it, and keeping it out of the process environment reduces your attack surface.
+The most common use is a "secret zero": a credential used only to fetch _other_ secrets (for example a vault/secrets-manager token). Your application never needs it, and keeping it out of the process environment reduces your attack surface.
 
 ```env-spec
 # the token below is only used to resolve the secrets that follow it
@@ -130,7 +130,7 @@ OP_TOKEN=
 DATABASE_URL=exec(`op read "op://app/db/url"`)
 ```
 
-Some plugin data types are **internal by default** — for example a [1Password `opServiceAccountToken`](/plugins/1password/) or other secrets-manager credential, which authenticates varlock but is rarely needed in app code. You can opt back in with `@internal=false`:
+Some plugin data types are **internal by default**. For example, a [1Password `opServiceAccountToken`](/plugins/1password/) or other secrets-manager credential authenticates varlock but is rarely needed in app code. You can opt back in with `@internal=false`:
 
 ```env-spec
 # @type=opServiceAccountToken @internal=false
@@ -138,11 +138,11 @@ OP_TOKEN=
 ```
 
 :::caution[Marking something internal stops injecting it]
-Because internal items still resolve and validate, marking a variable internal does **not** produce an error if your application actually reads it — the value simply won't be in the environment at runtime. If your app uses one of these credentials directly (e.g. to write secrets back, renew Vault leases, or fetch more secrets at runtime), set `@internal=false` so it keeps being injected.
+Because internal items still resolve and validate, marking a variable internal does **not** produce an error if your application actually reads it. The value simply won't be in the environment at runtime. If your app uses one of these credentials directly (e.g. to write secrets back, renew Vault leases, or fetch more secrets at runtime), set `@internal=false` so it keeps being injected.
 :::
 
 :::note
-`@internal` controls what varlock _injects_, not what it shows. Internal items still appear (redacted) in inspection output — the `varlock load` summary and `varlock load --agent` — so they can be set and debugged.
+`@internal` controls what varlock _injects_, not what it shows. Internal items still appear (redacted) in inspection output (the `varlock load` summary and `varlock load --agent`), so they can be set and debugged.
 :::
 
 `varlock run` strips internal items from the child process environment **even if they were set in the ambient environment** (e.g. `OP_TOKEN=xxx varlock run ...`), so a secret-zero token never leaks into your app. If a _nested_ `varlock run` needs the internal value for its own resolution, pass [`--include-internal`](/reference/cli-commands/#run) to keep it in the child env.

--- a/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
+++ b/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
@@ -1,18 +1,18 @@
 ---
 title: "Reserved variables"
-description: "varlock's reserved _VARLOCK_* and __VARLOCK_* environment variables — what they do and how the reserved namespace behaves"
+description: "varlock's reserved _VARLOCK_* and __VARLOCK_* environment variables: what they do and how the reserved namespace behaves"
 ---
 
 varlock reserves a couple of environment variable namespaces for its own use. Knowing them helps you avoid surprises and understand how varlock passes state between processes.
 
 | Prefix | Example | Who sets it |
 | --- | --- | --- |
-| `VARLOCK_*` (no underscore) | `VARLOCK_ENV` | varlock (computed) — see [Builtin variables](/reference/builtin-variables/) |
-| `_VARLOCK_*` (single underscore) | `_VARLOCK_ENV_KEY` | **you** — to configure varlock's behavior |
-| `__VARLOCK_*` (double underscore) | `__VARLOCK_ENV` | varlock internals — injected automatically, never set these yourself |
+| `VARLOCK_*` (no underscore) | `VARLOCK_ENV` | varlock (computed); see [Builtin variables](/reference/builtin-variables/) |
+| `_VARLOCK_*` (single underscore) | `_VARLOCK_ENV_KEY` | **you**, to configure varlock's behavior |
+| `__VARLOCK_*` (double underscore) | `__VARLOCK_ENV` | varlock internals, injected automatically; never set these yourself |
 
 :::caution[The `_VARLOCK_` prefix is reserved]
-Config items whose key starts with `_VARLOCK_` are reserved for varlock. They are **excluded** from the injected env blob, generated types, and override provenance — even if you define one in your `.env.schema`. varlock emits a warning if you do, since such an item won't behave like a normal config value. Don't name your own variables with this prefix.
+Config items whose key starts with `_VARLOCK_` are reserved for varlock. They are **excluded** from the injected env blob, generated types, and override provenance, even if you define one in your `.env.schema`. varlock emits a warning if you do, since such an item won't behave like a normal config value. Don't name your own variables with this prefix.
 :::
 
 ## Configuration variables (`_VARLOCK_*`)
@@ -31,13 +31,13 @@ Encryption key for the on-disk resolved-value cache. When set (e.g. as a CI secr
 
 Overrides [`varlock run`](/reference/cli-commands/#run) output redaction:
 
-- `true` / `1` — force redaction on (only applies to piped/redirected output; errors if attached to an interactive terminal)
-- `false` / `0` — disable redaction entirely
+- `true` / `1`: force redaction on (only applies to piped/redirected output; errors if attached to an interactive terminal)
+- `false` / `0`: disable redaction entirely
 
-The `--redact-stdout` / `--no-redact-stdout` flags take precedence over this env var. Useful when you can't easily change the command being run — for example in a wrapper script or CI config.
+The `--redact-stdout` / `--no-redact-stdout` flags take precedence over this env var. Useful when you can't easily change the command being run, for example in a wrapper script or CI config.
 
 {/*
-  Intentionally NOT documented for end users — internal/testing only.
+  Intentionally NOT documented for end users; internal/testing only.
   Kept here (and in VARLOCK_CONFIG_ENV_VARS with internal:true) for maintainer reference.
 
   ### `_VARLOCK_FORCE_FILE_ENCRYPTION_FALLBACK`
@@ -46,7 +46,7 @@ The `--redact-stdout` / `--no-redact-stdout` flags take precedence over this env
 
 ## Internal variables (`__VARLOCK_*`)
 
-These are injected automatically so that varlock state survives across process boundaries. You should never set them yourself — they're documented here only so you recognize them if you see them in a process environment.
+These are injected automatically so that varlock state survives across process boundaries. You should never set them yourself. They're documented here only so you recognize them if you see them in a process environment.
 
 ### `__VARLOCK_ENV`
 

--- a/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
+++ b/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
@@ -136,16 +136,16 @@ FOO=bar  # will be ignored
 
 Imports other `.env` file(s) - useful for sharing config across monorepos and splitting up large schemas. _Can be called multiple times._
 
-You may import a specific file, or a directory of files. Importing a **directory** (trailing `/`) brings everything that directory would load on its own — its `.env.schema` plus sibling `.env`, `.env.local`, and environment-specific files, resolved by the current environment flag — whereas importing a single file brings only that file. To pull in a sibling or root package's values (not just its schema), import the directory.
+You may import a specific file, or a directory of files. Importing a **directory** (trailing `/`) brings everything that directory would load on its own (its `.env.schema` plus sibling `.env`, `.env.local`, and environment-specific files, resolved by the current environment flag), whereas importing a single file brings only that file. To pull in a sibling or root package's values (not just its schema), import the directory.
 
 The optional `enabled` parameter allows conditional imports based on boolean expressions. It defaults to `true` if not specified.
 
 The optional `allowMissing` parameter makes the import optional - if set to `true`, the import will be silently skipped if the file or directory doesn't exist instead of causing a loading error. It defaults to `false` if not specified.
 
-**Filtering keys:** by default every key from the imported file(s) is brought in. Use `pick` to import only an allowlist of keys, or `omit` to import everything except a denylist. You can't use both in one import, and both accept simple globs (`*`, `?`). Across nested imports, filters intersect — a key must pass every filter in the chain.
+**Filtering keys:** by default every key from the imported file(s) is brought in. Use `pick` to import only an allowlist of keys, or `omit` to import everything except a denylist. You can't use both in one import, and both accept simple globs (`*`, `?`). Across nested imports, filters intersect: a key must pass every filter in the chain.
 
 :::caution[Positional keys are deprecated]
-Listing keys as positional args (`@import(./.env.other, KEY1, KEY2)`) is **deprecated** — use `pick=[KEY1, KEY2]` instead. The positional form still works (exact-match only, no globs) but will warn.
+Listing keys as positional args (`@import(./.env.other, KEY1, KEY2)`) is **deprecated**; use `pick=[KEY1, KEY2]` instead. The positional form still works (exact-match only, no globs) but will warn.
 :::
 
 See the [imports guide](/guides/import/) for more details and advanced usage.
@@ -171,20 +171,20 @@ IMPORTED_ITEM=overridden-value
 **Arg types:** `[ data: string ]`
 **Named args:** `format?: "json" | "env"`, `createMissing?: boolean`, `enabled?: boolean`, `pick?: string[]`, `omit?: string[]`
 
-Injects multiple config values at once from an external data source. The first argument is a resolver that produces a string — typically a bulk resolver from a [secrets provider plugin](/plugins/overview/) such as [`opLoadEnvironment()`](/plugins/1password/#oploadenvironment) (1Password), [`infisicalBulk()`](/plugins/infisical/), or [`vaultSecret(…, raw=true)`](/plugins/hashicorp-vault/) (HashiCorp Vault) — which is parsed and injected as definitions within the file containing the decorator.
+Injects multiple config values at once from an external data source. The first argument is a resolver that produces a string, typically a bulk resolver from a [secrets provider plugin](/plugins/overview/) such as [`opLoadEnvironment()`](/plugins/1password/#oploadenvironment) (1Password), [`infisicalBulk()`](/plugins/infisical/), or [`vaultSecret(…, raw=true)`](/plugins/hashicorp-vault/) (HashiCorp Vault). The string is parsed and injected as definitions within the file containing the decorator.
 
-Bulk values participate in the normal file override chain — `process.env` still overrides everything, higher-precedence files (`.env.local`, `.env.production`, etc.) override bulk values, and bulk values override schema-defined defaults in the same file. You control precedence by choosing which file to put `@setValuesBulk` in.
+Bulk values participate in the normal file override chain: `process.env` still overrides everything, higher-precedence files (`.env.local`, `.env.production`, etc.) override bulk values, and bulk values override schema-defined defaults in the same file. You control precedence by choosing which file to put `@setValuesBulk` in.
 
 **Options:**
 - `format`: How to parse the data string. `json` expects a flat JSON object, `env` expects `.env` file format. If not specified, auto-detected by checking if the string starts with `{`.
 - `createMissing`: If `true`, keys in the bulk data that don't already exist in your schema will be created as new config items. Defaults to `false` (unknown keys are silently skipped).
 - `enabled`: If `false`, the bulk data resolver is skipped entirely. Accepts any boolean expression, including dynamic references to other config items. Defaults to `true`.
-- `pick`: An array of key names to inject — an **allowlist**. Only matching keys are injected; everything else from the source is ignored.
-- `omit`: An array of key names to skip — a **denylist**. Every key _except_ the matches is injected.
+- `pick`: An array of key names to inject, an **allowlist**. Only matching keys are injected; everything else from the source is ignored.
+- `omit`: An array of key names to skip, a **denylist**. Every key _except_ the matches is injected.
 
-By default (neither `pick` nor `omit`) every key from the source is injected. You can't use `pick` and `omit` together. Both accept simple glob patterns — `*` matches any run of characters and `?` matches a single character (e.g. `pick=[API_*]`).
+By default (neither `pick` nor `omit`) every key from the source is injected. You can't use `pick` and `omit` together. Both accept simple glob patterns: `*` matches any run of characters and `?` matches a single character (e.g. `pick=[API_*]`).
 
-_Can be called multiple times — later calls overwrite earlier ones for the same keys._
+_Can be called multiple times; later calls overwrite earlier ones for the same keys._
 
 ```env-spec title=".env.schema"
 # Load all values from a 1Password environment
@@ -207,7 +207,7 @@ DB_PASSWORD=
 ```
 
 ```env-spec title=".env.schema"
-# Allowlist — only inject these keys (globs allowed, e.g. API_*)
+# Allowlist: only inject these keys (globs allowed, e.g. API_*)
 # @setValuesBulk(opLoadEnvironment(your-environment-id), pick=[API_KEY, DB_PASSWORD])
 # ---
 API_KEY=
@@ -215,7 +215,7 @@ DB_PASSWORD=
 ```
 
 ```env-spec title=".env.schema"
-# Denylist — inject everything except these keys
+# Denylist: inject everything except these keys
 # @setValuesBulk(infisicalBulk(), omit=[LEGACY_TOKEN, DEBUG_*])
 ```
 
@@ -232,14 +232,14 @@ API_KEY=
 APP_ENV=dev
 ```
 
-If a plugin doesn't exist for your provider, any CLI tool works via [`exec()`](/reference/functions/#exec) — e.g. `@setValuesBulk(exec("my-secrets-cli export --format=json"), format=json)`.
+If a plugin doesn't exist for your provider, any CLI tool works via [`exec()`](/reference/functions/#exec), e.g. `@setValuesBulk(exec("my-secrets-cli export --format=json"), format=json)`.
 
 :::note
 When using `format=env`, function calls like `$VAR` references in unquoted values are not supported and will cause an error. Use single quotes for literal `$` signs (e.g., `'$LITERAL'`) or use `format=json` instead.
 :::
 
 :::caution[`createMissing` and type generation]
-Items created via `createMissing=true` — those that don't already exist in your schema — **will not be included in generated TypeScript types**. Type generation happens at build/schema-load time before values are fetched, so dynamically created keys are invisible to the type generator.
+Items created via `createMissing=true` (those that don't already exist in your schema) **will not be included in generated TypeScript types**. Type generation happens at build/schema-load time before values are fetched, so dynamically created keys are invisible to the type generator.
 
 For this reason, **`createMissing=true` is not recommended**. Instead, declare all expected items explicitly in your schema (with an empty value) so they are known at type-generation time.
 :::
@@ -278,7 +278,7 @@ Sets global cache mode for [`cache()`](/reference/functions/#cache) and plugin c
 - `disabled`: disable caching globally
 - `auto` (default): uses `disk` when a native encryption backend is available outside CI; otherwise uses `disk` encrypted with `_VARLOCK_CACHE_KEY` if that env var is set, falling back to `memory` (see the [Caching guide](/guides/caching/))
 
-The value can also be set dynamically with a function — for example to change cache mode per environment. A function that resolves to no value falls back to `auto`.
+The value can also be set dynamically with a function, for example to change cache mode per environment. A function that resolves to no value falls back to `auto`.
 
 ```env-spec
 # @cache=memory
@@ -369,7 +369,7 @@ See note on [`@redactLogs`](#redactlogs) about potential performance impact.
 
 Controls whether the injected env blob in server-side build output is encrypted. When enabled, varlock encrypts the blob with AES-256-GCM using the `_VARLOCK_ENV_KEY` environment variable.
 
-This is primarily relevant for serverless deployments (Vercel, Netlify, etc.) where varlock injects resolved env data into the build output. The blob only appears in server-side code and is generally safe, but encryption provides extra protection — particularly against secrets leaking via sourcemaps.
+This is primarily relevant for serverless deployments (Vercel, Netlify, etc.) where varlock injects resolved env data into the build output. The blob only appears in server-side code and is generally safe, but encryption provides extra protection, particularly against secrets leaking via sourcemaps.
 
 **Options:**
 - `false` (default): Blob is injected as plaintext JSON
@@ -390,16 +390,16 @@ SECRET_KEY= # @sensitive
 ```
 
 **Key management:**
-- For **Cloudflare Workers**, the key is auto-generated and uploaded as a secret binding — no manual setup needed
+- For **Cloudflare Workers**, the key is auto-generated and uploaded as a secret binding, so no manual setup is needed
 - For **local dev**, a temporary key is auto-generated when running dev servers
-- For **production deploys** to other platforms, you must set `_VARLOCK_ENV_KEY` on your platform — see the [encrypted deployments guide](/guides/encrypted-deployments/)
+- For **production deploys** to other platforms, you must set `_VARLOCK_ENV_KEY` on your platform (see the [encrypted deployments guide](/guides/encrypted-deployments/))
 </div>
 
 <div>
 ### `@disableProcessEnvInjection`
 **Value type:** `boolean`
 
-Prevents varlock from injecting resolved values into `process.env`. When enabled, env vars are only accessible via the `ENV` proxy — `process.env.MY_VAR` will not contain varlock-resolved values.
+Prevents varlock from injecting resolved values into `process.env`. When enabled, env vars are only accessible via the `ENV` proxy; `process.env.MY_VAR` will not contain varlock-resolved values.
 
 This is useful for security hardening. Combined with [`@encryptInjectedEnv`](#encryptinjectedenv), it ensures that no plaintext secrets exist in `process.env` at all.
 
@@ -409,7 +409,7 @@ When set, [`@generateTsTypes`](#generatetstypes) stops augmenting `process.env` 
 - `false` (default): Values are injected into `process.env` as usual
 - `true`: Values are only accessible via `ENV`
 
-The value must be static (`true`/`false`) — because code generation reads this flag, an
+The value must be static (`true`/`false`). Because code generation reads this flag, an
 environment-dependent value would make generated output differ per environment.
 
 ```env-spec
@@ -424,7 +424,7 @@ When enabled, any code that reads from `process.env` directly (including third-p
 :::
 
 :::note
-This decorator only affects the runtime `initVarlockEnv()` behavior — it does **not** affect [`varlock run`](/reference/cli-commands/#run), which always injects individual env vars into the child process by default. Use `varlock run --no-inject-vars` if you also want to skip individual var injection when using `varlock run`.
+This decorator only affects the runtime `initVarlockEnv()` behavior. It does **not** affect [`varlock run`](/reference/cli-commands/#run), which always injects individual env vars into the child process by default. Use `varlock run --no-inject-vars` if you also want to skip individual var injection when using `varlock run`.
 :::
 </div>
 
@@ -432,7 +432,7 @@ This decorator only affects the runtime `initVarlockEnv()` behavior — it does 
 ### `@auditIgnorePaths()`
 **Arg types:** `[ ...paths: string[] ]`
 
-Excludes directories from the [`varlock audit`](/reference/cli-commands/#audit) code scanner. Paths are relative to the file containing the decorator. _Can be called multiple times — paths are merged additively._
+Excludes directories from the [`varlock audit`](/reference/cli-commands/#audit) code scanner. Paths are relative to the file containing the decorator. _Can be called multiple times; paths are merged additively._
 
 Useful for excluding generated code, vendored dependencies, or directories that contain env var references you don't want to audit.
 
@@ -443,7 +443,7 @@ API_KEY=
 ```
 
 ```env-spec
-# called multiple times — paths are merged
+# called multiple times, paths are merged
 # @auditIgnorePaths(vendor)
 # @auditIgnorePaths(generated/config, scripts/setup)
 # ---
@@ -455,12 +455,12 @@ API_KEY=
 
 ## Code generation ||code-generation||
 
-Code-generation decorators turn your schema into generated code — TypeScript type declarations or ready-to-use env modules for other languages — and [plugins](/guides/plugins/) can register generators that emit other kinds of code. See the [Code generation guide](/guides/code-generation/) for the full picture, and [Other languages](/integrations/other-languages/) for per-language usage.
+Code-generation decorators turn your schema into generated code, such as TypeScript type declarations or ready-to-use env modules for other languages, and [plugins](/guides/plugins/) can register generators that emit other kinds of code. See the [Code generation guide](/guides/code-generation/) for the full picture, and [Other languages](/integrations/other-languages/) for per-language usage.
 
 Every `@generate*` decorator below is a root decorator that _can be called multiple times_ (one per output file) and shares these common args:
 
 - `path`: Relative filepath to write the generated file to.
-- `auto`: Controls whether generation runs automatically on every load (defaults to `true`). Set to `false` to generate only when you run [`varlock codegen`](/reference/cli-commands/#codegen) explicitly — useful in a CI pipeline or a dedicated build step.
+- `auto`: Controls whether generation runs automatically on every load (defaults to `true`). Set to `false` to generate only when you run [`varlock codegen`](/reference/cli-commands/#codegen) explicitly, useful in a CI pipeline or a dedicated build step.
 - `executeWhenImported`: overrides the default of not executing when the containing file is imported (defaults to `false`).
 
 :::tip
@@ -471,14 +471,14 @@ Usually these decorators live in your primary `.env.schema` file, and are ignore
 <div>
 ### `@generateTsTypes()`
 
-TypeScript type declarations — makes `import { ENV } from 'varlock/env'` typed and augments `process.env` / `import.meta.env`. In addition to the [common code-generation args](#code-generation), it accepts:
+TypeScript type declarations. Makes `import { ENV } from 'varlock/env'` typed and augments `process.env` / `import.meta.env`. In addition to the [common code-generation args](#code-generation), it accepts:
 
 - `exposeEnv`: where the coerced `ENV` object lives (defaults to `global`).
-  - `global` — globally augment `varlock/env` so `import { ENV } from 'varlock/env'` is typed.
-  - `local` — export a package-local typed `ENV` from the generated file (with **no** global augmentation — `processEnv`/`importMetaEnv` default to `none` too, so nothing merges across packages). Use this in monorepos where multiple packages have different schemas. Requires a `.ts` output path (not `.d.ts` — it contains a runtime re-export), and you import from the generated file (e.g. `import { ENV } from './env'`).
-  - `none` — emit only the type definitions, no `ENV` binding.
-- `processEnv`: how `process.env` is typed — `strict`, `loose`, or `none` (defaults to `strict`; to `none` when `exposeEnv=local`, or when [`@disableProcessEnvInjection`](#disableprocessenvinjection) is set, since values aren't put on `process.env` then). Note that `@types/node` declares a base string index signature that can't be removed, so extra keys remain allowed on `process.env` regardless.
-- `importMetaEnv`: how `import.meta.env` is typed — `strict`, `loose`, or `none` (defaults to `strict`; to `none` when `exposeEnv=local`).
+  - `global`: globally augment `varlock/env` so `import { ENV } from 'varlock/env'` is typed.
+  - `local`: export a package-local typed `ENV` from the generated file (with **no** global augmentation, since `processEnv`/`importMetaEnv` default to `none` too, so nothing merges across packages). Use this in monorepos where multiple packages have different schemas. Requires a `.ts` output path (not `.d.ts`, since it contains a runtime re-export), and you import from the generated file (e.g. `import { ENV } from './env'`).
+  - `none`: emit only the type definitions, no `ENV` binding.
+- `processEnv`: how `process.env` is typed: `strict`, `loose`, or `none` (defaults to `strict`; to `none` when `exposeEnv=local`, or when [`@disableProcessEnvInjection`](#disableprocessenvinjection) is set, since values aren't put on `process.env` then). Note that `@types/node` declares a base string index signature that can't be removed, so extra keys remain allowed on `process.env` regardless.
+- `importMetaEnv`: how `import.meta.env` is typed: `strict`, `loose`, or `none` (defaults to `strict`; to `none` when `exposeEnv=local`).
 
 ```env-spec
 # @generateTsTypes(path=./env.d.ts)
@@ -490,7 +490,7 @@ TypeScript type declarations — makes `import { ENV } from 'varlock/env'` typed
 <div>
 ### `@generatePythonEnv()`
 
-A self-contained Python module — a coerced `Env` `TypedDict`, a `load_env()` that parses the injected env, and a `SENSITIVE_KEYS` constant. See [Python usage](/integrations/python/).
+A self-contained Python module: a coerced `Env` `TypedDict`, a `load_env()` that parses the injected env, and a `SENSITIVE_KEYS` constant. See [Python usage](/integrations/python/).
 
 ```env-spec
 # @generatePythonEnv(path=./env.py)
@@ -500,7 +500,7 @@ A self-contained Python module — a coerced `Env` `TypedDict`, a `load_env()` t
 <div>
 ### `@generateRustEnv()`
 
-A self-contained Rust module — a serde-derived `Env` struct, a `load()` function, and a `SENSITIVE_KEYS` constant. Requires the `serde` and `serde_json` crates. See [Rust usage](/integrations/rust/).
+A self-contained Rust module: a serde-derived `Env` struct, a `load()` function, and a `SENSITIVE_KEYS` constant. Requires the `serde` and `serde_json` crates. See [Rust usage](/integrations/rust/).
 
 ```env-spec
 # @generateRustEnv(path=./src/env.rs)
@@ -510,7 +510,7 @@ A self-contained Rust module — a serde-derived `Env` struct, a `load()` functi
 <div>
 ### `@generateGoEnv()`
 
-A self-contained Go package — an `Env` struct, a `Load()` function, and a `SensitiveKeys` map. See [Go usage](/integrations/go/).
+A self-contained Go package: an `Env` struct, a `Load()` function, and a `SensitiveKeys` map. See [Go usage](/integrations/go/).
 
 ```env-spec
 # @generateGoEnv(path=./env/env.go)
@@ -522,7 +522,7 @@ The package name defaults to the output directory (e.g. `path=env/env.go` → `p
 <div>
 ### `@generatePhpEnv()`
 
-A self-contained PHP class — a readonly `Env` with a static `load()` and a `SENSITIVE_KEYS` constant. Requires PHP 8.1+. See [PHP usage](/integrations/php/).
+A self-contained PHP class: a readonly `Env` with a static `load()` and a `SENSITIVE_KEYS` constant. Requires PHP 8.1+. See [PHP usage](/integrations/php/).
 
 ```env-spec
 # @generatePhpEnv(path=./Env.php)


### PR DESCRIPTION
A pass over all docs in `packages/varlock-website/src/content/docs/` to clean up the writing.

- Remove every em dash (588 across the docs), rewriting into plain sentences, commas, colons, or parens
- Pare back marketing/filler phrasing and tighten wordy sentences
- Keep all technical detail, flags, commands, code blocks, and links intact

61 doc files changed, prose only. Docs build passes.

Also adds a short "Documentation" writing-style section to `AGENTS.md` so these conventions stick going forward.