### PR TITLE
Support "use cache" and other new directives

### DIFF
--- a/.bumpy/brave-red-goat.md
+++ b/.bumpy/brave-red-goat.md
@@ -2,4 +2,4 @@
 "@varlock/nextjs-integration": patch
 ---
 
-Add support for "use cache" "use workflow" "use memo" and "use no memo"
+Preserve all "use ..." directives (e.g. "use cache", "use cache: remote", "use workflow", "use memo") including stacked ones, instead of only a fixed set

--- a/.bumpy/brave-red-goat.md
+++ b/.bumpy/brave-red-goat.md
@@ -1,0 +1,5 @@
+---
+"@varlock/nextjs-integration": patch
+---
+
+Add support for "use cache" "use workflow" "use memo" and "use no memo"

--- a/packages/integrations/nextjs/src/loader.ts
+++ b/packages/integrations/nextjs/src/loader.ts
@@ -39,7 +39,7 @@ const MIDDLEWARE_FILE_RE = /(?:^|[\\/])middleware\.(?:ts|js|mts|mjs)$/;
 
 // match directive prologue ('use server', 'use client', etc.) + optional trailing semicolons/newlines
 // captures the directive block so we can inject code after it
-const DIRECTIVE_PROLOGUE_RE = /^((?:[^\S\n]*\/\/[^\n]*\n|[^\S\n]*\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/[^\S\n]*\n|[^\S\n]*\n)*[^\S\n]*['"]use (?:server|client|strict|cache)['"][^\S\n]*;?[^\S\n]*\n?)/;
+const DIRECTIVE_PROLOGUE_RE = /^((?:[^\S\n]*\/\/[^\n]*\n|[^\S\n]*\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/[^\S\n]*\n|[^\S\n]*\n)*[^\S\n]*['"]use (?:server|client|strict|cache|workflow|memo|no memo)['"][^\S\n]*;?[^\S\n]*\n?)/;
 
 // rough check for ES module syntax (a line starting with import/export) — used to decide
 // whether the injected init guard can use import statements instead of require()

--- a/packages/integrations/nextjs/src/loader.ts
+++ b/packages/integrations/nextjs/src/loader.ts
@@ -37,9 +37,19 @@ const USE_CLIENT_RE = /^(?:[^\S\n]*\/\/[^\n]*\n|[^\S\n]*\/\*[^*]*\*+(?:[^/*][^*]
 const EDGE_RUNTIME_RE = /export\s+const\s+runtime\s*=\s*['"](?:edge|experimental-edge)['"]/;
 const MIDDLEWARE_FILE_RE = /(?:^|[\\/])middleware\.(?:ts|js|mts|mjs)$/;
 
-// match directive prologue ('use server', 'use client', etc.) + optional trailing semicolons/newlines
-// captures the directive block so we can inject code after it
-const DIRECTIVE_PROLOGUE_RE = /^((?:[^\S\n]*\/\/[^\n]*\n|[^\S\n]*\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/[^\S\n]*\n|[^\S\n]*\n)*[^\S\n]*['"]use (?:server|client|strict|cache|workflow|memo|no memo)['"][^\S\n]*;?[^\S\n]*\n?)/;
+// match the directive prologue ('use server', 'use client', 'use cache: remote', etc.)
+// captures the whole block - including interleaved comments/blank lines and repeated
+// directives - so injected code lands after all of them. a directive that is not the
+// last thing in the prologue stops being a directive, so we must not inject between them.
+// any 'use ...' string is matched rather than an allowlist, so new framework directives
+// keep working. requiring end-of-line after the directive keeps us from matching a string
+// that continues into a larger expression (`'use x' + y`).
+// uses [^\S\n]* (horizontal whitespace) instead of \s* to avoid exponential backtracking
+const COMMENT_OR_BLANK_LINE_RE_STR = String.raw`[^\S\n]*\/\/[^\n]*\n|[^\S\n]*\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/[^\S\n]*\n|[^\S\n]*\n`;
+const DIRECTIVE_RE_STR = String.raw`[^\S\n]*['"]use [^'"\n]*['"][^\S\n]*;?[^\S\n]*(?:\n|$)`;
+const DIRECTIVE_PROLOGUE_RE = new RegExp(
+  String.raw`^((?:${COMMENT_OR_BLANK_LINE_RE_STR})*(?:(?:${DIRECTIVE_RE_STR})(?:${COMMENT_OR_BLANK_LINE_RE_STR})*)+)`,
+);
 
 // rough check for ES module syntax (a line starting with import/export) — used to decide
 // whether the injected init guard can use import statements instead of require()
@@ -136,7 +146,10 @@ function inlineEnvValues(source: string, filePath: string, envGraph: SerializedE
 function prependAfterDirectives(source: string, codeToPrepend: string): string {
   const match = source.match(DIRECTIVE_PROLOGUE_RE);
   if (match) {
-    return `${match[1] + codeToPrepend}\n${source.slice(match[1].length)}`;
+    // the last directive may end at EOF with no trailing newline, in which case the
+    // injected code would be glued onto it (`'use server'if(...)`)
+    const separator = match[1].endsWith('\n') ? '' : '\n';
+    return `${match[1] + separator + codeToPrepend}\n${source.slice(match[1].length)}`;
   }
   return `${codeToPrepend}\n${source}`;
 }

--- a/packages/integrations/nextjs/src/loader.ts
+++ b/packages/integrations/nextjs/src/loader.ts
@@ -39,7 +39,7 @@ const MIDDLEWARE_FILE_RE = /(?:^|[\\/])middleware\.(?:ts|js|mts|mjs)$/;
 
 // match directive prologue ('use server', 'use client', etc.) + optional trailing semicolons/newlines
 // captures the directive block so we can inject code after it
-const DIRECTIVE_PROLOGUE_RE = /^((?:[^\S\n]*\/\/[^\n]*\n|[^\S\n]*\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/[^\S\n]*\n|[^\S\n]*\n)*[^\S\n]*['"]use (?:server|client|strict)['"][^\S\n]*;?[^\S\n]*\n?)/;
+const DIRECTIVE_PROLOGUE_RE = /^((?:[^\S\n]*\/\/[^\n]*\n|[^\S\n]*\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/[^\S\n]*\n|[^\S\n]*\n)*[^\S\n]*['"]use (?:server|client|strict|cache)['"][^\S\n]*;?[^\S\n]*\n?)/;
 
 // rough check for ES module syntax (a line starting with import/export) — used to decide
 // whether the injected init guard can use import statements instead of require()

--- a/packages/integrations/nextjs/test/loader.test.ts
+++ b/packages/integrations/nextjs/test/loader.test.ts
@@ -1,3 +1,4 @@
+import { parse as babelParse } from '@babel/parser';
 import {
   describe, it, expect, beforeEach, vi,
 } from 'vitest';
@@ -150,6 +151,88 @@ describe('static ENV.x replacement (turbopack)', () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+});
+
+describe('directive prologue handling', () => {
+  const SOURCE_BODY = 'export function fn() { return 1; }';
+  // a server file so the init guard gets injected — that is what has to land
+  // after the directives rather than in the middle of them
+  const runServerLoader = (source: string) => runLoader(source, {
+    resourcePath: `${PROJECT_ROOT}/app/thing.ts`,
+    options: { bundler: 'turbopack', dev: false },
+  });
+
+  /** directives babel still recognizes as directives in the loader output */
+  function directivesOf(code: string) {
+    const ast = babelParse(code, { sourceType: 'unambiguous', plugins: ['typescript'] });
+    return ast.program.directives.map((d) => d.value.value);
+  }
+
+  it.each([
+    ['use server'],
+    ['use strict'],
+    ['use cache'],
+    ['use cache: remote'],
+    ['use cache: private'],
+    ['use workflow'],
+    ['use memo'],
+    ['use no memo'],
+    // no allowlist — directives that do not exist yet must survive too
+    ['use some-future-directive'],
+  ])('preserves \'%s\' and injects after it', (directive) => {
+    const result = runServerLoader(`'${directive}';\n${SOURCE_BODY}`);
+    expect(directivesOf(result)).toContain(directive);
+    expect(result).toContain('globalThis.__varlockBuildInit');
+  });
+
+  // client components get no init guard, so only the directive itself is checked
+  it('preserves \'use client\'', () => {
+    const result = runServerLoader(`'use client';\n${SOURCE_BODY}`);
+    expect(directivesOf(result)).toEqual(['use client']);
+  });
+
+  it('preserves stacked directives (never injects between them)', () => {
+    const result = runServerLoader(`'use strict';\n'use server';\n'use cache';\n${SOURCE_BODY}`);
+    expect(directivesOf(result)).toEqual(['use strict', 'use server', 'use cache']);
+  });
+
+  it('handles directives without trailing semicolons and with double quotes', () => {
+    const result = runServerLoader(`"use server"\n'use cache'\n${SOURCE_BODY}`);
+    expect(directivesOf(result)).toEqual(['use server', 'use cache']);
+  });
+
+  it('handles comments and blank lines around directives', () => {
+    const result = runServerLoader([
+      '// leading line comment',
+      '',
+      '/* block',
+      '   comment */',
+      "'use server';",
+      '// between directives',
+      '',
+      "'use cache';",
+      '',
+      SOURCE_BODY,
+    ].join('\n'));
+    expect(directivesOf(result)).toEqual(['use server', 'use cache']);
+  });
+
+  it('handles a file that is only a directive', () => {
+    const result = runServerLoader("'use server'");
+    expect(directivesOf(result)).toEqual(['use server']);
+  });
+
+  it('injects at the top when there is no directive', () => {
+    const result = runServerLoader(SOURCE_BODY);
+    expect(result.startsWith('if(!globalThis.__varlockBuildInit)')).toBe(true);
+  });
+
+  it('does not treat a leading string that continues an expression as a directive', () => {
+    // `'use x' + y` is one expression statement — injecting inside it would be a syntax error
+    const result = runServerLoader(`'use x' + globalThis.y;\n${SOURCE_BODY}`);
+    expect(() => directivesOf(result)).not.toThrow();
+    expect(result).toContain("'use x' + globalThis.y;");
   });
 });
 


### PR DESCRIPTION
The following directives should not break under varlock

- "use memo" (https://react.dev/reference/react-compiler/directives/use-memo)
- "use no memo" (https://react.dev/reference/react-compiler/directives/use-no-memo)
- "use cache" (https://nextjs.org/docs/app/api-reference/directives/use-cache)
- "use workflow" (https://vercel.com/workflows)

Rather than extending the allowlist, the directive prologue regex in the next.js loader now matches _any_ `'use ...'` string. This also covers `"use cache: remote"` / `"use cache: private"` and any directive frameworks add in the future, with no code change needed. A leading string is only treated as a directive if it ends the line, so a string that continues into a larger expression (`'use x' + y`) is left alone.

Two latent bugs turned up while adding tests for this, fixed here as well:

- Only the first directive was captured, so injected code landed _between_ stacked directives (`'use strict'; 'use server';`). A directive only counts if nothing but other directives precedes it, so the later ones were silently demoted to plain string expressions. The prologue now matches repeated directives, along with comments and blank lines between them.
- A directive at EOF with no trailing newline had the injected code glued onto it (`'use server'if(...)`), a syntax error.

Tests drive the real loader and use babel to assert the output parses and that each directive is still recognized as a directive.

Not addressed here: `USE_CLIENT_RE` has the same single-directive limitation, so `'use strict'; 'use client';` is not detected as a client component. That affects which files get the init guard and static inlining, so it's left for a separate PR.
