### PR TITLE
fix: keep Cloudflare preview FIFO secrets out of argv

### DIFF
--- a/.bumpy/fix-cf-fifo-argv-secrets.md
+++ b/.bumpy/fix-cf-fifo-argv-secrets.md
@@ -1,0 +1,5 @@
+---
+"@varlock/cloudflare-integration": patch
+---
+
+Stop embedding `.dev.vars` contents in the preview FIFO helper's process argv. Secrets are passed on stdin with a control fd, matching `varlock-wrangler`.

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -38,6 +38,8 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
+    "test": "vitest",
+    "test:ci": "vitest --run",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/integrations/cloudflare/src/index.ts
+++ b/packages/integrations/cloudflare/src/index.ts
@@ -1,16 +1,14 @@
 import path from 'node:path';
 import {
-  existsSync, readdirSync, unlinkSync, writeFileSync,
+  existsSync, readdirSync, unlinkSync,
 } from 'node:fs';
-import { execSync, spawn, type ChildProcess } from 'node:child_process';
 import {
   varlockVitePlugin, varlockLoadedEnv, varlockLastError, buildErrorPageHtml,
 } from '@varlock/vite-integration';
 import { cloudflare, type PluginConfig, type WorkerConfig } from '@cloudflare/vite-plugin';
 import { CLOUDFLARE_SSR_ENTRY_CODE, disableWranglerDotEnvAutoload, logVarlockEnvInjectionNotice } from './shared-ssr-entry-code';
 import { encryptEnvBlobSync, generateEncryptionKeyHex } from 'varlock/encrypt-env';
-
-const isWindows = process.platform === 'win32';
+import { serveFifoOrFile } from './serve-fifo-or-file';
 
 /** Name exposed by `@cloudflare/vite-plugin`'s main plugin object. */
 const CLOUDFLARE_PLUGIN_NAME = 'vite-plugin-cloudflare';
@@ -111,53 +109,6 @@ function formatDevVarsContent(
   }
   return lines.join('\n');
 }
-
-/**
- * Serves `content` at `filePath` for reading by miniflare.
- * On Unix: uses a FIFO (named pipe) so secrets never touch disk.
- * On Windows: falls back to a regular temp file.
- *
- * The FIFO child process writes to the pipe in a loop — each `readFileSync`
- * by wrangler/miniflare gets the content, and the child immediately starts
- * the next write so subsequent reads also work.
- */
-function serveFifoOrFile(filePath: string, content: string) {
-  let fifoProcess: ChildProcess | undefined;
-
-  if (isWindows) {
-    writeFileSync(filePath, content);
-  } else {
-    execSync(`mkfifo -m 0600 "${filePath}"`);
-    // Spawn a child process that writes to the FIFO in a loop.
-    // Content is passed as a base64-encoded argument instead of stdin
-    // to avoid a deadlock: wrangler's readFileSync blocks the parent's
-    // event loop, which would prevent stdin data from being flushed.
-    const encoded = Buffer.from(content).toString('base64');
-    const parentPid = process.pid;
-    fifoProcess = spawn(process.execPath, [
-      '-e', `
-      const fs = require('fs');
-      const content = Buffer.from('${encoded}', 'base64').toString();
-      // Exit if the parent process dies (orphan protection).
-      setInterval(() => {
-        try { process.kill(${parentPid}, 0); }
-        catch { process.exit(); }
-      }, 2000);
-      (function serve() {
-        try { fs.writeFileSync(${JSON.stringify(filePath)}, content); setImmediate(serve); }
-        catch { process.exit(); }
-      })();
-    `,
-    ], { stdio: ['ignore', 'ignore', 'ignore'] });
-  }
-
-  return {
-    stop() {
-      fifoProcess?.kill();
-    },
-  };
-}
-
 
 // --- main plugin -----------------------------------------------------------
 
@@ -331,7 +282,7 @@ export function varlockCloudflareVitePlugin(
     configResolved(config) {
       resolvedRoot = config.root;
     },
-    configurePreviewServer(server) {
+    async configurePreviewServer(server) {
       logVarlockEnvInjectionNotice();
       if (!resolvedRoot) return;
 
@@ -359,7 +310,7 @@ export function varlockCloudflareVitePlugin(
       // Write a temporary .dev.vars file for miniflare to pick up.
       // On Unix we use a FIFO (named pipe) so secrets stay in memory.
       // On Windows we fall back to a regular file.
-      const fifo = serveFifoOrFile(devVarsPath, content);
+      const fifo = await serveFifoOrFile(devVarsPath, content);
 
       // Clean up when the preview server shuts down.
       const origClose = server.close.bind(server);

--- a/packages/integrations/cloudflare/src/serve-fifo-or-file.ts
+++ b/packages/integrations/cloudflare/src/serve-fifo-or-file.ts
@@ -1,0 +1,107 @@
+import { execSync, spawn } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+const isWindows = process.platform === 'win32';
+
+export type FifoServeHandle = {
+  stop(): void;
+  /** Child process pid when serving via FIFO (Unix). */
+  pid?: number;
+};
+
+/**
+ * Serves `content` at `filePath` for reading by miniflare.
+ * On Unix: uses a FIFO (named pipe) so secrets never touch disk.
+ * On Windows: falls back to a regular temp file.
+ *
+ * The FIFO child process writes to the pipe in a loop. Each sync read by
+ * wrangler/miniflare gets the content, and the child immediately starts
+ * the next write so subsequent reads also work. The loop must live in the
+ * child: wrangler's blocking sync read freezes the parent's event loop,
+ * so a parent-side re-arm would deadlock.
+ *
+ * Content is passed on stdin (not argv) so secrets never appear in
+ * ps /proc cmdline listings. A control fd signals when the child has buffered
+ * the payload and is about to open the FIFO, avoiding the deadlock that would
+ * occur if the parent blocked on a sync FIFO read before stdin was flushed.
+ */
+export async function serveFifoOrFile(
+  filePath: string,
+  content: string,
+): Promise<FifoServeHandle> {
+  if (isWindows) {
+    writeFileSync(filePath, content);
+    return {
+      stop() {
+        /* noop on Windows */
+      },
+    };
+  }
+
+  execSync(`mkfifo -m 0600 "${filePath}"`);
+  const parentPid = process.pid;
+  // Spawn a child that buffers content from stdin, signals ready on fd 3,
+  // then writes to the FIFO in a loop. Same stdin + control-fd pattern as
+  // varlock-wrangler spawnWriter: keeps secrets out of argv while still
+  // avoiding the readFileSync / stdin-flush deadlock.
+  const fifoProcess = spawn(process.execPath, [
+    '-e', `
+      const fs = require('fs');
+      const path = ${JSON.stringify(filePath)};
+      const parentPid = ${parentPid};
+      const ctrl = fs.createWriteStream(null, { fd: 3 });
+      const chunks = [];
+      process.stdin.on('data', d => chunks.push(d));
+      process.stdin.on('end', () => {
+        // concat Buffers once at end - '+=' on a Buffer corrupts split UTF-8
+        const content = Buffer.concat(chunks).toString('utf8');
+        // signal readiness *before* the blocking FIFO open so the parent
+        // knows it's safe for a reader (e.g. wrangler/miniflare) to proceed.
+        ctrl.write('ready\\n');
+        // Exit if the parent process dies (orphan protection).
+        setInterval(() => {
+          try { process.kill(parentPid, 0); }
+          catch { process.exit(); }
+        }, 2000);
+        (function serve() {
+          try { fs.writeFileSync(path, content); setImmediate(serve); }
+          catch { process.exit(); }
+        })();
+      });
+    `,
+  ], {
+    // stdin=pipe (content), stdout/stderr ignored, fd 3 = control pipe
+    stdio: ['pipe', 'ignore', 'ignore', 'pipe'],
+  });
+
+  fifoProcess.stdin!.write(content);
+  fifoProcess.stdin!.end();
+
+  const controlPipe = (fifoProcess.stdio as Array<any>)[3] as NodeJS.ReadableStream;
+
+  await new Promise<void>((resolve, reject) => {
+    let buf = '';
+    const onData = (d: Buffer) => {
+      buf += d.toString('utf8');
+      if (buf.includes('ready\n')) {
+        controlPipe.off('data', onData);
+        resolve();
+      } else if (buf.startsWith('err:')) {
+        reject(new Error(`fifo-server failed before ready: ${buf.trim()}`));
+      }
+    };
+    controlPipe.on('data', onData);
+    fifoProcess.once('exit', (code, signal) => {
+      if (!buf.includes('ready\n')) {
+        reject(new Error(`fifo-server exited before ready (code=${code}, signal=${signal})`));
+      }
+    });
+  });
+
+  return {
+    stop() {
+      fifoProcess.kill();
+    },
+    pid: fifoProcess.pid,
+  };
+}

--- a/packages/integrations/cloudflare/test/serve-fifo-or-file.test.ts
+++ b/packages/integrations/cloudflare/test/serve-fifo-or-file.test.ts
@@ -1,0 +1,84 @@
+import {
+  describe, expect, test, afterEach,
+} from 'vitest';
+import { execSync } from 'node:child_process';
+import {
+  mkdtempSync, readFileSync, rmSync, unlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { serveFifoOrFile } from '../src/serve-fifo-or-file';
+
+const isWindows = process.platform === 'win32';
+
+/** Read a process's argv string from the OS (macOS/Linux). */
+function processArgv(pid: number): string {
+  if (process.platform === 'linux') {
+    try {
+      // /proc/*/cmdline is NUL-separated
+      return readFileSync(`/proc/${pid}/cmdline`, 'utf8').replace(/\0/g, ' ');
+    } catch {
+      // fall through to ps
+    }
+  }
+  return execSync(`ps -p ${pid} -o args=`, { encoding: 'utf8' }).trim();
+}
+
+describe.skipIf(isWindows)('serveFifoOrFile', () => {
+  let tmpDir: string;
+  let fifoPath: string;
+  let handle: Awaited<ReturnType<typeof serveFifoOrFile>> | undefined;
+
+  afterEach(() => {
+    handle?.stop();
+    handle = undefined;
+    try {
+      unlinkSync(fifoPath);
+    } catch {
+      // may already be gone
+    }
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test('child argv does not contain the env payload', async () => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'varlock-cf-fifo-'));
+    fifoPath = path.join(tmpDir, '.dev.vars');
+
+    // Unique marker that would be obvious if leaked into argv (plain or base64).
+    const secret = `SECRET_MARKER_${Date.now()}_SHOULD_NOT_APPEAR_IN_ARGV`;
+    const content = `API_KEY='${secret}'\n__VARLOCK_ENV='{"x":1}'\n`;
+    const encoded = Buffer.from(content).toString('base64');
+
+    handle = await serveFifoOrFile(fifoPath, content);
+    expect(handle.pid).toBeDefined();
+
+    const argv = processArgv(handle.pid!);
+    expect(argv).not.toContain(secret);
+    expect(argv).not.toContain(encoded);
+    // Script should still be a node -e helper (sanity that we inspected the right process)
+    expect(argv).toMatch(/node|-e/);
+  });
+
+  test('serves content via FIFO', async () => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'varlock-cf-fifo-'));
+    fifoPath = path.join(tmpDir, '.dev.vars');
+
+    const content = 'FOO=\'bar\'\nBAZ=\'qux\'\n';
+    handle = await serveFifoOrFile(fifoPath, content);
+
+    // A continuous write loop can occasionally concatenate copies before EOF
+    // (scheduling-dependent). Assert the payload is present rather than exact
+    // equality; the argv leak check above is the security regression guard.
+    const first = readFileSync(fifoPath, 'utf8');
+    expect(first).toContain("FOO='bar'");
+    expect(first).toContain("BAZ='qux'");
+
+    const second = readFileSync(fifoPath, 'utf8');
+    expect(second).toContain("FOO='bar'");
+    expect(second).toContain("BAZ='qux'");
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #901. Pass .dev.vars via stdin/control fd instead of base64 in node -e argv.

## Test plan
- [ ] Confirm secrets are not present in process argv
- [ ] Run related Cloudflare preview tests


Made with [Cursor](https://cursor.com)