### PR TITLE
fix: honor falsy schema overrides for builtin vars

### DIFF
--- a/.bumpy/fix-varlock-is-ci-false-override.md
+++ b/.bumpy/fix-varlock-is-ci-false-override.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Honor falsy schema overrides for builtin vars like VARLOCK_IS_CI

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -209,10 +209,12 @@ export class ConfigItem {
     const hasInternalResolver = this._internalDefs.some((d) => d.itemDef.resolver);
     for (const def of this.defs) {
       if (def.itemDef.resolver) {
+        // Skip truly empty static values when an internal fallback exists
+        // (e.g. VARLOCK_ENV= to attach decorators). Do not treat false/0 as empty.
         if (
           hasInternalResolver
           && def.itemDef.resolver instanceof StaticValueResolver
-          && !def.itemDef.resolver.staticValue
+          && (def.itemDef.resolver.staticValue === undefined || def.itemDef.resolver.staticValue === '')
         ) {
           continue;
         }
@@ -230,12 +232,12 @@ export class ConfigItem {
     const hasInternalResolver = this._internalDefs.some((d) => d.itemDef.resolver);
     for (const def of this.defs) {
       if (def.itemDef.resolver) {
-        // Skip empty static values when an internal fallback resolver exists
-        // (e.g., user defines VARLOCK_ENV= to add decorators — the builtin resolver still applies)
+        // Skip truly empty static values when an internal fallback exists
+        // (e.g. VARLOCK_ENV= to attach decorators). Do not treat false/0 as empty.
         if (
           hasInternalResolver
           && def.itemDef.resolver instanceof StaticValueResolver
-          && !def.itemDef.resolver.staticValue
+          && (def.itemDef.resolver.staticValue === undefined || def.itemDef.resolver.staticValue === '')
         ) {
           continue;
         }

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -374,8 +374,14 @@ export class ConfigItem {
     // if no type is set explicitly, we can try to use inferred type from the resolver
     // currently only static value resolver does this - but you can imagine another resolver knowing the type ahead of time
     // (maybe we only want to do this if the value is set in a schema file? or if all inferred types match?)
-    if (!dataTypeName && this.valueResolver?.inferredType) {
-      dataTypeName = this.valueResolver.inferredType;
+    if (!dataTypeName) {
+      // builtin vars declare an authoritative type on their internal resolver
+      // (e.g. VARLOCK_IS_CI is boolean), which wins over inference from a
+      // user-provided static value so VARLOCK_IS_CI=0 still coerces to false
+      const internalResolverType = this._internalDefs.find(
+        (d) => d.itemDef.resolver?.inferredType,
+      )?.itemDef.resolver?.inferredType;
+      dataTypeName = internalResolverType || this.valueResolver?.inferredType;
     }
     dataTypeName ||= 'string';
     dataTypeArgs ||= [];

--- a/packages/varlock/src/env-graph/test/builtin-vars.test.ts
+++ b/packages/varlock/src/env-graph/test/builtin-vars.test.ts
@@ -213,8 +213,9 @@ describe('VARLOCK_* builtin variables', () => {
         GITHUB_REPOSITORY: 'owner/repo',
       },
       // Number 0 must not be treated as empty; schema wins over builtin true.
-      // Coercion may leave it as 0 rather than boolean false.
-      expectValues: { VARLOCK_IS_CI: 0 },
+      // The builtin's declared boolean type also wins over the value's inferred
+      // number type, so 0 coerces to false.
+      expectValues: { VARLOCK_IS_CI: false },
     }));
   });
 

--- a/packages/varlock/src/env-graph/test/builtin-vars.test.ts
+++ b/packages/varlock/src/env-graph/test/builtin-vars.test.ts
@@ -192,6 +192,30 @@ describe('VARLOCK_* builtin variables', () => {
       },
       expectValues: { VARLOCK_IS_CI: true },
     }));
+
+    // Regression (#899): empty-static skip used truthiness (`!staticValue`), which
+    // also skipped boolean false / number 0 when a builtin internal resolver exists.
+    test('schema override VARLOCK_IS_CI=false wins over CI detection', envFilesTest({
+      envFile: 'VARLOCK_IS_CI=false',
+      processEnv: {
+        CI: 'true',
+        GITHUB_ACTIONS: 'true',
+        GITHUB_REPOSITORY: 'owner/repo',
+      },
+      expectValues: { VARLOCK_IS_CI: false },
+    }));
+
+    test('schema override VARLOCK_IS_CI=0 is not skipped as empty', envFilesTest({
+      envFile: 'VARLOCK_IS_CI=0',
+      processEnv: {
+        CI: 'true',
+        GITHUB_ACTIONS: 'true',
+        GITHUB_REPOSITORY: 'owner/repo',
+      },
+      // Number 0 must not be treated as empty; schema wins over builtin true.
+      // Coercion may leave it as 0 rather than boolean false.
+      expectValues: { VARLOCK_IS_CI: 0 },
+    }));
   });
 
   describe('CI platform variables', () => {


### PR DESCRIPTION
## Summary
- Fixes #899. Empty-static skip used truthiness so VARLOCK_IS_CI=false was ignored. Skip only undefined/''.
- Also make a builtin's declared type win over type inference from a user-provided static value, so VARLOCK_IS_CI=0 coerces to boolean false instead of staying number 0.

## Test plan
- [x] Confirm VARLOCK_IS_CI=false in schema overrides builtin
- [x] Confirm VARLOCK_IS_CI=0 coerces to false via the builtin's boolean type
- [x] Run related unit/smoke tests


Made with [Cursor](https://cursor.com)