### PR TITLE
fix: JSON-encode object values for process.env injection

### DIFF
--- a/.bumpy/fix-simple-object-process-env.md
+++ b/.bumpy/fix-simple-object-process-env.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+JSON-encode object env values for process.env and varlock run

--- a/packages/varlock/src/cli/commands/load.command.ts
+++ b/packages/varlock/src/cli/commands/load.command.ts
@@ -4,6 +4,7 @@ import { gracefulExit } from 'exit-hook';
 
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
 import { getItemSummary } from '../../lib/formatting';
+import { envValueToProcessEnvString } from '../../lib/env-value-to-string';
 import { redactString } from '../../runtime/lib/redaction';
 import {
   checkForConfigErrors, checkForNoEnvFiles, checkForSchemaErrors, showPluginWarnings,
@@ -277,7 +278,8 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
           strValue = `"${value.replaceAll('"', '\\"').replaceAll('\n', '\\n')}"`;
         }
       } else {
-        strValue = JSON.stringify(value);
+        // numbers/booleans/objects — same encoding as process.env injection
+        strValue = envValueToProcessEnvString(value);
       }
       console.log(`${prefix}${key}=${strValue}`);
     }

--- a/packages/varlock/src/cli/commands/proxy.command.ts
+++ b/packages/varlock/src/cli/commands/proxy.command.ts
@@ -9,6 +9,7 @@ import { gracefulExit } from 'exit-hook';
 
 import { exec } from '../../lib/exec';
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
+import { mapResolvedEnvToProcessEnv } from '../../lib/env-value-to-string';
 import { startLocalProxyRuntime, type ProxyResponseInfo } from '../../proxy/runtime-proxy';
 import {
   createProxyAuditLog,
@@ -324,7 +325,7 @@ async function prepareProxyPolicy(entryFilePaths?: Array<string>): Promise<Prepa
   }
 
   return {
-    resolvedEnv,
+    resolvedEnv: mapResolvedEnvToProcessEnv(resolvedEnv),
     serializedGraph,
     schemaFingerprint,
     proxyManagedItems,

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -3,6 +3,7 @@ import { define } from 'gunshi';
 import { gracefulExit } from 'exit-hook';
 
 import { exec } from '../../lib/exec';
+import { mapResolvedEnvToProcessEnv } from '../../lib/env-value-to-string';
 import { isVarlockReservedKey } from '../../env-graph/lib/reserved-vars';
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
 import { checkForConfigErrors, checkForNoEnvFiles, checkForSchemaErrors } from '../helpers/error-checks';
@@ -215,7 +216,7 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
 
   const fullInjectedEnv: NodeJS.ProcessEnv = {
     ...process.env,
-    ...(injectVars ? resolvedEnv : {}),
+    ...(injectVars ? mapResolvedEnvToProcessEnv(resolvedEnv) : {}),
     __VARLOCK_RUN: '1', // flag for a child process to detect it is running via `varlock run`
     // honors @encryptInjectedEnv in blob-only mode; reuses/forwards an ambient key
     ...buildInjectedBlobEnv({

--- a/packages/varlock/src/lib/env-value-to-string.ts
+++ b/packages/varlock/src/lib/env-value-to-string.ts
@@ -1,0 +1,22 @@
+/**
+ * Convert a resolved env value to a string for process.env / child-process env.
+ *
+ * Matches `varlock load --format env` for non-strings (JSON.stringify).
+ * Undefined becomes '' so injection matches other .env loaders.
+ */
+export function envValueToProcessEnvString(value: unknown): string {
+  if (value === undefined) return '';
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+}
+
+/** Map a resolved env object to string values suitable for process/child env. */
+export function mapResolvedEnvToProcessEnv(
+  resolvedEnv: Record<string, unknown>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const key of Object.keys(resolvedEnv)) {
+    out[key] = envValueToProcessEnvString(resolvedEnv[key]);
+  }
+  return out;
+}

--- a/packages/varlock/src/lib/test/env-value-to-string.test.ts
+++ b/packages/varlock/src/lib/test/env-value-to-string.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { envValueToProcessEnvString, mapResolvedEnvToProcessEnv } from '../env-value-to-string';
+
+describe('envValueToProcessEnvString', () => {
+  it('maps undefined to empty string', () => {
+    expect(envValueToProcessEnvString(undefined)).toBe('');
+  });
+
+  it('leaves strings unchanged', () => {
+    expect(envValueToProcessEnvString('hello')).toBe('hello');
+    expect(envValueToProcessEnvString('{"already":"json"}')).toBe('{"already":"json"}');
+  });
+
+  it('stringifies numbers and booleans like JSON', () => {
+    expect(envValueToProcessEnvString(42)).toBe('42');
+    expect(envValueToProcessEnvString(true)).toBe('true');
+    expect(envValueToProcessEnvString(false)).toBe('false');
+  });
+
+  it('JSON-encodes plain objects (simple-object)', () => {
+    expect(envValueToProcessEnvString({ a: 1 })).toBe('{"a":1}');
+    expect(envValueToProcessEnvString({ nested: { b: true } })).toBe('{"nested":{"b":true}}');
+  });
+
+  it('JSON-encodes null and arrays', () => {
+    expect(envValueToProcessEnvString(null)).toBe('null');
+    expect(envValueToProcessEnvString([1, 2])).toBe('[1,2]');
+  });
+});
+
+describe('mapResolvedEnvToProcessEnv', () => {
+  it('stringifies each value for process/child env', () => {
+    expect(mapResolvedEnvToProcessEnv({
+      STR: 'hi',
+      OBJ: { a: 1 },
+      NUM: 7,
+      UNDEF: undefined,
+    })).toEqual({
+      STR: 'hi',
+      OBJ: '{"a":1}',
+      NUM: '7',
+      UNDEF: '',
+    });
+  });
+});

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -2,6 +2,7 @@ import { redactString } from './lib/redaction';
 
 import type { SerializedEnvGraph } from '../env-graph';
 import { isBrowser } from '../lib/detect-runtime';
+import { envValueToProcessEnvString } from '../lib/env-value-to-string';
 import { debug } from './lib/debug';
 
 // TODO: would like to move all of the redaction utils out of this file
@@ -368,9 +369,8 @@ export function initVarlockEnv(opts?: {
     envValues[itemKey] = itemValue;
     if (setProcessEnv) {
       envState.injectedProcessEnvKeys?.push(itemKey);
-      // when re-injecting into process.env, we treat undefined as empty string
-      // this more closely matches expected behaviour from other .env loaders
-      process.env[itemKey] = itemValue === undefined ? '' : String(itemValue);
+      // undefined → ''; objects/arrays → JSON (matches `load --format env`)
+      process.env[itemKey] = envValueToProcessEnvString(itemValue);
     }
   }
   envState.initialized = true;

--- a/packages/varlock/src/runtime/test/env-state.test.ts
+++ b/packages/varlock/src/runtime/test/env-state.test.ts
@@ -13,9 +13,9 @@ import {
 const ENV_STATE_KEY = '__varlockEnvState';
 const REDACTION_STATE_KEY = '__varlockRedactionState';
 
-const TEST_KEYS = ['EST_FOO', 'EST_BAR'];
+const TEST_KEYS = ['EST_FOO', 'EST_BAR', 'EST_OBJ'];
 
-function makeEnvBlob(config: Record<string, string | undefined>) {
+function makeEnvBlob(config: Record<string, unknown>) {
   return JSON.stringify({
     sources: [],
     settings: {},
@@ -95,5 +95,16 @@ describe('env state shared across module copies', () => {
     expect(() => envModule.initVarlockEnv()).toThrow(/still encrypted/);
     // and env should not be marked initialized
     expect(() => (envModule.ENV as any).ANYTHING).toThrow(/not initialized/);
+  });
+
+  it('JSON-encodes simple-object values when injecting into process.env', async () => {
+    process.env.__VARLOCK_ENV = makeEnvBlob({ EST_OBJ: { a: 1, b: true } });
+    const envModule = await importFreshEnvModuleCopy();
+    envModule.initVarlockEnv();
+
+    // ENV proxy keeps the real object
+    expect((envModule.ENV as any).EST_OBJ).toEqual({ a: 1, b: true });
+    // process.env gets JSON (not "[object Object]")
+    expect(process.env.EST_OBJ).toBe('{"a":1,"b":true}');
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #900. Objects became "[object Object]" via String(). Shared helper JSON-encodes for process.env and varlock run, matching load --format env.

## Test plan
- [ ] Confirm object env values round-trip as JSON
- [ ] Run related unit/smoke tests


Made with [Cursor](https://cursor.com)