### PR TITLE
fix: scan Buffer chunks in ServerResponse.end for leaks

### DIFF
--- a/.bumpy/fix-server-response-end-buffer.md
+++ b/.bumpy/fix-server-response-end-buffer.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Scan Buffer chunks in ServerResponse.end for leaks

--- a/packages/varlock/src/runtime/patch-server-response.ts
+++ b/packages/varlock/src/runtime/patch-server-response.ts
@@ -161,9 +161,17 @@ export function patchGlobalServerResponse(opts?: {
     // console.log('⚡️ patched ServerResponse.end');
     const endChunk = args[0];
     // this just needs to work (so far) for nextjs sending json bodies, so does not need to handle all cases...
+    let chunkStr: string | undefined;
     if (endChunk && typeof endChunk === 'string') {
+      chunkStr = endChunk;
+    } else if (endChunk && (Buffer.isBuffer(endChunk) || endChunk instanceof Uint8Array)) {
+      // decode Buffer/Uint8Array like write does when uncompressed
+      const decoder = new TextDecoder();
+      chunkStr = decoder.decode(endChunk);
+    }
+    if (chunkStr) {
       // TODO: currently this throws the error and then things just hang... do we want to try to return an error type response instead?
-      scanForLeaks(endChunk, { method: 'patched ServerResponse.end' });
+      scanForLeaks(chunkStr, { method: 'patched ServerResponse.end' });
     }
     // @ts-ignore
     return serverResponseEnd.apply(this, args);

--- a/packages/varlock/src/runtime/test/patch-server-response.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response.test.ts
@@ -129,4 +129,9 @@ describe('patched ServerResponse.end', () => {
     const res = makeRes({ 'content-type': 'application/json' });
     expect(() => res.end(JSON.stringify({ leaked: SECRET }))).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
   });
+
+  it('throws when a sensitive value appears in a Buffer end chunk', () => {
+    const res = makeRes({ 'content-type': 'application/json' });
+    expect(() => res.end(Buffer.from(JSON.stringify({ leaked: SECRET })))).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes #903. end only scanned strings; decode Buffer/Uint8Array like write.

## Test plan
- [ ] Verify Buffer/Uint8Array end payloads are scanned
- [ ] Run related unit tests


Made with [Cursor](https://cursor.com)