### PR TITLE
Add @excludeSensitiveFromInjectedEnv root setting

### DIFF
--- a/.bumpy/exclude-sensitive-from-injected-env.md
+++ b/.bumpy/exclude-sensitive-from-injected-env.md
@@ -1,0 +1,6 @@
+---
+"varlock": minor
+"@varlock/vite-integration": minor
+---
+
+new @excludeSensitiveFromInjectedEnv root setting keeps @sensitive values out of the SSR bundle injected by resolved-env mode; ENV falls back to runtime process.env for excluded items

--- a/framework-tests/frameworks/vite/files/schemas/.env.schema.exclude-sensitive
+++ b/framework-tests/frameworks/vite/files/schemas/.env.schema.exclude-sensitive
@@ -1,0 +1,14 @@
+# @defaultSensitive=false @defaultRequired=infer
+# @currentEnv=$APP_ENV
+# @excludeSensitiveFromInjectedEnv=true
+# ---
+
+# @type=enum(dev, prod)
+APP_ENV=dev
+
+PUBLIC_VAR=public-test-value
+API_URL=https://api.example.com
+ENV_SPECIFIC_VAR=env-specific-default
+
+# @sensitive
+SECRET_KEY=super-secret-value

--- a/framework-tests/frameworks/vite/vite-shared.ts
+++ b/framework-tests/frameworks/vite/vite-shared.ts
@@ -289,6 +289,33 @@ export function defineViteTests(
       });
     });
 
+    // ---- Exclude sensitive from injected env ----
+
+    describe('exclude sensitive from injected env', () => {
+      viteEnv.describeScenario('SSR build strips @sensitive values from the resolved-env blob', {
+        command: 'vite build --ssr src/ssr-entry.ts',
+        templateFiles: {
+          'vite.config.ts': 'vite-configs/vite.config.resolved-env.ts',
+          '.env.schema': 'schemas/.env.schema.exclude-sensitive',
+          'index.html': 'html/basic.html',
+          'src/ssr-entry.ts': 'pages/ssr-entry.ts',
+        },
+        expectSuccess: true,
+        fileAssertions: [
+          {
+            description: 'SSR output still carries the resolved env blob with public values',
+            fileGlob: 'dist/*.js',
+            shouldContain: ['__varlockLoadedEnv', 'public-test-value'],
+          },
+          {
+            description: 'sensitive value is stripped from the blob',
+            fileGlob: 'dist/*.js',
+            shouldNotContain: ['super-secret-value'],
+          },
+        ],
+      });
+    });
+
     // ---- Dev server ----
 
     describe('dev server', () => {

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -53,6 +53,8 @@ let lastErrorAt = 0;
 let configHookCalled = false;
 // one-time guard for the SvelteKit+Cloudflare auto-detection notice
 let cfDetectNoticeLogged = false;
+// one-time guard for the plaintext-sensitive-values-in-build-output notice
+let plaintextEnvNoticeLogged = false;
 let staticReplacements: Record<string, any> = {};
 let replacerFn: ReturnType<typeof createReplacerTransformFn>;
 
@@ -239,6 +241,21 @@ export function varlockVitePlugin(
           }
         }
         const excludeSensitive = varlockLoadedEnv?.settings?.excludeSensitiveFromInjectedEnv;
+
+        // warn once when @sensitive values will be embedded in plaintext in the build output
+        // (no encryption, no exclusion). Skipped in dev — the bundle isn't a deploy artifact there.
+        if (
+          !plaintextEnvNoticeLogged
+          && !encryptionKey
+          && !excludeSensitive
+          && !isDevCommand
+          && Object.values(varlockLoadedEnv?.config ?? {}).some(
+            (item) => item.isSensitive && typeof item.value === 'string' && item.value.length > 0,
+          )
+        ) {
+          plaintextEnvNoticeLogged = true;
+          console.warn('\x1b[36m🔒 [varlock] sensitive values are embedded in plaintext in the SSR build output. Encrypt the blob or set @excludeSensitiveFromInjectedEnv if the runtime provides them. See https://varlock.dev/integrations/vite/#encrypting-the-env-blob\x1b[0m');
+        }
 
         // strip @sensitive values from the blob when opted in, so they never land in the deploy
         // artifact. Skip in dev (the bundle isn't a deploy artifact and the values are needed

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -77,6 +77,32 @@ function resetStaticReplacements() {
 }
 
 
+/**
+ * Returns a shallow copy of the serialized env graph with plaintext values removed from every
+ * @sensitive item that has one, replaced by a `valueExcluded: true` flag. The runtime reads
+ * those keys from process.env instead (see initVarlockEnv in varlock/env). Never mutates the
+ * input: `varlockLoadedEnv` is exported and read by other consumers.
+ *
+ * This strip lives in the integration, not in `getSerializedGraph()`, because other
+ * serialization channels legitimately need the values: `varlock run` passes them to the child
+ * process env, varlock-wrangler uploads them as the runtime `__VARLOCK_ENV` secret binding, and
+ * `load --format json-full` shows them for inspection. Only this bundle-embedded copy, which
+ * lands in the deploy artifact, must not carry sensitive values.
+ */
+function stripSensitiveValues(graph: SerializedEnvGraph): SerializedEnvGraph {
+  const strippedConfig: SerializedEnvGraph['config'] = {};
+  for (const itemKey in graph.config) {
+    const item = graph.config[itemKey];
+    if (item.isSensitive && item.value !== undefined) {
+      // drop the value (JSON.stringify omits the undefined key from the blob) and flag it
+      strippedConfig[itemKey] = { ...item, value: undefined, valueExcluded: true };
+    } else {
+      strippedConfig[itemKey] = item;
+    }
+  }
+  return { ...graph, config: strippedConfig };
+}
+
 let loadCount = 0;
 let activeIntegrationTelemetry = {
   name: __VARLOCK_INTEGRATION_NAME__,
@@ -212,12 +238,21 @@ export function varlockVitePlugin(
             );
           }
         }
-        const serialized = JSON.stringify(varlockLoadedEnv);
+        const excludeSensitive = varlockLoadedEnv?.settings?.excludeSensitiveFromInjectedEnv;
+
+        // strip @sensitive values from the blob when opted in, so they never land in the deploy
+        // artifact. Skip in dev (the bundle isn't a deploy artifact and the values are needed
+        // in-process, mirroring how the encryption path also special-cases dev). Strip before
+        // encrypting so the serialized string is computed once from the possibly-stripped graph.
+        const envForBlob = excludeSensitive && !isDevCommand
+          ? stripSensitiveValues(varlockLoadedEnv)
+          : varlockLoadedEnv;
+        const serialized = JSON.stringify(envForBlob);
         if (encryptionKey) {
           const encrypted = encryptEnvBlobSync(serialized, encryptionKey);
           lines.push(`globalThis.__varlockEncryptedEnv = ${JSON.stringify(encrypted)};`);
         } else {
-          lines.push(`globalThis.__varlockLoadedEnv = ${JSON.stringify(varlockLoadedEnv)};`);
+          lines.push(`globalThis.__varlockLoadedEnv = ${serialized};`);
         }
       }
 

--- a/packages/varlock-website/src/content/docs/guides/encrypted-deployments.mdx
+++ b/packages/varlock-website/src/content/docs/guides/encrypted-deployments.mdx
@@ -9,6 +9,8 @@ When deploying SSR applications to **serverless platforms** (like Vercel, Netlif
 
 By default, this blob is **plaintext JSON**. Since it only appears in server-side code, it's generally safe: your secrets are not exposed to the client. However, encrypting the blob adds protection against secrets leaking via **sourcemaps** that may be uploaded to error tracking services.
 
+If the runtime platform already supplies the sensitive values (platform env vars, Cloudflare bindings, or the `varlock-wrangler` secret binding), you can leave them out of the build output entirely with [`@excludeSensitiveFromInjectedEnv`](/reference/root-decorators/#excludesensitivefrominjectedenv) instead. `ENV` falls back to `process.env` for the excluded items, and there is no key to manage.
+
 ## Enabling encryption
 
 Add the [`@encryptInjectedEnv`](/reference/root-decorators/#encryptinjectedenv) root decorator to your `.env.schema`:

--- a/packages/varlock-website/src/content/docs/integrations/vite.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/vite.mdx
@@ -247,6 +247,10 @@ All non-sensitive items are bundled at build time via `ENV`, while `import.meta.
 When using `ssrInjectMode: 'resolved-env'`, Varlock injects the fully resolved env data into your SSR build output. By default, this blob is plaintext JSON, meaning anyone with access to the build artifact can read your secrets. You can encrypt it for extra protection (e.g., against sourcemap leaks). See the [encrypted deployments guide](/guides/encrypted-deployments/) for setup instructions.
 :::
 
+:::note[Excluding sensitive values]
+If your runtime supplies sensitive values itself (platform env vars, Cloudflare bindings, or the `varlock-wrangler` secret binding), set the [`@excludeSensitiveFromInjectedEnv`](/reference/root-decorators/#excludesensitivefrominjectedenv) root decorator to keep them out of the build output entirely. For each excluded item, `ENV` falls back to `process.env` at runtime. Dev mode is unaffected: values stay embedded so the dev server has them in-process.
+:::
+
 ---
 
 ## Reference

--- a/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
+++ b/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
@@ -396,6 +396,28 @@ SECRET_KEY= # @sensitive
 </div>
 
 <div>
+### `@excludeSensitiveFromInjectedEnv`
+**Value type:** `boolean`
+
+Keeps `@sensitive` values out of the env blob that the [Vite integration](/integrations/vite/) injects into server-side build output in `ssrInjectMode: 'resolved-env'`. When enabled, each sensitive item is written to the blob without its value, and `ENV` falls back to `process.env` at runtime.
+
+Use this when the runtime platform supplies the sensitive values itself: platform env vars, Cloudflare bindings, or the `varlock-wrangler` `__VARLOCK_ENV` secret binding, which overrides the embedded blob at runtime anyway. The values are then never stored in the deploy artifact. This is an alternative to [`@encryptInjectedEnv`](#encryptinjectedenv) and needs no key management.
+
+**Options:**
+- `false` (default): Sensitive values are injected into the blob
+- `true`: Sensitive values are stripped from the blob; the runtime reads them from `process.env`
+- `forEnv(...)`: Conditionally enable based on the current environment
+
+```env-spec
+# @excludeSensitiveFromInjectedEnv
+# ---
+SECRET_KEY= # @sensitive
+```
+
+Dev mode is unaffected: values stay embedded so the dev server has them in-process. Non-sensitive values are always kept in the blob.
+</div>
+
+<div>
 ### `@disableProcessEnvInjection`
 **Value type:** `boolean`
 

--- a/packages/varlock/src/env-graph/lib/decorators.ts
+++ b/packages/varlock/src/env-graph/lib/decorators.ts
@@ -358,6 +358,9 @@ export const builtInRootDecorators: Array<RootDecoratorDef<any>> = [
     name: 'encryptInjectedEnv',
   },
   {
+    name: 'excludeSensitiveFromInjectedEnv',
+  },
+  {
     name: 'disableProcessEnvInjection',
     // static-only: code generation reads this flag (it controls whether process.env is typed as
     // populated), so an env-dependent value like forEnv(...) would make generated output differ

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -58,6 +58,7 @@ export type SerializedEnvGraph = {
     redactLogs?: boolean;
     preventLeaks?: boolean;
     encryptInjectedEnv?: boolean;
+    excludeSensitiveFromInjectedEnv?: boolean;
     disableProcessEnvInjection?: boolean;
   },
   config: Record<string, {
@@ -67,6 +68,8 @@ export type SerializedEnvGraph = {
     preventLeaks?: boolean;
     /** true = used only by varlock, not injected into the app. Only present in inspection output (never in the blob). */
     isInternal?: boolean;
+    /** true = value stripped from the bundle-embedded blob (via @excludeSensitiveFromInjectedEnv); the runtime reads it from process.env. Only set by the Vite resolved-env injection, never by getSerializedGraph. */
+    valueExcluded?: boolean;
   }>;
   /** provenance metadata for process.env overrides across nested invocations */
   __varlockOverrideMeta?: OverrideProvenanceMetadata;
@@ -596,6 +599,7 @@ export class EnvGraph {
     await this.getRootDec('redactLogs')?.resolve();
     await this.getRootDec('preventLeaks')?.resolve();
     await this.getRootDec('encryptInjectedEnv')?.resolve();
+    await this.getRootDec('excludeSensitiveFromInjectedEnv')?.resolve();
     await this.getRootDec('disableProcessEnvInjection')?.resolve();
   }
 
@@ -800,6 +804,7 @@ export class EnvGraph {
     serializedGraph.settings.redactLogs = this.getRootDec('redactLogs')?.resolvedValue ?? true;
     serializedGraph.settings.preventLeaks = this.getRootDec('preventLeaks')?.resolvedValue ?? true;
     serializedGraph.settings.encryptInjectedEnv = this.getRootDec('encryptInjectedEnv')?.resolvedValue ?? false;
+    serializedGraph.settings.excludeSensitiveFromInjectedEnv = this.getRootDec('excludeSensitiveFromInjectedEnv')?.resolvedValue ?? false;
     serializedGraph.settings.disableProcessEnvInjection = this.getRootDec('disableProcessEnvInjection')?.resolvedValue ?? false;
 
     // collect all errors into a single nested object

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -364,7 +364,16 @@ export function initVarlockEnv(opts?: {
   }
 
   for (const itemKey in serializedEnvData.config) {
-    const itemValue = serializedEnvData.config[itemKey].value;
+    const item = serializedEnvData.config[itemKey];
+    // Items stripped from the blob via @excludeSensitiveFromInjectedEnv carry no value — the
+    // runtime platform provides it (platform env, Cloudflare binding, etc). Read it from
+    // process.env and leave process.env untouched, so we never clobber that value with ''
+    // and never register the key for injection cleanup on reload.
+    if (item.valueExcluded) {
+      envValues[itemKey] = processExists ? process.env[itemKey] : undefined;
+      continue;
+    }
+    const itemValue = item.value;
     envValues[itemKey] = itemValue;
     if (setProcessEnv) {
       envState.injectedProcessEnvKeys?.push(itemKey);

--- a/packages/varlock/src/runtime/test/env-state.test.ts
+++ b/packages/varlock/src/runtime/test/env-state.test.ts
@@ -13,7 +13,7 @@ import {
 const ENV_STATE_KEY = '__varlockEnvState';
 const REDACTION_STATE_KEY = '__varlockRedactionState';
 
-const TEST_KEYS = ['EST_FOO', 'EST_BAR'];
+const TEST_KEYS = ['EST_FOO', 'EST_BAR', 'EST_EXCLUDED', 'EST_SECRET'];
 
 function makeEnvBlob(config: Record<string, string | undefined>) {
   return JSON.stringify({
@@ -21,6 +21,24 @@ function makeEnvBlob(config: Record<string, string | undefined>) {
     settings: {},
     config: Object.fromEntries(
       Object.entries(config).map(([key, value]) => [key, { value, isSensitive: false }]),
+    ),
+  });
+}
+
+type ConfigItemInput = { value?: any, isSensitive?: boolean, valueExcluded?: boolean };
+function makeConfigBlob(config: Record<string, ConfigItemInput>) {
+  return JSON.stringify({
+    sources: [],
+    settings: {},
+    config: Object.fromEntries(
+      Object.entries(config).map(([key, item]) => [
+        key, {
+          isSensitive: item.isSensitive ?? false,
+          // omit `value` entirely for excluded items — the runtime reads it from process.env
+          ...('value' in item ? { value: item.value } : {}),
+          ...(item.valueExcluded ? { valueExcluded: true } : {}),
+        },
+      ]),
     ),
   });
 }
@@ -95,5 +113,41 @@ describe('env state shared across module copies', () => {
     expect(() => envModule.initVarlockEnv()).toThrow(/still encrypted/);
     // and env should not be marked initialized
     expect(() => (envModule.ENV as any).ANYTHING).toThrow(/not initialized/);
+  });
+});
+
+describe('excluded sensitive values fall back to process.env', () => {
+  it('reads the platform-provided process.env value and does not clobber it', async () => {
+    process.env.EST_EXCLUDED = 'from-platform';
+    process.env.__VARLOCK_ENV = makeConfigBlob({
+      EST_EXCLUDED: { isSensitive: true, valueExcluded: true },
+    });
+    const copy = await importFreshEnvModuleCopy();
+    copy.initVarlockEnv();
+    expect((copy.ENV as any).EST_EXCLUDED).toBe('from-platform');
+    // the platform-provided value must survive init, not be overwritten with ''
+    expect(process.env.EST_EXCLUDED).toBe('from-platform');
+  });
+
+  it('yields undefined when process.env has no value for the excluded key', async () => {
+    delete process.env.EST_EXCLUDED;
+    process.env.__VARLOCK_ENV = makeConfigBlob({
+      EST_EXCLUDED: { isSensitive: true, valueExcluded: true },
+    });
+    const copy = await importFreshEnvModuleCopy();
+    copy.initVarlockEnv();
+    expect((copy.ENV as any).EST_EXCLUDED).toBeUndefined();
+    // must not materialize the key as an empty string in process.env
+    expect('EST_EXCLUDED' in process.env).toBe(false);
+  });
+
+  it('a normal sensitive item with a value is still injected as before', async () => {
+    process.env.__VARLOCK_ENV = makeConfigBlob({
+      EST_SECRET: { isSensitive: true, value: 'real-secret' },
+    });
+    const copy = await importFreshEnvModuleCopy();
+    copy.initVarlockEnv();
+    expect((copy.ENV as any).EST_SECRET).toBe('real-secret');
+    expect(process.env.EST_SECRET).toBe('real-secret');
   });
 });


### PR DESCRIPTION
## What

New root setting `@excludeSensitiveFromInjectedEnv`. When enabled, the vite integration's `resolved-env` inject mode writes `@sensitive` items into the bundle-embedded blob without their values, flagged `valueExcluded: true`, and `initVarlockEnv()` falls back to `process.env` for those keys. The fallback also leaves `process.env` untouched for excluded items, so a platform-provided runtime value is never clobbered with `''`. Dev mode keeps values embedded (the dev bundle is not a deploy artifact, mirroring how the encryption path special-cases dev), and the setting composes with `@encryptInjectedEnv` (strip first, then encrypt).

The strip lives in the integration rather than `getSerializedGraph()` because other serialization channels legitimately need the values (`varlock run` child env, the varlock-wrangler secret binding, `load --format json-full` inspection). Only the bundle-embedded copy must not carry them.

A separate commit adds a one-time notice when a production `resolved-env` build embeds unencrypted sensitive values. Easy to drop if unwanted.

## Why

The resolved-env blob is plaintext in the deploy artifact (the vite docs call this out). When the runtime already supplies sensitive values (platform env, Cloudflare bindings, or the varlock-wrangler `__VARLOCK_ENV` secret binding that overrides the embedded blob at runtime anyway), the embedded plaintext values have no consumer and are pure at-rest exposure. On Cloudflare, worker script contents are API-readable and archived per version, unlike the write-only secret bindings varlock-wrangler uses.

Resolves #876

New tests: runtime env-state tests for the `process.env` fallback and no-clobber behavior, and a vite framework-test scenario asserting the sensitive value is absent from SSR output while public values and the blob remain. Docs updated (vite integration, root decorators reference, encrypted deployments guide).
