### PR TITLE
fix: finish ServerResponse.end safely when leak detection throws

### DIFF
--- a/.bumpy/fix-server-response-end-hang.md
+++ b/.bumpy/fix-server-response-end-hang.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Finish ServerResponse.end safely when leak detection throws

--- a/packages/varlock/src/runtime/patch-server-response.ts
+++ b/packages/varlock/src/runtime/patch-server-response.ts
@@ -162,16 +162,42 @@ export function patchGlobalServerResponse(opts?: {
     const endChunk = args[0];
     // this just needs to work (so far) for nextjs sending json bodies, so does not need to handle all cases...
     let chunkStr: string | undefined;
+    let chunkType: 'string' | 'encoded' | null = null;
     if (endChunk && typeof endChunk === 'string') {
+      chunkType = 'string';
       chunkStr = endChunk;
     } else if (endChunk && (Buffer.isBuffer(endChunk) || endChunk instanceof Uint8Array)) {
       // decode Buffer/Uint8Array like write does when uncompressed
+      chunkType = 'encoded';
       const decoder = new TextDecoder();
       chunkStr = decoder.decode(endChunk);
     }
     if (chunkStr) {
-      // TODO: currently this throws the error and then things just hang... do we want to try to return an error type response instead?
-      scanForLeaks(chunkStr, { method: 'patched ServerResponse.end' });
+      try {
+        scanForLeaks(chunkStr, { method: 'patched ServerResponse.end' });
+      } catch (err) {
+        if (opts?.redactInsteadOfThrow) {
+          chunkStr = redactSensitiveConfig(chunkStr);
+          if (chunkType === 'string') {
+            args[0] = chunkStr;
+          } else if (chunkType === 'encoded') {
+            const encoder = new TextEncoder();
+            args[0] = encoder.encode(chunkStr);
+          }
+        } else {
+          // Finish the response so the client does not hang, then rethrow so
+          // callers still see the leak error (scanForLeaks already logged it).
+          if (!this.headersSent) {
+            this.statusCode = 500;
+            this.setHeader('Content-Type', 'text/plain; charset=utf-8');
+            // @ts-ignore
+            serverResponseEnd.call(this, 'Internal Server Error');
+          } else {
+            this.destroy();
+          }
+          throw err;
+        }
+      }
     }
     // @ts-ignore
     return serverResponseEnd.apply(this, args);

--- a/packages/varlock/src/runtime/test/patch-server-response-redact.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response-redact.test.ts
@@ -40,6 +40,12 @@ beforeAll(async () => {
     if (req.url === '/string-leak') {
       res.write(htmlWithSecret);
       res.end();
+    } else if (req.url === '/end-string-leak') {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ leaked: SECRET }));
+    } else if (req.url === '/end-buffer-leak') {
+      res.setHeader('content-type', 'application/json');
+      res.end(Buffer.from(JSON.stringify({ leaked: SECRET })));
     } else if (req.url === '/gzip-clean') {
       res.setHeader('content-encoding', 'gzip');
       const gz = zlib.gzipSync(htmlClean);
@@ -102,5 +108,21 @@ describe('patchGlobalServerResponse with redactInsteadOfThrow', () => {
     }
     expect(failed).toBe(true);
     expect(body).not.toContain(SECRET);
+  });
+
+  it('redacts a leaked secret in a string end chunk', async () => {
+    const resp = await fetch(`${baseUrl}/end-string-leak`);
+    expect(resp.status).toBe(200);
+    const body = await resp.text();
+    expect(body).not.toContain(SECRET);
+    expect(body).toContain('▒');
+  });
+
+  it('redacts a leaked secret in a Buffer end chunk', async () => {
+    const resp = await fetch(`${baseUrl}/end-buffer-leak`);
+    expect(resp.status).toBe(200);
+    const body = await resp.text();
+    expect(body).not.toContain(SECRET);
+    expect(body).toContain('▒');
   });
 });

--- a/packages/varlock/src/runtime/test/patch-server-response.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response.test.ts
@@ -6,11 +6,11 @@
   captures its options at patch time, so redactInsteadOfThrow mode is covered in a
   separate test file (vitest isolates files into separate workers).
 */
+import http, { IncomingMessage, ServerResponse } from 'node:http';
 import zlib from 'node:zlib';
-import { IncomingMessage, ServerResponse } from 'node:http';
 import { Socket } from 'node:net';
 import {
-  describe, it, expect, beforeAll,
+  describe, it, expect, beforeAll, afterAll,
 } from 'vitest';
 
 import { patchGlobalServerResponse } from '../patch-server-response';
@@ -41,9 +41,46 @@ function makeRes(headers: Record<string, string> = {}) {
   return res;
 }
 
-beforeAll(() => {
+let endServer: http.Server;
+let endBaseUrl: string;
+
+beforeAll(async () => {
   resetRedactionMap(FAKE_GRAPH);
   patchGlobalServerResponse();
+
+  // Real HTTP server so we can assert end-leak responses finish (no hang)
+  endServer = http.createServer((req, res) => {
+    res.setHeader('content-type', 'application/json');
+    try {
+      if (req.url === '/end-string-leak') {
+        res.end(JSON.stringify({ leaked: SECRET }));
+      } else if (req.url === '/end-buffer-leak') {
+        res.end(Buffer.from(JSON.stringify({ leaked: SECRET })));
+      } else if (req.url === '/end-after-headers') {
+        res.write(JSON.stringify({ ok: true }));
+        res.end(JSON.stringify({ leaked: SECRET }));
+      } else {
+        res.end('not found');
+      }
+    } catch {
+      // patched end finishes the response before rethrowing; catch so the
+      // server handler does not become an uncaught exception
+    }
+  });
+  await new Promise<void>((resolve) => {
+    endServer.listen(0, () => resolve());
+  });
+  const address = endServer.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('expected address info');
+  }
+  endBaseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    endServer.close((err) => (err ? reject(err) : resolve()));
+  });
 });
 
 describe('patched ServerResponse.write - uncompressed', () => {
@@ -133,5 +170,35 @@ describe('patched ServerResponse.end', () => {
   it('throws when a sensitive value appears in a Buffer end chunk', () => {
     const res = makeRes({ 'content-type': 'application/json' });
     expect(() => res.end(Buffer.from(JSON.stringify({ leaked: SECRET })))).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('finishes the HTTP response with 500 when end detects a string leak (no hang)', async () => {
+    const resp = await fetch(`${endBaseUrl}/end-string-leak`);
+    expect(resp.status).toBe(500);
+    const body = await resp.text();
+    expect(body).not.toContain(SECRET);
+    expect(body).toBe('Internal Server Error');
+  });
+
+  it('finishes the HTTP response with 500 when end detects a Buffer leak (no hang)', async () => {
+    const resp = await fetch(`${endBaseUrl}/end-buffer-leak`);
+    expect(resp.status).toBe(500);
+    const body = await resp.text();
+    expect(body).not.toContain(SECRET);
+    expect(body).toBe('Internal Server Error');
+  });
+
+  it('destroys the connection when headers were already sent before an end leak', async () => {
+    let failed = false;
+    let body = '';
+    try {
+      const resp = await fetch(`${endBaseUrl}/end-after-headers`);
+      body = await resp.text();
+    } catch {
+      failed = true;
+    }
+    // connection destroyed mid-response: fetch may error or return a truncated body
+    expect(failed || !body.includes(SECRET)).toBe(true);
+    expect(body).not.toContain(SECRET);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #897. Catch scan failures in end, honor redact mode, return 500 or destroy so clients do not hang. Stacked on Buffer-scan branch.

## Test plan
- [ ] Confirm end no longer hangs when leak scan throws
- [ ] Verify redact vs destroy behavior
- [ ] Merge after Buffer-scan PR (#903)


Made with [Cursor](https://cursor.com)