### PR TITLE
fix: resolve dynamic arguments in forEnv()

### DIFF
--- a/.bumpy/fix-forenv-nonstatic-args.md
+++ b/.bumpy/fix-forenv-nonstatic-args.md
@@ -2,4 +2,4 @@
 varlock: patch
 ---
 
-Resolve dynamic arguments in forEnv()
+Resolve dynamic arguments in forEnv(); a forEnv() argument that resolves to undefined is now an error instead of silently comparing against "undefined"

--- a/.bumpy/fix-forenv-nonstatic-args.md
+++ b/.bumpy/fix-forenv-nonstatic-args.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Resolve dynamic arguments in forEnv()

--- a/packages/varlock-website/src/content/docs/reference/functions.mdx
+++ b/packages/varlock-website/src/content/docs/reference/functions.mdx
@@ -205,6 +205,7 @@ list passed in as args.
 **Requirements:**
 - Requires an [`@currentEnv`](/reference/root-decorators/#currentenv) to be set in your `.env.schema` file
 - Takes one or more environment names as arguments
+- Arguments can be static strings or dynamic values (for example `$OTHER_VAR` or `concat()`); an argument that resolves to undefined is an error
 
 ```env-spec /forEnv\\(.*\\)/
 # @currentEnv=$APP_ENV @defaultRequired=false

--- a/packages/varlock-website/src/content/docs/reference/functions.mdx
+++ b/packages/varlock-website/src/content/docs/reference/functions.mdx
@@ -205,7 +205,6 @@ list passed in as args.
 **Requirements:**
 - Requires an [`@currentEnv`](/reference/root-decorators/#currentenv) to be set in your `.env.schema` file
 - Takes one or more environment names as arguments
-- Arguments can be static strings or dynamic values (for example `$OTHER_VAR` or `concat()`); an argument that resolves to undefined is an error
 
 ```env-spec /forEnv\\(.*\\)/
 # @currentEnv=$APP_ENV @defaultRequired=false

--- a/packages/varlock/src/env-graph/lib/resolver.ts
+++ b/packages/varlock/src/env-graph/lib/resolver.ts
@@ -583,16 +583,16 @@ export const ForEnvResolver: typeof Resolver = createResolver({
     arrayMinLength: 1,
   },
   process() {
-    // TODO: check if all options are static
-    // TODO: check against envFlag enum options?
-    const matchEnvs = this.arrArgs!.map((r) => String(r.staticValue));
-    return matchEnvs;
+    return this.arrArgs!;
   },
-  async resolve(matchEnvs) {
+  async resolve(matchEnvArgs) {
     // this will trigger resolution of the current env if not already done
     const currentEnv = await this.getCurrentEnv();
     if (!currentEnv) throw new SchemaError('current environment is not set');
-    return currentEnv && matchEnvs.includes(currentEnv || '');
+    const matchEnvs = await Promise.all(
+      matchEnvArgs.map(async (arg) => String(await arg.resolve())),
+    );
+    return matchEnvs.includes(currentEnv);
   },
 });
 

--- a/packages/varlock/src/env-graph/lib/resolver.ts
+++ b/packages/varlock/src/env-graph/lib/resolver.ts
@@ -589,9 +589,16 @@ export const ForEnvResolver: typeof Resolver = createResolver({
     // this will trigger resolution of the current env if not already done
     const currentEnv = await this.getCurrentEnv();
     if (!currentEnv) throw new SchemaError('current environment is not set');
-    const matchEnvs = await Promise.all(
-      matchEnvArgs.map(async (arg) => String(await arg.resolve())),
-    );
+    const matchEnvs: Array<string> = [];
+    for (const arg of matchEnvArgs) {
+      const argValue = await arg.resolve();
+      // stringifying undefined would give "undefined", which silently never matches
+      // (or false-matches an env literally named "undefined") - fail loudly instead
+      if (argValue === undefined) {
+        throw new SchemaError('argument resolved to undefined - check that any referenced variables are set');
+      }
+      matchEnvs.push(String(argValue));
+    }
     return matchEnvs.includes(currentEnv);
   },
 });

--- a/packages/varlock/src/env-graph/test/required-decorators.test.ts
+++ b/packages/varlock/src/env-graph/test/required-decorators.test.ts
@@ -257,6 +257,34 @@ describe('required decorators', () => {
         REQ_FOR_NOMATCH: false,
       },
     }));
+    test('`forEnv()` errors when an arg resolves to undefined', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @currentEnv=$APP_ENV @defaultRequired=false
+          # ---
+          APP_ENV=dev
+          UNSET_VAR=
+          REQ_FOR_UNSET= # @required=forEnv($UNSET_VAR)
+        `,
+      },
+      expectRequired: {
+        REQ_FOR_UNSET: SchemaError,
+      },
+    }));
+    test('`forEnv()` does not match an unset ref against an env named "undefined"', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @currentEnv=$APP_ENV @defaultRequired=false
+          # ---
+          APP_ENV="undefined"
+          UNSET_VAR=
+          REQ_FOR_UNSET= # @required=forEnv($UNSET_VAR)
+        `,
+      },
+      expectRequired: {
+        REQ_FOR_UNSET: SchemaError,
+      },
+    }));
   });
   describe('explicit @required overrides @defaultRequired from other files', () => {
     test('@required in schema wins over @defaultRequired=false in local', envFilesTest({

--- a/packages/varlock/src/env-graph/test/required-decorators.test.ts
+++ b/packages/varlock/src/env-graph/test/required-decorators.test.ts
@@ -222,6 +222,41 @@ describe('required decorators', () => {
         REQ_FOR_DEV: SchemaError,
       },
     }));
+    test('`forEnv()` resolves $REF args', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @currentEnv=$APP_ENV @defaultRequired=false
+          # ---
+          APP_ENV=dev
+          TARGET=dev
+          OTHER=staging
+          REQ_FOR_TARGET= # @required=forEnv($TARGET)
+          REQ_FOR_OTHER=  # @required=forEnv($OTHER)
+        `,
+      },
+      expectRequired: {
+        REQ_FOR_TARGET: true,
+        REQ_FOR_OTHER: false,
+      },
+    }));
+    test('`forEnv()` resolves concat() and mixed args', envFilesTest({
+      files: {
+        '.env.schema': outdent`
+          # @currentEnv=$APP_ENV @defaultRequired=false
+          # ---
+          APP_ENV=dev
+          PREFIX=d
+          REQ_FOR_CONCAT=  # @required=forEnv(concat($PREFIX, "ev"))
+          REQ_FOR_MIXED=   # @required=forEnv(staging, concat($PREFIX, "ev"))
+          REQ_FOR_NOMATCH= # @required=forEnv(concat($PREFIX, "prod"))
+        `,
+      },
+      expectRequired: {
+        REQ_FOR_CONCAT: true,
+        REQ_FOR_MIXED: true,
+        REQ_FOR_NOMATCH: false,
+      },
+    }));
   });
   describe('explicit @required overrides @defaultRequired from other files', () => {
     test('@required in schema wins over @defaultRequired=false in local', envFilesTest({


### PR DESCRIPTION
## Summary
- Fixes #898. forEnv only read staticValue so $REF/concat became "undefined". Resolve args like eq/if.
- A forEnv() argument that resolves to undefined (e.g. a ref to an unset variable) is now a SchemaError instead of silently comparing against the string "undefined", which could never-match or false-match an env literally named "undefined".

## Test plan
- [x] Verify forEnv with $REF/concat args
- [x] Tests for undefined-resolving args (silent no-match and "undefined" false-match cases)
- [x] Run related unit tests (full varlock suite passing)

Made with [Cursor](https://cursor.com)