### PR TITLE
fix: handle FIFO env sources (1Password Environments) across integrations

### DIFF
--- a/.bumpy/nextjs-fifo-env-sources.md
+++ b/.bumpy/nextjs-fifo-env-sources.md
@@ -1,0 +1,5 @@
+---
+"@varlock/nextjs-integration": patch
+---
+
+Detect FIFO/non-regular env sources (e.g. 1Password Environments) and disable watching and reload checks for them, fixing dev-server hangs and repeated reload logs

--- a/.bumpy/vite-fifo-env-sources.md
+++ b/.bumpy/vite-fifo-env-sources.md
@@ -1,0 +1,5 @@
+---
+"@varlock/vite-integration": patch
+---
+
+Detect FIFO/non-regular env sources (e.g. 1Password Environments) and skip registering them for dev-server restart watching, with a one-time notice

--- a/.bumpy/wrangler-fifo-and-mtime-guard.md
+++ b/.bumpy/wrangler-fifo-and-mtime-guard.md
@@ -1,0 +1,5 @@
+---
+"@varlock/cloudflare-integration": patch
+---
+
+varlock-wrangler dev: skip watching FIFO/non-regular env sources (fixes endless no-op reload logs), and ignore spurious watch events where file mtime is unchanged

--- a/.bumpy/write-back-non-regular-guard.md
+++ b/.bumpy/write-back-non-regular-guard.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Refuse to write back encrypted values to non-regular source files (FIFO/pipe) with a clear error instead of blocking

--- a/packages/integrations/cloudflare/src/varlock-wrangler.ts
+++ b/packages/integrations/cloudflare/src/varlock-wrangler.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 import {
-  writeFileSync, unlinkSync, watch, existsSync,
+  writeFileSync, unlinkSync, watch, existsSync, statSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -643,7 +643,32 @@ async function handleDev(args: Array<string>) {
       if (!source.enabled || !source.path) continue;
       const fullPath = join(loaded.graph.basePath, source.path);
       try {
-        const w = watch(fullPath, () => scheduleRestart(fullPath));
+        // Sources that are not regular files (e.g. a FIFO served by 1Password
+        // Environments) cannot be watched: their stat churns whenever they are
+        // read, and each reload re-reads every source, so watching one creates
+        // an endless reload loop. Live reload is disabled for those sources.
+        const initialStat = statSync(fullPath);
+        if (!initialStat.isFile()) {
+          console.log(`ℹ️ [varlock-wrangler] ${source.path} is not a regular file (FIFO/pipe), live reload is disabled for it`);
+          continue;
+        }
+        let lastMtimeMs = initialStat.mtimeMs;
+        const w = watch(fullPath, () => {
+          // macOS fs.watch emits spurious change events when another local tool
+          // merely opens/inspects the file (issue #845). A real save always
+          // updates mtime, so ignore events where mtime is unchanged.
+          try {
+            const currentMtimeMs = statSync(fullPath).mtimeMs;
+            if (currentMtimeMs === lastMtimeMs) {
+              debug('dev: ignoring watch event with unchanged mtime', fullPath);
+              return;
+            }
+            lastMtimeMs = currentMtimeMs;
+          } catch {
+            // file may have been deleted/renamed — treat as a change
+          }
+          scheduleRestart(fullPath);
+        });
         watchers.push(w);
         debug('dev: watching', fullPath);
       } catch {

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -93,9 +93,40 @@ function debugHash(hash: string | undefined) {
   return hash.slice(0, 10);
 }
 
+// Env sources may not be regular files — e.g. 1Password Environments serves
+// `.env` as a FIFO (named pipe) that `op` re-serves on every read. Reading such
+// a file from our reload machinery makes the serving process write to the pipe
+// again, which fires a new fs event, which triggers another reload check...
+// an endless loop of reloads/logs. So these files must never be read, watched,
+// or written to outside of the actual `varlock load` call.
+function isExistingNonRegularFile(filePath: string): boolean {
+  try {
+    return !fs.statSync(filePath).isFile();
+  } catch {
+    return false; // missing files are handled as "missing" by callers
+  }
+}
+
+// deduped via env var because Next.js loads duplicate copies of this module
+// (and spawns worker processes that would each log the same notice)
+const WARNED_NON_REGULAR_ENV_KEY = '__VARLOCK_NEXT_WARNED_NON_REGULAR_FILES';
+function warnNonRegularSourceOnce(filePath: string) {
+  const warnedList = (process.env[WARNED_NON_REGULAR_ENV_KEY] || '').split(',');
+  if (warnedList.includes(filePath)) return;
+  process.env[WARNED_NON_REGULAR_ENV_KEY] = [...warnedList.filter(Boolean), filePath].join(',');
+  const displayPath = rootDir ? (path.relative(rootDir, filePath) || filePath) : filePath;
+  logUserInfo(`ℹ️ [varlock] ${displayPath} is not a regular file (FIFO/pipe), live reload is disabled for it`);
+}
+
 function readFileHash(filePath: string): string | undefined {
   try {
     if (!fs.existsSync(filePath)) return undefined;
+    if (isExistingNonRegularFile(filePath)) {
+      // treat as opaque + constant — content is generated on read, so hashing it
+      // is meaningless and the read itself would re-trigger fs events
+      warnNonRegularSourceOnce(filePath);
+      return '(non-regular-file)';
+    }
     const contents = fs.readFileSync(filePath, 'utf-8');
     const hash = createHash('sha256');
     hash.update(contents, 'utf8');
@@ -135,6 +166,13 @@ function computeSourceStateHash(sources: SerializedEnvGraph['sources'], basePath
 const NEXT_WATCHED_ENV_FILES = ['.env', '.env.local', '.env.development', '.env.development.local'];
 const watchedExtraFiles = new Set<string>();
 const pendingReloadFiles = new Set<string>();
+
+// Next's own env watcher fires on FIFO mtime churn (every read/serve of the
+// pipe updates it), so "change detected" events for those files carry no signal
+function nextWatchedEnvFilesIncludeNonRegular(): boolean {
+  if (!rootDir) return false;
+  return NEXT_WATCHED_ENV_FILES.some((f) => isExistingNonRegularFile(path.join(rootDir!, f)));
+}
 
 // Exactly one process should own the extra-file watchers. Which process calls
 // loadEnvConfig varies by Next version: on next <= 15 the router server loads
@@ -185,9 +223,13 @@ function enableExtraFileWatchers(sources: SerializedEnvGraph['sources'], basePat
   for (const source of sources) {
     if (!source.enabled || !source.path) continue;
     const absPath = basePath ? path.resolve(basePath, source.path) : path.resolve(rootDir!, source.path);
-    if (!nextWatchedAbsolute.has(absPath) && !watchedExtraFiles.has(absPath)) {
-      extraFilePaths.push(absPath);
+    if (nextWatchedAbsolute.has(absPath) || watchedExtraFiles.has(absPath)) continue;
+    if (isExistingNonRegularFile(absPath)) {
+      // watching a FIFO/pipe is meaningless (stat churns on every read/serve)
+      warnNonRegularSourceOnce(absPath);
+      continue;
     }
+    extraFilePaths.push(absPath);
   }
   // Also always watch .env.schema even if it wasn't in sources (it may not exist yet)
   const envSchemaPath = path.join(rootDir!, '.env.schema');
@@ -198,17 +240,34 @@ function enableExtraFileWatchers(sources: SerializedEnvGraph['sources'], basePat
   if (!extraFilePaths.length) return;
 
   // Find a Next-watched file to touch as the reload trigger.
-  // Prefer an existing file (cheaper), otherwise we'll create+destroy .env
+  // Prefer an existing regular file (cheaper) — a FIFO/pipe must never be
+  // written to (it would block and interfere with whatever serves it).
+  // Otherwise we'll create+destroy the first watched name that doesn't exist.
   let triggerFilePath: string | null = null;
+  let mustDestroyTriggerFile = false;
   for (const envFileName of NEXT_WATCHED_ENV_FILES) {
     const filePath = path.join(rootDir!, envFileName);
-    if (fs.existsSync(filePath)) {
+    if (fs.existsSync(filePath) && !isExistingNonRegularFile(filePath)) {
       triggerFilePath = filePath;
       break;
     }
   }
-  const mustDestroyTriggerFile = !triggerFilePath;
-  triggerFilePath ||= path.join(rootDir!, '.env');
+  if (!triggerFilePath) {
+    for (const envFileName of NEXT_WATCHED_ENV_FILES) {
+      const filePath = path.join(rootDir!, envFileName);
+      if (!fs.existsSync(filePath)) {
+        triggerFilePath = filePath;
+        mustDestroyTriggerFile = true;
+        break;
+      }
+    }
+  }
+  if (!triggerFilePath) {
+    // all Next-watched env files exist but none are regular files — nothing we
+    // can safely touch to trigger a reload, so skip installing watchers
+    debug('no usable reload trigger file, skipping extra file watchers');
+    return;
+  }
 
   const pendingWatchChanges = new Set<string>();
   const watchedFileHashes = new Map<string, string | undefined>();
@@ -397,7 +456,9 @@ function replaceProcessEnv(sourceEnv: Env) {
   Object.keys(process.env).forEach((key) => {
     // Allow mutating internal Next.js env variables after the server has initiated.
     // This is necessary for dynamic things like the IPC server port.
-    if (!key.startsWith('__NEXT_PRIVATE')) {
+    // Also preserve varlock's own control flags (watcher ownership, dedupe markers)
+    // which are set after the initialEnv snapshot was taken.
+    if (!key.startsWith('__NEXT_PRIVATE') && !key.startsWith('__VARLOCK_NEXT_')) {
       if (sourceEnv[key] === undefined || sourceEnv[key] === '') {
         delete process.env[key];
       }
@@ -496,7 +557,12 @@ export function loadEnvConfig(
     if (currentSourceStateHash && currentSourceStateHash === lastLoadedSourceStateHash) {
       useCachedEnv = true;
       if (loadCount >= 2 && effectiveReloadSummary) {
-        if (Date.now() >= suppressSkipLogUntil) {
+        if (!reloadSummary && nextWatchedEnvFilesIncludeNonRegular()) {
+          // event came from Next's own watcher (not one of our tracked files) and
+          // a natively-watched env file is a FIFO — it's just churn from the pipe
+          // being read, not a user edit
+          debug('suppressing skip log for non-regular file watch churn');
+        } else if (Date.now() >= suppressSkipLogUntil) {
           logUserInfo(`ℹ️ [varlock] change detected in ${effectiveReloadSummary}; file contents unchanged, skipping reload.`);
         } else {
           debug('suppressing immediate follow-up skip log');
@@ -551,14 +617,17 @@ export function loadEnvConfig(
         version: __VARLOCK_INTEGRATION_VERSION__,
       },
     });
+    // The load itself reads every source file — for FIFO-backed sources (e.g.
+    // 1Password Environments) that read makes the pipe get re-served, firing
+    // new fs events. Suppress the "unchanged, skipping" log those immediate
+    // follow-up events would produce.
+    suppressSkipLogUntil = Date.now() + 1200;
     if (loadCount >= 2 && forceReload) {
       const envChanged = stdout !== previousSerializedEnv;
       if (effectiveReloadSummary) {
         if (envChanged) {
-          suppressSkipLogUntil = Date.now() + 1200;
           logUserInfo(`✅ [varlock] change detected in ${effectiveReloadSummary}; reloaded env, changes found.`);
         } else {
-          suppressSkipLogUntil = Date.now() + 1200;
           logUserInfo(`✅ [varlock] change detected in ${effectiveReloadSummary}; reloaded env, no changes found.`);
         }
       }

--- a/packages/integrations/nextjs/test/fifo-sources.test.ts
+++ b/packages/integrations/nextjs/test/fifo-sources.test.ts
@@ -1,0 +1,157 @@
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import * as realFs from 'node:fs';
+
+const {
+  mockExecSyncVarlock,
+  mockWatchFile,
+  mockUnwatchFile,
+  readFileSyncSpy,
+} = vi.hoisted(() => ({
+  mockExecSyncVarlock: vi.fn(),
+  mockWatchFile: vi.fn(),
+  mockUnwatchFile: vi.fn(),
+  readFileSyncSpy: vi.fn(),
+}));
+
+vi.mock('varlock/exec-sync-varlock', () => ({
+  execSyncVarlock: mockExecSyncVarlock,
+  VarlockExecError: class VarlockExecError extends Error {},
+}));
+
+vi.mock('varlock/env', () => ({
+  initVarlockEnv: vi.fn(),
+  resetRedactionMap: vi.fn(),
+}));
+
+vi.mock('varlock/patch-console', () => ({
+  patchGlobalConsole: vi.fn(),
+}));
+
+// next-env-compat uses `import * as fs from 'fs'`. We mock watchFile/unwatchFile
+// and spy on readFileSync — reading a FIFO with no writer blocks forever, so the
+// spy returns fake content for FIFO paths instead of delegating (a correct
+// implementation never reads them; the assertion below is what actually matters).
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  const readFileSync = (...args: Array<any>) => {
+    readFileSyncSpy(...args);
+    const filePath = args[0];
+    if (typeof filePath === 'string' && actual.existsSync(filePath) && !actual.statSync(filePath).isFile()) {
+      return 'FAKE_FIFO_CONTENT=1\n';
+    }
+    return (actual.readFileSync as any)(...args);
+  };
+  return {
+    ...actual,
+    readFileSync,
+    watchFile: mockWatchFile,
+    unwatchFile: mockUnwatchFile,
+    default: {
+      ...actual,
+      readFileSync,
+      watchFile: mockWatchFile,
+      unwatchFile: mockUnwatchFile,
+    },
+  };
+});
+
+function readFileSyncCallsFor(filePath: string) {
+  return readFileSyncSpy.mock.calls.filter((call) => call[0] === filePath);
+}
+
+describe.skipIf(process.platform === 'win32')('FIFO env sources (e.g. 1Password Environments)', () => {
+  let tmpDir: string;
+  let fifoEnvPath: string; // .env — a name Next.js natively watches
+  let fifoExtraPath: string; // .env.custom — a name varlock would extra-watch
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.__VARLOCK_ENV;
+    delete process.env.__VARLOCK_NEXT_ENV_WATCHER_PID;
+    delete process.env.__VARLOCK_NEXT_WARNED_NON_REGULAR_FILES;
+    (globalThis as any).__VARLOCK_INTEGRATION_NAME__ = '@varlock/nextjs-integration';
+    (globalThis as any).__VARLOCK_INTEGRATION_VERSION__ = '0.0.0-test';
+
+    tmpDir = realFs.mkdtempSync(path.join(os.tmpdir(), 'varlock-next-fifo-'));
+    realFs.writeFileSync(path.join(tmpDir, '.env.schema'), '# ---\nFOO=bar\n');
+    fifoEnvPath = path.join(tmpDir, '.env');
+    fifoExtraPath = path.join(tmpDir, '.env.custom');
+    execSync(`mkfifo "${fifoEnvPath}" "${fifoExtraPath}"`);
+
+    mockExecSyncVarlock.mockReturnValue({
+      stdout: JSON.stringify({
+        basePath: tmpDir,
+        sources: [
+          {
+            enabled: true, path: '.env.schema', type: 'file', label: '.env.schema',
+          },
+          {
+            enabled: true, path: '.env', type: 'file', label: '.env',
+          },
+          {
+            enabled: true, path: '.env.custom', type: 'file', label: '.env.custom',
+          },
+        ],
+        settings: {},
+        config: { FOO: { value: 'bar', isSensitive: false } },
+      }),
+      stderr: '',
+    });
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    realFs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.__VARLOCK_ENV;
+    delete process.env.__VARLOCK_NEXT_ENV_WATCHER_PID;
+    delete process.env.__VARLOCK_NEXT_WARNED_NON_REGULAR_FILES;
+  });
+
+  it('never reads or watches FIFO sources during load and reload checks', async () => {
+    const { loadEnvConfig } = await import('../src/next-env-compat');
+
+    loadEnvConfig(tmpDir, true);
+
+    // regular extra file (.env.schema) gets watched, FIFO sources do not
+    const watchedPaths = mockWatchFile.mock.calls.map((call) => call[0] as string);
+    expect(watchedPaths).toContain(path.join(tmpDir, '.env.schema'));
+    expect(watchedPaths).not.toContain(fifoEnvPath);
+    expect(watchedPaths).not.toContain(fifoExtraPath);
+
+    // the source-state hashing must not have read the FIFOs
+    expect(readFileSyncCallsFor(fifoEnvPath)).toHaveLength(0);
+    expect(readFileSyncCallsFor(fifoExtraPath)).toHaveLength(0);
+
+    // simulate Next's own .env watcher firing (it always watches .env);
+    // the forceReload hash check must still not read the FIFOs
+    vi.useFakeTimers();
+    try {
+      vi.advanceTimersByTime(2000); // get past the 1s reload throttle
+      loadEnvConfig(tmpDir, true, console, true);
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(readFileSyncCallsFor(fifoEnvPath)).toHaveLength(0);
+    expect(readFileSyncCallsFor(fifoExtraPath)).toHaveLength(0);
+  });
+
+  it('logs a one-time notice that live reload is disabled for FIFO sources', async () => {
+    const { loadEnvConfig } = await import('../src/next-env-compat');
+
+    loadEnvConfig(tmpDir, true);
+    loadEnvConfig(tmpDir, true);
+
+    const fifoNoticeLogs = consoleLogSpy.mock.calls.filter(
+      (call: Array<any>) => String(call[0]).includes('.env.custom') && String(call[0]).includes('live reload is disabled'),
+    );
+    expect(fifoNoticeLogs).toHaveLength(1);
+  });
+});

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 
+import fs from 'node:fs';
 import path from 'node:path';
 import type { Plugin } from 'vite';
 import MagicString from 'magic-string';
@@ -76,6 +77,27 @@ function resetStaticReplacements() {
   });
 }
 
+
+// Env sources may not be regular files — e.g. 1Password Environments serves
+// `.env` as a FIFO (named pipe) that is re-served on every read. Watching such
+// a file is meaningless (its stat churns whenever it is read) and registering
+// it in `configFileDependencies` would make vite restart the dev server in a
+// loop, since each restart re-reads the pipe and fires new fs events.
+function isExistingNonRegularFile(filePath: string): boolean {
+  try {
+    return !fs.statSync(filePath).isFile();
+  } catch {
+    return false; // missing files keep their current handling
+  }
+}
+
+const warnedNonRegularSources = new Set<string>();
+function warnNonRegularSourceOnce(absPath: string, basePath?: string) {
+  if (warnedNonRegularSources.has(absPath)) return;
+  warnedNonRegularSources.add(absPath);
+  const displayPath = basePath ? (path.relative(basePath, absPath) || absPath) : absPath;
+  console.log(`ℹ️ [varlock] ${displayPath} is not a regular file (FIFO/pipe), live reload is disabled for it`);
+}
 
 let loadCount = 0;
 let activeIntegrationTelemetry = {
@@ -417,7 +439,12 @@ See https://varlock.dev/integrations/vite/ for more details.
       for (const varlockSource of varlockLoadedEnv.sources) {
         if (!varlockSource.enabled) continue;
         if (varlockLoadedEnv.basePath && varlockSource.path) {
-          config.configFileDependencies.push(path.resolve(varlockLoadedEnv.basePath, varlockSource.path));
+          const absPath = path.resolve(varlockLoadedEnv.basePath, varlockSource.path);
+          if (isExistingNonRegularFile(absPath)) {
+            warnNonRegularSourceOnce(absPath, varlockLoadedEnv.basePath);
+            continue;
+          }
+          config.configFileDependencies.push(absPath);
         }
       }
     },

--- a/packages/varlock/src/lib/local-encrypt/builtin-resolver.ts
+++ b/packages/varlock/src/lib/local-encrypt/builtin-resolver.ts
@@ -217,6 +217,11 @@ export const VarlockResolver: typeof Resolver = createResolver<VarlockResolverSt
               tip: 'varlock(prompt=1) can only persist values from file-backed sources. Use `varlock encrypt` to generate an encrypted value manually.',
             });
           }
+          if (writeBackResult.reason === 'non-regular-source-file') {
+            throw new ResolutionError(`Unable to persist encrypted value for ${itemKey}`, {
+              tip: `${sourceFilePath} is not a regular file (FIFO/pipe), so varlock cannot write back to it.`,
+            });
+          }
 
           throw new ResolutionError(`Unable to persist encrypted value for ${itemKey}`, {
             tip: `Could not find a writable \`${itemKey}=varlock(...)\` entry to update in ${sourceFilePath}.`,
@@ -251,6 +256,11 @@ export const VarlockResolver: typeof Resolver = createResolver<VarlockResolverSt
         if (writeBackResult.reason === 'missing-source-file') {
           throw new ResolutionError(`Unable to persist encrypted value for ${itemKey}`, {
             tip: 'varlock(prompt=1) can only persist values from file-backed sources. Use `varlock encrypt` to generate an encrypted value manually.',
+          });
+        }
+        if (writeBackResult.reason === 'non-regular-source-file') {
+          throw new ResolutionError(`Unable to persist encrypted value for ${itemKey}`, {
+            tip: `${sourceFilePath} is not a regular file (FIFO/pipe), so varlock cannot write back to it.`,
           });
         }
 

--- a/packages/varlock/src/lib/local-encrypt/write-back.test.ts
+++ b/packages/varlock/src/lib/local-encrypt/write-back.test.ts
@@ -1,0 +1,54 @@
+import {
+  describe, it, expect, beforeEach, afterEach,
+} from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync, spawn, type ChildProcess } from 'node:child_process';
+
+import { writeBackValue } from './write-back';
+
+describe('writeBackValue', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'varlock-write-back-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('updates a value in a regular file', () => {
+    const filePath = path.join(tmpDir, '.env');
+    fs.writeFileSync(filePath, 'FOO=bar\n');
+    const result = writeBackValue('FOO', 'varlock("local:xyz")', filePath);
+    expect(result).toEqual({ updated: true });
+    expect(fs.readFileSync(filePath, 'utf-8')).toContain('FOO=varlock("local:xyz")');
+  });
+
+  it('returns missing-source-file when path is undefined or missing', () => {
+    expect(writeBackValue('FOO', 'x', undefined)).toEqual({ updated: false, reason: 'missing-source-file' });
+    expect(writeBackValue('FOO', 'x', path.join(tmpDir, 'nope.env'))).toEqual({ updated: false, reason: 'missing-source-file' });
+  });
+
+  describe.skipIf(process.platform === 'win32')('non-regular source files', () => {
+    let fifoWriter: ChildProcess | undefined;
+
+    afterEach(() => {
+      fifoWriter?.kill('SIGKILL');
+      fifoWriter = undefined;
+    });
+
+    it('refuses to write back to a FIFO without reading it', () => {
+      const fifoPath = path.join(tmpDir, '.env');
+      execSync(`mkfifo "${fifoPath}"`);
+      // keep a one-shot writer attached so that if the stat guard ever regresses,
+      // readFileSync gets served content and the test fails cleanly (item-not-found)
+      // instead of blocking forever on an unserved pipe
+      fifoWriter = spawn('bash', ['-c', `printf 'OTHER=x\\n' > "${fifoPath}"`], { stdio: 'ignore' });
+
+      const result = writeBackValue('FOO', 'x', fifoPath);
+      expect(result).toEqual({ updated: false, reason: 'non-regular-source-file' });
+    });
+  });
+});

--- a/packages/varlock/src/lib/local-encrypt/write-back.ts
+++ b/packages/varlock/src/lib/local-encrypt/write-back.ts
@@ -7,7 +7,7 @@
 import fs from 'node:fs';
 import { parseEnvSpecDotEnvFile } from '@env-spec/parser';
 
-type WriteBackResult = { updated: boolean; reason?: 'missing-source-file' | 'item-not-found' };
+type WriteBackResult = { updated: boolean; reason?: 'missing-source-file' | 'non-regular-source-file' | 'item-not-found' };
 
 /**
  * Update a config item's value in a .env file using AST-based replacement.
@@ -18,6 +18,17 @@ export function writeBackValue(
   sourceFilePath: string | undefined,
 ): WriteBackResult {
   if (!sourceFilePath) {
+    return { updated: false, reason: 'missing-source-file' };
+  }
+
+  // A source that is not a regular file (e.g. a FIFO served by 1Password
+  // Environments) cannot be rewritten in place — reading it may block and
+  // writing to it would fight with whatever process is serving it.
+  try {
+    if (!fs.statSync(sourceFilePath).isFile()) {
+      return { updated: false, reason: 'non-regular-source-file' };
+    }
+  } catch {
     return { updated: false, reason: 'missing-source-file' };
   }
 


### PR DESCRIPTION
Env sources served as FIFOs/named pipes (e.g. 1Password Environments mounting `.env`) broke dev-server watching. Any read of the pipe makes the serving process rewrite it, which fires new fs events, which triggers another reload check that reads the pipe again. Depending on platform and integration this manifested as log spam, an endless reload loop, or a full hang.

The fix, applied consistently everywhere the reload machinery touches env source paths: detect non-regular files (`statSync().isFile()`) and never read, watch, or write them, logging a one-time notice that live reload is disabled for that file. Values from FIFO sources still load normally; a dev-server restart picks up changes (live reload of per-read-generated content is inherently impossible).

## Per package

- **nextjs**: `next dev` hung forever at startup on Linux (content-hash `readFileSync` of the FIFO livelocks, no EOF) and looped `change detected... skipping reload` logs on macOS. FIFO sources are now excluded from content hashing, extra-file watchers, and reload-trigger-file selection (writing to a pipe blocks). Also preserves `__VARLOCK_NEXT_*` control vars across env resets and demotes FIFO watch-churn skip-logs to debug.
- **cloudflare**: `varlock-wrangler dev` with a FIFO `.env` printed 70 no-op reload logs in 50s on macOS (self-sustaining from boot). FIFO sources are no longer watched. Also ignores watch events where mtime is unchanged, so other tools merely opening env files no longer cause no-op reload logs — closes #845.
- **vite**: FIFO sources are skipped when registering `configFileDependencies` (chokidar happened to ignore them silently; now it's explicit, with the notice). Covers astro/sveltekit/tanstack-start, which wrap this plugin.
- **varlock core**: `writeBackValue` (local-encrypt) stat-checks before reading and returns a clear `non-regular-source-file` error instead of potentially blocking on the pipe.

Supersedes #883: the `disableWatch` option proposed there only tore down varlock's extra `fs.watchFile` watchers, but the loop also runs through Next's own `.env` watcher plus varlock's content-hash reads, and required users to discover a config flag. Auto-detection fixes the root cause with no config. (The `replaceProcessEnv` control-var preservation from that PR is included here — thanks @mhornbacher.)

## Verification

Each integration was exercised end-to-end against a real FIFO `.env` (loop-served, mimicking 1Password) on both macOS and Linux (docker), baseline vs fixed, plus regular-file regression runs confirming live reload still works. Unit tests added for the nextjs watcher/hash behavior and core write-back guard.