### PR TITLE
fix: reject numeric Infinity in number coercion

### DIFF
--- a/.bumpy/fix-coerce-number-infinity.md
+++ b/.bumpy/fix-coerce-number-infinity.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Reject numeric Infinity/-Infinity in number coercion

--- a/packages/varlock/src/env-graph/lib/data-types.ts
+++ b/packages/varlock/src/env-graph/lib/data-types.ts
@@ -159,8 +159,8 @@ function coerceToNumber(rawVal: any) {
     }
     numVal = parsed;
   } else if (_.isNumber(rawVal)) {
-    if (numVal === Infinity || numVal === -Infinity) {
-      throw new CoercionError('Inifinity is not a valid number');
+    if (rawVal === Infinity || rawVal === -Infinity) {
+      throw new CoercionError('Infinity is not a valid number');
     }
     numVal = rawVal;
   } else {

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { outdent } from 'outdent';
-import { DotEnvFileDataSource, EnvGraph } from '../index';
+import { DotEnvFileDataSource, EnvGraph, CoercionError } from '../index';
 
 async function loadAndResolve(envFileContent: string) {
   const g = new EnvGraph();
@@ -24,6 +24,25 @@ async function loadAndResolve(envFileContent: string) {
   await g.resolveEnvValues();
   return g;
 }
+
+describe('number data type - Infinity coercion', () => {
+  const numberType = () => new EnvGraph().dataTypesRegistry.number();
+
+  it('rejects numeric Infinity', () => {
+    expect(() => numberType().coerce(Infinity)).toThrow(CoercionError);
+    expect(() => numberType().coerce(Infinity)).toThrow(/Infinity is not a valid number/);
+  });
+
+  it('rejects numeric -Infinity', () => {
+    expect(() => numberType().coerce(-Infinity)).toThrow(CoercionError);
+    expect(() => numberType().coerce(-Infinity)).toThrow(/Infinity is not a valid number/);
+  });
+
+  it('rejects string Infinity and -Infinity', () => {
+    expect(() => numberType().coerce('Infinity')).toThrow(CoercionError);
+    expect(() => numberType().coerce('-Infinity')).toThrow(CoercionError);
+  });
+});
 
 describe('url data type', () => {
   describe('prependHttps', () => {


### PR DESCRIPTION
## Summary
- Fixes #904. Guard checked uninitialized numVal; now checks rawVal. Fixes Inifinity typo. Adds tests.

## Test plan
- [ ] Verify number coercion rejects Infinity / -Infinity
- [ ] Confirm related unit tests pass


Made with [Cursor](https://cursor.com)