### PR TITLE
fix env spec expansion

### DIFF
--- a/.bumpy/fix-exec-expansion-nested-parens.md
+++ b/.bumpy/fix-exec-expansion-nested-parens.md
@@ -1,0 +1,5 @@
+---
+"@env-spec/parser": patch
+---
+
+Fix $(...) truncation on nested parentheses and dropped spaces before $VAR/${VAR} inside unquoted exec expansion

--- a/packages/env-spec-parser/README.md
+++ b/packages/env-spec-parser/README.md
@@ -177,6 +177,7 @@ Examples:
   - instead you can use the `fallback` function directly `VAR=fallback(ref(FOO), ref(BAR))`
 - we do not support _unescaped_ quotes within exec expansion (ex: `VAR="$(echo "foo")"`)
   - we support backtick quotes, escaped quotes, or you can use `exec` function directly `VAR=exec(echo "foo")`
+- `$(...)` expansion supports nested parentheses and quoted `)` (ex: `$(jq -r '.address|join(".")')`)
 ------------------
 
 ## Local dev and testing workflow

--- a/packages/env-spec-parser/src/classes.ts
+++ b/packages/env-spec-parser/src/classes.ts
@@ -20,15 +20,21 @@ export class ParsedEnvSpecStaticValue {
     rawValue: any;
     quote?: '"' | "'" | '`' | undefined;
     isImplicit?: boolean;
+    /** Keep leading/trailing spaces (used by expansion slices so `$VAR` splits do not drop adjacent whitespace). */
+    skipTrim?: boolean;
     _location?: any;
   }) {
     if (!data.quote) {
-      // unquoted strings will get trimmed (leading/trailing spaces)
+      // unquoted strings will get trimmed (leading/trailing spaces), unless skipTrim is set
       if (typeof data.rawValue === 'string') {
-        const trimmed = data.rawValue.trim();
-        // trimmed empty string without quotes gets treated as undefined
-        if (trimmed === '') this.value = undefined;
-        else this.value = autoCoerce(trimmed);
+        if (data.skipTrim) {
+          this.value = autoCoerce(data.rawValue);
+        } else {
+          const trimmed = data.rawValue.trim();
+          // trimmed empty string without quotes gets treated as undefined
+          if (trimmed === '') this.value = undefined;
+          else this.value = autoCoerce(trimmed);
+        }
       } else {
         this.value = autoCoerce(data.rawValue);
       }

--- a/packages/env-spec-parser/src/expand.ts
+++ b/packages/env-spec-parser/src/expand.ts
@@ -6,17 +6,99 @@ import {
 // const EXPAND_VAR_REGEX_WITH_SIMPLE = /\$({([a-zA-Z_][a-zA-Z0-9_.]*)}|([a-zA-Z_][a-zA-Z0-9_]*))/g;
 const EXPAND_VAR_BRACKETED_REGEX = /(?<!\\)\${([a-zA-Z_][a-zA-Z0-9_.]*)((:?-)([^}]+))?}/g;
 const EXPAND_VAR_SIMPLE_REGEX = /(?<!\\)\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
-const EXPAND_EXEC_REGEX = /\$\(([^)]+)\)/g;
+
+type ExecExpansionMatch = {
+  index: number;
+  0: string;
+  1: string;
+};
+
+/**
+ * Find `$(...)` expansions with balanced parentheses and quote awareness.
+ * Unlike `/\$\(([^)]+)\)/g`, this does not stop at the first `)`.
+ */
+function findExecExpansions(str: string): Array<ExecExpansionMatch> {
+  const results: Array<ExecExpansionMatch> = [];
+  let i = 0;
+  while (i < str.length) {
+    // unescaped `$(`
+    if (
+      str[i] === '$'
+      && str[i + 1] === '('
+      && (i === 0 || str[i - 1] !== '\\')
+    ) {
+      const start = i;
+      i += 2;
+      let depth = 1;
+      let inQuote: '"' | "'" | '`' | null = null;
+      let escaped = false;
+      const cmdStart = i;
+
+      while (i < str.length && depth > 0) {
+        const c = str[i];
+        if (escaped) {
+          escaped = false;
+          i++;
+          continue;
+        }
+        if (c === '\\' && inQuote !== "'") {
+          escaped = true;
+          i++;
+          continue;
+        }
+        if (inQuote) {
+          if (c === inQuote) inQuote = null;
+        } else if (c === '"' || c === "'" || c === '`') {
+          inQuote = c;
+        } else if (c === '(') {
+          depth++;
+        } else if (c === ')') {
+          depth--;
+        }
+        i++;
+      }
+
+      if (depth === 0) {
+        results.push({
+          index: start,
+          0: str.slice(start, i),
+          1: str.slice(cmdStart, i - 1),
+        });
+      }
+      continue;
+    }
+    i++;
+  }
+  return results;
+}
+
+/** Build a StaticValue from an expansion slice, preserving whitespace when unquoted. */
+function staticFromExpansionSlice(
+  text: string,
+  quote: '"' | "'" | '`' | undefined,
+): ParsedEnvSpecStaticValue {
+  if (quote) {
+    return new ParsedEnvSpecStaticValue({
+      rawValue: `${quote}${text}${quote}`,
+      quote,
+    });
+  }
+  // Unquoted grammar values trim whitespace. Expansion slices must keep
+  // spaces adjacent to $refs (e.g. `drill -Q $HOST`).
+  return new ParsedEnvSpecStaticValue({
+    rawValue: text,
+    skipTrim: true,
+  });
+}
 
 
 function expandExecs(staticVal: ParsedEnvSpecStaticValue, _opts?: {}) {
   if (typeof staticVal.value !== 'string') return staticVal;
   const quote = staticVal.data.quote;
-  const quoteStr = quote ?? '';
   // single quoted strings are not expanded!
   if (quote === "'") return staticVal;
 
-  const execMatches = Array.from(staticVal.value.matchAll(EXPAND_EXEC_REGEX));
+  const execMatches = findExecExpansions(staticVal.value);
 
   // if no matches - we just return the original value
   if (execMatches.length === 0) return staticVal;
@@ -29,7 +111,7 @@ function expandExecs(staticVal: ParsedEnvSpecStaticValue, _opts?: {}) {
     // extract text before exec -- ex: `pretext-$(exec command)`
     if (lastIndex < match.index) {
       const preText = staticVal.value.slice(lastIndex, match.index);
-      parts.push(new ParsedEnvSpecStaticValue({ rawValue: `${quoteStr}${preText}${quoteStr}`, quote }));
+      parts.push(staticFromExpansionSlice(preText, quote));
     }
 
     // extract exec command
@@ -37,7 +119,7 @@ function expandExecs(staticVal: ParsedEnvSpecStaticValue, _opts?: {}) {
     parts.push(new ParsedEnvSpecFunctionCall({
       name: 'exec',
       args: new ParsedEnvSpecFunctionArgs({
-        values: [new ParsedEnvSpecStaticValue({ rawValue: `${quoteStr}${shellCmd}${quoteStr}`, quote })],
+        values: [staticFromExpansionSlice(shellCmd, quote)],
       }),
     }));
     lastIndex = match.index + match[0].length;
@@ -45,7 +127,7 @@ function expandExecs(staticVal: ParsedEnvSpecStaticValue, _opts?: {}) {
   // extract any remaining text after the last exec
   if (lastIndex < staticVal.value.length) {
     const postText = staticVal.value.slice(lastIndex);
-    parts.push(new ParsedEnvSpecStaticValue({ rawValue: `${quoteStr}${postText}${quoteStr}`, quote }));
+    parts.push(staticFromExpansionSlice(postText, quote));
   }
 
   // if there's only one part, we can just return it (ex: `VAR=$(whoami)`)
@@ -62,7 +144,6 @@ function expandExecs(staticVal: ParsedEnvSpecStaticValue, _opts?: {}) {
 function expandRefs(staticVal: ParsedEnvSpecStaticValue, mode: 'simple' | 'bracketed') {
   if (typeof staticVal.value !== 'string') return staticVal;
   const quote = staticVal.data.quote;
-  const quoteStr = quote ?? '';
   if (quote === "'") return staticVal;
 
   const varMatches = Array.from(staticVal.value.matchAll(mode === 'simple' ? EXPAND_VAR_SIMPLE_REGEX : EXPAND_VAR_BRACKETED_REGEX));
@@ -74,7 +155,7 @@ function expandRefs(staticVal: ParsedEnvSpecStaticValue, mode: 'simple' | 'brack
     // extract text before exec
     if (lastIndex < match.index) {
       const preText = staticVal.value.slice(lastIndex, match.index);
-      parts.push(new ParsedEnvSpecStaticValue({ rawValue: `${quoteStr}${preText}${quoteStr}`, quote }));
+      parts.push(staticFromExpansionSlice(preText, quote));
     }
 
     // extract var
@@ -97,7 +178,7 @@ function expandRefs(staticVal: ParsedEnvSpecStaticValue, mode: 'simple' | 'brack
       parts.push(new ParsedEnvSpecFunctionCall({
         name: 'fallback',
         args: new ParsedEnvSpecFunctionArgs({
-          values: [refFnCall, new ParsedEnvSpecStaticValue({ rawValue: `${quoteStr}${defaultVal}${quoteStr}`, quote })],
+          values: [refFnCall, staticFromExpansionSlice(defaultVal, quote)],
         }),
       }));
     } else {
@@ -107,7 +188,7 @@ function expandRefs(staticVal: ParsedEnvSpecStaticValue, mode: 'simple' | 'brack
   }
   if (lastIndex < staticVal.value.length) {
     const postText = staticVal.value.slice(lastIndex);
-    parts.push(new ParsedEnvSpecStaticValue({ rawValue: `${quoteStr}${postText}${quoteStr}`, quote }));
+    parts.push(staticFromExpansionSlice(postText, quote));
   }
 
   // if only a single part, just return it (ex: `VAR=${OTHERVAR}`)

--- a/packages/env-spec-parser/src/simple-resolver.ts
+++ b/packages/env-spec-parser/src/simple-resolver.ts
@@ -44,9 +44,13 @@ export function simpleResolver(
         });
         return resolvedArgs.join('');
       } else if (valOrFn.name === 'exec') {
-        const args = valOrFn.simplifiedArgs;
-        if (Array.isArray(args)) {
-          const cmdStr = args[0];
+        const args = valOrFn.data.args.values;
+        if (
+          args.length === 1
+          && (args[0] instanceof ParsedEnvSpecStaticValue || args[0] instanceof ParsedEnvSpecFunctionCall)
+        ) {
+          const cmdStr = valueResolver(args[0]);
+          if (typeof cmdStr !== 'string') throw new Error('Invalid `exec` command');
           return execSync(
             cmdStr,
             {

--- a/packages/env-spec-parser/test/functions.test.ts
+++ b/packages/env-spec-parser/test/functions.test.ts
@@ -100,6 +100,35 @@ describe('exec expansion', functionValueTests({
     input: 'ITEM=$(echo "foo bar")',
     expected: { ITEM: 'foo bar' },
   },
+  'exec expansion with nested parentheses': {
+    input: "ITEM=$(printf %s 'foo(bar)')",
+    expected: { ITEM: 'foo(bar)' },
+  },
+  'exec expansion with paren inside quotes': {
+    input: 'ITEM=$(printf %s \'join(".")\')',
+    expected: { ITEM: 'join(".")' },
+  },
+  'exec expansion preserves space before simple ref': {
+    input: outdent`
+      HOST=localhost
+      ITEM=$(echo hello $HOST)
+    `,
+    expected: { ITEM: 'hello localhost' },
+  },
+  'exec expansion preserves space before bracketed ref': {
+    input: outdent`
+      HOST=localhost
+      ITEM=$(echo hello \${HOST})
+    `,
+    expected: { ITEM: 'hello localhost' },
+  },
+  'exec expansion preserves space before ref - quoted': {
+    input: outdent`
+      HOST=localhost
+      ITEM="$(echo hello $HOST)"
+    `,
+    expected: { ITEM: 'hello localhost' },
+  },
 }));
 
 describe('ref expansion', functionValueTests({


### PR DESCRIPTION
Root cause: Post-parse expansion in @env-spec/parser, not the grammar or exec runtime.

Changes:

- Nested parens — Replaced /\$\(([^)]+)\)/g with a quote-aware balanced-paren scanner in [expand.ts](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/packages/env-spec-parser/src/expand.ts)
- Space stripping — Added skipTrim on ParsedEnvSpecStaticValue and staticFromExpansionSlice() so ref splits keep adjacent whitespace
- Tests — Regression coverage for nested ), quoted ), and spaces before $HOST / ${HOST} (248 passing)
- Test harness — simpleResolver now resolves nested concat/ref inside exec args (matching real ExecResolver)