### PR TITLE
Fix nested varlock run command-local override provenance

### DIFF
--- a/.bumpy/fix-nested-run-command-local-override.md
+++ b/.bumpy/fix-nested-run-command-local-override.md
@@ -1,0 +1,5 @@
+---
+"varlock": patch
+---
+
+Fix nested `varlock run`: a command-local override (`FOO=bar varlock ...`) inside a parent `varlock run` now wins over the parent's injected value again, instead of being clobbered by the re-injected env blob.

--- a/packages/varlock/src/lib/load-graph.ts
+++ b/packages/varlock/src/lib/load-graph.ts
@@ -9,6 +9,7 @@ import { runWithWorkspaceInfo } from './workspace-utils';
 import { readVarlockPackageJsonConfig } from './package-json-config';
 import { createDebug } from './debug';
 import { parseBlobOverrideKeys, selectOverrideValuesFromEnv } from './injected-env-provenance';
+import { getPreInjectionProcessEnv } from '../runtime/env';
 import { getActiveProxySession, getProxyResolutionViewForEnv } from '../proxy/session-registry';
 import { PROXY_CHILD_ENV_VAR } from '../proxy/env-vars';
 import { enforceProxySchemaFingerprint } from '../cli/helpers/proxy-schema-fingerprint';
@@ -18,7 +19,12 @@ const debug = createDebug('varlock:load');
 function getGraphEnvOverridesFromRuntimeEnv() {
   const overrideKeys = parseBlobOverrideKeys(process.env.__VARLOCK_ENV);
   if (!overrideKeys) return undefined;
-  return selectOverrideValuesFromEnv(process.env, overrideKeys);
+  // Select from the pre-injection process.env snapshot, not the live one: the
+  // runtime auto-init re-injects the parent blob's resolved values into
+  // process.env, which would otherwise clobber a command-local override
+  // (`FOO=bar varlock ...`) back to the parent's value when a nested `varlock`
+  // runs under a parent `varlock run`.
+  return selectOverrideValuesFromEnv(getPreInjectionProcessEnv(), overrideKeys);
 }
 
 function normalizePkgLoadPath(pkgLoadPath: string | Array<string>): Array<string> {

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -299,6 +299,20 @@ const envState = getEnvState();
 const envValues = envState.values;
 export const varlockSettings = envState.settings;
 
+/**
+ * Snapshot of process.env as it was before varlock injected any resolved values
+ * into it (captured on first load, before the module-level auto-init below).
+ *
+ * Callers that need the caller's *real* env, distinct from values varlock itself
+ * re-injected, must read this rather than the live `process.env`. In particular,
+ * a nested `varlock` running under a parent `varlock run` sees the parent blob's
+ * values re-injected into `process.env`, which would otherwise mask a
+ * command-local override (`FOO=bar varlock ...`).
+ */
+export function getPreInjectionProcessEnv(): Record<string, string | undefined> {
+  return getEnvState().originalProcessEnv;
+}
+
 export function initVarlockEnv(opts?: {
   allowFail?: boolean,
 }) {


### PR DESCRIPTION
## What

Fixes the failing `Smoke Test` job (`nested varlock run keeps inner command-local overrides over outer shell overrides`), which was red on `main`.

## Why

When a nested `varlock` runs under a parent `varlock run`, a command-local override was being clobbered:

```
SHARED_VAR=from-shell-outer  varlock run --inject all -- \
  sh -c 'SHARED_VAR=from-shell-inner  varlock load ...'   # resolved to from-shell-outer (wrong)
```

`runtime/env.ts`'s module-level auto-init re-injects the parent blob's resolved values into `process.env` when `__VARLOCK_ENV` is present. That overwrote the inner command-local `SHARED_VAR=from-shell-inner` back to the parent's value. `getGraphEnvOverridesFromRuntimeEnv` then read the clobbered live `process.env` for override provenance, so the parent's value won.

## Fix

`envState.originalProcessEnv` is snapshotted before the auto-init clobber, so it holds the real caller env. Exposed it as `getPreInjectionProcessEnv()` and made override provenance read from that snapshot instead of the live `process.env`. Only the nested case is affected; a plain `FOO=bar varlock load` still uses the full-`process.env` override path.

## Verification

- All three nested-run scenarios now resolve correctly (command-local override wins, outer-shell override preserved, no-override falls through to fresh resolution).
- Full `varlock` unit suite passes (1250 passed, 1 skipped).