### PR TITLE
fix(varlock): install Windows encrypt helper on WSL via install.sh

### DIFF
--- a/.bumpy/fix-install-wsl-encrypt-exe.md
+++ b/.bumpy/fix-install-wsl-encrypt-exe.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Install `varlock-local-encrypt.exe` from the Linux standalone archive when running on WSL, so local encryption can use the Windows TPM/Hello backend.

--- a/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
+++ b/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
@@ -137,7 +137,7 @@ Treat this gate as a **consent prompt**, not an at-rest boundary. On Linux the T
 - Native helper with **TPM-sealed** key protection when a TPM 2.0 chip is available (via NCrypt / Platform Crypto Provider)
 - Falls back to **DPAPI** (user-session-scoped) when TPM sealing is unavailable
 - **Windows Hello** gates interactive decrypts (fingerprint/face/PIN), separate from at-rest protection, same as before
-- Windows native and **WSL** workflows are both supported (WSL uses the Windows `.exe` via `--via-daemon`; Hello + TPM behavior is identical)
+- Windows native and **WSL** workflows are both supported (WSL uses the Windows `.exe` via `--via-daemon`; Hello + TPM behavior is identical). The standalone `install.sh` installs that `.exe` alongside the Linux helper when it detects WSL (pass `--skip-win-exe` to opt out).
 - Automated daemon startup/installation behavior is built in for biometric session flows
 - WSL decrypt flows use a native bridge to the Windows daemon path
 

--- a/packages/varlock/install.sh
+++ b/packages/varlock/install.sh
@@ -27,6 +27,7 @@ INSTALL_DIR="${VARLOCK_CONFIG_DIR}/bin"
 INSTALL_DIR_UNEXPANDED="\${XDG_CONFIG_HOME:-~/.config}/varlock/bin"
 REINSTALL=""
 FORCE_NO_BREW="false"
+SKIP_WIN_EXE="false"
 
 usage() {
   echo "Usage: $0 [options]"
@@ -38,6 +39,7 @@ usage() {
   echo "  --reinstall       reinstall even if already installed (default: false)"
   echo "  --version         version of varlock to install (defaults to latest)"
   echo "  --force-no-brew   force install without homebrew even when detected (default: false)"
+  echo "  --skip-win-exe    on WSL, skip installing varlock-local-encrypt.exe (default: false)"
   echo ""
 }
 
@@ -56,6 +58,9 @@ parse_args() {
     ;;
     force-no-brew | --force-no-brew)
       FORCE_NO_BREW="true"
+    ;;
+    skip-win-exe | --skip-win-exe)
+      SKIP_WIN_EXE="true"
     ;;
     help | --help)
       usage
@@ -182,10 +187,18 @@ main() {
       fi
     ;;
     linux)
+      # Linux release archives include both the Linux helper and the Windows
+      # .exe (for WSL2 / Windows Hello + TPM). Always install the Linux binary;
+      # on WSL also install the .exe unless --skip-win-exe.
       if [ -f "${_temp_dir}/varlock-local-encrypt" ]; then
         install "${_temp_dir}/varlock-local-encrypt" "${INSTALL_DIR}/"
         chmod u+x "${INSTALL_DIR}/varlock-local-encrypt"
         echo "  Installed native encryption binary (varlock-local-encrypt)"
+      fi
+      if is_wsl && [ "$SKIP_WIN_EXE" = "false" ] && [ -f "${_temp_dir}/varlock-local-encrypt.exe" ]; then
+        install "${_temp_dir}/varlock-local-encrypt.exe" "${INSTALL_DIR}/"
+        chmod u+x "${INSTALL_DIR}/varlock-local-encrypt.exe"
+        echo "  Installed native encryption binary (varlock-local-encrypt.exe)"
       fi
     ;;
     win-*)
@@ -246,6 +259,22 @@ get_architecture() {
       LIBC="musl-"
     fi
   fi
+}
+
+# Match packages/varlock/src/lib/local-encrypt/wsl-detect.ts
+is_wsl() {
+  if [ -n "${WSL_DISTRO_NAME:-}" ]; then
+    return 0
+  fi
+
+  if [ -r /proc/version ] && grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
+    return 0
+  fi
+
+  case "$(uname -r 2>/dev/null)" in
+    *[Mm]icrosoft*|*[Ww][Ss][Ll]*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 # $1 - url for download. $2 - path to download


### PR DESCRIPTION
## Summary
- Linux standalone archives already bundle `varlock-local-encrypt.exe` for WSL2; `install.sh` now installs it when WSL is detected.
- Non-WSL Linux still always gets `varlock-local-encrypt` (fixes the regression in #895's current approach).
- Adds `--skip-win-exe` to opt out of the Windows helper on WSL.
- Documents the behavior in the local encryption guide.

Related: #895 (same intent; this avoids gating the Linux helper on WSL/`.exe` presence)

## Test plan
- [x] `sh -n packages/varlock/install.sh`
- [x] `is_wsl` false on macOS; true when `WSL_DISTRO_NAME` is set
- [ ] On WSL: `curl -sSfL … | sh -s -- --force-no-brew` installs both helpers; `varlock encrypt` resolves Windows TPM backend
- [ ] On non-WSL Linux: Linux helper still installed; no `.exe` required
- [ ] On WSL with `--skip-win-exe`: Linux helper only