### PR TITLE
allowMissing for Infisical

### DIFF
--- a/.bumpy/infisical-allow-missing.md
+++ b/.bumpy/infisical-allow-missing.md
@@ -1,0 +1,5 @@
+---
+"@varlock/infisical-plugin": minor
+---
+
+Add allowMissing flag to infisical() and @initInfisical() for optional secrets

--- a/bun.lock
+++ b/bun.lock
@@ -314,6 +314,7 @@
         "@env-spec/utils": "workspace:^",
         "@infisical/sdk": "^5.0.2",
         "@types/node": "catalog:",
+        "outdent": "catalog:",
         "tsup": "catalog:",
         "varlock": "workspace:^",
         "vitest": "catalog:",

--- a/packages/plugins/infisical/README.md
+++ b/packages/plugins/infisical/README.md
@@ -14,6 +14,7 @@ Load secrets from [Infisical](https://infisical.com/) into your Varlock configur
 - ✅ Secret paths and hierarchical organization
 - ✅ Filter secrets by tag
 - ✅ Multiple plugin instances for different projects/environments
+- ✅ **`allowMissing`** option for optional secrets
 - ✅ Helpful error messages with resolution tips
 
 ## Installation
@@ -93,6 +94,7 @@ See the [OIDC Workload Identity guide](https://varlock.dev/guides/oidc/) for ful
 - **`siteUrl`** (optional): Custom Infisical instance URL (defaults to `https://app.infisical.com`)
 - **`secretPath`** (optional): Default secret path for all secrets (defaults to `/`)
 - **`cacheTtl`** (optional): Cache resolved values for the specified duration (`"5m"`, `"1h"`, `"1d"`, or `"forever"` to cache until manually cleared); set to `false` (or an empty string) to disable caching
+- **`allowMissing`** (optional): When `true`, missing secrets return `undefined` instead of throwing. Can be a dynamic value (e.g., `allowMissing=forEnv(development)`). Other errors (auth failures, permission errors, etc.) still throw.
 - **`id`** (optional): Instance identifier for using multiple instances
 
 ## Usage
@@ -114,6 +116,24 @@ STRIPE_SECRET=infisical("STRIPE_SECRET_KEY")
 ```
 
 When called without arguments, `infisical()` automatically uses the config item key as the secret name in Infisical. This provides a convenient convention-over-configuration approach.
+
+### Optional secrets
+
+Use `allowMissing=true` on `infisical()` to return `undefined` when a secret doesn't exist in Infisical, then combine with `fallback()` to provide a default value:
+
+```env-spec
+# If present in Infisical, use it; if missing, fall back to undefined or a default
+RESEND_API_KEY=fallback(infisical(allowMissing=true), undefined)
+SOME_OPTIONAL_KEY=fallback(infisical(allowMissing=true), "")
+```
+
+You can also set `allowMissing` on `@initInfisical()` to apply it to all `infisical()` calls for that instance. It can be a dynamic value, e.g. `forEnv(development)` to only allow missing secrets in dev:
+
+```env-spec
+# @initInfisical(projectId=my-project, environment=dev, clientId=$ID, clientSecret=$SECRET, allowMissing=forEnv(development))
+```
+
+When `allowMissing` is enabled, mark optional items with `@required=false` or wrap the resolver with `fallback()` so validation does not fail.
 
 ### Using Secret Paths
 
@@ -217,6 +237,7 @@ Root decorator to initialize an Infisical plugin instance.
 - `siteUrl?: string` - Custom Infisical instance URL
 - `secretPath?: string` - Default secret path
 - `cacheTtl?: string | number` - Cache resolved values for the provided TTL
+- `allowMissing?: boolean` - When `true`, all `infisical()` calls for this instance return `undefined` instead of throwing when the secret is not found. Can be a dynamic value (e.g., `allowMissing=forEnv(development)`). Other errors still throw.
 - `id?: string` - Instance identifier (static)
 
 ### `infisical()`
@@ -229,8 +250,13 @@ Resolver function to fetch secret values.
 - `infisical(secretName, secretPath)` - Fetch with custom path from default instance
 - `infisical(instanceId, secretName)` - Fetch from named instance
 - `infisical(instanceId, secretName, secretPath)` - Full form with named instance
+- `infisical(secretName, allowMissing=true)` - Return `undefined` if the secret is not found
+- `infisical(instanceId, secretName, allowMissing=true)` - Same, with a specific instance
 
-**Returns:** The secret value as a string
+**Named args:**
+- `allowMissing?: boolean` - When `true`, returns `undefined` instead of throwing if the secret is not found. Can be a dynamic value (e.g., `allowMissing=forEnv(development)`). Useful when combined with `fallback()` to provide a default value. Other errors (auth failures, permission errors, etc.) still throw.
+
+**Returns:** The secret value as a string, or `undefined` when `allowMissing` is enabled and the secret is missing
 
 **Note:** When called without arguments, the config item key is automatically used as the secret name in Infisical. For example, `DATABASE_URL=infisical()` will fetch a secret named `DATABASE_URL` from Infisical.
 

--- a/packages/plugins/infisical/package.json
+++ b/packages/plugins/infisical/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
+    "build:test": "tsup --config tsup.test.config.ts",
     "test": "vitest",
     "typecheck": "tsc --noEmit"
   },
@@ -48,6 +49,7 @@
     "@infisical/sdk": "^5.0.2",
     "@env-spec/utils": "workspace:^",
     "@types/node": "catalog:",
+    "outdent": "catalog:",
     "tsup": "catalog:",
     "varlock": "workspace:^",
     "vitest": "catalog:"

--- a/packages/plugins/infisical/src/plugin.ts
+++ b/packages/plugins/infisical/src/plugin.ts
@@ -45,6 +45,8 @@ class InfisicalPluginInstance {
   private oidcToken?: string;
   /** Optional default secret path */
   private secretPath?: string;
+  /** If true, missing secrets return undefined instead of throwing */
+  allowMissing?: boolean;
   /** optional cache TTL - when set, resolved values are cached */
   cacheTtl?: string | number;
 
@@ -71,6 +73,7 @@ class InfisicalPluginInstance {
     secretPath?: string,
     identityId?: any,
     oidcToken?: any,
+    allowMissing?: boolean,
   ) {
     if (projectId && typeof projectId === 'string') this.projectId = projectId;
     if (environment && typeof environment === 'string') this.environment = environment;
@@ -80,6 +83,7 @@ class InfisicalPluginInstance {
     if (oidcToken && typeof oidcToken === 'string') this.oidcToken = oidcToken;
     if (siteUrl && typeof siteUrl === 'string') this.siteUrl = siteUrl;
     this.secretPath = secretPath;
+    if (allowMissing !== undefined) this.allowMissing = allowMissing;
     debug('infisical instance', this.id, 'set auth - projectId:', projectId, 'environment:', environment, 'hasIdentityId:', !!identityId);
   }
 
@@ -311,6 +315,19 @@ class InfisicalPluginInstance {
 
 const pluginInstances: Record<string, InfisicalPluginInstance> = {};
 
+/** Returns true if the error represents a missing Infisical secret */
+function isNotFoundError(err: any): boolean {
+  if (err instanceof ResolutionError) {
+    const msg = err.message || '';
+    return msg.includes('not found') || msg.includes('NotFound');
+  }
+  const errorMsg = err?.message || String(err);
+  const statusCode = err?.statusCode || err?.response?.status;
+  return statusCode === 404
+    || errorMsg.includes('not found')
+    || errorMsg.includes('NotFound');
+}
+
 plugin.registerRootDecorator({
   name: 'initInfisical',
   description: 'Initialize an Infisical plugin instance for infisical() resolver',
@@ -370,6 +387,7 @@ plugin.registerRootDecorator({
     return {
       id,
       cacheTtlResolver: objArgs.cacheTtl,
+      allowMissingResolver: objArgs.allowMissing,
       siteUrlResolver: objArgs.siteUrl,
       secretPath,
       projectIdResolver: objArgs.projectId,
@@ -383,6 +401,7 @@ plugin.registerRootDecorator({
   async execute({
     id,
     cacheTtlResolver,
+    allowMissingResolver,
     siteUrlResolver,
     secretPath,
     projectIdResolver,
@@ -401,6 +420,7 @@ plugin.registerRootDecorator({
     const identityId = await identityIdResolver?.resolve();
     const oidcToken = await oidcTokenResolver?.resolve();
     const siteUrl = await siteUrlResolver?.resolve();
+    const allowMissing = await allowMissingResolver?.resolve();
 
     pluginInstances[id].setAuth(
       projectId,
@@ -411,6 +431,7 @@ plugin.registerRootDecorator({
       secretPath,
       identityId,
       oidcToken,
+      allowMissing as boolean | undefined,
     );
     const cacheTtl = await resolveCacheTtl(cacheTtlResolver);
     if (cacheTtl !== undefined) {
@@ -451,7 +472,7 @@ plugin.registerResolverFunction({
   label: 'Fetch secret value from Infisical',
   icon: INFISICAL_ICON,
   argsSchema: {
-    type: 'array',
+    type: 'mixed',
     arrayMinLength: 0,
   },
   process() {
@@ -526,12 +547,14 @@ plugin.registerResolverFunction({
       }
     }
 
+    const allowMissingResolver = this.objArgs?.allowMissing;
+
     return {
-      instanceId, itemKey, secretNameResolver, secretPathResolver,
+      instanceId, itemKey, secretNameResolver, secretPathResolver, allowMissingResolver,
     };
   },
   async resolve({
-    instanceId, itemKey, secretNameResolver, secretPathResolver,
+    instanceId, itemKey, secretNameResolver, secretPathResolver, allowMissingResolver,
   }) {
     const selectedInstance = pluginInstances[instanceId];
 
@@ -558,17 +581,30 @@ plugin.registerResolverFunction({
       secretPath = resolvedPath;
     }
 
+    const allowMissing = allowMissingResolver ? !!(await allowMissingResolver.resolve()) : undefined;
+    const shouldAllowMissing = allowMissing ?? selectedInstance.allowMissing;
+
+    const fetchSecret = async () => {
+      try {
+        return await selectedInstance.getSecret(secretName, secretPath);
+      } catch (err) {
+        if (shouldAllowMissing && isNotFoundError(err)) {
+          return undefined;
+        }
+        throw err;
+      }
+    };
+
     if (selectedInstance.cacheTtl !== undefined && pluginCache) {
       const cacheKey = `infisical:${instanceId}:${selectedInstance.cacheKeyIdentity}:${secretPath || ''}:${secretName}`;
       return await pluginCache.getOrSet(
         cacheKey,
         selectedInstance.cacheTtl,
-        async () => await selectedInstance.getSecret(secretName, secretPath),
+        fetchSecret,
       );
     }
 
-    const secretValue = await selectedInstance.getSecret(secretName, secretPath);
-    return secretValue;
+    return await fetchSecret();
   },
 });
 

--- a/packages/plugins/infisical/test/infisical.test.ts
+++ b/packages/plugins/infisical/test/infisical.test.ts
@@ -1,0 +1,199 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import {
+  afterAll, beforeAll, describe, test,
+} from 'vitest';
+import outdent from 'outdent';
+import { pluginTest } from 'varlock/test-helpers';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SDK_TEST_PLUGIN_PATH = path.join(__dirname, '..', 'dist-test');
+const SDK_TEST_PLUGIN_CJS = path.join(SDK_TEST_PLUGIN_PATH, 'plugin.cjs');
+
+const sdkMockState = {
+  secrets: {} as Record<string, string>,
+  secretErrors: {} as Record<string, any>,
+  listSecrets: [] as Array<{ secretKey: string; secretValue: string }>,
+};
+
+function resetSdkMockState() {
+  sdkMockState.secrets = {};
+  sdkMockState.secretErrors = {};
+  sdkMockState.listSecrets = [];
+}
+
+const mockSdkClient = {
+  auth: () => ({
+    universalAuth: {
+      login: async () => undefined,
+    },
+    accessToken: () => undefined,
+  }),
+  secrets: () => ({
+    async getSecret(opts: { secretName: string }) {
+      const { secretName } = opts;
+      if (sdkMockState.secretErrors[secretName]) {
+        throw sdkMockState.secretErrors[secretName];
+      }
+      if (!(secretName in sdkMockState.secrets)) {
+        const err = new Error('Secret not found');
+        (err as any).statusCode = 404;
+        throw err;
+      }
+      return { secretValue: sdkMockState.secrets[secretName] };
+    },
+    async listSecretsWithImports() {
+      return sdkMockState.listSecrets;
+    },
+  }),
+};
+
+const mockSdkExports = {
+  InfisicalSDK: class {
+    auth() {
+      return mockSdkClient.auth();
+    }
+
+    secrets() {
+      return mockSdkClient.secrets();
+    }
+  },
+};
+
+beforeAll(() => {
+  fs.writeFileSync(
+    path.join(SDK_TEST_PLUGIN_PATH, 'package.json'),
+    JSON.stringify({ exports: { './plugin': './plugin.cjs' } }),
+  );
+
+  const testRequire = createRequire(SDK_TEST_PLUGIN_CJS);
+  const sdkResolvedPath = testRequire.resolve('@infisical/sdk');
+  testRequire.cache[sdkResolvedPath] = {
+    id: sdkResolvedPath,
+    filename: sdkResolvedPath,
+    loaded: true,
+    exports: mockSdkExports,
+    children: [],
+    paths: [],
+    path: path.dirname(sdkResolvedPath),
+  } as any;
+});
+
+afterAll(() => {
+  try {
+    fs.unlinkSync(path.join(SDK_TEST_PLUGIN_PATH, 'package.json'));
+  } catch { /* may not exist */ }
+});
+
+type InfisicalTestOpts = {
+  mockSecrets?: Record<string, string>;
+  mockSecretErrors?: Record<string, any>;
+  schema?: string;
+  initParams?: string;
+  fullSchema?: string;
+} & Omit<Parameters<typeof pluginTest>[0], 'schema'>;
+
+function infisicalTest(opts: InfisicalTestOpts) {
+  const {
+    mockSecrets = {},
+    mockSecretErrors = {},
+    schema,
+    initParams = '',
+    fullSchema: fullSchemaOverride,
+    ...rest
+  } = opts;
+
+  return async () => {
+    sdkMockState.secrets = mockSecrets;
+    sdkMockState.secretErrors = mockSecretErrors;
+
+    const initLine = `# @initInfisical(projectId=test-project, environment=dev, clientId=$INFISICAL_CLIENT_ID, clientSecret=$INFISICAL_CLIENT_SECRET${initParams ? `, ${initParams}` : ''})`;
+
+    const fullSchema = fullSchemaOverride ?? outdent`
+      # @plugin(${SDK_TEST_PLUGIN_PATH})
+      ${initLine}
+      # ---
+      # @type=infisicalClientId
+      INFISICAL_CLIENT_ID=
+      # @type=infisicalClientSecret @sensitive @internal
+      INFISICAL_CLIENT_SECRET=
+      ${schema}
+    `;
+
+    try {
+      await pluginTest({
+        ...rest,
+        schema: fullSchema,
+        injectValues: {
+          INFISICAL_CLIENT_ID: 'test-client-id',
+          INFISICAL_CLIENT_SECRET: 'test-client-secret',
+          ...rest.injectValues,
+        },
+      })();
+    } finally {
+      resetSdkMockState();
+    }
+  };
+}
+
+describe('infisical plugin', () => {
+  test('resolves an existing secret', infisicalTest({
+    mockSecrets: { API_KEY: 'secret-value' },
+    schema: 'API_KEY=infisical("API_KEY")',
+    expectValues: { API_KEY: 'secret-value' },
+  }));
+
+  test('throws when a secret is missing', infisicalTest({
+    mockSecrets: { API_KEY: 'secret-value' },
+    schema: outdent`
+      API_KEY=infisical("API_KEY")
+      MISSING=infisical("MISSING")
+    `,
+    expectValues: {
+      API_KEY: 'secret-value',
+      MISSING: Error,
+    },
+  }));
+
+  test('returns undefined for missing secrets when allowMissing is set per call', infisicalTest({
+    mockSecrets: { API_KEY: 'secret-value' },
+    schema: outdent`
+      API_KEY=infisical("API_KEY")
+      # @required=false
+      MISSING=infisical("MISSING", allowMissing=true)
+    `,
+    expectValues: {
+      API_KEY: 'secret-value',
+      MISSING: undefined,
+    },
+  }));
+
+  test('returns undefined for missing secrets when allowMissing is set on init', infisicalTest({
+    mockSecrets: { API_KEY: 'secret-value' },
+    initParams: 'allowMissing=true',
+    schema: outdent`
+      API_KEY=infisical("API_KEY")
+      # @required=false
+      MISSING=infisical("MISSING")
+    `,
+    expectValues: {
+      API_KEY: 'secret-value',
+      MISSING: undefined,
+    },
+  }));
+
+  test('still throws auth errors when allowMissing is enabled', infisicalTest({
+    mockSecretErrors: {
+      API_KEY: Object.assign(new Error('Unauthorized'), { statusCode: 401 }),
+    },
+    schema: outdent`
+      # @required=false
+      API_KEY=infisical("API_KEY", allowMissing=true)
+    `,
+    expectValues: {
+      API_KEY: Error,
+    },
+  }));
+});

--- a/packages/plugins/infisical/tsup.test.config.ts
+++ b/packages/plugins/infisical/tsup.test.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup';
+
+/**
+ * Test-only build config — identical to production except `@infisical/sdk`
+ * is external so tests can mock it via `require.cache`.
+ */
+export default defineConfig({
+  entry: ['src/plugin.ts'],
+  dts: false,
+  sourcemap: true,
+  treeshake: true,
+  clean: false,
+  outDir: 'dist-test',
+  format: ['cjs'],
+  splitting: false,
+  target: 'esnext',
+  external: ['varlock', '@infisical/sdk'],
+});

--- a/packages/plugins/infisical/vitest.config.ts
+++ b/packages/plugins/infisical/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    conditions: ['ts-src'],
+  },
+  define: {
+    __VARLOCK_BUILD_TYPE__: JSON.stringify('test'),
+    __VARLOCK_SEA_BUILD__: 'false',
+  },
+});

--- a/packages/varlock-website/src/content/docs/plugins/infisical.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/infisical.mdx
@@ -25,6 +25,7 @@ The plugin uses machine identities with Universal Auth or [OIDC workload identit
 - **Filter by tag** to load only matching secrets
 - **Multiple plugin instances** for different projects/environments
 - **Auto-infer secret names** from variable names for convenience
+- **`allowMissing`** option for optional secrets
 - **Helpful error messages** with resolution tips
 
 ## Installation and setup
@@ -179,6 +180,23 @@ STRIPE_SECRET=infisical("STRIPE_SECRET_KEY")
 
 When called without arguments, `infisical()` uses the config item key as the secret name in Infisical.
 
+### Optional secrets
+
+Use `allowMissing=true` on `infisical()` to return `undefined` when a secret doesn't exist in Infisical, then combine with `fallback()` to provide a default value:
+
+```env-spec title=".env.schema"
+RESEND_API_KEY=fallback(infisical(allowMissing=true), undefined)
+SOME_OPTIONAL_KEY=fallback(infisical(allowMissing=true), "")
+```
+
+You can also set `allowMissing` on `@initInfisical()` to apply it to all `infisical()` calls for that instance. It can be a dynamic value, e.g. `forEnv(development)` to only allow missing secrets in dev:
+
+```env-spec title=".env.schema"
+# @initInfisical(projectId=my-project, environment=dev, clientId=$ID, clientSecret=$SECRET, allowMissing=forEnv(development))
+```
+
+When `allowMissing` is enabled, mark optional items with `@required=false` or wrap the resolver with `fallback()` so validation does not fail.
+
 ### Using secret paths
 
 Organize secrets with hierarchical paths:
@@ -257,6 +275,7 @@ Initialize an Infisical plugin instance for accessing secrets.
 - `oidcToken` (optional): Explicit OIDC JWT token (auto-detected from platform if omitted)
 - `secretPath` (optional): Default secret path for all secrets (defaults to `/`)
 - `cacheTtl` (optional): cache resolved values for the specified duration (e.g. `"5m"`, `"1h"`, `"1d"`, or `forever` to cache until manually cleared). For cache mode behavior and CLI cache controls, see the [Caching guide](/guides/caching/).
+- `allowMissing` (optional): if `true`, missing secrets return `undefined` instead of throwing. Can be a dynamic value (e.g. `allowMissing=forEnv(development)`). Other errors (auth failures, permission errors, etc.) still throw.
 - `id` (optional): Instance identifier for multiple instances
 
 ```env-spec "@initInfisical"
@@ -317,6 +336,9 @@ Fetch a secret from Infisical.
 - `secretName` (optional): secret name in Infisical. If omitted, uses the variable name.
 - `secretPath` (optional): path to the secret (overrides default path)
 
+**Key/value args:**
+- `allowMissing` (optional): if `true`, returns `undefined` instead of throwing when the secret is not found. Can be a dynamic value (e.g. `allowMissing=forEnv(development)`). Useful with `fallback()` to provide a default value. Other errors still throw.
+
 ```env-spec /infisical\\(.*\\)/
 # Auto-infer secret name from variable
 DATABASE_URL=infisical()
@@ -332,6 +354,9 @@ DEV_SECRET=infisical(dev, "DATABASE_URL")
 
 # Full form
 PROD_SECRET=infisical(prod, "DATABASE_URL", "/production")
+
+# Optional secret with fallback
+RESEND_API_KEY=fallback(infisical(allowMissing=true), undefined)
 ```
 </div>
 
@@ -427,6 +452,7 @@ EU_DATABASE=infisical(eu, "DATABASE_URL")
 - Check the secret name matches exactly (including case)
 - Verify the secret path is correct if using paths
 - Ensure your machine identity has access to the secret
+- If the secret is genuinely optional, set `allowMissing=true` on `infisical()` or `@initInfisical()` and use `@required=false` or `fallback()`
 
 ### Access denied
 - Check that your machine identity has been granted access to the project and environment


### PR DESCRIPTION
## Summary

Adds `allowMissing` to `@varlock/infisical-plugin`, matching the behavior already shipped for 1Password in #586.

Closes #875.

When `allowMissing` is truthy, Infisical 404 / not-found errors resolve to `undefined` instead of throwing. That makes optional Infisical-backed secrets work with Varlock's normal composition tools (`fallback()`, `@required=false`, `forEnv()`, etc.). Auth failures, permission errors, and other non-not-found errors still throw.

- **`infisical(allowMissing=true)`** — per-call override
- **`@initInfisical(allowMissing=...)`** — instance-level default (supports dynamic values like `forEnv(development)`)
- Per-call `allowMissing` overrides the instance default

## Example

```env-spec
# @initInfisical(
#   projectId=$INFISICAL_PROJECT_ID,
#   environment=dev,
#   clientId=$INFISICAL_CLIENT_ID,
#   clientSecret=$INFISICAL_CLIENT_SECRET
# )
# ---

# Optional provider secret: use Infisical when present, otherwise undefined
RESEND_API_KEY=fallback(infisical(allowMissing=true), undefined)