### PR TITLE
Add WSL detection to install script

### DIFF
--- a/.bumpy/fix-wsl-install-encrypt-exe.md
+++ b/.bumpy/fix-wsl-install-encrypt-exe.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+install.sh now installs varlock-local-encrypt.exe on WSL so local encryption can use the Windows TPM/Hello backend (pass --skip-win-exe to opt out)

--- a/packages/varlock-website/src/content/docs/getting-started/installation.mdx
+++ b/packages/varlock-website/src/content/docs/getting-started/installation.mdx
@@ -69,11 +69,11 @@ Usage: install.sh [options]
 install varlock binary
 
 Options:
-  --dir             directory to install varlock to (default: "$HOME/.config/varlock/bin")
+  --dir             directory to install varlock to (defaults to $XDG_CONFIG_HOME/varlock/bin, else ~/.varlock/bin if it exists, else ~/.config/varlock/bin)
   --reinstall       reinstall even if already installed (default: false)
   --version         version of varlock to install (defaults to latest)
   --force-no-brew   force install without homebrew even when detected (default: false)
-  --skip-win-exe   skip installing the Windows native encryption binary, only applicable when running in WSL (default: false)
+  --skip-win-exe    on WSL, skip installing the Windows encryption helper (varlock-local-encrypt.exe) (default: false)
 ```
 
 ## Varlock skill

--- a/packages/varlock-website/src/content/docs/getting-started/installation.mdx
+++ b/packages/varlock-website/src/content/docs/getting-started/installation.mdx
@@ -61,6 +61,21 @@ varlock init
 If Windows flags `varlock-local-encrypt.exe`, see the [local encryption guide, Windows Defender false positives](/guides/local-encryption/#windows-defender-false-positives) for verification and recovery steps.
 :::
 
+**Installation script usage**
+
+```
+Usage: install.sh [options]
+
+install varlock binary
+
+Options:
+  --dir             directory to install varlock to (default: "$HOME/.config/varlock/bin")
+  --reinstall       reinstall even if already installed (default: false)
+  --version         version of varlock to install (defaults to latest)
+  --force-no-brew   force install without homebrew even when detected (default: false)
+  --skip-win-exe   skip installing the Windows native encryption binary, only applicable when running in WSL (default: false)
+```
+
 ## Varlock skill
 
 Then install the Varlock agent skill:

--- a/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
+++ b/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
@@ -156,7 +156,7 @@ Treat this gate as a **consent prompt**, not an at-rest boundary. On Linux the T
 ✅ No additional install/setup steps required
 
 :::tip
-The standalone `install.sh` installs both `varlock-local-encrypt` and `varlock-local-encrypt.exe` encryption helpers by default. You can opt out by passing `--skip-win-exe` during installation.
+On WSL, the standalone `install.sh` installs the Windows encryption helper (`varlock-local-encrypt.exe`) alongside the Linux `varlock-local-encrypt` binary by default. Pass `--skip-win-exe` to install only the Linux binary. On regular Linux and macOS, only the native binary is installed.
 :::
 
 #### Upgrading existing keys to TPM

--- a/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
+++ b/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
@@ -92,6 +92,18 @@ Varlock chooses the best available backend automatically:
 
 If native capabilities are unavailable, varlock falls back to file-based local encryption.
 
+**Verify encryption backend (macOS/Linux)**
+
+```bash
+varlock-local-encrypt status
+```
+
+**Verify encryption backend (Windows/WSL)**
+
+```bash
+varlock-local-encrypt.exe status
+```
+
 ## Unattended decryption (headless servers & CI)
 
 Local encryption isn't just for laptops. On a headless host with a TPM (a home server, a CI runner, a container host), varlock seals the key to the machine's TPM and decrypts automatically at load with **no prompt**. That makes it a good way to store a "secret-zero" (like a 1Password service account token) that bootstraps the rest of your secrets:
@@ -137,11 +149,15 @@ Treat this gate as a **consent prompt**, not an at-rest boundary. On Linux the T
 - Native helper with **TPM-sealed** key protection when a TPM 2.0 chip is available (via NCrypt / Platform Crypto Provider)
 - Falls back to **DPAPI** (user-session-scoped) when TPM sealing is unavailable
 - **Windows Hello** gates interactive decrypts (fingerprint/face/PIN), separate from at-rest protection, same as before
-- Windows native and **WSL** workflows are both supported (WSL uses the Windows `.exe` via `--via-daemon`; Hello + TPM behavior is identical)
+- Windows native and **WSL** workflows are both supported (WSL uses the Windows `varlock-local-encrypt.exe` via `--via-daemon`; Hello + TPM behavior is identical)
 - Automated daemon startup/installation behavior is built in for biometric session flows
 - WSL decrypt flows use a native bridge to the Windows daemon path
 
 ✅ No additional install/setup steps required
+
+:::tip
+The standalone `install.sh` installs both `varlock-local-encrypt` and `varlock-local-encrypt.exe` encryption helpers by default. You can opt out by passing `--skip-win-exe` during installation.
+:::
 
 #### Upgrading existing keys to TPM
 

--- a/packages/varlock/install.sh
+++ b/packages/varlock/install.sh
@@ -27,6 +27,7 @@ INSTALL_DIR="${VARLOCK_CONFIG_DIR}/bin"
 INSTALL_DIR_UNEXPANDED="\${XDG_CONFIG_HOME:-~/.config}/varlock/bin"
 REINSTALL=""
 FORCE_NO_BREW="false"
+FORCE_LINUX_ENC_BIN="false"
 
 usage() {
   echo "Usage: $0 [options]"
@@ -38,6 +39,7 @@ usage() {
   echo "  --reinstall       reinstall even if already installed (default: false)"
   echo "  --version         version of varlock to install (defaults to latest)"
   echo "  --force-no-brew   force install without homebrew even when detected (default: false)"
+  echo "  --force-linux-enc-bin   force install the Linux native encryption binary, only applicable when running in WSL (default: false)"
   echo ""
 }
 
@@ -56,6 +58,9 @@ parse_args() {
     ;;
     force-no-brew | --force-no-brew)
       FORCE_NO_BREW="true"
+    ;;
+    force-linux-enc-bin | --force-linux-enc-bin)
+      FORCE_LINUX_ENC_BIN="true"
     ;;
     help | --help)
       usage
@@ -182,7 +187,7 @@ main() {
       fi
     ;;
     linux)
-      if is_wsl && [ -f "${_temp_dir}/varlock-local-encrypt.exe" ]; then
+      if is_wsl && [ "$FORCE_LINUX_ENC_BIN" = "false" ] && [ -f "${_temp_dir}/varlock-local-encrypt.exe" ]; then
         install "${_temp_dir}/varlock-local-encrypt.exe" "${INSTALL_DIR}/"
         echo "  Installed native encryption binary (varlock-local-encrypt.exe)"
       elif [ -f "${_temp_dir}/varlock-local-encrypt" ]; then

--- a/packages/varlock/install.sh
+++ b/packages/varlock/install.sh
@@ -189,8 +189,8 @@ main() {
     linux)
       if is_wsl && [ "$FORCE_LINUX_ENC_BIN" = "false" ] && [ -f "${_temp_dir}/varlock-local-encrypt.exe" ]; then
         install "${_temp_dir}/varlock-local-encrypt.exe" "${INSTALL_DIR}/"
+        chmod u+x "${INSTALL_DIR}/varlock-local-encrypt.exe"
         echo "  Installed native encryption binary (varlock-local-encrypt.exe)"
-      elif [ -f "${_temp_dir}/varlock-local-encrypt" ]; then
         install "${_temp_dir}/varlock-local-encrypt" "${INSTALL_DIR}/"
         chmod u+x "${INSTALL_DIR}/varlock-local-encrypt"
         echo "  Installed native encryption binary (varlock-local-encrypt)"

--- a/packages/varlock/install.sh
+++ b/packages/varlock/install.sh
@@ -27,7 +27,7 @@ INSTALL_DIR="${VARLOCK_CONFIG_DIR}/bin"
 INSTALL_DIR_UNEXPANDED="\${XDG_CONFIG_HOME:-~/.config}/varlock/bin"
 REINSTALL=""
 FORCE_NO_BREW="false"
-FORCE_LINUX_ENC_BIN="false"
+SKIP_WIN_EXE="false"
 
 usage() {
   echo "Usage: $0 [options]"
@@ -39,7 +39,7 @@ usage() {
   echo "  --reinstall       reinstall even if already installed (default: false)"
   echo "  --version         version of varlock to install (defaults to latest)"
   echo "  --force-no-brew   force install without homebrew even when detected (default: false)"
-  echo "  --force-linux-enc-bin   force install the Linux native encryption binary, only applicable when running in WSL (default: false)"
+  echo "  --skip-win-exe   skip installing the Windows native encryption binary, only applicable when running in WSL (default: false)"
   echo ""
 }
 
@@ -59,8 +59,8 @@ parse_args() {
     force-no-brew | --force-no-brew)
       FORCE_NO_BREW="true"
     ;;
-    force-linux-enc-bin | --force-linux-enc-bin)
-      FORCE_LINUX_ENC_BIN="true"
+    skip-win-exe | --skip-win-exe)
+      SKIP_WIN_EXE="true"
     ;;
     help | --help)
       usage
@@ -187,13 +187,15 @@ main() {
       fi
     ;;
     linux)
-      if is_wsl && [ "$FORCE_LINUX_ENC_BIN" = "false" ] && [ -f "${_temp_dir}/varlock-local-encrypt.exe" ]; then
-        install "${_temp_dir}/varlock-local-encrypt.exe" "${INSTALL_DIR}/"
-        chmod u+x "${INSTALL_DIR}/varlock-local-encrypt.exe"
-        echo "  Installed native encryption binary (varlock-local-encrypt.exe)"
+      if [ -f "${_temp_dir}/varlock-local-encrypt" ]; then
         install "${_temp_dir}/varlock-local-encrypt" "${INSTALL_DIR}/"
         chmod u+x "${INSTALL_DIR}/varlock-local-encrypt"
         echo "  Installed native encryption binary (varlock-local-encrypt)"
+      fi
+      if is_wsl && [ "$SKIP_WIN_EXE" != "true" ] && [ -f "${_temp_dir}/varlock-local-encrypt.exe" ]; then
+        install "${_temp_dir}/varlock-local-encrypt.exe" "${INSTALL_DIR}/"
+        chmod u+x "${INSTALL_DIR}/varlock-local-encrypt.exe"
+        echo "  Installed WSL encryption binary (varlock-local-encrypt.exe)"
       fi
     ;;
     win-*)

--- a/packages/varlock/install.sh
+++ b/packages/varlock/install.sh
@@ -257,11 +257,21 @@ get_architecture() {
 }
 
 is_wsl() {
-	case "$(uname -r)" in
-	*microsoft* ) true ;; # WSL 2
-	*Microsoft* ) true ;; # WSL 1
-	* ) false;;
-	esac
+  # Fast path: WSL sets this env var
+  if [ -n "${WSL_DISTRO_NAME:-}" ]; then
+    return 0
+  fi
+
+  # Fallback: check /proc/version for Microsoft/WSL signature
+  if [ -r /proc/version ] && grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
+    return 0
+  fi
+
+  # Last resort: kernel release string
+  case "$(uname -r 2>/dev/null)" in
+    *[Mm]icrosoft*|*[Ww][Ss][Ll]*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 # $1 - url for download. $2 - path to download

--- a/packages/varlock/install.sh
+++ b/packages/varlock/install.sh
@@ -39,7 +39,7 @@ usage() {
   echo "  --reinstall       reinstall even if already installed (default: false)"
   echo "  --version         version of varlock to install (defaults to latest)"
   echo "  --force-no-brew   force install without homebrew even when detected (default: false)"
-  echo "  --skip-win-exe   skip installing the Windows native encryption binary, only applicable when running in WSL (default: false)"
+  echo "  --skip-win-exe    on WSL, skip installing the Windows encryption helper (varlock-local-encrypt.exe) (default: false)"
   echo ""
 }
 
@@ -195,7 +195,7 @@ main() {
       if is_wsl && [ "$SKIP_WIN_EXE" != "true" ] && [ -f "${_temp_dir}/varlock-local-encrypt.exe" ]; then
         install "${_temp_dir}/varlock-local-encrypt.exe" "${INSTALL_DIR}/"
         chmod u+x "${INSTALL_DIR}/varlock-local-encrypt.exe"
-        echo "  Installed WSL encryption binary (varlock-local-encrypt.exe)"
+        echo "  Installed Windows encryption helper for WSL (varlock-local-encrypt.exe)"
       fi
     ;;
     win-*)

--- a/packages/varlock/install.sh
+++ b/packages/varlock/install.sh
@@ -182,7 +182,10 @@ main() {
       fi
     ;;
     linux)
-      if [ -f "${_temp_dir}/varlock-local-encrypt" ]; then
+      if is_wsl && [ -f "${_temp_dir}/varlock-local-encrypt.exe" ]; then
+        install "${_temp_dir}/varlock-local-encrypt.exe" "${INSTALL_DIR}/"
+        echo "  Installed native encryption binary (varlock-local-encrypt.exe)"
+      elif [ -f "${_temp_dir}/varlock-local-encrypt" ]; then
         install "${_temp_dir}/varlock-local-encrypt" "${INSTALL_DIR}/"
         chmod u+x "${INSTALL_DIR}/varlock-local-encrypt"
         echo "  Installed native encryption binary (varlock-local-encrypt)"
@@ -246,6 +249,14 @@ get_architecture() {
       LIBC="musl-"
     fi
   fi
+}
+
+is_wsl() {
+	case "$(uname -r)" in
+	*microsoft* ) true ;; # WSL 2
+	*Microsoft* ) true ;; # WSL 1
+	* ) false;;
+	esac
 }
 
 # $1 - url for download. $2 - path to download


### PR DESCRIPTION
When running the install script on WSL, the `varlock-local-encrypt.exe` binary  was ignored meaning anything checking `isWSL` won't find the expected exe

The linux block to install the local encrypt binary now also copies the `exe`, unless overriden with new `--skip-win-exe ` flag

Installation folder now contains the linux native binary and windows exe:

<img width="381" height="146" alt="image" src="https://github.com/user-attachments/assets/d6fd4904-a878-4a4e-8a04-5671ea1d114d" />

`varlock encrypt` now correctly resolves the Windows TPM backend:

<img width="735" height="201" alt="image" src="https://github.com/user-attachments/assets/fbf7ebbf-7b6a-4106-8430-3440326a3606" />

