### PR TITLE
Include cascade-bumped dependents in PR preview releases

### DIFF
--- a/scripts/check-release-packages.ts
+++ b/scripts/check-release-packages.ts
@@ -50,11 +50,9 @@ if (bumpyStatusRaw) {
       const branchReleasePaths = branchReleases
         .map((r: any) => path.resolve(MONOREPO_ROOT, r.dir));
 
-      // Also include transitive workspace dependencies of bumped packages
-      // (so preview packages that reference each other have consistent versions)
       const workspaces = await listWorkspaces(MONOREPO_ROOT);
       const workspacesByName = new Map(workspaces.map((ws) => [ws.name, ws]));
-      const allReleasePaths = new Set(bumpyReleases.map((r: any) => path.resolve(MONOREPO_ROOT, r.dir)));
+      const allReleasePaths = new Set<string>(bumpyReleases.map((r: any) => path.resolve(MONOREPO_ROOT, r.dir)));
 
       function getWorkspaceDeps(pkgPath: string): Array<string> {
         const pkgJsonPath = path.join(pkgPath, 'package.json');
@@ -74,11 +72,30 @@ if (bumpyStatusRaw) {
         }
       }
 
-      const neededPackages = new Set<string>();
-      const queue = [...branchReleasePaths];
+      const neededPackages = new Set<string>(branchReleasePaths);
+
+      // Include cascade-bumped dependents — packages bumpy wants to release
+      // because a package bumped in this branch is in their dependency tree
+      // (e.g. varlock cascades when @env-spec/parser is bumped)
+      const depsByPath = new Map(
+        [...allReleasePaths].map((p) => [p, getWorkspaceDeps(p)]),
+      );
+      let addedDependent = true;
+      while (addedDependent) {
+        addedDependent = false;
+        for (const [pkg, deps] of depsByPath) {
+          if (!neededPackages.has(pkg) && deps.some((dep) => neededPackages.has(dep))) {
+            neededPackages.add(pkg);
+            addedDependent = true;
+          }
+        }
+      }
+
+      // Also include transitive workspace dependencies of included packages
+      // (so preview packages that reference each other have consistent versions)
+      const queue = [...neededPackages];
       while (queue.length > 0) {
         const pkg = queue.pop()!;
-        if (neededPackages.has(pkg)) continue;
         neededPackages.add(pkg);
         for (const dep of getWorkspaceDeps(pkg)) {
           // Only include deps that bumpy also wants to release
@@ -90,7 +107,7 @@ if (bumpyStatusRaw) {
 
       releasePackagePaths = [...neededPackages];
       console.log('Packages bumped in this branch:', branchReleasePaths);
-      console.log('Packages to preview (+ dependencies):', releasePackagePaths);
+      console.log('Packages to preview (+ cascades + dependencies):', releasePackagePaths);
     } else {
       releasePackagePaths = bumpyReleases
         .map((r: any) => path.resolve(MONOREPO_ROOT, r.dir));


### PR DESCRIPTION
On PRs, `check-release-packages.ts` filtered bumpy releases to `inCurrentBranch` only, then walked from bumped packages down to their workspace *dependencies*. Cascade bumps go the other way: bumping `@env-spec/parser` cascades to `varlock` (a dependent), which bumpy reports with `isCascadeBump: true, inCurrentBranch: false` — so it was dropped and never reached the pkg.pr.new publish step (seen on #889, where no varlock preview package was built).

This adds an upward walk over the workspace dependency graph: any release bumpy plans whose transitive workspace deps include a branch-bumped package is included, then the existing downward dependency walk runs from that expanded set. Unrelated pending bumps on main stay excluded. As a side effect, `includes-varlock` is now true for cascades, so the binary/native preview jobs run for these PRs too.

Verified against #889's branch state: output now includes both `packages/env-spec-parser` and `packages/varlock`; a PR with no changesets still yields an empty list.