### PR TITLE
feat: add sensitive/non-sensitive filter flag to load command

### DIFF
--- a/.bumpy/load-sensitive-filter.md
+++ b/.bumpy/load-sensitive-filter.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+Add --sensitive / --non-sensitive flags to `varlock load` to filter output to only sensitive or non-sensitive items (e.g. `varlock load --format env --sensitive | fly secrets import`)

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -101,6 +101,8 @@ varlock load [options]
 - `--agent`:      Agent-safe mode: defaults to JSON output and redacts sensitive values. Not compatible with `--format env` or `--format shell`.
 - `--compact`:    Compact output (json-full: no indentation, env/shell: skip undefined values)
 - `--show-all`:   Shows all items, not just failing ones, when validation is failing
+- `--sensitive`:  Only include sensitive items in the output. Not compatible with `--non-sensitive`.
+- `--non-sensitive`: Only include non-sensitive items in the output. Not compatible with `--sensitive`.
 - [Common options](#common-options): `--env`, `--path` / `-p`, `--clear-cache`, `--skip-cache`
 
 **Examples:**
@@ -137,6 +139,9 @@ varlock load -p ./envs -p ./overrides
 
 # Agent-safe JSON output with sensitive values redacted
 varlock load --agent
+
+# Pipe only secrets to another tool (e.g. import into Fly.io)
+varlock load --format env --sensitive | fly secrets import
 ```
 
 **Exit codes:**

--- a/packages/varlock/src/cli/commands/load.command.ts
+++ b/packages/varlock/src/cli/commands/load.command.ts
@@ -34,6 +34,14 @@ export const commandSpec = define({
       type: 'boolean',
       description: 'When load is failing, show all items rather than only failing items',
     },
+    sensitive: {
+      type: 'boolean',
+      description: 'Only include sensitive items in the output',
+    },
+    'non-sensitive': {
+      type: 'boolean',
+      description: 'Only include non-sensitive items in the output',
+    },
     env: {
       type: 'string',
       description: 'Set the environment (e.g., production, development, etc) - will be overridden by @currentEnv in the schema if present',
@@ -77,6 +85,7 @@ Examples:
   varlock load --format json-full --summary-stderr   # JSON on stdout + redacted human summary on stderr
   varlock load --format json-full --summary-file /tmp/summary.txt   # JSON on stdout + redacted human summary written to file
   varlock load --agent            # Agent-safe JSON output with sensitive values redacted
+  varlock load --format env --sensitive | fly secrets import   # Pipe only secrets to another tool
 `.trim(),
 });
 
@@ -93,12 +102,16 @@ export function formatShellValue(value: string): string {
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   const {
     format, compact, 'show-all': showAll, 'summary-stderr': summaryStderr, 'summary-file': summaryFile, agent,
+    sensitive, 'non-sensitive': nonSensitive,
   } = ctx.values;
   // --agent defaults to json if no explicit --format was set, but respects --format if provided
   const outputFormat = agent && format === 'pretty' ? 'json' : format;
 
   if (agent && (outputFormat === 'env' || outputFormat === 'shell')) {
     throw new Error(`--agent is not compatible with --format ${outputFormat}`);
+  }
+  if (sensitive && nonSensitive) {
+    throw new Error('--sensitive and --non-sensitive are mutually exclusive');
   }
 
   const envGraph = await loadVarlockEnvGraph({
@@ -141,8 +154,14 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     }
   }
 
+  /** true if the item passes the --sensitive / --non-sensitive filter (no flag = everything passes) */
+  function matchesSensitiveFilter(key: string) {
+    if (!sensitive && !nonSensitive) return true;
+    return !!envGraph.configSchema[key]?.isSensitive === !!sensitive;
+  }
+
   if ((summaryStderr || summaryFile) && outputFormat !== 'pretty') {
-    const summaryLines = envGraph.sortedConfigKeys.map(
+    const summaryLines = envGraph.sortedConfigKeys.filter(matchesSensitiveFilter).map(
       (key) => getItemSummary(envGraph.configSchema[key]),
     );
     const summaryStr = `${summaryLines.join('\n')}\n`;
@@ -181,17 +200,24 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     }
     console.error(ansis.bold.green('-- Resolved config --'));
     for (const itemKey of envGraph.sortedConfigKeys) {
+      if (!matchesSensitiveFilter(itemKey)) continue;
       const item = envGraph.configSchema[itemKey];
       console.log(getItemSummary(item));
     }
   } else if (outputFormat === 'json') {
-    const env = agent ? getRedactedEnvObject() : envGraph.getResolvedEnvObject();
+    const fullEnv: Record<string, unknown> = agent ? getRedactedEnvObject() : envGraph.getResolvedEnvObject();
+    const env = Object.fromEntries(
+      Object.entries(fullEnv).filter(([key]) => matchesSensitiveFilter(key)),
+    );
     console.log(JSON.stringify(env, null, 2));
   } else if (outputFormat === 'json-full') {
     const indent = compact ? 0 : 2;
     // this is an inspection dump (not the injected blob), so include @internal items —
     // they're flagged with isInternal and redacted below like any other sensitive value
     const serialized = envGraph.getSerializedGraph({ includeInternal: true });
+    for (const key in serialized.config) {
+      if (!matchesSensitiveFilter(key)) delete serialized.config[key];
+    }
     if (agent) {
       for (const key in serialized.config) {
         const item = serialized.config[key];
@@ -214,6 +240,7 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     const prefix = outputFormat === 'shell' ? 'export ' : '';
 
     for (const key in resolvedEnv) {
+      if (!matchesSensitiveFilter(key)) continue;
       const value = resolvedEnv[key];
 
       if (value === undefined && skipUndefined) {

--- a/smoke-tests/tests/cli.test.ts
+++ b/smoke-tests/tests/cli.test.ts
@@ -116,6 +116,27 @@ describe('CLI Commands', () => {
     expect(() => JSON.parse(result.stdout)).not.toThrow();
   });
 
+  describe('--sensitive / --non-sensitive filters', () => {
+    test('--sensitive only outputs sensitive items', () => {
+      const result = runVarlock(['load', '--format', 'json', '--sensitive'], { cwd: 'smoke-test-basic' });
+      expect(result.exitCode).toBe(0);
+      const vars = JSON.parse(result.stdout);
+      expect(Object.keys(vars)).toEqual(['SECRET_TOKEN']);
+    });
+
+    test('--non-sensitive excludes sensitive items', () => {
+      const result = runVarlock(['load', '--format', 'env', '--non-sensitive'], { cwd: 'smoke-test-basic' });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('PUBLIC_VAR=');
+      expect(result.stdout).not.toContain('SECRET_TOKEN');
+    });
+
+    test('--sensitive and --non-sensitive together fails', () => {
+      const result = runVarlock(['load', '--sensitive', '--non-sensitive'], { cwd: 'smoke-test-basic' });
+      expect(result.exitCode).not.toBe(0);
+    });
+  });
+
   test('varlock load --format shell should output export statements', () => {
     const result = varlockLoad({ cwd: 'smoke-test-basic', format: 'shell' });
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
Adds the ability to filter `load` output by sensitive/non-sensitive variables. This allows easier automation with other tools like flyctl for Fly.io

`varlock load --format env --sensitive | fly secrets import`
