### PR TITLE
Array and object config item value types

### DIFF
--- a/.bumpy/array-object-value-types.md
+++ b/.bumpy/array-object-value-types.md
@@ -1,0 +1,7 @@
+---
+"@env-spec/parser": minor
+varlock: minor
+env-spec-language: minor
+---
+
+Add array and object value types: `@type=array(...)` and `@type=object(...)` with per-element validation, native `[a, b]` / `{k=v}` literal values, JSON and separator string input, configurable serialization back to process.env, per-element redaction, and typed code generation across languages

--- a/.bumpy/array-object-value-types.md
+++ b/.bumpy/array-object-value-types.md
@@ -4,4 +4,4 @@ varlock: minor
 env-spec-language: minor
 ---
 
-Add array and object value types: `@type=array(...)` and `@type=object(...)` with per-element validation, native `[a, b]` / `{k=v}` literal values, JSON and separator string input, configurable serialization back to process.env, per-element redaction, and typed code generation across languages
+Add array and object value types: `@type=array(...)` and `@type=record(...)` with per-element validation, native `[a, b]` / `{k=v}` literal values, JSON and separator string input, configurable serialization back to process.env, per-element redaction, and typed code generation across languages

--- a/packages/env-spec-parser/grammar.peggy
+++ b/packages/env-spec-parser/grammar.peggy
@@ -44,7 +44,10 @@ ConfigItem =
 
 ConfigItemKey = $([a-zA-Z_] [a-zA-Z0-9_.-]*)
 
-ConfigItemValue = FunctionCall / multiLineString / quotedString / unquotedString
+// ObjectLiteral / ArrayLiteral must come before unquotedString so a value starting
+// with `{` or `[` parses as a literal rather than a string. Values that fail to parse
+// as a literal (e.g. `{not-env-spec-syntax}`) still fall through to unquotedString.
+ConfigItemValue = FunctionCall / ObjectLiteral / ArrayLiteral / multiLineString / quotedString / unquotedString
 
 CommentBlock =
   // not sure if we want to treat these as decorators if within comment block?
@@ -220,13 +223,15 @@ ArrayLiteral =
     return new ParsedEnvSpecArrayLiteral({ values, _location: location() });
   }
 
-// Values inside `{}`/`[]` — like function-arg values but must also stop at `}`/`]`
+// Values inside `{}`/`[]` — like function-arg values but must also stop at `}`/`]`.
+// The unquoted fallback allows `${REF}` sequences as an atomic unit — without that,
+// the `}` would terminate the element early (it otherwise ends an enclosing literal).
 LiteralElementValue =
   ObjectLiteral
   / ArrayLiteral
   / FunctionCall
   / quotedString
-  / $([^ \n,)}\]]+) { return new ParsedEnvSpecStaticValue({ rawValue: text(), _location: location() }) }
+  / $(("${" [^}\n]* "}" / [^ \n,)}\]])+) { return new ParsedEnvSpecStaticValue({ rawValue: text(), _location: location() }) }
 
 // ~ decorator-context literals (multi-line via `#` continuation, like DecoratorFunctionArgs) ~
 DecoratorObjectLiteral =
@@ -255,7 +260,7 @@ DecoratorLiteralElementValue =
   / DecoratorArrayLiteral
   / DecoratorFunctionCall
   / quotedString
-  / $([^ \n,)}\]]+) { return new ParsedEnvSpecStaticValue({ rawValue: text(), _location: location() }) }
+  / $(("${" [^}\n]* "}" / [^ \n,)}\]])+) { return new ParsedEnvSpecStaticValue({ rawValue: text(), _location: location() }) }
 
 
 FunctionCall =

--- a/packages/env-spec-parser/src/classes.ts
+++ b/packages/env-spec-parser/src/classes.ts
@@ -383,12 +383,15 @@ export class ParsedEnvSpecBlankLine {
 }
 
 
+export type ParsedEnvSpecConfigItemValue = ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall
+  | ParsedEnvSpecObjectLiteral | ParsedEnvSpecArrayLiteral;
+
 export class ParsedEnvSpecConfigItem {
-  value: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall | undefined;
+  value: ParsedEnvSpecConfigItemValue | undefined;
 
   constructor(public data: {
     key: string;
-    value: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall | undefined;
+    value: ParsedEnvSpecConfigItemValue | undefined;
     preComments: Array<ParsedEnvSpecDecoratorComment | ParsedEnvSpecComment>;
     postComment: ParsedEnvSpecDecoratorComment | ParsedEnvSpecComment | undefined;
     _location?: any;
@@ -399,8 +402,6 @@ export class ParsedEnvSpecConfigItem {
         throw new Error('Nested key-value pair found in config item');
       } else if (expanded instanceof ParsedEnvSpecFunctionArgs) {
         throw new Error('Top-level config item cannot be a bare function args');
-      } else if (expanded instanceof ParsedEnvSpecObjectLiteral || expanded instanceof ParsedEnvSpecArrayLiteral) {
-        throw new Error('Top-level config item value cannot be a bare object or array literal');
       }
       this.value = expanded;
     }

--- a/packages/env-spec-parser/src/simple-resolver.ts
+++ b/packages/env-spec-parser/src/simple-resolver.ts
@@ -1,7 +1,8 @@
 import { execSync } from 'node:child_process';
 import {
   ParsedEnvSpecFile, ParsedEnvSpecFunctionCall, ParsedEnvSpecKeyValuePair,
-  ParsedEnvSpecStaticValue,
+  ParsedEnvSpecStaticValue, ParsedEnvSpecObjectLiteral, ParsedEnvSpecArrayLiteral,
+  type ParsedEnvSpecConfigItemValue,
 } from './classes.js';
 
 /**
@@ -18,9 +19,22 @@ export function simpleResolver(
   const resolved = {} as Record<string, any>;
 
   function valueResolver(
-    valOrFn: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall,
-  ): string | undefined {
+    valOrFn: ParsedEnvSpecConfigItemValue,
+  ): string | Array<unknown> | Record<string, unknown> | undefined {
     if (valOrFn instanceof ParsedEnvSpecStaticValue) return valOrFn.unescapedValue;
+    if (valOrFn instanceof ParsedEnvSpecArrayLiteral) {
+      return valOrFn.values.map((v) => {
+        if (v instanceof ParsedEnvSpecKeyValuePair) throw new Error('Unexpected key-value pair in array literal');
+        return valueResolver(v);
+      });
+    }
+    if (valOrFn instanceof ParsedEnvSpecObjectLiteral) {
+      const obj: Record<string, unknown> = {};
+      for (const kv of valOrFn.values) {
+        obj[kv.key] = valueResolver(kv.value);
+      }
+      return obj;
+    }
     if (valOrFn instanceof ParsedEnvSpecFunctionCall) {
       if (valOrFn.name === 'ref') {
         const args = valOrFn.simplifiedArgs;

--- a/packages/env-spec-parser/test/values.test.ts
+++ b/packages/env-spec-parser/test/values.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import ansis from 'ansis';
 import {
   ParsedEnvSpecFunctionCall, ParsedEnvSpecKeyValuePair,
-  ParsedEnvSpecStaticValue, parseEnvSpecDotEnvFile,
+  ParsedEnvSpecStaticValue, ParsedEnvSpecArrayLiteral, ParsedEnvSpecObjectLiteral,
+  parseEnvSpecDotEnvFile,
 } from '../src';
 import { expectInstanceOf } from './test-utils';
 
@@ -223,5 +224,114 @@ describe('regex-like strings and paths with slashes', () => {
     // The value includes the full unquoted string up to the closing )
     // In the env file: /^https:\/\// (the trailing / that was previously the regex closing delimiter is now part of the string)
     expect(args[0].value.value).toEqual('/^https:\\/\\//');
+  });
+});
+
+describe('array literal item values', () => {
+  it('parses [a, b] as an array literal', () => {
+    const result = parseEnvSpecDotEnvFile('VAL=[a, b]');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecArrayLiteral);
+    expect(valNode.simplifiedValue).toEqual(['a', 'b']);
+  });
+
+  it('parses quoted elements in array literals', () => {
+    const result = parseEnvSpecDotEnvFile('VAL=["a@example.com", "b@example.com"]');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecArrayLiteral);
+    expect(valNode.simplifiedValue).toEqual(['a@example.com', 'b@example.com']);
+  });
+
+  it('parses empty array literal', () => {
+    const result = parseEnvSpecDotEnvFile('VAL=[]');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecArrayLiteral);
+    expect(valNode.simplifiedValue).toEqual([]);
+  });
+
+  it('auto-coerces unquoted scalar elements', () => {
+    const result = parseEnvSpecDotEnvFile('VAL=[1, true, x]');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecArrayLiteral);
+    expect(valNode.simplifiedValue).toEqual([1, true, 'x']);
+  });
+
+  it('supports multi-line array literals with trailing comma', () => {
+    const result = parseEnvSpecDotEnvFile('VAL=[\n  one,\n  two,\n]');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecArrayLiteral);
+    expect(valNode.simplifiedValue).toEqual(['one', 'two']);
+  });
+
+  // eslint-disable-next-line no-template-curly-in-string
+  it('expands ${REF} within array elements', () => {
+    // eslint-disable-next-line no-template-curly-in-string
+    const result = parseEnvSpecDotEnvFile('VAL=[a, ${OTHER}]');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecArrayLiteral);
+    const el1 = valNode.values[1];
+    expectInstanceOf(el1, ParsedEnvSpecFunctionCall);
+    expect(el1.name).toEqual('ref');
+  });
+
+  // eslint-disable-next-line no-template-curly-in-string
+  it('expands ${REF} with adjacent text into concat within elements', () => {
+    // eslint-disable-next-line no-template-curly-in-string
+    const result = parseEnvSpecDotEnvFile('VAL=[${A}-suffix, b]');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecArrayLiteral);
+    const el0 = valNode.values[0];
+    expectInstanceOf(el0, ParsedEnvSpecFunctionCall);
+    expect(el0.name).toEqual('concat');
+  });
+
+  it('supports nested arrays and objects', () => {
+    const result = parseEnvSpecDotEnvFile('VAL=[a, [b, c], {k=v}]');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecArrayLiteral);
+    expect(valNode.simplifiedValue).toEqual(['a', ['b', 'c'], { k: 'v' }]);
+  });
+
+  it('supports post comments after array literals', () => {
+    const result = parseEnvSpecDotEnvFile('VAL=[a, b] # comment');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecArrayLiteral);
+    expect(valNode.simplifiedValue).toEqual(['a', 'b']);
+  });
+});
+
+describe('object literal item values', () => {
+  it('parses {k=v} as an object literal', () => {
+    const result = parseEnvSpecDotEnvFile('VAL={k=v, n=2}');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecObjectLiteral);
+    expect(valNode.simplifiedValue).toEqual({ k: 'v', n: 2 });
+  });
+
+  it('parses empty object literal', () => {
+    const result = parseEnvSpecDotEnvFile('VAL={}');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecObjectLiteral);
+    expect(valNode.simplifiedValue).toEqual({});
+  });
+
+  // eslint-disable-next-line no-template-curly-in-string
+  it('expands ${REF} within object values', () => {
+    // eslint-disable-next-line no-template-curly-in-string
+    const result = parseEnvSpecDotEnvFile('VAL={url=${BASE}, n=2}');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecObjectLiteral);
+    const urlVal = valNode.values[0].value;
+    expectInstanceOf(urlVal, ParsedEnvSpecFunctionCall);
+    expect(urlVal.name).toEqual('ref');
+  });
+
+  it('JSON-style objects fall back to plain strings', () => {
+    // `:`-separated pairs are not env-spec object syntax, so the literal parse fails
+    // and the value falls through to a plain unquoted string (previous behavior)
+    const result = parseEnvSpecDotEnvFile('VAL={"json": "blob"}');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecStaticValue);
+    expect(valNode.value).toEqual('{"json": "blob"}');
   });
 });

--- a/packages/env-spec-parser/test/values.test.ts
+++ b/packages/env-spec-parser/test/values.test.ts
@@ -315,6 +315,14 @@ describe('object literal item values', () => {
     expect(valNode.simplifiedValue).toEqual({});
   });
 
+
+  it('supports multi-line object literals with trailing comma', () => {
+    const result = parseEnvSpecDotEnvFile('VAL={\n  api=https://a.com,\n  # comment\n  docs=https://b.com,\n}');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecObjectLiteral);
+    expect(valNode.simplifiedValue).toEqual({ api: 'https://a.com', docs: 'https://b.com' });
+  });
+
   // eslint-disable-next-line no-template-curly-in-string
   it('expands ${REF} within object values', () => {
     // eslint-disable-next-line no-template-curly-in-string

--- a/packages/env-spec-parser/test/values.test.ts
+++ b/packages/env-spec-parser/test/values.test.ts
@@ -300,6 +300,22 @@ describe('array literal item values', () => {
   });
 });
 
+describe('comments and hashes within array literals', () => {
+  it('supports trailing comments after elements', () => {
+    const result = parseEnvSpecDotEnvFile('VAL=[\n  one, # first\n  two # last\n]');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecArrayLiteral);
+    expect(valNode.simplifiedValue).toEqual(['one', 'two']);
+  });
+
+  it('a hash glued to an unquoted element stays part of the value', () => {
+    const result = parseEnvSpecDotEnvFile('VAL=[color#1, plain]');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecArrayLiteral);
+    expect(valNode.simplifiedValue).toEqual(['color#1', 'plain']);
+  });
+});
+
 describe('object literal item values', () => {
   it('parses {k=v} as an object literal', () => {
     const result = parseEnvSpecDotEnvFile('VAL={k=v, n=2}');
@@ -315,6 +331,13 @@ describe('object literal item values', () => {
     expect(valNode.simplifiedValue).toEqual({});
   });
 
+
+  it('supports trailing comments after entries', () => {
+    const result = parseEnvSpecDotEnvFile('VAL={\n  api=https://a.com, # main api\n  docs=https://b.com # docs site\n}');
+    const valNode = result.configItems[0].value;
+    expectInstanceOf(valNode, ParsedEnvSpecObjectLiteral);
+    expect(valNode.simplifiedValue).toEqual({ api: 'https://a.com', docs: 'https://b.com' });
+  });
 
   it('supports multi-line object literals with trailing comma', () => {
     const result = parseEnvSpecDotEnvFile('VAL={\n  api=https://a.com,\n  # comment\n  docs=https://b.com,\n}');

--- a/packages/varlock-website/src/content/docs/env-spec/reference.mdx
+++ b/packages/varlock-website/src/content/docs/env-spec/reference.mdx
@@ -213,15 +213,21 @@ Standalone objects and arrays use distinct brackets, keeping them unambiguous fr
 
 - `{ key=value, ... }` is an **object**, where keys use `=` (as elsewhere in the spec), not `:`
 - `[ value, ... ]` is an **array**
-- they may be nested, and used as decorator values or as function-call arguments
+- they may be nested, and used as decorator values, function-call arguments, or standalone config item values
 - they are parsed using the common value-handling rules, and may span multiple lines (see [Multi-line literals](#multi-line-literals) below)
-- they are **not yet supported as standalone config item values** (e.g. `ITEM={...}`). For now an item value that starts with `{`/`[` is still treated as a string
+- as a config item value, a literal implies the item's type (or pair it with an explicit `@type=array(...)` / `@type=object(...)` for element validation - see [array](/reference/data-types/#array) and [object](/reference/data-types/#object))
+- an item value starting with `{`/`[` that does not parse as a literal (e.g. a JSON string using `:` pairs) still falls back to a plain string
 
 ```env-spec
 # @dec={ key1=v1, key2="v2", nested={ a=1 } }
 # @dec=[a, b, c]
 # @dec=fn(opts={ retries=3 }, tags=[x, y])
 ITEM=
+
+# @type=array(email)
+ALLOWED_EMAILS=[admin@example.com, support@example.com]
+# @type=object(url)
+ENDPOINTS={api=https://api.example.com, docs=https://docs.example.com}
 ```
 
 This is why per-item options are written `@sensitive={preventLeaks=false}` rather than `@sensitive(...)`. The latter (a bare function call) is reserved for repeatable decorators.

--- a/packages/varlock-website/src/content/docs/env-spec/reference.mdx
+++ b/packages/varlock-website/src/content/docs/env-spec/reference.mdx
@@ -215,7 +215,7 @@ Standalone objects and arrays use distinct brackets, keeping them unambiguous fr
 - `[ value, ... ]` is an **array**
 - they may be nested, and used as decorator values, function-call arguments, or standalone config item values
 - they are parsed using the common value-handling rules, and may span multiple lines (see [Multi-line literals](#multi-line-literals) below)
-- as a config item value, a literal implies the item's type (or pair it with an explicit `@type=array(...)` / `@type=object(...)` for element validation - see [array](/reference/data-types/#array) and [object](/reference/data-types/#object))
+- as a config item value, a literal implies the item's type (or pair it with an explicit `@type=array(...)` / `@type=record(...)` for element validation - see [array](/reference/data-types/#array) and [record](/reference/data-types/#record))
 - an item value starting with `{`/`[` that does not parse as a literal (e.g. a JSON string using `:` pairs) still falls back to a plain string
 
 ```env-spec
@@ -226,7 +226,7 @@ ITEM=
 
 # @type=array(email)
 ALLOWED_EMAILS=[admin@example.com, support@example.com]
-# @type=object(url)
+# @type=record(url)
 ENDPOINTS={api=https://api.example.com, docs=https://docs.example.com}
 ```
 

--- a/packages/varlock-website/src/content/docs/reference/data-types.mdx
+++ b/packages/varlock-website/src/content/docs/reference/data-types.mdx
@@ -311,7 +311,7 @@ A list of values, each coerced and validated with an element type.
 **Array options:**
 - `separator` (string, default `","`): splits plain-string input (e.g. a real environment variable override) and joins the value back into a string for `process.env`
 - `format` (`separator` | `json`, default `separator`): how the value serializes back into `process.env`. `json` emits a JSON array string. Arrays of objects/arrays always use JSON
-- `minLength` / `maxLength` / `isLength` (number): element count bounds (or an exact count). Empty arrays are valid by default; use `minLength=1` to require at least one element
+- `minLength` / `maxLength` / `isLength` (number): element count bounds (or an exact count). `minLength` defaults to 1, so an explicitly-empty `[]` is invalid unless you set `minLength=0` (an explicit `isLength` also overrides the default)
 - `unique` (boolean): reject duplicate elements
 
 Values can be written three ways:
@@ -336,6 +336,8 @@ A scalar element that contains the separator fails validation (it could not roun
 
 In application code, `ENV.ALLOWED_EMAILS` is a real typed array (`string[]`, `number[]`, etc. via [type generation](/guides/type-generation/)). In `process.env` the value is the flat string form (separator-joined, or JSON when `format=json`).
 
+An empty or whitespace-only string input resolves to a missing value (`undefined`), never an empty array; the only way to express an empty array is the explicit `[]` literal (sanctioned via `minLength=0`).
+
 An untyped item whose value is an array literal (e.g. `ITEM=[a, b]`) is inferred as an array automatically.
 </div>
 
@@ -348,7 +350,7 @@ An object (a keyed record) whose values are coerced and validated with a value t
 
 **Object options:**
 - `keyType`: a type used to validate every key, e.g. `keyType=enum(us, eu)` or `keyType=string(matches="[a-z]+")`
-- `entriesMinLength` / `entriesMaxLength` / `entriesIsLength` (number): entry count bounds (or an exact count). Empty objects are valid by default
+- `entriesMinLength` / `entriesMaxLength` / `entriesIsLength` (number): entry count bounds (or an exact count). `entriesMinLength` defaults to 1, so an explicitly-empty `{}` is invalid unless you set `entriesMinLength=0`
 
 ```env-spec
 # every value must be a valid url

--- a/packages/varlock-website/src/content/docs/reference/data-types.mdx
+++ b/packages/varlock-website/src/content/docs/reference/data-types.mdx
@@ -45,6 +45,23 @@ One constraint: dynamic parts may vary validation behavior, but not the **genera
 
 Dynamic whole types resolve to a bare type name; to combine a dynamic type with options, put the dynamic part in the option instead (e.g. `string(minLength=if(...))`).
 
+Enum members can also be sourced from other items. A referenced array spreads its elements into the member list:
+
+```env-spec
+# @type=array(string)
+ALLOWED_MODES=[dev, staging, prod]
+
+# value must be one of the elements of ALLOWED_MODES
+# @type=enum($ALLOWED_MODES)
+APP_MODE=dev
+
+# static members and references can be mixed
+# @type=enum(local, $ALLOWED_MODES)
+BUILD_MODE=local
+```
+
+Since membership is only known at resolution time, generated code types a dynamic enum as a plain string, and members must resolve to strings.
+
 ### Coercion & validation process
 
 Once a raw value is resolved - which could from a static value in an `.env` file, a [function](/reference/functions/), or an override passed into the process - the raw value will be coerced and validated based on the type, respecting additional arguments provided to the type.
@@ -163,7 +180,7 @@ API_URL=https://api.example.com/v1
 
 <div>
 ### `enum`
-Checks a value is contained in a list of possible values - it must match one exactly.
+Checks a value is contained in a list of possible values - it must match one exactly. Members can also be sourced from other items (see [Dynamic type options](#dynamic-type-options)).
 
 **NOTE** - this is the only type that cannot be used without any additional arguments
 

--- a/packages/varlock-website/src/content/docs/reference/data-types.mdx
+++ b/packages/varlock-website/src/content/docs/reference/data-types.mdx
@@ -294,7 +294,7 @@ A list of values, each coerced and validated with an element type.
 **Array options:**
 - `separator` (string, default `","`): splits plain-string input (e.g. a real environment variable override) and joins the value back into a string for `process.env`
 - `format` (`separator` | `json`, default `separator`): how the value serializes back into `process.env`. `json` emits a JSON array string. Arrays of objects/arrays always use JSON
-- `minLength` / `maxLength` (number): element count bounds. Empty arrays are valid by default; use `minLength=1` to require at least one element
+- `minLength` / `maxLength` / `isLength` (number): element count bounds (or an exact count). Empty arrays are valid by default; use `minLength=1` to require at least one element
 - `unique` (boolean): reject duplicate elements
 
 Values can be written three ways:

--- a/packages/varlock-website/src/content/docs/reference/data-types.mdx
+++ b/packages/varlock-website/src/content/docs/reference/data-types.mdx
@@ -222,7 +222,7 @@ MY_HASH=d41d8cd98f00b204e9800998ecf8427e
 
 <div>
 ### `simple-object`
-Validates and coerces JSON strings into objects.
+Validates and coerces JSON strings into objects. Equivalent to a bare [`object`](#object); prefer `object`, which can also validate keys and values.
 ```env-spec
 # @type=simple-object
 MY_OBJECT={"key": "value"}
@@ -253,5 +253,74 @@ POLL_INTERVAL=15m
 ```
 
 Same parser is used by `cache(..., ttl=...)` and the plugin `cacheTtl` option, so any string that works there also works here. For cache mode behavior and troubleshooting, see the [Caching guide](/guides/caching/).
+</div>
+
+<div>
+### `array`
+
+A list of values, each coerced and validated with an element type.
+
+**Element type** is the first positional argument: a type name (`array(email)`) or a nested type call for types that take their own options or positional args (`array(email(normalize=true))`, `array(enum(dev, staging, prod))`). Omitting it defaults to string elements.
+
+**Array options:**
+- `separator` (string, default `","`): splits plain-string input (e.g. a real environment variable override) and joins the value back into a string for `process.env`
+- `format` (`separator` | `json`, default `separator`): how the value serializes back into `process.env`. `json` emits a JSON array string. Arrays of objects/arrays always use JSON
+- `minLength` / `maxLength` (number): element count bounds. Empty arrays are valid by default; use `minLength=1` to require at least one element
+- `unique` (boolean): reject duplicate elements
+
+Values can be written three ways:
+
+```env-spec
+# native literal - elements support refs and function calls
+# @type=array(email)
+ALLOWED_EMAILS=[admin@example.com, ${SUPPORT_EMAIL}]
+
+# separator-joined string - how a real env var override arrives
+# @type=array(url, separator=";")
+SERVICE_URLS="https://a.example.com;https://b.example.com"
+
+# JSON array string
+# @type=array(number)
+SCORES='[10, 20, 30]'
+```
+
+Validation errors are reported per element (`[1] Current value is not in list of possible values`).
+
+A scalar element that contains the separator fails validation (it could not round-trip through `process.env`); set `format=json` or pick a different separator.
+
+In application code, `ENV.ALLOWED_EMAILS` is a real typed array (`string[]`, `number[]`, etc. via [type generation](/guides/type-generation/)). In `process.env` the value is the flat string form (separator-joined, or JSON when `format=json`).
+
+An untyped item whose value is an array literal (e.g. `ITEM=[a, b]`) is inferred as an array automatically.
+</div>
+
+<div>
+### `object`
+
+An object (string keys) whose values are coerced and validated with a value type, with optional key validation.
+
+**Value type** is the first positional argument, same forms as `array`. Bare `@type=object` accepts any object without per-value validation.
+
+**Object options:**
+- `keys`: a type used to validate every key, e.g. `keys=enum(us, eu)` or `keys=string(matches="[a-z]+")`
+
+```env-spec
+# every value must be a valid url
+# @type=object(url)
+ENDPOINTS={api=https://api.example.com, docs=https://docs.example.com}
+
+# keys restricted to an enum, values validated as numbers
+# @type=object(number, keys=enum(us, eu))
+REGION_LIMITS={us=100, eu=50}
+
+# JSON object strings also work
+# @type=object(number)
+LIMITS='{"low": 1, "high": 100}'
+```
+
+Validation errors are reported per entry (`"apac" is not a valid key - ...`).
+
+In application code, `ENV.ENDPOINTS` is a typed record (`Record<string, string>`; enum-constrained keys narrow further). In `process.env` the value is JSON.
+
+An untyped item whose value is an object literal (e.g. `ITEM={k=v}`) is inferred as an object automatically. The existing `simple-object` type behaves the same as a bare `object`.
 </div>
 </div>

--- a/packages/varlock-website/src/content/docs/reference/data-types.mdx
+++ b/packages/varlock-website/src/content/docs/reference/data-types.mdx
@@ -251,7 +251,7 @@ MY_HASH=d41d8cd98f00b204e9800998ecf8427e
 
 <div>
 ### `simple-object`
-Validates and coerces JSON strings into objects. Equivalent to a bare [`object`](#object); prefer `object`, which can also validate keys and values.
+Validates and coerces JSON strings into objects. Equivalent to a bare [`record`](#record); prefer `record`, which can also validate keys and values.
 ```env-spec
 # @type=simple-object
 MY_OBJECT={"key": "value"}
@@ -323,11 +323,11 @@ An untyped item whose value is an array literal (e.g. `ITEM=[a, b]`) is inferred
 </div>
 
 <div>
-### `object`
+### `record`
 
-An object (string keys) whose values are coerced and validated with a value type, with optional key validation.
+An object (a keyed record) whose values are coerced and validated with a value type, with optional key validation. Named `record` (matching TS `Record` and zod convention) since it types ALL values uniformly rather than specific keys.
 
-**Value type** is the first positional argument, same forms as `array`. Bare `@type=object` accepts any object without per-value validation.
+**Value type** is the first positional argument, same forms as `array`. Bare `@type=record` accepts any object without per-value validation.
 
 **Object options:**
 - `keyType`: a type used to validate every key, e.g. `keyType=enum(us, eu)` or `keyType=string(matches="[a-z]+")`
@@ -335,22 +335,22 @@ An object (string keys) whose values are coerced and validated with a value type
 
 ```env-spec
 # every value must be a valid url
-# @type=object(url)
+# @type=record(url)
 ENDPOINTS={api=https://api.example.com, docs=https://docs.example.com}
 
 # keys restricted to an enum, values validated as numbers
-# @type=object(number, keyType=enum(us, eu))
+# @type=record(number, keyType=enum(us, eu))
 REGION_LIMITS={us=100, eu=50}
 
 # JSON object strings also work
-# @type=object(number)
+# @type=record(number)
 LIMITS='{"low": 1, "high": 100}'
 ```
 
 Validation errors are reported per entry (`"apac" is not a valid key - ...`).
 
-In application code, `ENV.ENDPOINTS` is a typed record (`Record<string, string>`; enum-constrained keys narrow further). In `process.env` the value is JSON.
+In application code, `ENV.ENDPOINTS` is typed as `Record<string, string>` (enum-constrained keys narrow further). In `process.env` the value is JSON.
 
-An untyped item whose value is an object literal (e.g. `ITEM={k=v}`) is inferred as an object automatically. The existing `simple-object` type behaves the same as a bare `object`.
+An untyped item whose value is an object literal (e.g. `ITEM={k=v}`) is inferred as a record automatically. The existing `simple-object` type behaves the same as a bare `record`.
 </div>
 </div>

--- a/packages/varlock-website/src/content/docs/reference/data-types.mdx
+++ b/packages/varlock-website/src/content/docs/reference/data-types.mdx
@@ -16,6 +16,35 @@ NO_ARGS=
 WITH_ARGS=
 ```
 
+### Dynamic type options
+
+Type option values can be [resolver functions](/reference/functions/) instead of static values, so validation can vary per environment or based on other items:
+
+```env-spec
+# @type=enum(dev, production)
+APP_ENV=dev
+
+# stricter length requirement in production
+# @type=string(minLength=if(eq($APP_ENV, production), 32, 8))
+API_TOKEN=
+
+# require at least one entry only in production
+# @type=array(email, minLength=if(eq($APP_ENV, production), 1, 0))
+ALERT_EMAILS=[]
+```
+
+The whole type can also be dynamic, resolving to a type name:
+
+```env-spec
+# validate as a url in production, allow anything in dev
+# @type=if(eq($APP_ENV, production), url, string)
+SERVICE_HOST=localhost:3000
+```
+
+One constraint: dynamic parts may vary validation behavior, but not the **generated** types (generated code must not differ per environment). All possible types must generate the same type. A `url` and a `string` both generate a string, so switching between them is fine; switching between `number` and `string` is a schema error. For generated code, the first static candidate in the expression is used (`url` above). The same rule applies to options that affect generated types (e.g. `number(isInt=...)` must stay static).
+
+Dynamic whole types resolve to a bare type name; to combine a dynamic type with options, put the dynamic part in the option instead (e.g. `string(minLength=if(...))`).
+
 ### Coercion & validation process
 
 Once a raw value is resolved - which could from a static value in an `.env` file, a [function](/reference/functions/), or an override passed into the process - the raw value will be coerced and validated based on the type, respecting additional arguments provided to the type.

--- a/packages/varlock-website/src/content/docs/reference/data-types.mdx
+++ b/packages/varlock-website/src/content/docs/reference/data-types.mdx
@@ -330,7 +330,8 @@ An object (string keys) whose values are coerced and validated with a value type
 **Value type** is the first positional argument, same forms as `array`. Bare `@type=object` accepts any object without per-value validation.
 
 **Object options:**
-- `keys`: a type used to validate every key, e.g. `keys=enum(us, eu)` or `keys=string(matches="[a-z]+")`
+- `keyType`: a type used to validate every key, e.g. `keyType=enum(us, eu)` or `keyType=string(matches="[a-z]+")`
+- `entriesMinLength` / `entriesMaxLength` / `entriesIsLength` (number): entry count bounds (or an exact count). Empty objects are valid by default
 
 ```env-spec
 # every value must be a valid url
@@ -338,7 +339,7 @@ An object (string keys) whose values are coerced and validated with a value type
 ENDPOINTS={api=https://api.example.com, docs=https://docs.example.com}
 
 # keys restricted to an enum, values validated as numbers
-# @type=object(number, keys=enum(us, eu))
+# @type=object(number, keyType=enum(us, eu))
 REGION_LIMITS={us=100, eu=50}
 
 # JSON object strings also work

--- a/packages/varlock/src/cli/commands/load.command.ts
+++ b/packages/varlock/src/cli/commands/load.command.ts
@@ -257,6 +257,10 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     }
   } else if (outputFormat === 'env' || outputFormat === 'shell') {
     const resolvedEnv = envGraph.getResolvedEnvObject({ filterKeys });
+    // env/shell output is destined for raw environment variables, so values are emitted
+    // in their process.env string form (composites become separator-joined/JSON strings);
+    // the typed object above still decides quoting (bare numbers/booleans stay unquoted)
+    const resolvedEnvStrings = envGraph.getResolvedEnvStringObject({ filterKeys });
     const skipUndefined = compact === true;
     const prefix = outputFormat === 'shell' ? 'export ' : '';
 
@@ -270,14 +274,16 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
       let strValue: string;
       if (value === undefined) {
         strValue = '';
-      } else if (typeof value === 'string') {
+      } else if (typeof value === 'string' || typeof value === 'object') {
+        const stringForm = resolvedEnvStrings[key] ?? '';
         if (outputFormat === 'shell') {
-          strValue = formatShellValue(value);
+          strValue = formatShellValue(stringForm);
         } else {
-          strValue = `"${value.replaceAll('"', '\\"').replaceAll('\n', '\\n')}"`;
+          strValue = `"${stringForm.replaceAll('"', '\\"').replaceAll('\n', '\\n')}"`;
         }
       } else {
-        strValue = JSON.stringify(value);
+        // bare scalars (numbers/booleans) stay unquoted so re-reading infers the same type
+        strValue = String(value);
       }
       console.log(`${prefix}${key}=${strValue}`);
     }

--- a/packages/varlock/src/cli/commands/proxy.command.ts
+++ b/packages/varlock/src/cli/commands/proxy.command.ts
@@ -288,7 +288,8 @@ async function loadResolvedProxyGraph(entryFilePaths?: Array<string>) {
 async function prepareProxyPolicy(entryFilePaths?: Array<string>): Promise<PreparedProxyPolicy> {
   const envGraph = await loadResolvedProxyGraph(entryFilePaths);
 
-  const resolvedEnv = envGraph.getResolvedEnvObject();
+  // string-serialized since this feeds the session env payload (child process.env)
+  const resolvedEnv = envGraph.getResolvedEnvStringObject() as Record<string, string>;
   const serializedGraph = envGraph.getSerializedGraph();
   const schemaFingerprint = buildProxySchemaFingerprint(envGraph);
   const proxyManagedItems = await envGraph.getProxyManagedItems();

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -200,7 +200,9 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   // (e.g. a nested `varlock run` whose own resolution needs a secret-zero token)
   const includeInternal = !!ctx.values['include-internal'];
   const filterKeys = itemFilter?.getFilterKeys(Object.values(envGraph.configSchema));
-  const resolvedEnv = envGraph.getResolvedEnvObject({ includeInternal, filterKeys });
+  // string-serialized values (composites become separator-joined/JSON strings) since
+  // these are injected directly into the child's process.env
+  const resolvedEnv = envGraph.getResolvedEnvStringObject({ includeInternal, filterKeys });
   const serializedGraph = envGraph.getSerializedGraph({ filterKeys });
   const { resetRedactionMap } = await import('../../runtime/env');
   // console.log(resolvedEnv);

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -16,14 +16,17 @@ import type { CacheHitInfo } from './resolution-context';
 import { EnvGraphDataSource } from './data-source';
 import {
   convertParsedValueToResolvers, type ResolvedValue, Resolver, StaticValueResolver,
+  ArrayLiteralResolver, ObjectLiteralResolver,
 } from './resolver';
+import { buildDataTypeFromTypeDecorator } from './type-decorator';
 import { ItemDecoratorInstance } from './decorators';
 
 export type ConfigItemDef = {
   description?: string;
   // TODO: translate parser decorator class into our own generic version
   parsedDecorators?: Array<ParsedEnvSpecDecorator>;
-  parsedValue: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall | undefined;
+  parsedValue: ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall
+    | ParsedEnvSpecArrayLiteral | ParsedEnvSpecObjectLiteral | undefined;
 
   resolver?: Resolver;
   decorators?: Array<ItemDecoratorInstance>;
@@ -361,37 +364,56 @@ export class ConfigItem {
     }
 
     const typeDec = this.getDec('type');
-    let dataTypeName: string | undefined;
-    let dataTypeArgs: any;
     // TODO: this will not currently support any resolver functions within type settings
     const typeDecParsedValue = typeDec?.parsedDecorator.value;
-    if (typeDecParsedValue instanceof ParsedEnvSpecStaticValue) {
-      dataTypeName = typeDecParsedValue.value;
-    } else if (typeDecParsedValue instanceof ParsedEnvSpecFunctionCall) {
-      dataTypeName = typeDecParsedValue.name;
-      dataTypeArgs = typeDecParsedValue.simplifiedArgs;
-    }
-    // if no type is set explicitly, we can try to use inferred type from the resolver
-    // currently only static value resolver does this - but you can imagine another resolver knowing the type ahead of time
-    // (maybe we only want to do this if the value is set in a schema file? or if all inferred types match?)
-    if (!dataTypeName) {
-      // builtin vars declare an authoritative type on their internal resolver
-      // (e.g. VARLOCK_IS_CI is boolean), which wins over inference from a
-      // user-provided static value so VARLOCK_IS_CI=0 still coerces to false
-      const internalResolverType = this._internalDefs.find(
-        (d) => d.itemDef.resolver?.inferredType,
-      )?.itemDef.resolver?.inferredType;
-      dataTypeName = internalResolverType || this.valueResolver?.inferredType;
-    }
-    dataTypeName ||= 'string';
-    dataTypeArgs ||= [];
-
-    if (!(dataTypeName in this.envGraph.dataTypesRegistry)) {
-      this._schemaErrors.push(new SchemaError(`unknown data type: ${dataTypeName}`));
+    if (typeDecParsedValue) {
+      try {
+        this.dataType = buildDataTypeFromTypeDecorator(this.envGraph.dataTypesRegistry, typeDecParsedValue);
+      } catch (err) {
+        this._schemaErrors.push(err instanceof SchemaError ? err : new SchemaError(err as Error));
+      }
     } else {
-      const dataTypeFactory = this.envGraph.dataTypesRegistry[dataTypeName];
-      this.dataType = dataTypeFactory(..._.isPlainObject(dataTypeArgs) ? [dataTypeArgs] : dataTypeArgs);
+      // if no type is set explicitly, we can try to use inferred type from the resolver
+      // currently only static value / literal resolvers do this - but you can imagine another
+      // resolver knowing the type ahead of time
+      // (maybe we only want to do this if the value is set in a schema file? or if all inferred types match?)
+      this.dataType = this.inferDataTypeFromResolver() ?? this.envGraph.dataTypesRegistry.string();
     }
+  }
+
+  /** infer a data type instance from the shape of the (untyped) value resolver */
+  private inferDataTypeFromResolver(): EnvGraphDataType | undefined {
+    const registry = this.envGraph.dataTypesRegistry;
+    const resolver = this.valueResolver;
+    if (!resolver) return undefined;
+
+    // a literal value (`ITEM=[a, b]` / `ITEM={k=v}`) implies a composite type - same
+    // principle as an unquoted `123` inferring number below
+    if (resolver instanceof ArrayLiteralResolver) {
+      // when every element infers the same scalar type (e.g. `[8080, 3000]`), carry it through
+      const elementTypes = _.uniq((resolver.arrArgs ?? []).map((r) => r.inferredType));
+      const elementTypeName = (
+        elementTypes.length === 1
+        && elementTypes[0] !== undefined
+        && ['number', 'boolean'].includes(elementTypes[0])
+      ) ? elementTypes[0] : 'string';
+      return registry.array({ element: registry[elementTypeName](), elementTypeName });
+    }
+    if (resolver instanceof ObjectLiteralResolver) {
+      return registry.object();
+    }
+
+    // builtin vars declare an authoritative type on their internal resolver
+    // (e.g. VARLOCK_IS_CI is boolean), which wins over inference from a
+    // user-provided static value so VARLOCK_IS_CI=0 still coerces to false
+    const internalResolverType = this._internalDefs.find(
+      (d) => d.itemDef.resolver?.inferredType,
+    )?.itemDef.resolver?.inferredType;
+    const inferredTypeName = internalResolverType || resolver.inferredType;
+    if (inferredTypeName && inferredTypeName in registry) {
+      return registry[inferredTypeName]();
+    }
+    return undefined;
   }
 
   get dependencyKeys() {
@@ -692,6 +714,17 @@ export class ConfigItem {
 
   get isCoerced() {
     return this.resolvedRawValue !== this.resolvedValue;
+  }
+
+  /**
+   * The resolved value serialized to its process.env string form (undefined stays
+   * undefined). Scalars stringify naturally; composite types (array/object) use their
+   * data type's serialize() (separator-joined or JSON).
+   */
+  get resolvedEnvStringValue(): string | undefined {
+    if (this.resolvedValue === undefined) return undefined;
+    if (this.dataType) return this.dataType.serialize(this.resolvedValue);
+    return typeof this.resolvedValue === 'string' ? this.resolvedValue : String(this.resolvedValue);
   }
 
   async resolve(reset = false) {

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -18,7 +18,7 @@ import {
   convertParsedValueToResolvers, type ResolvedValue, Resolver, StaticValueResolver,
   ArrayLiteralResolver, ObjectLiteralResolver,
 } from './resolver';
-import { buildDataTypeFromTypeDecorator } from './type-decorator';
+import { buildTypeSpecPlan, coercedTypesMatch, type TypeSpecPlan } from './type-decorator';
 import { ItemDecoratorInstance } from './decorators';
 
 export type ConfigItemDef = {
@@ -272,10 +272,24 @@ export class ConfigItem {
   }
 
 
+  /**
+   * provisional (static/deterministic) data type instance - used for type generation.
+   * When the type spec has dynamic (resolver-valued) parts, the final instance is built
+   * during resolve() into _resolvedDataType; use `effectiveDataType` for coercion etc.
+   */
   dataType?: EnvGraphDataType;
+  /** final data type instance after dynamic type spec parts resolved (see dataType) */
+  _resolvedDataType?: EnvGraphDataType;
+  get effectiveDataType() { return this._resolvedDataType ?? this.dataType; }
+  /** parsed @type spec - carries deferred resolvers when parts are dynamic */
+  private _typeSpecPlan?: TypeSpecPlan;
+
   _schemaErrors: Array<SchemaError> = [];
   get resolverSchemaErrors() {
-    return this.valueResolver?.schemaErrors || [];
+    return [
+      ...this.valueResolver?.schemaErrors || [],
+      ...(this._typeSpecPlan?.deferred ?? []).flatMap((d) => d.resolver.schemaErrors),
+    ];
   }
   get decoratorSchemaErrors() {
     return _.values(this.allDecorators).flatMap((d) => d.schemaErrors);
@@ -364,11 +378,23 @@ export class ConfigItem {
     }
 
     const typeDec = this.getDec('type');
-    // TODO: this will not currently support any resolver functions within type settings
     const typeDecParsedValue = typeDec?.parsedDecorator.value;
     if (typeDecParsedValue) {
       try {
-        this.dataType = buildDataTypeFromTypeDecorator(this.envGraph.dataTypesRegistry, typeDecParsedValue);
+        this._typeSpecPlan = buildTypeSpecPlan({
+          registry: this.envGraph.dataTypesRegistry,
+          resolverFns: this.envGraph.registeredResolverFunctions,
+          dataSource: typeDec!.dataSource,
+        }, typeDecParsedValue);
+        // dynamic parts (option values / whole type) go through the normal resolver
+        // lifecycle - process now (validates args, registers deps), resolve during item
+        // resolution just before coercion
+        for (const d of this._typeSpecPlan.deferred) {
+          d.resolver.process(typeDec);
+        }
+        // provisional instance: deterministic (dynamic parts omitted/candidate-substituted),
+        // used for type generation and any pre-resolution introspection
+        this.dataType = this._typeSpecPlan.build();
       } catch (err) {
         this._schemaErrors.push(err instanceof SchemaError ? err : new SchemaError(err as Error));
       }
@@ -419,6 +445,8 @@ export class ConfigItem {
   get dependencyKeys() {
     return _.uniq([
       ...this.valueResolver?.deps || [],
+      // dynamic @type parts (e.g. minLength=if(eq($APP_MODE, ...), 1, 0)) may reference other items
+      ...(this._typeSpecPlan?.deferred ?? []).flatMap((d) => d.resolver.deps),
       ..._.values(this.effectiveDecorators).flatMap(
         (dec) => dec.decValueResolver?.deps || [],
       ),
@@ -723,7 +751,8 @@ export class ConfigItem {
    */
   get resolvedEnvStringValue(): string | undefined {
     if (this.resolvedValue === undefined) return undefined;
-    if (this.dataType) return this.dataType.serialize(this.resolvedValue);
+    const dataType = this.effectiveDataType;
+    if (dataType) return dataType.serialize(this.resolvedValue);
     return typeof this.resolvedValue === 'string' ? this.resolvedValue : String(this.resolvedValue);
   }
 
@@ -740,6 +769,7 @@ export class ConfigItem {
       this.validationErrors = undefined;
       this.resolvedRawValue = undefined;
       this.resolvedValue = undefined;
+      this._resolvedDataType = undefined;
     }
     if (this.isResolved) {
       // previously we would throw an error, now we resolve the envFlag early, so we can just return
@@ -826,11 +856,44 @@ export class ConfigItem {
       return;
     }
 
-    if (!this.dataType) throw new Error('expected dataType to be set');
+    // finalize a dynamic type spec - resolve deferred parts (option values / whole type)
+    // and rebuild the instance. The final type may vary validation behavior but must
+    // generate the same types as the provisional one (which is what codegen saw).
+    if (this._typeSpecPlan?.deferred.length) {
+      try {
+        const resolvedTypeParts = new Map<Resolver, any>();
+        for (const d of this._typeSpecPlan.deferred) {
+          resolvedTypeParts.set(d.resolver, await d.resolver.resolve());
+        }
+        const finalType = this._typeSpecPlan.build(resolvedTypeParts);
+        if (this.dataType && !coercedTypesMatch(this.dataType, finalType)) {
+          throw new SchemaError(
+            `dynamic @type resolved to "${finalType.name}", which does not generate the same type as "${this.dataType.name}"`,
+            { tip: 'a dynamic @type may vary validation but not the generated type - e.g. url vs string is ok, number vs string is not' },
+          );
+        }
+        this._resolvedDataType = finalType;
+      } catch (err) {
+        if (err instanceof ValidationError) {
+          this.validationErrors = [err];
+        } else if (err instanceof SchemaError) {
+          this.validationErrors = [new ValidationError(err.message, { tip: err.tip })];
+        } else if (err instanceof ResolutionError) {
+          this.resolutionError = err;
+        } else {
+          this.resolutionError = new ResolutionError(`error resolving dynamic @type parts: ${err}`);
+          this.resolutionError.cause = err as Error;
+        }
+        return;
+      }
+    }
+
+    const dataType = this.effectiveDataType;
+    if (!dataType) throw new Error('expected dataType to be set');
 
     // COERCE VALUE - often will do nothing, but gives us a chance to convert strings to numbers, etc
     try {
-      const coerceResult = this.dataType.coerce(this.resolvedRawValue);
+      const coerceResult = dataType.coerce(this.resolvedRawValue);
       if (coerceResult instanceof Error) throw coerceResult;
       this.resolvedValue = coerceResult;
     } catch (err) {
@@ -848,7 +911,7 @@ export class ConfigItem {
 
     // VALIDATE
     try {
-      const validateResult = await this.dataType.validate(this.resolvedValue);
+      const validateResult = await dataType.validate(this.resolvedValue);
       if (
         validateResult instanceof Error
         || (_.isArray(validateResult) && validateResult[0] instanceof Error)

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -4,7 +4,7 @@ import {
   ParsedEnvSpecFunctionCall, ParsedEnvSpecStaticValue,
 } from '@env-spec/parser';
 
-import { EnvGraphDataType } from './data-types';
+import { EnvGraphDataType, isCompositeCoercedType } from './data-types';
 import { EnvGraph } from './env-graph';
 import {
   CoercionError, EmptyRequiredValueError, ResolutionError, SchemaError,
@@ -849,7 +849,14 @@ export class ConfigItem {
     // first deal with empty values and checking required
     if (this.resolvedRawValue === undefined || this.resolvedRawValue === '') {
       // we preserve undefined vs empty string - might want to change this?
-      this.resolvedValue = this.resolvedRawValue;
+      // EXCEPT for composite types (array/record), where an empty string means "missing" -
+      // preserving '' would misrepresent the item's type, and it must never become an
+      // empty container
+      if (this.resolvedRawValue === '' && isCompositeCoercedType(this.dataType?.coercedType)) {
+        this.resolvedValue = undefined;
+      } else {
+        this.resolvedValue = this.resolvedRawValue;
+      }
       if (this.isRequired) {
         this.validationErrors = [new EmptyRequiredValueError(undefined)];
       }
@@ -896,6 +903,15 @@ export class ConfigItem {
       const coerceResult = dataType.coerce(this.resolvedRawValue);
       if (coerceResult instanceof Error) throw coerceResult;
       this.resolvedValue = coerceResult;
+      // coercion may resolve a non-empty raw value to "missing" (e.g. a whitespace-only
+      // string on a composite type) - treat like the empty short-circuit above instead
+      // of running validation against undefined
+      if (this.resolvedValue === undefined) {
+        if (this.isRequired) {
+          this.validationErrors = [new EmptyRequiredValueError(undefined)];
+        }
+        return;
+      }
     } catch (err) {
       if (err instanceof CoercionError) {
         this.coercionError = err;

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -426,7 +426,7 @@ export class ConfigItem {
       return registry.array({ element: registry[elementTypeName](), elementTypeName });
     }
     if (resolver instanceof ObjectLiteralResolver) {
-      return registry.object();
+      return registry.record();
     }
 
     // builtin vars declare an authoritative type on their internal resolver

--- a/packages/varlock/src/env-graph/lib/data-types.ts
+++ b/packages/varlock/src/env-graph/lib/data-types.ts
@@ -846,13 +846,19 @@ export type ObjectDataTypeSettings = {
   values?: EnvGraphDataType;
   /** value type display name for messages/descriptions */
   valuesTypeName?: string;
-  /** key validation type instance - built from the `keys=...` option (e.g. `keys=enum(a, b)`) */
-  keys?: EnvGraphDataType;
+  /** key validation type instance - built from the `keyType=...` option (e.g. `keyType=enum(a, b)`) */
+  keyType?: EnvGraphDataType;
+  /** minimum number of entries */
+  entriesMinLength?: number;
+  /** maximum number of entries */
+  entriesMaxLength?: number;
+  /** exact number of entries */
+  entriesIsLength?: number;
 };
 
 const ObjectDataType = createEnvGraphDataType((settings?: ObjectDataTypeSettings) => {
   const valuesType = settings?.values;
-  const keysType = settings?.keys;
+  const keysType = settings?.keyType;
 
   let coercedType: CoercedType = 'object';
   if (valuesType || keysType) {
@@ -917,6 +923,17 @@ const ObjectDataType = createEnvGraphDataType((settings?: ObjectDataTypeSettings
     async validate(val) {
       const obj = val as Record<string, unknown>;
       const errors: Array<ValidationError> = [];
+
+      const entryCount = Object.keys(obj).length;
+      if (settings?.entriesMinLength !== undefined && entryCount < settings.entriesMinLength) {
+        errors.push(new ValidationError(`Object must have at least ${settings.entriesMinLength} entry(s)`));
+      }
+      if (settings?.entriesMaxLength !== undefined && entryCount > settings.entriesMaxLength) {
+        errors.push(new ValidationError(`Object must have at most ${settings.entriesMaxLength} entry(s)`));
+      }
+      if (settings?.entriesIsLength !== undefined && entryCount !== settings.entriesIsLength) {
+        errors.push(new ValidationError(`Object must have exactly ${settings.entriesIsLength} entry(s)`));
+      }
 
       for (const [key, value] of Object.entries(obj)) {
         if (keysType) {

--- a/packages/varlock/src/env-graph/lib/data-types.ts
+++ b/packages/varlock/src/env-graph/lib/data-types.ts
@@ -762,7 +762,9 @@ const ArrayDataType = createEnvGraphDataType((settings?: ArrayDataTypeSettings) 
       } else if (_.isString(rawVal)) {
         const trimmed = rawVal.trim();
         if (trimmed === '') {
-          arr = [];
+          // an empty/whitespace-only string means "missing value" - it never becomes an
+          // empty array (the explicit `[]` literal is the only way to express one)
+          return undefined;
         } else if (trimmed.startsWith('[')) {
           let parsed: unknown;
           try {
@@ -800,8 +802,14 @@ const ArrayDataType = createEnvGraphDataType((settings?: ArrayDataTypeSettings) 
       const arr = val as Array<unknown>;
       const errors: Array<ValidationError> = [];
 
-      if (settings?.minLength !== undefined && arr.length < settings.minLength) {
-        errors.push(new ValidationError(`Array must have at least ${settings.minLength} element(s)`));
+      if (settings?.minLength !== undefined) {
+        if (arr.length < settings.minLength) {
+          errors.push(new ValidationError(`Array must have at least ${settings.minLength} element(s)`));
+        }
+      } else if (settings?.isLength === undefined && arr.length === 0) {
+        // minLength defaults to 1 - an explicitly-empty array is usually a placeholder
+        // to fill in, so it must be sanctioned deliberately
+        errors.push(new ValidationError('Array must not be empty', { tip: 'set minLength=0 to allow an empty array' }));
       }
       if (settings?.maxLength !== undefined && arr.length > settings.maxLength) {
         errors.push(new ValidationError(`Array must have at most ${settings.maxLength} element(s)`));
@@ -884,7 +892,8 @@ const RecordDataType = createEnvGraphDataType((settings?: RecordDataTypeSettings
       } else if (_.isString(rawVal)) {
         const trimmed = rawVal.trim();
         if (trimmed === '') {
-          obj = {};
+          // empty/whitespace-only string means "missing value" - never an empty object
+          return undefined;
         } else if (trimmed.startsWith('{')) {
           let parsed: unknown;
           try {
@@ -925,8 +934,13 @@ const RecordDataType = createEnvGraphDataType((settings?: RecordDataTypeSettings
       const errors: Array<ValidationError> = [];
 
       const entryCount = Object.keys(obj).length;
-      if (settings?.entriesMinLength !== undefined && entryCount < settings.entriesMinLength) {
-        errors.push(new ValidationError(`Object must have at least ${settings.entriesMinLength} entry(s)`));
+      if (settings?.entriesMinLength !== undefined) {
+        if (entryCount < settings.entriesMinLength) {
+          errors.push(new ValidationError(`Object must have at least ${settings.entriesMinLength} entry(s)`));
+        }
+      } else if (settings?.entriesIsLength === undefined && entryCount === 0) {
+        // entriesMinLength defaults to 1 - see the array type's matching default
+        errors.push(new ValidationError('Object must not be empty', { tip: 'set entriesMinLength=0 to allow an empty object' }));
       }
       if (settings?.entriesMaxLength !== undefined && entryCount > settings.entriesMaxLength) {
         errors.push(new ValidationError(`Object must have at most ${settings.entriesMaxLength} entry(s)`));

--- a/packages/varlock/src/env-graph/lib/data-types.ts
+++ b/packages/varlock/src/env-graph/lib/data-types.ts
@@ -722,6 +722,8 @@ export type ArrayDataTypeSettings = {
   minLength?: number;
   /** maximum number of elements */
   maxLength?: number;
+  /** exact number of elements */
+  isLength?: number;
   /** reject duplicate elements */
   unique?: boolean;
   /**
@@ -803,6 +805,9 @@ const ArrayDataType = createEnvGraphDataType((settings?: ArrayDataTypeSettings) 
       }
       if (settings?.maxLength !== undefined && arr.length > settings.maxLength) {
         errors.push(new ValidationError(`Array must have at most ${settings.maxLength} element(s)`));
+      }
+      if (settings?.isLength !== undefined && arr.length !== settings.isLength) {
+        errors.push(new ValidationError(`Array must have exactly ${settings.isLength} element(s)`));
       }
       if (settings?.unique) {
         const seen = new Set<string | undefined>();

--- a/packages/varlock/src/env-graph/lib/data-types.ts
+++ b/packages/varlock/src/env-graph/lib/data-types.ts
@@ -841,8 +841,8 @@ const ArrayDataType = createEnvGraphDataType((settings?: ArrayDataTypeSettings) 
   };
 });
 
-export type ObjectDataTypeSettings = {
-  /** value type instance - built from the first positional arg of `@type=object(...)` */
+export type RecordDataTypeSettings = {
+  /** value type instance - built from the first positional arg of `@type=record(...)` */
   values?: EnvGraphDataType;
   /** value type display name for messages/descriptions */
   valuesTypeName?: string;
@@ -856,7 +856,7 @@ export type ObjectDataTypeSettings = {
   entriesIsLength?: number;
 };
 
-const ObjectDataType = createEnvGraphDataType((settings?: ObjectDataTypeSettings) => {
+const RecordDataType = createEnvGraphDataType((settings?: RecordDataTypeSettings) => {
   const valuesType = settings?.values;
   const keysType = settings?.keyType;
 
@@ -871,11 +871,11 @@ const ObjectDataType = createEnvGraphDataType((settings?: ObjectDataTypeSettings
   }
 
   return {
-    name: 'object',
+    name: 'record',
     icon: 'tabler:code-dots',
     typeDescription: valuesType
-      ? `object of ${settings?.valuesTypeName ?? valuesType.name} values`
-      : 'object',
+      ? `record of ${settings?.valuesTypeName ?? valuesType.name} values`
+      : 'record (untyped object)',
     coercedType,
     coerce(rawVal) {
       let obj: Record<string, unknown>;
@@ -978,5 +978,5 @@ export const BaseDataTypes: Array<EnvGraphDataTypeFactory> = [
   Md5DataType,
   DurationDataType,
   ArrayDataType,
-  ObjectDataType,
+  RecordDataType,
 ];

--- a/packages/varlock/src/env-graph/lib/data-types.ts
+++ b/packages/varlock/src/env-graph/lib/data-types.ts
@@ -19,8 +19,19 @@ export type CoercedType = | 'string'
   | 'int' // integer number
   | 'number' // general (possibly fractional) number
   | 'boolean'
-  | 'object'
-  | { enum: Array<string | number | boolean> };
+  | 'object' // free-form object (no per-value typing)
+  | { enum: Array<string | number | boolean> }
+  | { arrayOf: CoercedType } // typed array (e.g. `array(email)` → { arrayOf: 'string' })
+  // typed record - `values` is the per-value type, `keys` restricts keys (e.g. an enum);
+  // either may be absent when that side is unconstrained
+  | { recordOf: { keys?: CoercedType, values?: CoercedType } };
+
+/** a composite coerced value (array/object shaped) cannot be losslessly joined into a
+ * flat separator string, so serialization for these always falls back to JSON */
+export function isCompositeCoercedType(ct: CoercedType | undefined): boolean {
+  if (ct === 'object') return true;
+  return !!ct && typeof ct === 'object' && ('arrayOf' in ct || 'recordOf' in ct);
+}
 
 type EnvGraphDataTypeDef<CoerceReturnType, ValidateInputType = FallbackIfUnknown<CoerceReturnType, string>> = {
   /** this will be the name of the type, used to reference it when using it in a schema */
@@ -60,6 +71,13 @@ type EnvGraphDataTypeDef<CoerceReturnType, ValidateInputType = FallbackIfUnknown
    * (e.g. `int` in Go) instead of assuming `string`. Omit for string-valued types.
    */
   coercedType?: CoercedType;
+
+  /**
+   * serialize a coerced value back to the string form injected into process.env.
+   * Defaults to `String(value)` — composite types (array/object) override this so
+   * child processes receive a usable flat string (separator-joined or JSON).
+   */
+  serialize?: (value: any) => string;
 
   // asyncValidate? - async validation function, meant to be called more sparingly
   // for example, when could validate an API key is currently valid
@@ -118,6 +136,13 @@ export class EnvGraphDataType {
 
   validate(val: any) {
     return this.def.validate ? this.def.validate(val) : true;
+  }
+
+  /** serialize a coerced value back to the string form injected into process.env */
+  serialize(val: any): string {
+    if (val === undefined || val === null) return '';
+    if (this.def.serialize) return this.def.serialize(val);
+    return typeof val === 'string' ? val : String(val);
   }
 }
 // but we can pass in a function if the data type accepts additional usage options
@@ -426,6 +451,8 @@ const SimpleObjectDataType = createEnvGraphDataType({
     if (_.isPlainObject(val)) return true;
     return new ValidationError('Value must be an object');
   },
+  // without this, process.env injection would stringify to "[object Object]"
+  serialize: (val) => JSON.stringify(val),
 });
 
 
@@ -659,6 +686,260 @@ const DurationDataType = createEnvGraphDataType(
 );
 
 
+/// COMPOSITE DATA TYPES (array / object) ///////////////////////////////////////////////
+
+/**
+ * Run a nested type's validate() and normalize every possible outcome (throw, returned
+ * error, returned array, `false`) into a flat list of ValidationErrors — mirrors the
+ * handling in ConfigItem.resolve() so element validation behaves like item validation.
+ */
+async function runNestedValidate(type: EnvGraphDataType, val: any): Promise<Array<ValidationError>> {
+  const asValidationError = (err: Error) => (
+    err instanceof ValidationError ? err : new ValidationError(err.message, { err })
+  );
+  try {
+    const result = await type.validate(val);
+    if (result instanceof Error) return [asValidationError(result)];
+    if (_.isArray(result)) return result.filter((e) => e instanceof Error).map(asValidationError);
+    if ((result as any) === false) return [new ValidationError('validation failed with `false` return value')];
+    return [];
+  } catch (err) {
+    if (_.isArray(err)) return err.filter((e) => e instanceof Error).map(asValidationError);
+    if (err instanceof Error) return [asValidationError(err)];
+    return [new ValidationError(`Unexpected non-error thrown during validation - ${err}`)];
+  }
+}
+
+/** re-wrap a nested validation error with a positional prefix (array index / object key) */
+function prefixValidationError(prefix: string, err: ValidationError): ValidationError {
+  return new ValidationError(`${prefix} ${err.message}`, { err, tip: err.tip });
+}
+
+const DEFAULT_ARRAY_SEPARATOR = ',';
+
+export type ArrayDataTypeSettings = {
+  /** minimum number of elements */
+  minLength?: number;
+  /** maximum number of elements */
+  maxLength?: number;
+  /** reject duplicate elements */
+  unique?: boolean;
+  /**
+   * separator used both to split plain-string input (e.g. a process.env override)
+   * and to join the value back into a string for process.env injection (default ",")
+   */
+  separator?: string;
+  /**
+   * how the value serializes back into process.env - "separator" (default) joins
+   * elements with the separator; "json" emits a JSON array string. Composite element
+   * types (arrays/objects) always use JSON regardless of this setting.
+   */
+  format?: 'separator' | 'json';
+  /** element type instance - built from the first positional arg of `@type=array(...)` */
+  element?: EnvGraphDataType;
+  /** element type display name (e.g. `enum`) for messages/descriptions */
+  elementTypeName?: string;
+};
+
+const ArrayDataType = createEnvGraphDataType((settings?: ArrayDataTypeSettings) => {
+  const element = settings?.element ?? StringDataType();
+  const elementTypeName = settings?.elementTypeName ?? element.name;
+  const separator = settings?.separator ?? DEFAULT_ARRAY_SEPARATOR;
+  // composite elements cannot round-trip through a separator-joined string
+  const jsonOnly = settings?.format === 'json' || isCompositeCoercedType(element.coercedType);
+
+  return {
+    name: 'array',
+    icon: 'tabler:brackets',
+    typeDescription: `array of ${elementTypeName}`,
+    coercedType: { arrayOf: element.coercedType ?? 'string' },
+    coerce(rawVal) {
+      let arr: Array<unknown>;
+      if (Array.isArray(rawVal)) {
+        arr = rawVal;
+      } else if (_.isString(rawVal)) {
+        const trimmed = rawVal.trim();
+        if (trimmed === '') {
+          arr = [];
+        } else if (trimmed.startsWith('[')) {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(trimmed);
+          } catch (err) {
+            return new CoercionError('Error parsing string starting with `[` as a JSON array', { err: err as Error });
+          }
+          if (!Array.isArray(parsed)) return new CoercionError('JSON-parsed string value is not an array');
+          arr = parsed;
+        } else {
+          arr = trimmed.split(separator).map((part) => part.trim()).filter((part) => part !== '');
+        }
+      } else {
+        return new CoercionError('Cannot coerce value to an array');
+      }
+
+      // coerce each element with the element type, collecting ALL failures (not just the first)
+      const coerced: Array<unknown> = [];
+      const elementErrors: Array<string> = [];
+      for (let i = 0; i < arr.length; i++) {
+        try {
+          const result = element.coerce(arr[i]);
+          if (result instanceof Error) throw result;
+          coerced.push(result);
+        } catch (err) {
+          elementErrors.push(`[${i}] ${(err as Error).message}`);
+        }
+      }
+      if (elementErrors.length) {
+        return new CoercionError(`Invalid array element(s): ${elementErrors.join('; ')}`);
+      }
+      return coerced;
+    },
+    async validate(val) {
+      const arr = val as Array<unknown>;
+      const errors: Array<ValidationError> = [];
+
+      if (settings?.minLength !== undefined && arr.length < settings.minLength) {
+        errors.push(new ValidationError(`Array must have at least ${settings.minLength} element(s)`));
+      }
+      if (settings?.maxLength !== undefined && arr.length > settings.maxLength) {
+        errors.push(new ValidationError(`Array must have at most ${settings.maxLength} element(s)`));
+      }
+      if (settings?.unique) {
+        const seen = new Set<string | undefined>();
+        for (let i = 0; i < arr.length; i++) {
+          const key = JSON.stringify(arr[i]);
+          if (seen.has(key)) errors.push(new ValidationError(`[${i}] duplicate value`));
+          seen.add(key);
+        }
+      }
+
+      for (let i = 0; i < arr.length; i++) {
+        // a scalar element containing the separator would not survive the process.env
+        // round-trip (the child would re-split it differently), so we reject it upfront
+        if (!jsonOnly && String(arr[i]).includes(separator)) {
+          errors.push(new ValidationError(
+            `[${i}] value contains the "${separator}" separator and would not round-trip through process.env`,
+            { tip: 'set format=json, or use a different separator' },
+          ));
+        }
+        const elementErrors = await runNestedValidate(element, arr[i]);
+        errors.push(...elementErrors.map((e) => prefixValidationError(`[${i}]`, e)));
+      }
+
+      return errors.length ? errors : true;
+    },
+    serialize(val) {
+      const arr = val as Array<unknown>;
+      if (jsonOnly) return JSON.stringify(arr);
+      return arr.map((el) => element.serialize(el)).join(separator);
+    },
+  };
+});
+
+export type ObjectDataTypeSettings = {
+  /** value type instance - built from the first positional arg of `@type=object(...)` */
+  values?: EnvGraphDataType;
+  /** value type display name for messages/descriptions */
+  valuesTypeName?: string;
+  /** key validation type instance - built from the `keys=...` option (e.g. `keys=enum(a, b)`) */
+  keys?: EnvGraphDataType;
+};
+
+const ObjectDataType = createEnvGraphDataType((settings?: ObjectDataTypeSettings) => {
+  const valuesType = settings?.values;
+  const keysType = settings?.keys;
+
+  let coercedType: CoercedType = 'object';
+  if (valuesType || keysType) {
+    coercedType = {
+      recordOf: {
+        ...keysType?.coercedType !== undefined ? { keys: keysType.coercedType } : {},
+        ...valuesType ? { values: valuesType.coercedType ?? 'string' } : {},
+      },
+    };
+  }
+
+  return {
+    name: 'object',
+    icon: 'tabler:code-dots',
+    typeDescription: valuesType
+      ? `object of ${settings?.valuesTypeName ?? valuesType.name} values`
+      : 'object',
+    coercedType,
+    coerce(rawVal) {
+      let obj: Record<string, unknown>;
+      if (_.isPlainObject(rawVal)) {
+        obj = rawVal;
+      } else if (_.isString(rawVal)) {
+        const trimmed = rawVal.trim();
+        if (trimmed === '') {
+          obj = {};
+        } else if (trimmed.startsWith('{')) {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(trimmed);
+          } catch (err) {
+            return new CoercionError('Error parsing string starting with `{` as a JSON object', { err: err as Error });
+          }
+          if (!_.isPlainObject(parsed)) return new CoercionError('JSON-parsed string value is not an object');
+          obj = parsed as Record<string, unknown>;
+        } else {
+          return new CoercionError('Cannot coerce value to an object');
+        }
+      } else {
+        return new CoercionError('Cannot coerce value to an object');
+      }
+
+      if (!valuesType) return obj;
+
+      // coerce each value with the values type, collecting ALL failures
+      const coerced: Record<string, unknown> = {};
+      const valueErrors: Array<string> = [];
+      for (const [key, value] of Object.entries(obj)) {
+        try {
+          const result = valuesType.coerce(value);
+          if (result instanceof Error) throw result;
+          coerced[key] = result;
+        } catch (err) {
+          valueErrors.push(`"${key}" ${(err as Error).message}`);
+        }
+      }
+      if (valueErrors.length) {
+        return new CoercionError(`Invalid object value(s): ${valueErrors.join('; ')}`);
+      }
+      return coerced;
+    },
+    async validate(val) {
+      const obj = val as Record<string, unknown>;
+      const errors: Array<ValidationError> = [];
+
+      for (const [key, value] of Object.entries(obj)) {
+        if (keysType) {
+          // keys are always strings on the wire; run them through the key type's
+          // coerce+validate (e.g. enum membership, string pattern)
+          let keyErrors: Array<ValidationError>;
+          try {
+            const coercedKey = keysType.coerce(key);
+            if (coercedKey instanceof Error) throw coercedKey;
+            keyErrors = await runNestedValidate(keysType, coercedKey);
+          } catch (err) {
+            keyErrors = [err instanceof ValidationError ? err : new ValidationError((err as Error).message)];
+          }
+          errors.push(...keyErrors.map((e) => prefixValidationError(`"${key}" is not a valid key -`, e)));
+        }
+        if (valuesType) {
+          const valueErrors = await runNestedValidate(valuesType, value);
+          errors.push(...valueErrors.map((e) => prefixValidationError(`"${key}"`, e)));
+        }
+      }
+
+      return errors.length ? errors : true;
+    },
+    // objects have no meaningful flat-string form, so they always serialize as JSON
+    serialize: (val) => JSON.stringify(val),
+  };
+});
+
 export const BaseDataTypes: Array<EnvGraphDataTypeFactory> = [
   StringDataType,
   NumberDataType,
@@ -674,4 +955,6 @@ export const BaseDataTypes: Array<EnvGraphDataTypeFactory> = [
   UuidDataType,
   Md5DataType,
   DurationDataType,
+  ArrayDataType,
+  ObjectDataType,
 ];

--- a/packages/varlock/src/env-graph/lib/decorators.ts
+++ b/packages/varlock/src/env-graph/lib/decorators.ts
@@ -150,8 +150,14 @@ export abstract class DecoratorInstance {
         }
       }
 
-      // this is so we can deal with @type, where each data type is not a real resolver
-      // so instead we just make a new dummy resolver holding the args
+      // some decorators (currently @type) consume their raw parsed value directly rather
+      // than through the resolver system - nested type calls like array(enum(a, b)) are
+      // not resolver functions, so converting them would produce bogus "unknown function"
+      // errors. Those decorators opt out of value-resolver creation entirely.
+      if (this.decoratorDef.skipValueResolver) return;
+
+      // this is so we can deal with bare fn-call decorators, where args are not a single
+      // resolvable value - so instead we make a new dummy resolver holding the args
       if (
         this.decoratorDef.useFnArgsResolver
         && (
@@ -198,6 +204,11 @@ export abstract class DecoratorInstance {
     if (this.isResolved) return this.resolvedValue;
 
     await this.process();
+    // decorators that skip value-resolver creation (see process()) have nothing to resolve
+    if (this.decoratorDef?.skipValueResolver) {
+      this.isResolved = true;
+      return this.resolvedValue;
+    }
     if (!this.decValueResolver) {
       // process() already recorded schema errors, don't throw again
       if (this._errors.length) return;
@@ -325,6 +336,12 @@ export type RootDecoratorDef<Processed = any> = {
   process?: (decoratorValue: Resolver) => (Processed | Promise<Processed>);
   execute?: (executeInput: Processed) => void | Promise<void>;
   useFnArgsResolver?: boolean,
+  /**
+   * Skip value-resolver creation entirely - for decorators whose raw parsed value is
+   * consumed by other machinery (e.g. `@type`, where nested calls like `enum(a, b)`
+   * are type specs, not resolver functions).
+   */
+  skipValueResolver?: boolean,
 };
 
 /**
@@ -770,6 +787,8 @@ export type ItemDecoratorDef<T = any> = {
   process?: (decoratorValue: Resolver) => T | Promise<T>;
   execute?: (executeInput: T) => void | Promise<void>;
   useFnArgsResolver?: boolean,
+  /** See {@link RootDecoratorDef.skipValueResolver}. */
+  skipValueResolver?: boolean,
 };
 
 export const builtInItemDecorators: Array<ItemDecoratorDef<any>> = [
@@ -793,7 +812,7 @@ export const builtInItemDecorators: Array<ItemDecoratorDef<any>> = [
   },
   {
     name: 'type',
-    useFnArgsResolver: true,
+    skipValueResolver: true,
   },
   {
     name: 'example',

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -75,6 +75,12 @@ export type SerializedEnvGraph = {
   },
   config: Record<string, {
     value: any;
+    /**
+     * process.env-ready string form - present only for composite values (arrays/objects),
+     * whose flat form depends on the item's type settings (separator vs JSON). Consumers
+     * injecting into process.env should use `envStr ?? String(value)`.
+     */
+    envStr?: string;
     isSensitive: boolean;
     /** false = opted out of runtime leak detection (still redacted in logs). Omitted when true (the default). */
     preventLeaks?: boolean;
@@ -815,6 +821,22 @@ export class EnvGraph {
     return envObject;
   }
 
+  /**
+   * like getResolvedEnvObject, but values are serialized to their process.env string
+   * form (composite values become separator-joined or JSON strings). Undefined values
+   * stay undefined so callers can distinguish unset items.
+   */
+  getResolvedEnvStringObject(opts?: { includeInternal?: boolean, filterKeys?: Set<string> }) {
+    const envObject: Record<string, string | undefined> = {};
+    for (const itemKey of this.sortedConfigKeys) {
+      const item = this.configSchema[itemKey];
+      if (item.isInternal && !opts?.includeInternal) continue;
+      if (opts?.filterKeys && !opts.filterKeys.has(itemKey)) continue;
+      envObject[itemKey] = item.resolvedEnvStringValue;
+    }
+    return envObject;
+  }
+
   getSerializedGraph(opts?: { includeInternal?: boolean, filterKeys?: Set<string> }): SerializedEnvGraph {
     const serializedGraph: SerializedEnvGraph = {
       basePath: this.basePath,
@@ -845,6 +867,10 @@ export class EnvGraph {
       if (opts?.filterKeys && !opts.filterKeys.has(itemKey)) continue;
       serializedGraph.config[itemKey] = {
         value: item.resolvedValue,
+        // composite values carry their flat string form, since re-deriving it requires
+        // the item's type settings (separator vs JSON) which don't travel in the blob
+        ...(typeof item.resolvedValue === 'object' && item.resolvedValue !== null)
+          ? { envStr: item.resolvedEnvStringValue } : {},
         isSensitive: item.isSensitive,
         ...item.isInternal ? { isInternal: true } : {},
         // only emit when opted out — keeps the common-case blob smaller

--- a/packages/varlock/src/env-graph/lib/type-decorator.ts
+++ b/packages/varlock/src/env-graph/lib/type-decorator.ts
@@ -7,7 +7,7 @@ import {
   ParsedEnvSpecStaticValue,
   type ParsedEnvSpecDecorator,
 } from '@env-spec/parser';
-import type { EnvGraphDataType, EnvGraphDataTypeFactory } from './data-types';
+import type { CoercedType, EnvGraphDataType, EnvGraphDataTypeFactory } from './data-types';
 import { convertParsedValueToResolvers, type Resolver } from './resolver';
 import type { EnvGraphDataSource } from './data-source';
 import { SchemaError } from './errors';
@@ -315,6 +315,72 @@ function extractScalarTypeArgs(
 }
 
 /**
+ * Enum gets a dedicated builder because its members may be resolver-valued -
+ * `enum($ALLOWED_MODES)` sources members from another item at resolution time, and a
+ * member that resolves to an ARRAY spreads its elements (the typed-array payoff).
+ *
+ * Typegen: a dynamic enum cannot produce a literal union deterministically, so its
+ * provisional instance is a plain string type - generated code widens to `string`,
+ * which stays valid since resolved members are required to be strings.
+ */
+function buildEnumTypePlan(
+  ctx: TypeSpecContext,
+  fnCall: ParsedEnvSpecFunctionCall,
+  context: string,
+): TypeSpecPlan {
+  const deferred: TypeSpecPlan['deferred'] = [];
+  const members: Array<any> = [];
+
+  for (const arg of fnCall.data.args.values) {
+    if (arg instanceof ParsedEnvSpecKeyValuePair) {
+      throw new SchemaError(`${context} - enum does not take named options, only a list of members`);
+    } else if (arg instanceof ParsedEnvSpecStaticValue) {
+      members.push(arg.value);
+    } else if (arg instanceof ParsedEnvSpecFunctionCall && arg.name in ctx.resolverFns) {
+      const resolver = convertParsedValueToResolvers(arg, ctx.dataSource, ctx.resolverFns);
+      if (!resolver) throw new SchemaError(`${context} - could not build resolver for enum member`);
+      deferred.push({ resolver, label: 'enum member' });
+      members.push(new DeferredValue(resolver));
+    } else {
+      throw new SchemaError(`${context} - enum members must be static values or resolver calls (e.g. $OTHER_ITEM)`);
+    }
+  }
+
+  return {
+    deferred,
+    build: (resolved) => {
+      if (!deferred.length) return ctx.registry.enum(...members);
+      // provisional build for a dynamic enum - membership unknown until resolution
+      if (!resolved) return ctx.registry.string();
+
+      const finalMembers: Array<any> = [];
+      for (const member of members) {
+        if (!(member instanceof DeferredValue)) {
+          finalMembers.push(member);
+          continue;
+        }
+        const resolvedVal = resolved.get(member.resolver);
+        if (Array.isArray(resolvedVal)) finalMembers.push(...resolvedVal);
+        else if (resolvedVal !== undefined) finalMembers.push(resolvedVal);
+      }
+      if (!finalMembers.length) {
+        throw new SchemaError(`${context} - dynamic enum members resolved to an empty list`);
+      }
+      for (const member of finalMembers) {
+        // generated code saw `string` (see provisional above), so members must be strings
+        if (typeof member !== 'string') {
+          throw new SchemaError(
+            `${context} - dynamic enum members must resolve to strings (got ${JSON.stringify(member)})`,
+            { tip: 'generated types treat a dynamic enum as a string, so non-string members would not round-trip' },
+          );
+        }
+      }
+      return ctx.registry.enum(...finalMembers);
+    },
+  };
+}
+
+/**
  * Build a plan from a `@type=...` call node whose name IS a registered data type.
  * The composite types (`array(...)`, `object(...)`) get strict option validation +
  * recursive element/key types; scalar types call their factory with either positional
@@ -330,6 +396,7 @@ function buildTypeCallPlan(
 
   if (name === 'array') return buildArrayTypePlan(ctx, fnCall, context);
   if (name === 'record') return buildRecordTypePlan(ctx, fnCall, context);
+  if (name === 'enum') return buildEnumTypePlan(ctx, fnCall, context);
 
   const deferred: TypeSpecPlan['deferred'] = [];
   const { positionals, settings } = extractScalarTypeArgs(fnCall, ctx, deferred, context);
@@ -428,7 +495,32 @@ export function buildTypeSpecPlan(
   throw new SchemaError('@type must be set to a type name (e.g. @type=number) or a type call (e.g. @type=enum(a, b))');
 }
 
-/** fingerprint comparison helper used by the caller's provisional-vs-final guard */
-export function coercedTypesMatch(a: EnvGraphDataType, b: EnvGraphDataType): boolean {
-  return coercedTypeFingerprint(a) === coercedTypeFingerprint(b);
+/**
+ * Structural compatibility for the provisional-vs-final guard: exact match, plus one
+ * safe widening - a resolved enum whose members are all strings stays assignable to a
+ * provisional plain-string type (dynamic enums generate `string`). Checked recursively
+ * so the widening also applies inside composites (e.g. `array(enum($MODES))`).
+ */
+function coercedTypeCompatible(provisional: CoercedType, final: CoercedType): boolean {
+  if (JSON.stringify(provisional) === JSON.stringify(final)) return true;
+  if (
+    provisional === 'string'
+    && typeof final === 'object' && 'enum' in final
+    && final.enum.every((m) => typeof m === 'string')
+  ) return true;
+  if (typeof provisional === 'object' && typeof final === 'object') {
+    if ('arrayOf' in provisional && 'arrayOf' in final) {
+      return coercedTypeCompatible(provisional.arrayOf, final.arrayOf);
+    }
+    if ('recordOf' in provisional && 'recordOf' in final) {
+      return coercedTypeCompatible(provisional.recordOf.values ?? 'string', final.recordOf.values ?? 'string')
+        && coercedTypeCompatible(provisional.recordOf.keys ?? 'string', final.recordOf.keys ?? 'string');
+    }
+  }
+  return false;
+}
+
+/** compatibility check used by the caller's provisional-vs-final guard */
+export function coercedTypesMatch(provisional: EnvGraphDataType, final: EnvGraphDataType): boolean {
+  return coercedTypeCompatible(provisional.coercedType ?? 'string', final.coercedType ?? 'string');
 }

--- a/packages/varlock/src/env-graph/lib/type-decorator.ts
+++ b/packages/varlock/src/env-graph/lib/type-decorator.ts
@@ -62,7 +62,7 @@ function materializeSettings(
   return out;
 }
 
-const ARRAY_OPTION_KEYS = ['minLength', 'maxLength', 'unique', 'separator', 'format'] as const;
+const ARRAY_OPTION_KEYS = ['minLength', 'maxLength', 'isLength', 'unique', 'separator', 'format'] as const;
 const OBJECT_OPTION_KEYS = ['keys'] as const;
 
 function typeSpecDisplayName(node: TypeSpecNode): string {
@@ -132,7 +132,7 @@ function validateArraySettings(settings: Record<string, any>, context: string) {
   if (settings.format !== undefined && settings.format !== 'separator' && settings.format !== 'json') {
     throw new SchemaError(`${context} - format must be "separator" or "json"`);
   }
-  for (const lengthKey of ['minLength', 'maxLength'] as const) {
+  for (const lengthKey of ['minLength', 'maxLength', 'isLength'] as const) {
     if (settings[lengthKey] !== undefined && !_.isNumber(settings[lengthKey])) {
       throw new SchemaError(`${context} - ${lengthKey} must be a number`);
     }

--- a/packages/varlock/src/env-graph/lib/type-decorator.ts
+++ b/packages/varlock/src/env-graph/lib/type-decorator.ts
@@ -63,7 +63,7 @@ function materializeSettings(
 }
 
 const ARRAY_OPTION_KEYS = ['minLength', 'maxLength', 'isLength', 'unique', 'separator', 'format'] as const;
-const OBJECT_OPTION_KEYS = ['keys'] as const;
+const OBJECT_OPTION_KEYS = ['keyType', 'entriesMinLength', 'entriesMaxLength', 'entriesIsLength'] as const;
 
 function typeSpecDisplayName(node: TypeSpecNode): string {
   return node instanceof ParsedEnvSpecFunctionCall ? node.name : String(node.value);
@@ -198,6 +198,14 @@ function buildArrayTypePlan(
   };
 }
 
+function validateObjectSettings(settings: Record<string, any>, context: string) {
+  for (const lengthKey of ['entriesMinLength', 'entriesMaxLength', 'entriesIsLength'] as const) {
+    if (settings[lengthKey] !== undefined && !_.isNumber(settings[lengthKey])) {
+      throw new SchemaError(`${context} - ${lengthKey} must be a number`);
+    }
+  }
+}
+
 function buildObjectTypePlan(
   ctx: TypeSpecContext,
   fnCall: ParsedEnvSpecFunctionCall,
@@ -205,7 +213,8 @@ function buildObjectTypePlan(
 ): TypeSpecPlan {
   const deferred: TypeSpecPlan['deferred'] = [];
   const positionals: Array<TypeSpecNode> = [];
-  let keysPlan: TypeSpecPlan | undefined;
+  const settings: Record<string, any> = {};
+  let keyTypePlan: TypeSpecPlan | undefined;
 
   for (const arg of fnCall.data.args.values) {
     if (arg instanceof ParsedEnvSpecKeyValuePair) {
@@ -215,15 +224,19 @@ function buildObjectTypePlan(
           { tip: 'value type options go in a nested call, e.g. object(string(minLength=2))' },
         );
       }
-      // `keys=` takes a type spec (name or call), not a scalar
-      if (
-        arg.value instanceof ParsedEnvSpecStaticValue
-        || arg.value instanceof ParsedEnvSpecFunctionCall
-      ) {
-        keysPlan = buildNestedTypePlan(ctx, arg.value, context);
-        deferred.push(...keysPlan.deferred);
+      if (arg.key === 'keyType') {
+        // `keyType=` takes a type spec (name or call), not a scalar
+        if (
+          arg.value instanceof ParsedEnvSpecStaticValue
+          || arg.value instanceof ParsedEnvSpecFunctionCall
+        ) {
+          keyTypePlan = buildNestedTypePlan(ctx, arg.value, context);
+          deferred.push(...keyTypePlan.deferred);
+        } else {
+          throw new SchemaError(`${context} - keyType must be a type name or type call, e.g. keyType=enum(us, eu)`);
+        }
       } else {
-        throw new SchemaError(`${context} - keys must be a type name or type call, e.g. keys=enum(us, eu)`);
+        settings[arg.key] = optionValue(arg, ctx, deferred, context);
       }
     } else if (arg instanceof ParsedEnvSpecStaticValue || arg instanceof ParsedEnvSpecFunctionCall) {
       positionals.push(arg);
@@ -243,16 +256,20 @@ function buildObjectTypePlan(
     deferred.push(...valuesPlan.deferred);
   }
 
+  // validate the static settings upfront so schema errors surface at load time
+  validateObjectSettings(materializeSettings(settings), context);
+
   return {
     deferred,
     build: (resolved) => {
-      const settings: Record<string, any> = {};
+      const materialized = materializeSettings(settings, resolved);
+      validateObjectSettings(materialized, context);
       if (valuesPlan) {
-        settings.values = valuesPlan.build(resolved);
-        settings.valuesTypeName = valuesTypeName;
+        materialized.values = valuesPlan.build(resolved);
+        materialized.valuesTypeName = valuesTypeName;
       }
-      if (keysPlan) settings.keys = keysPlan.build(resolved);
-      return ctx.registry.object(settings);
+      if (keyTypePlan) materialized.keyType = keyTypePlan.build(resolved);
+      return ctx.registry.object(materialized);
     },
   };
 }

--- a/packages/varlock/src/env-graph/lib/type-decorator.ts
+++ b/packages/varlock/src/env-graph/lib/type-decorator.ts
@@ -1,7 +1,9 @@
 import _ from '@env-spec/utils/my-dash';
 import {
+  ParsedEnvSpecArrayLiteral,
   ParsedEnvSpecFunctionCall,
   ParsedEnvSpecKeyValuePair,
+  ParsedEnvSpecObjectLiteral,
   ParsedEnvSpecStaticValue,
   type ParsedEnvSpecDecorator,
 } from '@env-spec/parser';
@@ -141,10 +143,55 @@ function buildObjectDataType(
 }
 
 /**
- * Build a data type instance from a `@type=...` call node. Handles the composite types
- * (`array(...)`, `object(...)`) with strict option validation + recursive element/key
- * types; all other types keep the legacy arg handling (positional spread for enum,
- * settings object for named options).
+ * Extract a scalar type call's args into positional values + named settings. Same
+ * walk as the composite types use for their options, so every type call in a spec
+ * shares one arg-handling convention. Nested type calls are only meaningful as
+ * array/object element types, which have their own handling above.
+ */
+function extractScalarTypeArgs(
+  fnCall: ParsedEnvSpecFunctionCall,
+  context: string,
+): { positionals: Array<any>, settings: Record<string, any> } {
+  const positionals: Array<any> = [];
+  const settings: Record<string, any> = {};
+
+  for (const arg of fnCall.data.args.values) {
+    if (arg instanceof ParsedEnvSpecKeyValuePair) {
+      const val = arg.value;
+      if (val instanceof ParsedEnvSpecStaticValue) {
+        settings[arg.key] = val.value;
+      } else if (val instanceof ParsedEnvSpecObjectLiteral || val instanceof ParsedEnvSpecArrayLiteral) {
+        settings[arg.key] = val.simplifiedValue;
+      } else if (val instanceof ParsedEnvSpecFunctionCall && val.name === 'regex') {
+        // deprecated `regex("...")` option form, converted to a RegExp instance
+        const regexArgs = val.simplifiedArgs;
+        if (Array.isArray(regexArgs) && typeof regexArgs[0] === 'string') {
+          settings[arg.key] = new RegExp(regexArgs[0]);
+        } else {
+          throw new SchemaError(`${context} - invalid regex() in option "${arg.key}"`);
+        }
+      } else {
+        throw new SchemaError(`${context} - option "${arg.key}" must be a static value`);
+      }
+    } else if (arg instanceof ParsedEnvSpecStaticValue) {
+      positionals.push(arg.value);
+    } else if (arg instanceof ParsedEnvSpecFunctionCall) {
+      throw new SchemaError(
+        `${context} - nested type calls are only supported as array/object element types`,
+      );
+    } else {
+      throw new SchemaError(`${context} - invalid argument`);
+    }
+  }
+
+  return { positionals, settings };
+}
+
+/**
+ * Build a data type instance from a `@type=...` call node. The composite types
+ * (`array(...)`, `object(...)`) get strict option validation + recursive element/key
+ * types; scalar types call their factory with either positional args spread (e.g.
+ * enum members) or a single settings object (named options) - never both.
  */
 function buildDataTypeFromTypeSpec(
   registry: DataTypesRegistry,
@@ -157,11 +204,14 @@ function buildDataTypeFromTypeSpec(
   if (name === 'array') return buildArrayDataType(registry, fnCall, context);
   if (name === 'object') return buildObjectDataType(registry, fnCall, context);
 
-  // legacy handling for all scalar types - `simplifiedArgs` returns an array (all
-  // positional, e.g. enum members) or a plain object (all named options)
-  const args = fnCall.simplifiedArgs;
+  const { positionals, settings } = extractScalarTypeArgs(fnCall, context);
   const factory = registry[name];
-  return factory(..._.isPlainObject(args) ? [args] : args as Array<any>);
+  if (positionals.length && Object.keys(settings).length) {
+    throw new SchemaError(`${context} - cannot mix positional args and named options`);
+  }
+  if (positionals.length) return factory(...positionals);
+  if (Object.keys(settings).length) return factory(settings);
+  return factory();
 }
 
 /**

--- a/packages/varlock/src/env-graph/lib/type-decorator.ts
+++ b/packages/varlock/src/env-graph/lib/type-decorator.ts
@@ -1,0 +1,184 @@
+import _ from '@env-spec/utils/my-dash';
+import {
+  ParsedEnvSpecFunctionCall,
+  ParsedEnvSpecKeyValuePair,
+  ParsedEnvSpecStaticValue,
+  type ParsedEnvSpecDecorator,
+} from '@env-spec/parser';
+import type { EnvGraphDataType, EnvGraphDataTypeFactory } from './data-types';
+import { SchemaError } from './errors';
+
+type DataTypesRegistry = Record<string, EnvGraphDataTypeFactory>;
+
+/** a node that can describe a type - either a bare name (`email`) or a call (`enum(a, b)`) */
+type TypeSpecNode = ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall;
+
+const ARRAY_OPTION_KEYS = ['minLength', 'maxLength', 'unique', 'separator', 'format'] as const;
+const OBJECT_OPTION_KEYS = ['keys'] as const;
+
+function typeSpecDisplayName(node: TypeSpecNode): string {
+  return node instanceof ParsedEnvSpecFunctionCall ? node.name : String(node.value);
+}
+
+/** build a type instance from a nested type spec (element type of `array(...)`, `keys=`/values of `object(...)`) */
+function buildNestedDataType(
+  registry: DataTypesRegistry,
+  node: TypeSpecNode,
+  context: string,
+): EnvGraphDataType {
+  if (node instanceof ParsedEnvSpecStaticValue) {
+    const name = String(node.value);
+    if (!(name in registry)) throw new SchemaError(`${context} - unknown data type: ${name}`);
+    return registry[name]();
+  }
+  // mutual recursion - nested composite types (array of objects, etc.) recurse back through here
+  // eslint-disable-next-line no-use-before-define
+  return buildDataTypeFromTypeSpec(registry, node, context);
+}
+
+/** a named option inside `array(...)`/`object(...)` must be a static scalar (not a call/ref) */
+function staticOptionValue(kv: ParsedEnvSpecKeyValuePair, context: string): any {
+  if (!(kv.value instanceof ParsedEnvSpecStaticValue)) {
+    throw new SchemaError(`${context} - option "${kv.key}" must be a static value`);
+  }
+  return kv.value.value;
+}
+
+function buildArrayDataType(
+  registry: DataTypesRegistry,
+  fnCall: ParsedEnvSpecFunctionCall,
+  context: string,
+): EnvGraphDataType {
+  const positionals: Array<TypeSpecNode> = [];
+  const settings: Record<string, any> = {};
+
+  for (const arg of fnCall.data.args.values) {
+    if (arg instanceof ParsedEnvSpecKeyValuePair) {
+      if (!(ARRAY_OPTION_KEYS as ReadonlyArray<string>).includes(arg.key)) {
+        throw new SchemaError(
+          `${context} - unknown array option "${arg.key}" (valid: ${ARRAY_OPTION_KEYS.join(', ')})`,
+          { tip: 'element type options go in a nested call, e.g. array(email(normalize=true))' },
+        );
+      }
+      settings[arg.key] = staticOptionValue(arg, context);
+    } else if (arg instanceof ParsedEnvSpecStaticValue || arg instanceof ParsedEnvSpecFunctionCall) {
+      positionals.push(arg);
+    } else {
+      throw new SchemaError(`${context} - invalid argument in array(...)`);
+    }
+  }
+
+  if (positionals.length > 1) {
+    throw new SchemaError(`${context} - array(...) takes a single element type argument`, {
+      tip: 'to allow a fixed set of values use a nested enum, e.g. array(enum(dev, staging, prod))',
+    });
+  }
+
+  if (settings.separator !== undefined && (!_.isString(settings.separator) || settings.separator === '')) {
+    throw new SchemaError(`${context} - separator must be a non-empty string`);
+  }
+  if (settings.format !== undefined && settings.format !== 'separator' && settings.format !== 'json') {
+    throw new SchemaError(`${context} - format must be "separator" or "json"`);
+  }
+  for (const lengthKey of ['minLength', 'maxLength'] as const) {
+    if (settings[lengthKey] !== undefined && !_.isNumber(settings[lengthKey])) {
+      throw new SchemaError(`${context} - ${lengthKey} must be a number`);
+    }
+  }
+  if (settings.unique !== undefined && !_.isBoolean(settings.unique)) {
+    throw new SchemaError(`${context} - unique must be a boolean`);
+  }
+
+  if (positionals.length === 1) {
+    settings.element = buildNestedDataType(registry, positionals[0], context);
+    settings.elementTypeName = typeSpecDisplayName(positionals[0]);
+  }
+
+  return registry.array(settings);
+}
+
+function buildObjectDataType(
+  registry: DataTypesRegistry,
+  fnCall: ParsedEnvSpecFunctionCall,
+  context: string,
+): EnvGraphDataType {
+  const positionals: Array<TypeSpecNode> = [];
+  const settings: Record<string, any> = {};
+
+  for (const arg of fnCall.data.args.values) {
+    if (arg instanceof ParsedEnvSpecKeyValuePair) {
+      if (!(OBJECT_OPTION_KEYS as ReadonlyArray<string>).includes(arg.key)) {
+        throw new SchemaError(
+          `${context} - unknown object option "${arg.key}" (valid: ${OBJECT_OPTION_KEYS.join(', ')})`,
+          { tip: 'value type options go in a nested call, e.g. object(url(allowedDomains=[example.com]))' },
+        );
+      }
+      // `keys=` takes a type spec (name or call), not a scalar
+      if (
+        arg.value instanceof ParsedEnvSpecStaticValue
+        || arg.value instanceof ParsedEnvSpecFunctionCall
+      ) {
+        settings.keys = buildNestedDataType(registry, arg.value, context);
+      } else {
+        throw new SchemaError(`${context} - keys must be a type name or type call, e.g. keys=enum(us, eu)`);
+      }
+    } else if (arg instanceof ParsedEnvSpecStaticValue || arg instanceof ParsedEnvSpecFunctionCall) {
+      positionals.push(arg);
+    } else {
+      throw new SchemaError(`${context} - invalid argument in object(...)`);
+    }
+  }
+
+  if (positionals.length > 1) {
+    throw new SchemaError(`${context} - object(...) takes a single value type argument`);
+  }
+  if (positionals.length === 1) {
+    settings.values = buildNestedDataType(registry, positionals[0], context);
+    settings.valuesTypeName = typeSpecDisplayName(positionals[0]);
+  }
+
+  return registry.object(settings);
+}
+
+/**
+ * Build a data type instance from a `@type=...` call node. Handles the composite types
+ * (`array(...)`, `object(...)`) with strict option validation + recursive element/key
+ * types; all other types keep the legacy arg handling (positional spread for enum,
+ * settings object for named options).
+ */
+function buildDataTypeFromTypeSpec(
+  registry: DataTypesRegistry,
+  fnCall: ParsedEnvSpecFunctionCall,
+  context: string,
+): EnvGraphDataType {
+  const name = fnCall.name;
+  if (!(name in registry)) throw new SchemaError(`${context} - unknown data type: ${name}`);
+
+  if (name === 'array') return buildArrayDataType(registry, fnCall, context);
+  if (name === 'object') return buildObjectDataType(registry, fnCall, context);
+
+  // legacy handling for all scalar types - `simplifiedArgs` returns an array (all
+  // positional, e.g. enum members) or a plain object (all named options)
+  const args = fnCall.simplifiedArgs;
+  const factory = registry[name];
+  return factory(..._.isPlainObject(args) ? [args] : args as Array<any>);
+}
+
+/**
+ * Build a data type instance from the parsed `@type` decorator value.
+ * Throws SchemaError for unknown types / invalid options.
+ */
+export function buildDataTypeFromTypeDecorator(
+  registry: DataTypesRegistry,
+  decoratorValue: NonNullable<ParsedEnvSpecDecorator['value']>,
+): EnvGraphDataType {
+  if (decoratorValue instanceof ParsedEnvSpecStaticValue) {
+    const name = String(decoratorValue.value);
+    if (!(name in registry)) throw new SchemaError(`unknown data type: ${name}`);
+    return registry[name]();
+  }
+  if (decoratorValue instanceof ParsedEnvSpecFunctionCall) {
+    return buildDataTypeFromTypeSpec(registry, decoratorValue, `@type=${decoratorValue.name}(...)`);
+  }
+  throw new SchemaError('@type must be set to a type name (e.g. @type=number) or a type call (e.g. @type=enum(a, b))');
+}

--- a/packages/varlock/src/env-graph/lib/type-decorator.ts
+++ b/packages/varlock/src/env-graph/lib/type-decorator.ts
@@ -63,7 +63,15 @@ function materializeSettings(
 }
 
 const ARRAY_OPTION_KEYS = ['minLength', 'maxLength', 'isLength', 'unique', 'separator', 'format'] as const;
-const OBJECT_OPTION_KEYS = ['keyType', 'entriesMinLength', 'entriesMaxLength', 'entriesIsLength'] as const;
+const RECORD_OPTION_KEYS = ['keyType', 'entriesMinLength', 'entriesMaxLength', 'entriesIsLength'] as const;
+
+function unknownDataTypeError(name: string, context?: string): SchemaError {
+  return new SchemaError(`${context ? `${context} - ` : ''}unknown data type: ${name}`, {
+    // `object` is the natural guess for what varlock calls `record` (reserved for a
+    // possible future per-key shape type)
+    ...name === 'object' ? { tip: 'use record(...) for typed key/value maps, or simple-object for untyped JSON objects' } : {},
+  });
+}
 
 function typeSpecDisplayName(node: TypeSpecNode): string {
   return node instanceof ParsedEnvSpecFunctionCall ? node.name : String(node.value);
@@ -117,7 +125,7 @@ function buildNestedTypePlan(
 ): TypeSpecPlan {
   if (node instanceof ParsedEnvSpecStaticValue) {
     const name = String(node.value);
-    if (!(name in ctx.registry)) throw new SchemaError(`${context} - unknown data type: ${name}`);
+    if (!(name in ctx.registry)) throw unknownDataTypeError(name, context);
     return { deferred: [], build: () => ctx.registry[name]() };
   }
   // mutual recursion - nested composite types (array of objects, etc.) recurse back through here
@@ -198,7 +206,7 @@ function buildArrayTypePlan(
   };
 }
 
-function validateObjectSettings(settings: Record<string, any>, context: string) {
+function validateRecordSettings(settings: Record<string, any>, context: string) {
   for (const lengthKey of ['entriesMinLength', 'entriesMaxLength', 'entriesIsLength'] as const) {
     if (settings[lengthKey] !== undefined && !_.isNumber(settings[lengthKey])) {
       throw new SchemaError(`${context} - ${lengthKey} must be a number`);
@@ -206,7 +214,7 @@ function validateObjectSettings(settings: Record<string, any>, context: string) 
   }
 }
 
-function buildObjectTypePlan(
+function buildRecordTypePlan(
   ctx: TypeSpecContext,
   fnCall: ParsedEnvSpecFunctionCall,
   context: string,
@@ -218,10 +226,10 @@ function buildObjectTypePlan(
 
   for (const arg of fnCall.data.args.values) {
     if (arg instanceof ParsedEnvSpecKeyValuePair) {
-      if (!(OBJECT_OPTION_KEYS as ReadonlyArray<string>).includes(arg.key)) {
+      if (!(RECORD_OPTION_KEYS as ReadonlyArray<string>).includes(arg.key)) {
         throw new SchemaError(
-          `${context} - unknown object option "${arg.key}" (valid: ${OBJECT_OPTION_KEYS.join(', ')})`,
-          { tip: 'value type options go in a nested call, e.g. object(string(minLength=2))' },
+          `${context} - unknown record option "${arg.key}" (valid: ${RECORD_OPTION_KEYS.join(', ')})`,
+          { tip: 'value type options go in a nested call, e.g. record(string(minLength=2))' },
         );
       }
       if (arg.key === 'keyType') {
@@ -241,12 +249,12 @@ function buildObjectTypePlan(
     } else if (arg instanceof ParsedEnvSpecStaticValue || arg instanceof ParsedEnvSpecFunctionCall) {
       positionals.push(arg);
     } else {
-      throw new SchemaError(`${context} - invalid argument in object(...)`);
+      throw new SchemaError(`${context} - invalid argument in record(...)`);
     }
   }
 
   if (positionals.length > 1) {
-    throw new SchemaError(`${context} - object(...) takes a single value type argument`);
+    throw new SchemaError(`${context} - record(...) takes a single value type argument`);
   }
   let valuesPlan: TypeSpecPlan | undefined;
   let valuesTypeName: string | undefined;
@@ -257,19 +265,19 @@ function buildObjectTypePlan(
   }
 
   // validate the static settings upfront so schema errors surface at load time
-  validateObjectSettings(materializeSettings(settings), context);
+  validateRecordSettings(materializeSettings(settings), context);
 
   return {
     deferred,
     build: (resolved) => {
       const materialized = materializeSettings(settings, resolved);
-      validateObjectSettings(materialized, context);
+      validateRecordSettings(materialized, context);
       if (valuesPlan) {
         materialized.values = valuesPlan.build(resolved);
         materialized.valuesTypeName = valuesTypeName;
       }
       if (keyTypePlan) materialized.keyType = keyTypePlan.build(resolved);
-      return ctx.registry.object(materialized);
+      return ctx.registry.record(materialized);
     },
   };
 }
@@ -318,10 +326,10 @@ function buildTypeCallPlan(
   context: string,
 ): TypeSpecPlan {
   const name = fnCall.name;
-  if (!(name in ctx.registry)) throw new SchemaError(`${context} - unknown data type: ${name}`);
+  if (!(name in ctx.registry)) throw unknownDataTypeError(name, context);
 
   if (name === 'array') return buildArrayTypePlan(ctx, fnCall, context);
-  if (name === 'object') return buildObjectTypePlan(ctx, fnCall, context);
+  if (name === 'record') return buildRecordTypePlan(ctx, fnCall, context);
 
   const deferred: TypeSpecPlan['deferred'] = [];
   const { positionals, settings } = extractScalarTypeArgs(fnCall, ctx, deferred, context);
@@ -405,7 +413,7 @@ export function buildTypeSpecPlan(
 ): TypeSpecPlan {
   if (decoratorValue instanceof ParsedEnvSpecStaticValue) {
     const name = String(decoratorValue.value);
-    if (!(name in ctx.registry)) throw new SchemaError(`unknown data type: ${name}`);
+    if (!(name in ctx.registry)) throw unknownDataTypeError(name);
     return { deferred: [], build: () => ctx.registry[name]() };
   }
   if (decoratorValue instanceof ParsedEnvSpecFunctionCall) {
@@ -415,7 +423,7 @@ export function buildTypeSpecPlan(
     if (decoratorValue.name in ctx.resolverFns) {
       return buildDynamicTypePlan(ctx, decoratorValue);
     }
-    throw new SchemaError(`unknown data type: ${decoratorValue.name}`);
+    throw unknownDataTypeError(decoratorValue.name);
   }
   throw new SchemaError('@type must be set to a type name (e.g. @type=number) or a type call (e.g. @type=enum(a, b))');
 }

--- a/packages/varlock/src/env-graph/lib/type-decorator.ts
+++ b/packages/varlock/src/env-graph/lib/type-decorator.ts
@@ -8,12 +8,59 @@ import {
   type ParsedEnvSpecDecorator,
 } from '@env-spec/parser';
 import type { EnvGraphDataType, EnvGraphDataTypeFactory } from './data-types';
+import { convertParsedValueToResolvers, type Resolver } from './resolver';
+import type { EnvGraphDataSource } from './data-source';
 import { SchemaError } from './errors';
 
 type DataTypesRegistry = Record<string, EnvGraphDataTypeFactory>;
 
+export type TypeSpecContext = {
+  registry: DataTypesRegistry;
+  /** resolver function registry - option VALUES may be resolver calls (if, remap, ...) */
+  resolverFns: Record<string, any>;
+  dataSource?: EnvGraphDataSource;
+};
+
 /** a node that can describe a type - either a bare name (`email`) or a call (`enum(a, b)`) */
 type TypeSpecNode = ParsedEnvSpecStaticValue | ParsedEnvSpecFunctionCall;
+
+/**
+ * A parsed `@type` spec, built in two phases so dynamic (resolver-valued) parts don't
+ * make code generation env-dependent:
+ * - `build()` with no args returns the PROVISIONAL instance - deferred settings omitted,
+ *   a dynamic whole type replaced by its first static candidate (or string). Deterministic,
+ *   safe for type generation.
+ * - `build(resolved)` returns the FINAL instance once the deferred resolvers have resolved.
+ *   The caller must verify the final `coercedType` matches the provisional one, so dynamic
+ *   parts can vary validation behavior but never the generated types.
+ */
+export type TypeSpecPlan = {
+  /** resolver-valued parts to resolve before the final build; empty = fully static */
+  deferred: Array<{ resolver: Resolver, label: string }>;
+  build: (resolved?: Map<Resolver, any>) => EnvGraphDataType;
+};
+
+/** marker wrapping a deferred (resolver-valued) option in a settings record */
+class DeferredValue {
+  constructor(readonly resolver: Resolver) {}
+}
+
+/** replace DeferredValue markers with their resolved values (or omit them in provisional mode) */
+function materializeSettings(
+  settings: Record<string, any>,
+  resolved?: Map<Resolver, any>,
+): Record<string, any> {
+  const out: Record<string, any> = {};
+  for (const [key, val] of Object.entries(settings)) {
+    if (val instanceof DeferredValue) {
+      if (resolved?.has(val.resolver)) out[key] = resolved.get(val.resolver);
+      // not resolved yet (provisional build) - omit the setting entirely
+    } else {
+      out[key] = val;
+    }
+  }
+  return out;
+}
 
 const ARRAY_OPTION_KEYS = ['minLength', 'maxLength', 'unique', 'separator', 'format'] as const;
 const OBJECT_OPTION_KEYS = ['keys'] as const;
@@ -22,60 +69,63 @@ function typeSpecDisplayName(node: TypeSpecNode): string {
   return node instanceof ParsedEnvSpecFunctionCall ? node.name : String(node.value);
 }
 
-/** build a type instance from a nested type spec (element type of `array(...)`, `keys=`/values of `object(...)`) */
-function buildNestedDataType(
-  registry: DataTypesRegistry,
+function coercedTypeFingerprint(type: EnvGraphDataType): string {
+  return JSON.stringify(type.coercedType ?? 'string');
+}
+
+/**
+ * Interpret a named-option VALUE: static scalars and literals pass through; a resolver
+ * call (if, remap, ref via `$VAR`, ...) becomes a DeferredValue resolved at item
+ * resolution time. The deprecated `regex("...")` form converts to a RegExp.
+ */
+function optionValue(
+  kv: ParsedEnvSpecKeyValuePair,
+  ctx: TypeSpecContext,
+  deferred: TypeSpecPlan['deferred'],
+  context: string,
+): any {
+  const val = kv.value;
+  if (val instanceof ParsedEnvSpecStaticValue) return val.value;
+  if (val instanceof ParsedEnvSpecObjectLiteral || val instanceof ParsedEnvSpecArrayLiteral) {
+    return val.simplifiedValue;
+  }
+  if (val instanceof ParsedEnvSpecFunctionCall) {
+    if (val.name === 'regex') {
+      // deprecated `regex("...")` option form, converted to a RegExp instance
+      const regexArgs = val.simplifiedArgs;
+      if (Array.isArray(regexArgs) && typeof regexArgs[0] === 'string') {
+        return new RegExp(regexArgs[0]);
+      }
+      throw new SchemaError(`${context} - invalid regex() in option "${kv.key}"`);
+    }
+    if (val.name in ctx.resolverFns) {
+      const resolver = convertParsedValueToResolvers(val, ctx.dataSource, ctx.resolverFns);
+      if (!resolver) throw new SchemaError(`${context} - could not build resolver for option "${kv.key}"`);
+      deferred.push({ resolver, label: kv.key });
+      return new DeferredValue(resolver);
+    }
+    throw new SchemaError(`${context} - option "${kv.key}" is not a static value or a known resolver function`);
+  }
+  throw new SchemaError(`${context} - option "${kv.key}" must be a static value or resolver call`);
+}
+
+/** build a nested type plan (element type of `array(...)`, values/`keys=` of `object(...)`) */
+function buildNestedTypePlan(
+  ctx: TypeSpecContext,
   node: TypeSpecNode,
   context: string,
-): EnvGraphDataType {
+): TypeSpecPlan {
   if (node instanceof ParsedEnvSpecStaticValue) {
     const name = String(node.value);
-    if (!(name in registry)) throw new SchemaError(`${context} - unknown data type: ${name}`);
-    return registry[name]();
+    if (!(name in ctx.registry)) throw new SchemaError(`${context} - unknown data type: ${name}`);
+    return { deferred: [], build: () => ctx.registry[name]() };
   }
   // mutual recursion - nested composite types (array of objects, etc.) recurse back through here
   // eslint-disable-next-line no-use-before-define
-  return buildDataTypeFromTypeSpec(registry, node, context);
+  return buildTypeCallPlan(ctx, node, context);
 }
 
-/** a named option inside `array(...)`/`object(...)` must be a static scalar (not a call/ref) */
-function staticOptionValue(kv: ParsedEnvSpecKeyValuePair, context: string): any {
-  if (!(kv.value instanceof ParsedEnvSpecStaticValue)) {
-    throw new SchemaError(`${context} - option "${kv.key}" must be a static value`);
-  }
-  return kv.value.value;
-}
-
-function buildArrayDataType(
-  registry: DataTypesRegistry,
-  fnCall: ParsedEnvSpecFunctionCall,
-  context: string,
-): EnvGraphDataType {
-  const positionals: Array<TypeSpecNode> = [];
-  const settings: Record<string, any> = {};
-
-  for (const arg of fnCall.data.args.values) {
-    if (arg instanceof ParsedEnvSpecKeyValuePair) {
-      if (!(ARRAY_OPTION_KEYS as ReadonlyArray<string>).includes(arg.key)) {
-        throw new SchemaError(
-          `${context} - unknown array option "${arg.key}" (valid: ${ARRAY_OPTION_KEYS.join(', ')})`,
-          { tip: 'element type options go in a nested call, e.g. array(email(normalize=true))' },
-        );
-      }
-      settings[arg.key] = staticOptionValue(arg, context);
-    } else if (arg instanceof ParsedEnvSpecStaticValue || arg instanceof ParsedEnvSpecFunctionCall) {
-      positionals.push(arg);
-    } else {
-      throw new SchemaError(`${context} - invalid argument in array(...)`);
-    }
-  }
-
-  if (positionals.length > 1) {
-    throw new SchemaError(`${context} - array(...) takes a single element type argument`, {
-      tip: 'to allow a fixed set of values use a nested enum, e.g. array(enum(dev, staging, prod))',
-    });
-  }
-
+function validateArraySettings(settings: Record<string, any>, context: string) {
   if (settings.separator !== undefined && (!_.isString(settings.separator) || settings.separator === '')) {
     throw new SchemaError(`${context} - separator must be a non-empty string`);
   }
@@ -90,29 +140,79 @@ function buildArrayDataType(
   if (settings.unique !== undefined && !_.isBoolean(settings.unique)) {
     throw new SchemaError(`${context} - unique must be a boolean`);
   }
-
-  if (positionals.length === 1) {
-    settings.element = buildNestedDataType(registry, positionals[0], context);
-    settings.elementTypeName = typeSpecDisplayName(positionals[0]);
-  }
-
-  return registry.array(settings);
 }
 
-function buildObjectDataType(
-  registry: DataTypesRegistry,
+function buildArrayTypePlan(
+  ctx: TypeSpecContext,
   fnCall: ParsedEnvSpecFunctionCall,
   context: string,
-): EnvGraphDataType {
+): TypeSpecPlan {
+  const deferred: TypeSpecPlan['deferred'] = [];
   const positionals: Array<TypeSpecNode> = [];
   const settings: Record<string, any> = {};
+
+  for (const arg of fnCall.data.args.values) {
+    if (arg instanceof ParsedEnvSpecKeyValuePair) {
+      if (!(ARRAY_OPTION_KEYS as ReadonlyArray<string>).includes(arg.key)) {
+        throw new SchemaError(
+          `${context} - unknown array option "${arg.key}" (valid: ${ARRAY_OPTION_KEYS.join(', ')})`,
+          { tip: 'element type options go in a nested call, e.g. array(email(normalize=true))' },
+        );
+      }
+      settings[arg.key] = optionValue(arg, ctx, deferred, context);
+    } else if (arg instanceof ParsedEnvSpecStaticValue || arg instanceof ParsedEnvSpecFunctionCall) {
+      positionals.push(arg);
+    } else {
+      throw new SchemaError(`${context} - invalid argument in array(...)`);
+    }
+  }
+
+  if (positionals.length > 1) {
+    throw new SchemaError(`${context} - array(...) takes a single element type argument`, {
+      tip: 'to allow a fixed set of values use a nested enum, e.g. array(enum(dev, staging, prod))',
+    });
+  }
+
+  let elementPlan: TypeSpecPlan | undefined;
+  let elementTypeName: string | undefined;
+  if (positionals.length === 1) {
+    elementPlan = buildNestedTypePlan(ctx, positionals[0], context);
+    elementTypeName = typeSpecDisplayName(positionals[0]);
+    deferred.push(...elementPlan.deferred);
+  }
+
+  // validate the static settings upfront so schema errors surface at load time
+  validateArraySettings(materializeSettings(settings), context);
+
+  return {
+    deferred,
+    build: (resolved) => {
+      const materialized = materializeSettings(settings, resolved);
+      validateArraySettings(materialized, context);
+      if (elementPlan) {
+        materialized.element = elementPlan.build(resolved);
+        materialized.elementTypeName = elementTypeName;
+      }
+      return ctx.registry.array(materialized);
+    },
+  };
+}
+
+function buildObjectTypePlan(
+  ctx: TypeSpecContext,
+  fnCall: ParsedEnvSpecFunctionCall,
+  context: string,
+): TypeSpecPlan {
+  const deferred: TypeSpecPlan['deferred'] = [];
+  const positionals: Array<TypeSpecNode> = [];
+  let keysPlan: TypeSpecPlan | undefined;
 
   for (const arg of fnCall.data.args.values) {
     if (arg instanceof ParsedEnvSpecKeyValuePair) {
       if (!(OBJECT_OPTION_KEYS as ReadonlyArray<string>).includes(arg.key)) {
         throw new SchemaError(
           `${context} - unknown object option "${arg.key}" (valid: ${OBJECT_OPTION_KEYS.join(', ')})`,
-          { tip: 'value type options go in a nested call, e.g. object(url(allowedDomains=[example.com]))' },
+          { tip: 'value type options go in a nested call, e.g. object(string(minLength=2))' },
         );
       }
       // `keys=` takes a type spec (name or call), not a scalar
@@ -120,7 +220,8 @@ function buildObjectDataType(
         arg.value instanceof ParsedEnvSpecStaticValue
         || arg.value instanceof ParsedEnvSpecFunctionCall
       ) {
-        settings.keys = buildNestedDataType(registry, arg.value, context);
+        keysPlan = buildNestedTypePlan(ctx, arg.value, context);
+        deferred.push(...keysPlan.deferred);
       } else {
         throw new SchemaError(`${context} - keys must be a type name or type call, e.g. keys=enum(us, eu)`);
       }
@@ -134,12 +235,26 @@ function buildObjectDataType(
   if (positionals.length > 1) {
     throw new SchemaError(`${context} - object(...) takes a single value type argument`);
   }
+  let valuesPlan: TypeSpecPlan | undefined;
+  let valuesTypeName: string | undefined;
   if (positionals.length === 1) {
-    settings.values = buildNestedDataType(registry, positionals[0], context);
-    settings.valuesTypeName = typeSpecDisplayName(positionals[0]);
+    valuesPlan = buildNestedTypePlan(ctx, positionals[0], context);
+    valuesTypeName = typeSpecDisplayName(positionals[0]);
+    deferred.push(...valuesPlan.deferred);
   }
 
-  return registry.object(settings);
+  return {
+    deferred,
+    build: (resolved) => {
+      const settings: Record<string, any> = {};
+      if (valuesPlan) {
+        settings.values = valuesPlan.build(resolved);
+        settings.valuesTypeName = valuesTypeName;
+      }
+      if (keysPlan) settings.keys = keysPlan.build(resolved);
+      return ctx.registry.object(settings);
+    },
+  };
 }
 
 /**
@@ -150,6 +265,8 @@ function buildObjectDataType(
  */
 function extractScalarTypeArgs(
   fnCall: ParsedEnvSpecFunctionCall,
+  ctx: TypeSpecContext,
+  deferred: TypeSpecPlan['deferred'],
   context: string,
 ): { positionals: Array<any>, settings: Record<string, any> } {
   const positionals: Array<any> = [];
@@ -157,27 +274,12 @@ function extractScalarTypeArgs(
 
   for (const arg of fnCall.data.args.values) {
     if (arg instanceof ParsedEnvSpecKeyValuePair) {
-      const val = arg.value;
-      if (val instanceof ParsedEnvSpecStaticValue) {
-        settings[arg.key] = val.value;
-      } else if (val instanceof ParsedEnvSpecObjectLiteral || val instanceof ParsedEnvSpecArrayLiteral) {
-        settings[arg.key] = val.simplifiedValue;
-      } else if (val instanceof ParsedEnvSpecFunctionCall && val.name === 'regex') {
-        // deprecated `regex("...")` option form, converted to a RegExp instance
-        const regexArgs = val.simplifiedArgs;
-        if (Array.isArray(regexArgs) && typeof regexArgs[0] === 'string') {
-          settings[arg.key] = new RegExp(regexArgs[0]);
-        } else {
-          throw new SchemaError(`${context} - invalid regex() in option "${arg.key}"`);
-        }
-      } else {
-        throw new SchemaError(`${context} - option "${arg.key}" must be a static value`);
-      }
+      settings[arg.key] = optionValue(arg, ctx, deferred, context);
     } else if (arg instanceof ParsedEnvSpecStaticValue) {
       positionals.push(arg.value);
     } else if (arg instanceof ParsedEnvSpecFunctionCall) {
       throw new SchemaError(
-        `${context} - nested type calls are only supported as array/object element types`,
+        `${context} - nested type calls are only supported as array/object element types; positional args must be static`,
       );
     } else {
       throw new SchemaError(`${context} - invalid argument`);
@@ -188,47 +290,120 @@ function extractScalarTypeArgs(
 }
 
 /**
- * Build a data type instance from a `@type=...` call node. The composite types
- * (`array(...)`, `object(...)`) get strict option validation + recursive element/key
- * types; scalar types call their factory with either positional args spread (e.g.
- * enum members) or a single settings object (named options) - never both.
+ * Build a plan from a `@type=...` call node whose name IS a registered data type.
+ * The composite types (`array(...)`, `object(...)`) get strict option validation +
+ * recursive element/key types; scalar types call their factory with either positional
+ * args spread (e.g. enum members) or a single settings object (named options) - never both.
  */
-function buildDataTypeFromTypeSpec(
-  registry: DataTypesRegistry,
+function buildTypeCallPlan(
+  ctx: TypeSpecContext,
   fnCall: ParsedEnvSpecFunctionCall,
   context: string,
-): EnvGraphDataType {
+): TypeSpecPlan {
   const name = fnCall.name;
-  if (!(name in registry)) throw new SchemaError(`${context} - unknown data type: ${name}`);
+  if (!(name in ctx.registry)) throw new SchemaError(`${context} - unknown data type: ${name}`);
 
-  if (name === 'array') return buildArrayDataType(registry, fnCall, context);
-  if (name === 'object') return buildObjectDataType(registry, fnCall, context);
+  if (name === 'array') return buildArrayTypePlan(ctx, fnCall, context);
+  if (name === 'object') return buildObjectTypePlan(ctx, fnCall, context);
 
-  const { positionals, settings } = extractScalarTypeArgs(fnCall, context);
-  const factory = registry[name];
+  const deferred: TypeSpecPlan['deferred'] = [];
+  const { positionals, settings } = extractScalarTypeArgs(fnCall, ctx, deferred, context);
+  const factory = ctx.registry[name];
   if (positionals.length && Object.keys(settings).length) {
     throw new SchemaError(`${context} - cannot mix positional args and named options`);
   }
-  if (positionals.length) return factory(...positionals);
-  if (Object.keys(settings).length) return factory(settings);
-  return factory();
+  return {
+    deferred,
+    build: (resolved) => {
+      if (positionals.length) return factory(...positionals);
+      const materialized = materializeSettings(settings, resolved);
+      if (Object.keys(materialized).length) return factory(materialized);
+      return factory();
+    },
+  };
 }
 
 /**
- * Build a data type instance from the parsed `@type` decorator value.
+ * A DYNAMIC whole type - `@type=if(forEnv(production), url, string)` - where the
+ * decorator value is a resolver call that resolves to a type NAME at resolution time.
+ *
+ * Code generation stays deterministic: the provisional instance comes from the first
+ * static candidate type name found in the call's top-level args (`url` above), and all
+ * candidates must generate the same type (a url and a string are both strings for
+ * type generation's sake - a number and a string are not). The caller re-verifies the
+ * resolved type's coercedType against the provisional one, which also covers opaque
+ * expressions with no extractable candidates.
+ */
+function buildDynamicTypePlan(
+  ctx: TypeSpecContext,
+  fnCall: ParsedEnvSpecFunctionCall,
+): TypeSpecPlan {
+  const context = `@type=${fnCall.name}(...)`;
+  const resolver = convertParsedValueToResolvers(fnCall, ctx.dataSource, ctx.resolverFns);
+  if (!resolver) throw new SchemaError(`${context} - could not build resolver`);
+
+  // candidate type names = static string args (positional or named values) naming registry types
+  const candidates: Array<string> = [];
+  for (const arg of fnCall.data.args.values) {
+    let staticVal: any;
+    if (arg instanceof ParsedEnvSpecStaticValue) staticVal = arg.value;
+    else if (arg instanceof ParsedEnvSpecKeyValuePair && arg.value instanceof ParsedEnvSpecStaticValue) {
+      staticVal = arg.value.value;
+    }
+    if (typeof staticVal === 'string' && staticVal in ctx.registry && !candidates.includes(staticVal)) {
+      candidates.push(staticVal);
+    }
+  }
+
+  const candidateFingerprints = _.uniq(candidates.map((name) => coercedTypeFingerprint(ctx.registry[name]())));
+  if (candidateFingerprints.length > 1) {
+    throw new SchemaError(
+      `${context} - possible types (${candidates.join(', ')}) do not all generate the same type`,
+      { tip: 'a dynamic @type may vary validation but not the generated type - e.g. url vs string is ok, number vs string is not' },
+    );
+  }
+
+  const provisionalName = candidates[0] ?? 'string';
+
+  return {
+    deferred: [{ resolver, label: '@type' }],
+    build: (resolved) => {
+      if (!resolved?.has(resolver)) return ctx.registry[provisionalName]();
+      const resolvedName = resolved.get(resolver);
+      if (typeof resolvedName !== 'string' || !(resolvedName in ctx.registry)) {
+        throw new SchemaError(`${context} - resolved to invalid data type: ${JSON.stringify(resolvedName)}`);
+      }
+      return ctx.registry[resolvedName]();
+    },
+  };
+}
+
+/**
+ * Build a TypeSpecPlan from the parsed `@type` decorator value.
  * Throws SchemaError for unknown types / invalid options.
  */
-export function buildDataTypeFromTypeDecorator(
-  registry: DataTypesRegistry,
+export function buildTypeSpecPlan(
+  ctx: TypeSpecContext,
   decoratorValue: NonNullable<ParsedEnvSpecDecorator['value']>,
-): EnvGraphDataType {
+): TypeSpecPlan {
   if (decoratorValue instanceof ParsedEnvSpecStaticValue) {
     const name = String(decoratorValue.value);
-    if (!(name in registry)) throw new SchemaError(`unknown data type: ${name}`);
-    return registry[name]();
+    if (!(name in ctx.registry)) throw new SchemaError(`unknown data type: ${name}`);
+    return { deferred: [], build: () => ctx.registry[name]() };
   }
   if (decoratorValue instanceof ParsedEnvSpecFunctionCall) {
-    return buildDataTypeFromTypeSpec(registry, decoratorValue, `@type=${decoratorValue.name}(...)`);
+    if (decoratorValue.name in ctx.registry) {
+      return buildTypeCallPlan(ctx, decoratorValue, `@type=${decoratorValue.name}(...)`);
+    }
+    if (decoratorValue.name in ctx.resolverFns) {
+      return buildDynamicTypePlan(ctx, decoratorValue);
+    }
+    throw new SchemaError(`unknown data type: ${decoratorValue.name}`);
   }
   throw new SchemaError('@type must be set to a type name (e.g. @type=number) or a type call (e.g. @type=enum(a, b))');
+}
+
+/** fingerprint comparison helper used by the caller's provisional-vs-final guard */
+export function coercedTypesMatch(a: EnvGraphDataType, b: EnvGraphDataType): boolean {
+  return coercedTypeFingerprint(a) === coercedTypeFingerprint(b);
 }

--- a/packages/varlock/src/env-graph/lib/type-generation/emitters/csharp.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation/emitters/csharp.ts
@@ -132,6 +132,10 @@ function csharpTypeKind(coerced: CoercedType): CsharpTypeKind {
     if (kind === 'boolean') return 'bool';
     if (kind === 'mixed') return 'object';
   }
+  // typed arrays/records surface as JsonElement - consumers deserialize to the shape they want
+  if (typeof coerced === 'object' && ('arrayOf' in coerced || 'recordOf' in coerced)) {
+    return 'json';
+  }
   return 'string';
 }
 

--- a/packages/varlock/src/env-graph/lib/type-generation/emitters/go.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation/emitters/go.ts
@@ -19,6 +19,13 @@ function getGoCoercedTypeString(coerced: CoercedType): string {
   if (coerced === 'number') return 'float64';
   if (coerced === 'boolean') return 'bool';
   if (coerced === 'object') return 'map[string]any';
+  // the blob value is a real JSON array/object, so slices/maps unmarshal natively
+  if (typeof coerced === 'object' && 'arrayOf' in coerced) {
+    return `[]${getGoCoercedTypeString(coerced.arrayOf)}`;
+  }
+  if (typeof coerced === 'object' && 'recordOf' in coerced) {
+    return `map[string]${coerced.recordOf.values ? getGoCoercedTypeString(coerced.recordOf.values) : 'any'}`;
+  }
   // Go has no literal-union types, so an enum field gets its members' scalar type — the blob
   // carries the *coerced* value, so a numeric enum must be numeric or Unmarshal fails at runtime
   if (typeof coerced === 'object' && 'enum' in coerced && coerced.enum.length) {
@@ -41,7 +48,8 @@ const GO_EXPORTED_FIELD_NAME = /^[A-Z][A-Za-z0-9]*$/;
 
 // maps and `any` are already nullable in Go (nil means "absent"), so they don't get a pointer
 function goFieldType(baseType: string, isRequired: boolean): string {
-  if (isRequired || baseType.startsWith('map[') || baseType === 'any') return baseType;
+  // maps/slices are already nilable — no pointer wrapping needed for optionals
+  if (isRequired || baseType.startsWith('map[') || baseType.startsWith('[]') || baseType === 'any') return baseType;
   return `*${baseType}`;
 }
 

--- a/packages/varlock/src/env-graph/lib/type-generation/emitters/java.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation/emitters/java.ts
@@ -95,7 +95,7 @@ function isJavaReserved(name: string): boolean {
 /** one or more identifiers joined by dots, e.g. `com.example` or `Env` */
 const JAVA_PACKAGE = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
 
-type JavaTypeKind = 'long' | 'double' | 'boolean' | 'String' | 'Map' | 'Object';
+type JavaTypeKind = 'long' | 'double' | 'boolean' | 'String' | 'Map' | 'List' | 'Object';
 
 function javaTypeKind(coerced: CoercedType): JavaTypeKind {
   if (coerced === 'int') return 'long';
@@ -109,12 +109,15 @@ function javaTypeKind(coerced: CoercedType): JavaTypeKind {
     if (kind === 'boolean') return 'boolean';
     if (kind === 'mixed') return 'Object';
   }
+  if (typeof coerced === 'object' && 'arrayOf' in coerced) return 'List';
+  if (typeof coerced === 'object' && 'recordOf' in coerced) return 'Map';
   return 'String';
 }
 
 /** Field type as written on the class (boxed when optional so null is representable). */
 function javaFieldType(kind: JavaTypeKind, isRequired: boolean): string {
   if (kind === 'Map') return 'Map<String, Object>';
+  if (kind === 'List') return 'List<Object>';
   if (kind === 'Object') return 'Object';
   if (kind === 'String') return 'String';
   if (isRequired) {
@@ -152,6 +155,7 @@ function javaLoadLocal(field: ResolvedFieldType): Array<string> {
 
   let readValue: string;
   if (kind === 'Map') readValue = `mapper.convertValue(${entry}.get("value"), MAP_TYPE)`;
+  else if (kind === 'List') readValue = `mapper.convertValue(${entry}.get("value"), LIST_TYPE)`;
   else if (kind === 'Object') readValue = `mapper.treeToValue(${entry}.get("value"), Object.class)`;
   else if (kind === 'String') readValue = `${entry}.get("value").asText()`;
   else if (kind === 'long') readValue = `${entry}.get("value").asLong()`;
@@ -199,6 +203,7 @@ export function generateJavaEnvSrc(
 
   const sensitiveKeys = getSensitiveKeys(fields);
   const needsMap = safe.some((f) => javaTypeKind(f.coerced) === 'Map');
+  const needsList = safe.some((f) => javaTypeKind(f.coerced) === 'List');
   const sensitiveInit = sensitiveKeys.length
     ? `Set.of(${sensitiveKeys.map(javaStringLiteral).join(', ')})`
     : 'Set.of()';
@@ -209,10 +214,10 @@ export function generateJavaEnvSrc(
     '',
     'import com.fasterxml.jackson.databind.JsonNode;',
     'import com.fasterxml.jackson.databind.ObjectMapper;',
-    ...(needsMap ? [
-      'import com.fasterxml.jackson.databind.type.MapType;',
-      'import com.fasterxml.jackson.databind.type.TypeFactory;',
-    ] : []),
+    ...(needsMap ? ['import com.fasterxml.jackson.databind.type.MapType;'] : []),
+    ...(needsList ? ['import com.fasterxml.jackson.databind.type.CollectionType;'] : []),
+    ...(needsMap || needsList ? ['import com.fasterxml.jackson.databind.type.TypeFactory;'] : []),
+    ...(needsList ? ['import java.util.List;'] : []),
     ...(needsMap ? ['import java.util.Map;'] : []),
     'import java.util.Set;',
     '',
@@ -224,6 +229,11 @@ export function generateJavaEnvSrc(
     ...(needsMap ? [
       '  private static final MapType MAP_TYPE = TypeFactory.defaultInstance()',
       '      .constructMapType(java.util.LinkedHashMap.class, String.class, Object.class);',
+      '',
+    ] : []),
+    ...(needsList ? [
+      '  private static final CollectionType LIST_TYPE = TypeFactory.defaultInstance()',
+      '      .constructCollectionType(java.util.ArrayList.class, Object.class);',
       '',
     ] : []),
     ...safe.flatMap((field) => {

--- a/packages/varlock/src/env-graph/lib/type-generation/emitters/php.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation/emitters/php.ts
@@ -41,6 +41,10 @@ function phpBaseType(coerced: CoercedType): string {
       return (['string', 'int', 'float', 'bool'] as const).filter((k) => phpKinds.has(k)).join('|');
     }
   }
+  // typed arrays/records both decode to PHP arrays; the @var refinement carries the detail
+  if (typeof coerced === 'object' && ('arrayOf' in coerced || 'recordOf' in coerced)) {
+    return 'array';
+  }
   return 'string';
 }
 
@@ -55,6 +59,15 @@ function phpVarType(coerced: CoercedType): string | undefined {
   if (coerced === 'object') return 'array<string, mixed>';
   if (typeof coerced === 'object' && 'enum' in coerced && coerced.enum.length) {
     return coerced.enum.map(phpEnumLiteral).join('|');
+  }
+  if (typeof coerced === 'object' && 'arrayOf' in coerced) {
+    const inner = phpVarType(coerced.arrayOf) ?? phpBaseType(coerced.arrayOf);
+    return `array<int, ${inner}>`;
+  }
+  if (typeof coerced === 'object' && 'recordOf' in coerced) {
+    const { values } = coerced.recordOf;
+    const inner = values ? (phpVarType(values) ?? phpBaseType(values)) : 'mixed';
+    return `array<string, ${inner}>`;
   }
   return undefined;
 }

--- a/packages/varlock/src/env-graph/lib/type-generation/emitters/python.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation/emitters/python.ts
@@ -76,6 +76,13 @@ function getPythonCoercedTypeString(coerced: CoercedType): string {
     });
     return `Literal[${options.join(', ')}]`;
   }
+  // the blob value is a real JSON array/object, so list/dict annotations match json.loads output
+  if (typeof coerced === 'object' && 'arrayOf' in coerced) {
+    return `list[${getPythonCoercedTypeString(coerced.arrayOf)}]`;
+  }
+  if (typeof coerced === 'object' && 'recordOf' in coerced) {
+    return `dict[str, ${coerced.recordOf.values ? getPythonCoercedTypeString(coerced.recordOf.values) : 'Any'}]`;
+  }
   return 'str';
 }
 
@@ -134,7 +141,8 @@ export function generatePythonEnvSrc(fields: Array<ResolvedFieldType>): string {
   const typeStrings = safe.map((f) => getPythonCoercedTypeString(f.coerced));
   const typeOnlyImports: Array<string> = [];
   if (typeStrings.some((t) => t.includes('Any'))) typeOnlyImports.push('Any');
-  if (typeStrings.some((t) => t.startsWith('Literal['))) typeOnlyImports.push('Literal');
+  // includes (not startsWith): Literal can be nested, e.g. list[Literal["a", "b"]]
+  if (typeStrings.some((t) => t.includes('Literal['))) typeOnlyImports.push('Literal');
   if (safe.some((f) => !f.isRequired)) typeOnlyImports.push('NotRequired');
   typeOnlyImports.sort();
 

--- a/packages/varlock/src/env-graph/lib/type-generation/emitters/rust.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation/emitters/rust.ts
@@ -27,6 +27,14 @@ function getRustCoercedTypeString(coerced: CoercedType): string {
     if (kind === 'boolean') return 'bool';
     if (kind === 'mixed') return 'serde_json::Value';
   }
+  // the blob value is a real JSON array, so Vec<T> deserializes natively; records stay
+  // serde_json::Value (a typed map would drag in a HashMap import for marginal benefit)
+  if (typeof coerced === 'object' && 'arrayOf' in coerced) {
+    return `Vec<${getRustCoercedTypeString(coerced.arrayOf)}>`;
+  }
+  if (typeof coerced === 'object' && 'recordOf' in coerced) {
+    return 'serde_json::Value';
+  }
   return 'String';
 }
 

--- a/packages/varlock/src/env-graph/lib/type-generation/emitters/ts.ts
+++ b/packages/varlock/src/env-graph/lib/type-generation/emitters/ts.ts
@@ -23,6 +23,22 @@ function getItemTsTypeString(coerced: CoercedType): string {
     if (!coerced.enum.length) return 'never';
     return coerced.enum.map((option) => JSON.stringify(option)).join(' | ');
   }
+  if (typeof coerced === 'object' && 'arrayOf' in coerced) {
+    const inner = getItemTsTypeString(coerced.arrayOf);
+    // parenthesize compound inner types so `("a" | "b")[]` doesn't become `"a" | "b"[]`
+    return /[|<\s]/.test(inner) ? `(${inner})[]` : `${inner}[]`;
+  }
+  if (typeof coerced === 'object' && 'recordOf' in coerced) {
+    const valuesType = coerced.recordOf.values ? getItemTsTypeString(coerced.recordOf.values) : 'any';
+    const keys = coerced.recordOf.keys;
+    // enum-constrained keys narrow the record's key union; Partial since the constraint
+    // limits which keys are allowed, not which must be present
+    if (keys && typeof keys === 'object' && 'enum' in keys && keys.enum.length) {
+      const keyUnion = keys.enum.map((option) => JSON.stringify(String(option))).join(' | ');
+      return `Partial<Record<${keyUnion}, ${valuesType}>>`;
+    }
+    return `Record<string, ${valuesType}>`;
+  }
   return 'string';
 }
 

--- a/packages/varlock/src/env-graph/test/composite-serialization.test.ts
+++ b/packages/varlock/src/env-graph/test/composite-serialization.test.ts
@@ -60,7 +60,7 @@ describe('composite value serialization', () => {
 
   it('arrays of composites force JSON regardless of format', async () => {
     const g = await loadAndResolve(outdent`
-      # @type=array(object)
+      # @type=array(record)
       ITEMS=[{name=a}, {name=b}]
     `);
     expect(g.configSchema.ITEMS.resolvedEnvStringValue).toBe('[{"name":"a"},{"name":"b"}]');
@@ -68,7 +68,7 @@ describe('composite value serialization', () => {
 
   it('objects serialize as JSON', async () => {
     const g = await loadAndResolve(outdent`
-      # @type=object(number)
+      # @type=record(number)
       LIMITS={low=1, high=100}
     `);
     expect(g.configSchema.LIMITS.resolvedEnvStringValue).toBe('{"low":1,"high":100}');
@@ -109,7 +109,7 @@ describe('serialized graph envStr', () => {
     const g = await loadAndResolve(outdent`
       # @type=array(string, separator=";")
       ITEM=[a, b]
-      # @type=object
+      # @type=record
       OBJ={k=v}
       # @type=number
       PORT=8080
@@ -136,7 +136,7 @@ describe('composite redaction', () => {
 
   it('registers nested object values of sensitive items', async () => {
     const g = await loadAndResolve(outdent`
-      # @type=object
+      # @type=record
       # @sensitive
       CREDS={user=admin-user-name-x, pass=super-secret-passphrase-1}
     `);
@@ -151,7 +151,7 @@ describe('runtime re-injection of composite values (initVarlockEnv)', () => {
     const g = await loadAndResolve(outdent`
       # @type=array(string, separator=";")
       HOSTS=[a.com, b.com]
-      # @type=object(number)
+      # @type=record(number)
       LIMITS={low=1}
       # @type=number
       PORT=8080

--- a/packages/varlock/src/env-graph/test/composite-serialization.test.ts
+++ b/packages/varlock/src/env-graph/test/composite-serialization.test.ts
@@ -1,0 +1,147 @@
+/*
+  Tests for how composite (array/object) values serialize back out:
+  - `resolvedEnvStringValue` / getResolvedEnvStringObject (process.env injection)
+  - `envStr` in the serialized graph blob
+  - redaction map registration of composite elements
+*/
+
+import { describe, it, expect } from 'vitest';
+import { outdent } from 'outdent';
+import { DotEnvFileDataSource, EnvGraph } from '../index';
+import { resetRedactionMap, redactSensitiveConfig } from '../../runtime/env';
+
+async function loadAndResolve(envFileContent: string) {
+  const g = new EnvGraph();
+  const testDataSource = new DotEnvFileDataSource('.env.schema', {
+    overrideContents: outdent`
+      # @defaultRequired=false
+      # ---
+      ${envFileContent}
+    `,
+  });
+  await g.setRootDataSource(testDataSource);
+  await g.finishLoad();
+  await g.resolveEnvValues();
+  return g;
+}
+
+describe('composite value serialization', () => {
+  it('arrays of scalars join with the default separator', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      ITEM=[a, b, c]
+    `);
+    expect(g.configSchema.ITEM.resolvedEnvStringValue).toBe('a,b,c');
+  });
+
+  it('arrays join with a custom separator', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string, separator=";")
+      ITEM=[a, b]
+    `);
+    expect(g.configSchema.ITEM.resolvedEnvStringValue).toBe('a;b');
+  });
+
+  it('array elements serialize with their element type (booleans/numbers)', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(number)
+      PORTS=[8080, 3000]
+    `);
+    expect(g.configSchema.PORTS.resolvedEnvStringValue).toBe('8080,3000');
+  });
+
+  it('format=json emits a JSON array', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string, format=json)
+      ITEM=[a, b]
+    `);
+    expect(g.configSchema.ITEM.resolvedEnvStringValue).toBe('["a","b"]');
+  });
+
+  it('arrays of composites force JSON regardless of format', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(object)
+      ITEMS=[{name=a}, {name=b}]
+    `);
+    expect(g.configSchema.ITEMS.resolvedEnvStringValue).toBe('[{"name":"a"},{"name":"b"}]');
+  });
+
+  it('objects serialize as JSON', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=object(number)
+      LIMITS={low=1, high=100}
+    `);
+    expect(g.configSchema.LIMITS.resolvedEnvStringValue).toBe('{"low":1,"high":100}');
+  });
+
+  it('scalars pass through unchanged', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=number
+      PORT=8080
+      NAME=hello
+    `);
+    expect(g.configSchema.PORT.resolvedEnvStringValue).toBe('8080');
+    expect(g.configSchema.NAME.resolvedEnvStringValue).toBe('hello');
+  });
+
+  it('undefined values stay undefined', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      ITEM=
+    `);
+    expect(g.configSchema.ITEM.resolvedEnvStringValue).toBe(undefined);
+  });
+
+  describe('separator round-trip via string re-parse', () => {
+    it('a joined string parses back to the same array', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(email)
+        EMAILS="one@example.com,two@example.com"
+      `);
+      expect(g.configSchema.EMAILS.resolvedValue).toEqual(['one@example.com', 'two@example.com']);
+      expect(g.configSchema.EMAILS.resolvedEnvStringValue).toBe('one@example.com,two@example.com');
+    });
+  });
+});
+
+describe('serialized graph envStr', () => {
+  it('includes envStr for composite values only', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string, separator=";")
+      ITEM=[a, b]
+      # @type=object
+      OBJ={k=v}
+      # @type=number
+      PORT=8080
+    `);
+    const serialized = g.getSerializedGraph();
+    expect(serialized.config.ITEM.envStr).toBe('a;b');
+    expect(serialized.config.OBJ.envStr).toBe('{"k":"v"}');
+    expect(serialized.config.PORT.envStr).toBe(undefined);
+    expect(serialized.config.PORT.value).toBe(8080);
+  });
+});
+
+describe('composite redaction', () => {
+  it('registers each string element of a sensitive array for redaction', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      # @sensitive
+      TOKENS=[secret-token-one-xyz, secret-token-two-abc]
+    `);
+    resetRedactionMap(g.getSerializedGraph());
+    const redacted = redactSensitiveConfig('leaked: secret-token-two-abc !');
+    expect(redacted).not.toContain('secret-token-two-abc');
+  });
+
+  it('registers nested object values of sensitive items', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=object
+      # @sensitive
+      CREDS={user=admin-user-name-x, pass=super-secret-passphrase-1}
+    `);
+    resetRedactionMap(g.getSerializedGraph());
+    const redacted = redactSensitiveConfig('pass is super-secret-passphrase-1');
+    expect(redacted).not.toContain('super-secret-passphrase-1');
+  });
+});

--- a/packages/varlock/src/env-graph/test/composite-serialization.test.ts
+++ b/packages/varlock/src/env-graph/test/composite-serialization.test.ts
@@ -145,3 +145,41 @@ describe('composite redaction', () => {
     expect(redacted).not.toContain('super-secret-passphrase-1');
   });
 });
+
+describe('runtime re-injection of composite values (initVarlockEnv)', () => {
+  it('injects the envStr flat form into process.env, typed value into ENV', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string, separator=";")
+      HOSTS=[a.com, b.com]
+      # @type=object(number)
+      LIMITS={low=1}
+      # @type=number
+      PORT=8080
+    `);
+    const { initVarlockEnv, ENV } = await import('../../runtime/env');
+
+    const prevBlob = process.env.__VARLOCK_ENV;
+    const prevKeys = { HOSTS: process.env.HOSTS, LIMITS: process.env.LIMITS, PORT: process.env.PORT };
+    try {
+      process.env.__VARLOCK_ENV = JSON.stringify(g.getSerializedGraph());
+      initVarlockEnv();
+
+      // process.env gets the flat string form (separator-joined / JSON)
+      expect(process.env.HOSTS).toBe('a.com;b.com');
+      expect(process.env.LIMITS).toBe('{"low":1}');
+      expect(process.env.PORT).toBe('8080');
+
+      // the ENV proxy exposes the real typed values
+      expect((ENV as any).HOSTS).toEqual(['a.com', 'b.com']);
+      expect((ENV as any).LIMITS).toEqual({ low: 1 });
+      expect((ENV as any).PORT).toBe(8080);
+    } finally {
+      if (prevBlob === undefined) delete process.env.__VARLOCK_ENV;
+      else process.env.__VARLOCK_ENV = prevBlob;
+      for (const [k, v] of Object.entries(prevKeys)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  });
+});

--- a/packages/varlock/src/env-graph/test/composite-serialization.test.ts
+++ b/packages/varlock/src/env-graph/test/composite-serialization.test.ts
@@ -194,29 +194,4 @@ describe('simple-object serialization (issue #900)', () => {
     expect(g.configSchema.MY_OBJECT.resolvedEnvStringValue).toBe('{"key":"value"}');
     expect(g.getSerializedGraph().config.MY_OBJECT.envStr).toBe('{"key":"value"}');
   });
-
-  it('a blob from an older CLI (no envStr) still JSON-encodes composites on re-injection', async () => {
-    const g = await loadAndResolve(outdent`
-      # @type=simple-object
-      MY_OBJECT='{"key": "value"}'
-    `);
-    const { initVarlockEnv } = await import('../../runtime/env');
-
-    // simulate an older-CLI blob: composite value present, envStr field absent
-    const serialized = g.getSerializedGraph();
-    delete serialized.config.MY_OBJECT.envStr;
-
-    const prevBlob = process.env.__VARLOCK_ENV;
-    const prevVal = process.env.MY_OBJECT;
-    try {
-      process.env.__VARLOCK_ENV = JSON.stringify(serialized);
-      initVarlockEnv();
-      expect(process.env.MY_OBJECT).toBe('{"key":"value"}');
-    } finally {
-      if (prevBlob === undefined) delete process.env.__VARLOCK_ENV;
-      else process.env.__VARLOCK_ENV = prevBlob;
-      if (prevVal === undefined) delete process.env.MY_OBJECT;
-      else process.env.MY_OBJECT = prevVal;
-    }
-  });
 });

--- a/packages/varlock/src/env-graph/test/composite-serialization.test.ts
+++ b/packages/varlock/src/env-graph/test/composite-serialization.test.ts
@@ -183,3 +183,40 @@ describe('runtime re-injection of composite values (initVarlockEnv)', () => {
     }
   });
 });
+
+describe('simple-object serialization (issue #900)', () => {
+  it('simple-object values serialize as JSON, not "[object Object]"', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=simple-object
+      MY_OBJECT='{"key": "value"}'
+    `);
+    expect(g.configSchema.MY_OBJECT.resolvedValue).toEqual({ key: 'value' });
+    expect(g.configSchema.MY_OBJECT.resolvedEnvStringValue).toBe('{"key":"value"}');
+    expect(g.getSerializedGraph().config.MY_OBJECT.envStr).toBe('{"key":"value"}');
+  });
+
+  it('a blob from an older CLI (no envStr) still JSON-encodes composites on re-injection', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=simple-object
+      MY_OBJECT='{"key": "value"}'
+    `);
+    const { initVarlockEnv } = await import('../../runtime/env');
+
+    // simulate an older-CLI blob: composite value present, envStr field absent
+    const serialized = g.getSerializedGraph();
+    delete serialized.config.MY_OBJECT.envStr;
+
+    const prevBlob = process.env.__VARLOCK_ENV;
+    const prevVal = process.env.MY_OBJECT;
+    try {
+      process.env.__VARLOCK_ENV = JSON.stringify(serialized);
+      initVarlockEnv();
+      expect(process.env.MY_OBJECT).toBe('{"key":"value"}');
+    } finally {
+      if (prevBlob === undefined) delete process.env.__VARLOCK_ENV;
+      else process.env.__VARLOCK_ENV = prevBlob;
+      if (prevVal === undefined) delete process.env.MY_OBJECT;
+      else process.env.MY_OBJECT = prevVal;
+    }
+  });
+});

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -590,11 +590,11 @@ describe('array data type', () => {
   });
 });
 
-describe('object data type', () => {
+describe('record data type', () => {
   describe('input forms', () => {
     it('coerces native object literal values', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object
+        # @type=record
         ITEM={k=v, n=2}
       `);
       expect(g.configSchema.ITEM.isValid).toBe(true);
@@ -603,7 +603,7 @@ describe('object data type', () => {
 
     it('parses JSON object strings', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object
+        # @type=record
         ITEM='{"k": "v", "n": 2}'
       `);
       expect(g.configSchema.ITEM.isValid).toBe(true);
@@ -613,7 +613,7 @@ describe('object data type', () => {
     it('resolves refs within object literal values', async () => {
       const g = await loadAndResolve(outdent`
         BASE=https://example.com
-        # @type=object(url)
+        # @type=record(url)
         ENDPOINTS={api=\${BASE}, other=https://other.com}
       `);
       expect(g.configSchema.ENDPOINTS.isValid).toBe(true);
@@ -627,7 +627,7 @@ describe('object data type', () => {
   describe('value validation', () => {
     it('validates every value with the value type', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(url)
+        # @type=record(url)
         ITEM={good=https://example.com, bad=not-a-url}
       `);
       expect(g.configSchema.ITEM.isValid).toBe(false);
@@ -636,7 +636,7 @@ describe('object data type', () => {
 
     it('coerces values with the value type', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(number)
+        # @type=record(number)
         LIMITS={low=1, high=100}
       `);
       expect(g.configSchema.LIMITS.isValid).toBe(true);
@@ -647,7 +647,7 @@ describe('object data type', () => {
   describe('key validation', () => {
     it('validates keys against an enum', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(url, keyType=enum(us, eu))
+        # @type=record(url, keyType=enum(us, eu))
         REGIONS={us=https://us.example.com, eu=https://eu.example.com}
       `);
       expect(g.configSchema.REGIONS.isValid).toBe(true);
@@ -655,7 +655,7 @@ describe('object data type', () => {
 
     it('rejects keys not in the enum', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(url, keyType=enum(us, eu))
+        # @type=record(url, keyType=enum(us, eu))
         REGIONS={us=https://us.example.com, apac=https://apac.example.com}
       `);
       expect(g.configSchema.REGIONS.isValid).toBe(false);
@@ -664,7 +664,7 @@ describe('object data type', () => {
 
     it('validates keys with a pattern via string type options', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(string, keyType=string(matches="[a-z]+"))
+        # @type=record(string, keyType=string(matches="[a-z]+"))
         ITEM={lower=ok, UPPER=bad}
       `);
       expect(g.configSchema.ITEM.isValid).toBe(false);
@@ -672,10 +672,10 @@ describe('object data type', () => {
     });
   });
 
-  describe('object options', () => {
-    it('rejects unknown object options', async () => {
+  describe('record options', () => {
+    it('rejects unknown record options', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(string, whatever=true)
+        # @type=record(string, whatever=true)
         ITEM={k=v}
       `);
       expect(g.configSchema.ITEM.isValid).toBe(false);
@@ -684,7 +684,7 @@ describe('object data type', () => {
 
     it('allows empty objects', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(string)
+        # @type=record(string)
         ITEM={}
       `);
       expect(g.configSchema.ITEM.isValid).toBe(true);
@@ -693,7 +693,7 @@ describe('object data type', () => {
 
     it('enforces entriesMinLength', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(string, entriesMinLength=2)
+        # @type=record(string, entriesMinLength=2)
         ITEM={only=one}
       `);
       expect(g.configSchema.ITEM.isValid).toBe(false);
@@ -702,7 +702,7 @@ describe('object data type', () => {
 
     it('enforces entriesMaxLength', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(string, entriesMaxLength=1)
+        # @type=record(string, entriesMaxLength=1)
         ITEM={a=1, b=2}
       `);
       expect(g.configSchema.ITEM.isValid).toBe(false);
@@ -711,13 +711,13 @@ describe('object data type', () => {
 
     it('enforces entriesIsLength (exact entry count)', async () => {
       const good = await loadAndResolve(outdent`
-        # @type=object(string, entriesIsLength=2)
+        # @type=record(string, entriesIsLength=2)
         ITEM={a=1, b=2}
       `);
       expect(good.configSchema.ITEM.isValid).toBe(true);
 
       const bad = await loadAndResolve(outdent`
-        # @type=object(string, entriesIsLength=2)
+        # @type=record(string, entriesIsLength=2)
         ITEM={a=1}
       `);
       expect(bad.configSchema.ITEM.isValid).toBe(false);
@@ -727,7 +727,7 @@ describe('object data type', () => {
     it('entry count options support dynamic values', async () => {
       const g = await loadAndResolve(outdent`
         STRICT=true
-        # @type=object(string, entriesMinLength=if($STRICT, 2, 0))
+        # @type=record(string, entriesMinLength=if($STRICT, 2, 0))
         ITEM={only=one}
       `);
       expect(g.configSchema.ITEM.isValid).toBe(false);
@@ -740,7 +740,7 @@ describe('object data type', () => {
         ITEM={k=v, n=2}
       `);
       expect(g.configSchema.ITEM.isValid).toBe(true);
-      expect(g.configSchema.ITEM.dataType?.name).toBe('object');
+      expect(g.configSchema.ITEM.dataType?.name).toBe('record');
       expect(g.configSchema.ITEM.resolvedValue).toEqual({ k: 'v', n: 2 });
     });
   });
@@ -748,7 +748,7 @@ describe('object data type', () => {
   describe('nesting composites', () => {
     it('supports arrays of objects (forced JSON serialization)', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=array(object)
+        # @type=array(record)
         ITEMS=[{name=a}, {name=b}]
       `);
       expect(g.configSchema.ITEMS.isValid).toBe(true);
@@ -757,7 +757,7 @@ describe('object data type', () => {
 
     it('supports objects of arrays', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(array(number))
+        # @type=record(array(number))
         GROUPS={a=[1, 2], b=[3]}
       `);
       expect(g.configSchema.GROUPS.isValid).toBe(true);
@@ -946,7 +946,7 @@ describe('composite coercion error paths', () => {
 
   it('rejects a scalar value for an object type', async () => {
     const g = await loadAndResolve(outdent`
-      # @type=object(string)
+      # @type=record(string)
       ITEM=123
     `);
     expect(g.configSchema.ITEM.isValid).toBe(false);
@@ -954,7 +954,7 @@ describe('composite coercion error paths', () => {
 
   it('errors on malformed JSON object strings', async () => {
     const g = await loadAndResolve(outdent`
-      # @type=object(string)
+      # @type=record(string)
       ITEM='{"a": '
     `);
     expect(g.configSchema.ITEM.isValid).toBe(false);
@@ -963,7 +963,7 @@ describe('composite coercion error paths', () => {
 
   it('reports ALL invalid object values during coercion', async () => {
     const g = await loadAndResolve(outdent`
-      # @type=object(number)
+      # @type=record(number)
       LIMITS={a=x, b=2, c=y}
     `);
     expect(g.configSchema.LIMITS.isValid).toBe(false);
@@ -992,10 +992,10 @@ describe('@type option validation error paths', () => {
     ['array(string, isLength=abc)', 'isLength must be a number'],
     ['array(string, unique=maybe)', 'unique must be a boolean'],
     ['array(string, number)', 'single element type argument'],
-    ['object(string, number)', 'single value type argument'],
-    ['object(string, keyType={a=b})', 'keyType must be a type name or type call'],
-    ['object(string, keys=enum(a, b))', 'unknown object option "keys"'],
-    ['object(string, entriesMinLength=abc)', 'entriesMinLength must be a number'],
+    ['record(string, number)', 'single value type argument'],
+    ['record(string, keyType={a=b})', 'keyType must be a type name or type call'],
+    ['record(string, keys=enum(a, b))', 'unknown record option "keys"'],
+    ['record(string, entriesMinLength=abc)', 'entriesMinLength must be a number'],
   ] as const;
 
   for (const [spec, expectedError] of badSpecs) {
@@ -1008,6 +1008,16 @@ describe('@type option validation error paths', () => {
       expect(g.configSchema.ITEM.errors[0].message).toContain(expectedError);
     });
   }
+
+  it('points object users at record', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=object(url)
+      ITEM={k=v}
+    `);
+    expect(g.configSchema.ITEM.isValid).toBe(false);
+    expect(g.configSchema.ITEM.errors[0].message).toContain('unknown data type: object');
+    expect(g.configSchema.ITEM.errors[0].tip).toContain('record(...)');
+  });
 
   it('rejects a fn call that is neither a type nor a resolver', async () => {
     const g = await loadAndResolve(outdent`

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -719,13 +719,13 @@ describe('@type arg handling (scalar types)', () => {
     expect(g.configSchema.ITEM.errors[0].message).toContain('cannot mix');
   });
 
-  it('rejects non-static option values with a clear error', async () => {
+  it('rejects unknown functions in option values with a clear error', async () => {
     const g = await loadAndResolve(outdent`
-      # @type=string(matches=fallback(a, b))
+      # @type=string(matches=notAFunction(a, b))
       ITEM=x
     `);
     expect(g.configSchema.ITEM.isValid).toBe(false);
-    expect(g.configSchema.ITEM.errors[0].message).toContain('must be a static value');
+    expect(g.configSchema.ITEM.errors[0].message).toContain('not a static value or a known resolver function');
   });
 
   it('rejects nested type calls on scalar types', async () => {
@@ -746,5 +746,121 @@ describe('@type arg handling (scalar types)', () => {
     `);
     expect(g.configSchema.GOOD.isValid).toBe(true);
     expect(g.configSchema.BAD.isValid).toBe(false);
+  });
+});
+
+describe('dynamic @type parts (resolver-valued)', () => {
+  describe('dynamic option values', () => {
+    it('resolves option values via if() with refs to other items', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=enum(sandbox, production)
+        APP_MODE=production
+        # @type=array(email, minLength=if(eq($APP_MODE, production), 2, 0))
+        ALLOWED_EMAILS=[only-one@example.com]
+      `);
+      expect(g.configSchema.ALLOWED_EMAILS.isValid).toBe(false);
+      const messages = (g.configSchema.ALLOWED_EMAILS.validationErrors ?? []).map((e) => e.message).join('\n');
+      expect(messages).toContain('at least 2');
+    });
+
+    it('dynamic option values pass when the resolved constraint is satisfied', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=enum(sandbox, production)
+        APP_MODE=sandbox
+        # @type=array(email, minLength=if(eq($APP_MODE, production), 2, 0))
+        ALLOWED_EMAILS=[only-one@example.com]
+      `);
+      expect(g.configSchema.ALLOWED_EMAILS.isValid).toBe(true);
+    });
+
+    it('supports dynamic options on scalar types', async () => {
+      const g = await loadAndResolve(outdent`
+        STRICT=true
+        # @type=string(minLength=if($STRICT, 10, 1))
+        TOKEN=short
+      `);
+      expect(g.configSchema.TOKEN.isValid).toBe(false);
+    });
+
+    it('rejects dynamic options that would change the generated type', async () => {
+      const g = await loadAndResolve(outdent`
+        FLAG=true
+        # @type=number(isInt=if($FLAG, true, false))
+        VAL=1.5
+      `);
+      expect(g.configSchema.VAL.isValid).toBe(false);
+      const messages = (g.configSchema.VAL.validationErrors ?? []).map((e) => e.message).join('\n');
+      expect(messages).toContain('generate the same type');
+    });
+  });
+
+  describe('dynamic whole types', () => {
+    it('switches the type via if() when candidates generate the same type', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=enum(dev, production)
+        APP_ENV=production
+        # @type=if(eq($APP_ENV, production), url, string)
+        SERVICE_HOST=not-a-url
+      `);
+      // in production the value must be a url
+      expect(g.configSchema.SERVICE_HOST.isValid).toBe(false);
+    });
+
+    it('relaxes validation when the dynamic type resolves to the looser candidate', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=enum(dev, production)
+        APP_ENV=dev
+        # @type=if(eq($APP_ENV, production), url, string)
+        SERVICE_HOST=not-a-url
+      `);
+      expect(g.configSchema.SERVICE_HOST.isValid).toBe(true);
+    });
+
+    it('keeps typegen deterministic - provisional type comes from static candidates', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=enum(dev, production)
+        APP_ENV=production
+        # @type=if(eq($APP_ENV, production), url, string)
+        SERVICE_HOST=https://example.com
+      `);
+      // the provisional (typegen-facing) instance stays the first candidate regardless of env
+      expect(g.configSchema.SERVICE_HOST.dataType?.name).toBe('url');
+      expect(g.configSchema.SERVICE_HOST.effectiveDataType?.name).toBe('url');
+      expect(g.configSchema.SERVICE_HOST.isValid).toBe(true);
+    });
+
+    it('rejects candidate types that generate different types at load time', async () => {
+      const g = await loadAndResolve(outdent`
+        FLAG=true
+        # @type=if($FLAG, number, string)
+        VAL=123
+      `);
+      expect(g.configSchema.VAL.isValid).toBe(false);
+      expect(g.configSchema.VAL.errors[0].message).toContain('do not all generate the same type');
+    });
+
+    it('rejects an opaque dynamic type resolving to a non-string-generating type', async () => {
+      const g = await loadAndResolve(outdent`
+        TYPE_NAME=number
+        # @type=fallback($TYPE_NAME, string)
+        VAL=123
+      `);
+      // fallback($TYPE_NAME, string) resolves to "number", whose generated type (number)
+      // differs from the provisional candidate (string) - rejected at resolution time
+      expect(g.configSchema.VAL.isValid).toBe(false);
+      const messages = (g.configSchema.VAL.validationErrors ?? []).map((e) => e.message).join('\n');
+      expect(messages).toContain('does not generate the same type');
+    });
+
+    it('errors when the dynamic type resolves to an unknown type name', async () => {
+      const g = await loadAndResolve(outdent`
+        TYPE_NAME=not-a-real-type
+        # @type=fallback($TYPE_NAME, string)
+        VAL=x
+      `);
+      expect(g.configSchema.VAL.isValid).toBe(false);
+      const messages = (g.configSchema.VAL.validationErrors ?? []).map((e) => e.message).join('\n');
+      expect(messages).toContain('invalid data type');
+    });
   });
 });

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -767,13 +767,13 @@ describe('record data type', () => {
 });
 
 describe('@type arg handling (scalar types)', () => {
-  it('rejects mixing positional args and named options', async () => {
+  it('rejects named options on enum', async () => {
     const g = await loadAndResolve(outdent`
       # @type=enum(a, b, someOpt=true)
       ITEM=a
     `);
     expect(g.configSchema.ITEM.isValid).toBe(false);
-    expect(g.configSchema.ITEM.errors[0].message).toContain('cannot mix');
+    expect(g.configSchema.ITEM.errors[0].message).toContain('does not take named options');
   });
 
   it('rejects unknown functions in option values with a clear error', async () => {
@@ -1105,6 +1105,101 @@ describe('per-environment dynamic types via forEnv', () => {
     const g = await loadWithEnv('dev');
     expect(g.configSchema.API_TOKEN.isValid).toBe(true);
     expect(g.configSchema.SERVICE_HOST.isValid).toBe(true);
+  });
+});
+
+describe('enum members sourced from other items', () => {
+  it('validates against members spread from a referenced array item', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      ALLOWED_MODES=[dev, staging, prod]
+      # @type=enum($ALLOWED_MODES)
+      APP_MODE=staging
+    `);
+    expect(g.configSchema.APP_MODE.isValid).toBe(true);
+    expect(g.configSchema.APP_MODE.resolvedValue).toBe('staging');
+  });
+
+  it('rejects values not in the referenced array', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      ALLOWED_MODES=[dev, staging, prod]
+      # @type=enum($ALLOWED_MODES)
+      APP_MODE=nope
+    `);
+    expect(g.configSchema.APP_MODE.isValid).toBe(false);
+    const err = g.configSchema.APP_MODE.validationErrors?.[0];
+    expect(err?.message).toContain('not in list of possible values');
+    expect(err?.tip).toContain('dev');
+  });
+
+  it('supports mixing static members with referenced arrays', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      EXTRA_MODES=[staging, preview]
+      # @type=enum(dev, $EXTRA_MODES, prod)
+      APP_MODE=preview
+    `);
+    expect(g.configSchema.APP_MODE.isValid).toBe(true);
+  });
+
+  it('a scalar reference contributes a single member', async () => {
+    const g = await loadAndResolve(outdent`
+      DEFAULT_MODE=dev
+      # @type=enum($DEFAULT_MODE, prod)
+      APP_MODE=dev
+    `);
+    expect(g.configSchema.APP_MODE.isValid).toBe(true);
+  });
+
+  it('the provisional (typegen-facing) type is a plain string', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      ALLOWED_MODES=[dev, prod]
+      # @type=enum($ALLOWED_MODES)
+      APP_MODE=dev
+    `);
+    expect(g.configSchema.APP_MODE.dataType?.name).toBe('string');
+    expect(g.configSchema.APP_MODE.effectiveDataType?.name).toBe('enum');
+  });
+
+  it('rejects non-string dynamic members (typegen saw string)', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(number)
+      LEVELS=[1, 2, 3]
+      # @type=enum($LEVELS)
+      LEVEL=2
+    `);
+    expect(g.configSchema.LEVEL.isValid).toBe(false);
+    const messages = (g.configSchema.LEVEL.validationErrors ?? []).map((e) => e.message).join('\n');
+    expect(messages).toContain('must resolve to strings');
+  });
+
+  it('rejects an empty resolved member list', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      ALLOWED_MODES=[]
+      # @type=enum($ALLOWED_MODES)
+      APP_MODE=dev
+    `);
+    expect(g.configSchema.APP_MODE.isValid).toBe(false);
+    const messages = (g.configSchema.APP_MODE.validationErrors ?? []).map((e) => e.message).join('\n');
+    expect(messages).toContain('empty list');
+  });
+
+  it('works as an array element type (array(enum($MODES)))', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      ALLOWED_MODES=[dev, staging, prod]
+      # @type=array(enum($ALLOWED_MODES))
+      ACTIVE_MODES=[dev, prod]
+      # @type=array(enum($ALLOWED_MODES))
+      BAD_MODES=[dev, nope]
+    `);
+    expect(g.configSchema.ACTIVE_MODES.isValid).toBe(true);
+    expect(g.configSchema.ACTIVE_MODES.resolvedValue).toEqual(['dev', 'prod']);
+    expect(g.configSchema.BAD_MODES.isValid).toBe(false);
+    expect(g.configSchema.BAD_MODES.validationErrors?.[0]?.message).toContain('[1]');
   });
 });
 

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -1113,7 +1113,7 @@ describe('multi-line composite literal values', () => {
     const g = await loadAndResolve(outdent`
       # @type=array(email)
       ALLOWED_EMAILS=[
-        admin@example.com,
+        admin@example.com, # the boss
         # ops folks
         ops@example.com,
 

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -864,3 +864,176 @@ describe('dynamic @type parts (resolver-valued)', () => {
     });
   });
 });
+
+describe('composite coercion error paths', () => {
+  it('reports ALL invalid elements during coercion, not just the first', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(number)
+      NUMS=[abc, 2, xyz]
+    `);
+    expect(g.configSchema.NUMS.isValid).toBe(false);
+    const msg = g.configSchema.NUMS.coercionError?.message ?? '';
+    expect(msg).toContain('[0]');
+    expect(msg).toContain('[2]');
+    expect(msg).not.toContain('[1]');
+  });
+
+  it('rejects a scalar non-string value for an array type', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      ITEM=123
+    `);
+    expect(g.configSchema.ITEM.isValid).toBe(false);
+    expect(g.configSchema.ITEM.coercionError?.message).toContain('Cannot coerce');
+  });
+
+  it('rejects a scalar value for an object type', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=object(string)
+      ITEM=123
+    `);
+    expect(g.configSchema.ITEM.isValid).toBe(false);
+  });
+
+  it('errors on malformed JSON object strings', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=object(string)
+      ITEM='{"a": '
+    `);
+    expect(g.configSchema.ITEM.isValid).toBe(false);
+    expect(g.configSchema.ITEM.coercionError?.message).toContain('JSON');
+  });
+
+  it('reports ALL invalid object values during coercion', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=object(number)
+      LIMITS={a=x, b=2, c=y}
+    `);
+    expect(g.configSchema.LIMITS.isValid).toBe(false);
+    const msg = g.configSchema.LIMITS.coercionError?.message ?? '';
+    expect(msg).toContain('"a"');
+    expect(msg).toContain('"c"');
+    expect(msg).not.toContain('"b"');
+  });
+
+  it('whitespace-only string coerces to an empty array', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      ITEM=" "
+    `);
+    expect(g.configSchema.ITEM.isValid).toBe(true);
+    expect(g.configSchema.ITEM.resolvedValue).toEqual([]);
+  });
+});
+
+describe('@type option validation error paths', () => {
+  const badSpecs = [
+    ['array(string, separator=7)', 'separator must be a non-empty string'],
+    ['array(string, separator="")', 'separator must be a non-empty string'],
+    ['array(string, format=yaml)', 'format must be "separator" or "json"'],
+    ['array(string, minLength=abc)', 'minLength must be a number'],
+    ['array(string, unique=maybe)', 'unique must be a boolean'],
+    ['array(string, number)', 'single element type argument'],
+    ['object(string, number)', 'single value type argument'],
+    ['object(string, keys={a=b})', 'keys must be a type name or type call'],
+  ] as const;
+
+  for (const [spec, expectedError] of badSpecs) {
+    it(`rejects ${spec}`, async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=${spec}
+        ITEM=[a]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      expect(g.configSchema.ITEM.errors[0].message).toContain(expectedError);
+    });
+  }
+
+  it('rejects a fn call that is neither a type nor a resolver', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=notARealThing(a, b)
+      ITEM=x
+    `);
+    expect(g.configSchema.ITEM.isValid).toBe(false);
+    expect(g.configSchema.ITEM.errors[0].message).toContain('unknown data type: notARealThing');
+  });
+
+  it('supports the deprecated regex() option form', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=string(matches=regex("^[A-Z]+$"))
+      GOOD=ABC
+      # @type=string(matches=regex("^[A-Z]+$"))
+      BAD=abc
+    `);
+    expect(g.configSchema.GOOD.isValid).toBe(true);
+    expect(g.configSchema.BAD.isValid).toBe(false);
+  });
+
+  it('surfaces schema errors from resolver-valued options (bad arg counts)', async () => {
+    const g = await loadAndResolve(outdent`
+      OTHER=x
+      # @type=string(minLength=eq($OTHER))
+      ITEM=abc
+    `);
+    expect(g.configSchema.ITEM.isValid).toBe(false);
+    const messages = g.configSchema.ITEM.errors.map((e) => e.message).join('\n');
+    expect(messages).toContain('eq()');
+  });
+});
+
+describe('dynamic options within nested element types', () => {
+  it('resolves dynamic options inside array element types', async () => {
+    const g = await loadAndResolve(outdent`
+      STRICT=true
+      # @type=array(string(minLength=if($STRICT, 5, 1)))
+      ITEMS=[ok, toolongisfine, x]
+    `);
+    expect(g.configSchema.ITEMS.isValid).toBe(false);
+    const messages = (g.configSchema.ITEMS.validationErrors ?? []).map((e) => e.message).join('\n');
+    expect(messages).toContain('[0]');
+    expect(messages).toContain('[2]');
+  });
+
+  it('relaxes nested element constraints when the condition flips', async () => {
+    const g = await loadAndResolve(outdent`
+      STRICT=false
+      # @type=array(string(minLength=if($STRICT, 5, 1)))
+      ITEMS=[ok, toolongisfine, x]
+    `);
+    expect(g.configSchema.ITEMS.isValid).toBe(true);
+  });
+});
+
+describe('per-environment dynamic types via forEnv', () => {
+  async function loadWithEnv(appEnv: string) {
+    const g = new EnvGraph();
+    const testDataSource = new DotEnvFileDataSource('.env.schema', {
+      overrideContents: outdent`
+        # @currentEnv=$APP_ENV @defaultRequired=false
+        # ---
+        # @type=enum(dev, production)
+        APP_ENV=${appEnv}
+        # @type=string(minLength=if(forEnv(production), 10, 1))
+        API_TOKEN=short
+        # @type=if(forEnv(production), url, string)
+        SERVICE_HOST=not a url
+      `,
+    });
+    await g.setRootDataSource(testDataSource);
+    await g.finishLoad();
+    await g.resolveEnvValues();
+    return g;
+  }
+
+  it('applies strict constraints in production', async () => {
+    const g = await loadWithEnv('production');
+    expect(g.configSchema.API_TOKEN.isValid).toBe(false);
+    expect(g.configSchema.SERVICE_HOST.isValid).toBe(false);
+  });
+
+  it('relaxes constraints outside production', async () => {
+    const g = await loadWithEnv('dev');
+    expect(g.configSchema.API_TOKEN.isValid).toBe(true);
+    expect(g.configSchema.SERVICE_HOST.isValid).toBe(true);
+  });
+});

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -322,3 +322,389 @@ describe('duration data type', () => {
     });
   });
 });
+
+describe('array data type', () => {
+  describe('input forms', () => {
+    it('coerces native array literal values', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(string)
+        ITEM=[alpha, beta]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.resolvedValue).toEqual(['alpha', 'beta']);
+    });
+
+    it('parses JSON array strings', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(string)
+        ITEM='["a", "b"]'
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.resolvedValue).toEqual(['a', 'b']);
+    });
+
+    it('splits plain strings on the default comma separator', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(email)
+        ITEM="one@example.com, two@example.com"
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.resolvedValue).toEqual(['one@example.com', 'two@example.com']);
+    });
+
+    it('splits on a custom separator', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(string, separator=";")
+        ITEM="a;b;c"
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.resolvedValue).toEqual(['a', 'b', 'c']);
+    });
+
+    it('errors on malformed JSON array strings instead of splitting them', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(string)
+        ITEM='["a", "b"'
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      expect(g.configSchema.ITEM.coercionError?.message).toContain('JSON');
+    });
+
+    it('resolves refs within array literal elements', async () => {
+      const g = await loadAndResolve(outdent`
+        OTHER=bravo
+        # @type=array(string)
+        ITEM=[alpha, \${OTHER}]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.resolvedValue).toEqual(['alpha', 'bravo']);
+    });
+  });
+
+  describe('element validation', () => {
+    it('validates each element with the element type', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(email)
+        ITEM=[good@example.com, not-an-email]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      expect(g.configSchema.ITEM.validationErrors?.[0]?.message).toContain('[1]');
+    });
+
+    it('reports ALL invalid elements, not just the first', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(email)
+        ITEM=[bad-one, good@example.com, bad-two]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      const messages = (g.configSchema.ITEM.validationErrors ?? []).map((e) => e.message).join('\n');
+      expect(messages).toContain('[0]');
+      expect(messages).toContain('[2]');
+    });
+
+    it('supports element type options via nested call', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(email(normalize=true))
+        ITEM=[User@Example.com]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.resolvedValue).toEqual(['user@example.com']);
+    });
+
+    it('supports nested enum element type', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(enum(sandbox, whitelist, production))
+        ITEM=[sandbox, whitelist]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.resolvedValue).toEqual(['sandbox', 'whitelist']);
+    });
+
+    it('rejects invalid enum values in array', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(enum(sandbox, whitelist, production))
+        ITEM=[sandbox, invalid]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+    });
+
+    it('coerces array of numbers from literals', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(number)
+        PORTS=[8080, 3000, 443]
+      `);
+      expect(g.configSchema.PORTS.isValid).toBe(true);
+      expect(g.configSchema.PORTS.resolvedValue).toEqual([8080, 3000, 443]);
+    });
+
+    it('coerces array of booleans', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(boolean)
+        FLAGS=[true, false, 1, 0]
+      `);
+      expect(g.configSchema.FLAGS.isValid).toBe(true);
+      expect(g.configSchema.FLAGS.resolvedValue).toEqual([true, false, true, false]);
+    });
+
+    it('rejects ports outside nested port constraints', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(port(min=1024))
+        PORTS=[8080, 80]
+      `);
+      expect(g.configSchema.PORTS.isValid).toBe(false);
+      expect(g.configSchema.PORTS.validationErrors?.[0]?.message).toContain('[1]');
+    });
+  });
+
+  describe('array options', () => {
+    it('allows empty arrays by default', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(string)
+        ITEM=[]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.resolvedValue).toEqual([]);
+    });
+
+    it('enforces minLength', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(string, minLength=1)
+        ITEM=[]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+    });
+
+    it('enforces maxLength', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(string, maxLength=2)
+        ITEM=[a, b, c]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+    });
+
+    it('enforces unique elements', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(string, unique=true)
+        ITEM=[dup, other, dup]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      const messages = (g.configSchema.ITEM.validationErrors ?? []).map((e) => e.message).join('\n');
+      expect(messages).toContain('[2]');
+    });
+
+    it('rejects unknown array options with a helpful message', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(email, normalize=true)
+        ITEM=[a@example.com]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      expect(g.configSchema.ITEM.errors[0].message).toContain('normalize');
+      expect(g.configSchema.ITEM.errors[0].tip).toContain('nested call');
+    });
+
+    it('rejects elements containing the separator (no silent bad round-trip)', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(string)
+        ITEM=["has,comma", other]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      expect(g.configSchema.ITEM.validationErrors?.[0]?.message).toContain('separator');
+    });
+
+    it('allows elements containing the separator when format=json', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(string, format=json)
+        ITEM=["has,comma", other]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.resolvedValue).toEqual(['has,comma', 'other']);
+    });
+  });
+
+  describe('type inference', () => {
+    it('infers array type from an untyped array literal', async () => {
+      const g = await loadAndResolve(outdent`
+        ITEM=[a, b]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.dataType?.name).toBe('array');
+      expect(g.configSchema.ITEM.resolvedValue).toEqual(['a', 'b']);
+    });
+
+    it('infers element type when all elements share a scalar type', async () => {
+      const g = await loadAndResolve(outdent`
+        PORTS=[8080, 3000]
+      `);
+      expect(g.configSchema.PORTS.isValid).toBe(true);
+      expect(g.configSchema.PORTS.resolvedValue).toEqual([8080, 3000]);
+    });
+
+    it('falls back to string elements for mixed literals', async () => {
+      const g = await loadAndResolve(outdent`
+        MIXED=[1, two]
+      `);
+      expect(g.configSchema.MIXED.isValid).toBe(true);
+      expect(g.configSchema.MIXED.resolvedValue).toEqual(['1', 'two']);
+    });
+  });
+
+  describe('interplay with other decorators', () => {
+    it('works with conditional required', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=enum(sandbox, restricted, production)
+        APP_MODE=sandbox
+        # @type=array(email(normalize=true))
+        # @required=eq($APP_MODE, restricted)
+        ALLOWED_EMAILS=[admin@example.com, support@example.com]
+      `);
+      expect(g.configSchema.ALLOWED_EMAILS.isValid).toBe(true);
+      expect(g.configSchema.ALLOWED_EMAILS.resolvedValue).toEqual([
+        'admin@example.com',
+        'support@example.com',
+      ]);
+    });
+
+    it('required array with no value fails as usual', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(string)
+        # @required
+        ITEM=
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+    });
+  });
+});
+
+describe('object data type', () => {
+  describe('input forms', () => {
+    it('coerces native object literal values', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=object
+        ITEM={k=v, n=2}
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.resolvedValue).toEqual({ k: 'v', n: 2 });
+    });
+
+    it('parses JSON object strings', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=object
+        ITEM='{"k": "v", "n": 2}'
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.resolvedValue).toEqual({ k: 'v', n: 2 });
+    });
+
+    it('resolves refs within object literal values', async () => {
+      const g = await loadAndResolve(outdent`
+        BASE=https://example.com
+        # @type=object(url)
+        ENDPOINTS={api=\${BASE}, other=https://other.com}
+      `);
+      expect(g.configSchema.ENDPOINTS.isValid).toBe(true);
+      expect(g.configSchema.ENDPOINTS.resolvedValue).toEqual({
+        api: 'https://example.com',
+        other: 'https://other.com',
+      });
+    });
+  });
+
+  describe('value validation', () => {
+    it('validates every value with the value type', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=object(url)
+        ITEM={good=https://example.com, bad=not-a-url}
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      expect(g.configSchema.ITEM.validationErrors?.[0]?.message).toContain('"bad"');
+    });
+
+    it('coerces values with the value type', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=object(number)
+        LIMITS={low=1, high=100}
+      `);
+      expect(g.configSchema.LIMITS.isValid).toBe(true);
+      expect(g.configSchema.LIMITS.resolvedValue).toEqual({ low: 1, high: 100 });
+    });
+  });
+
+  describe('key validation', () => {
+    it('validates keys against an enum', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=object(url, keys=enum(us, eu))
+        REGIONS={us=https://us.example.com, eu=https://eu.example.com}
+      `);
+      expect(g.configSchema.REGIONS.isValid).toBe(true);
+    });
+
+    it('rejects keys not in the enum', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=object(url, keys=enum(us, eu))
+        REGIONS={us=https://us.example.com, apac=https://apac.example.com}
+      `);
+      expect(g.configSchema.REGIONS.isValid).toBe(false);
+      expect(g.configSchema.REGIONS.validationErrors?.[0]?.message).toContain('"apac"');
+    });
+
+    it('validates keys with a pattern via string type options', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=object(string, keys=string(matches="[a-z]+"))
+        ITEM={lower=ok, UPPER=bad}
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      expect(g.configSchema.ITEM.validationErrors?.[0]?.message).toContain('"UPPER"');
+    });
+  });
+
+  describe('object options', () => {
+    it('rejects unknown object options', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=object(string, whatever=true)
+        ITEM={k=v}
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      expect(g.configSchema.ITEM.errors[0].message).toContain('whatever');
+    });
+
+    it('allows empty objects', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=object(string)
+        ITEM={}
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.resolvedValue).toEqual({});
+    });
+  });
+
+  describe('type inference', () => {
+    it('infers object type from an untyped object literal', async () => {
+      const g = await loadAndResolve(outdent`
+        ITEM={k=v, n=2}
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(true);
+      expect(g.configSchema.ITEM.dataType?.name).toBe('object');
+      expect(g.configSchema.ITEM.resolvedValue).toEqual({ k: 'v', n: 2 });
+    });
+  });
+
+  describe('nesting composites', () => {
+    it('supports arrays of objects (forced JSON serialization)', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(object)
+        ITEMS=[{name=a}, {name=b}]
+      `);
+      expect(g.configSchema.ITEMS.isValid).toBe(true);
+      expect(g.configSchema.ITEMS.resolvedValue).toEqual([{ name: 'a' }, { name: 'b' }]);
+    });
+
+    it('supports objects of arrays', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=object(array(number))
+        GROUPS={a=[1, 2], b=[3]}
+      `);
+      expect(g.configSchema.GROUPS.isValid).toBe(true);
+      expect(g.configSchema.GROUPS.resolvedValue).toEqual({ a: [1, 2], b: [3] });
+    });
+  });
+});

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -1107,3 +1107,57 @@ describe('per-environment dynamic types via forEnv', () => {
     expect(g.configSchema.SERVICE_HOST.isValid).toBe(true);
   });
 });
+
+describe('multi-line composite literal values', () => {
+  it('resolves multi-line array literals (trailing comma, comments, blank lines)', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(email)
+      ALLOWED_EMAILS=[
+        admin@example.com,
+        # ops folks
+        ops@example.com,
+
+        support@example.com,
+      ]
+      AFTER=still-parses
+    `);
+    expect(g.configSchema.ALLOWED_EMAILS.isValid).toBe(true);
+    expect(g.configSchema.ALLOWED_EMAILS.resolvedValue).toEqual([
+      'admin@example.com',
+      'ops@example.com',
+      'support@example.com',
+    ]);
+    expect(g.configSchema.AFTER.resolvedValue).toBe('still-parses');
+  });
+
+  it('resolves multi-line record literals with refs', async () => {
+    const g = await loadAndResolve(outdent`
+      BASE=https://api.example.com
+      # @type=record(url)
+      ENDPOINTS={
+        api=${'$'}{BASE},
+        docs=https://docs.example.com,
+      }
+    `);
+    expect(g.configSchema.ENDPOINTS.isValid).toBe(true);
+    expect(g.configSchema.ENDPOINTS.resolvedValue).toEqual({
+      api: 'https://api.example.com',
+      docs: 'https://docs.example.com',
+    });
+  });
+
+  it('resolves multi-line arrays of records', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(record)
+      ITEMS=[
+        {name=a, weight=1},
+        {name=b, weight=2},
+      ]
+    `);
+    expect(g.configSchema.ITEMS.isValid).toBe(true);
+    expect(g.configSchema.ITEMS.resolvedValue).toEqual([
+      { name: 'a', weight: 1 },
+      { name: 'b', weight: 2 },
+    ]);
+  });
+});

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -708,3 +708,43 @@ describe('object data type', () => {
     });
   });
 });
+
+describe('@type arg handling (scalar types)', () => {
+  it('rejects mixing positional args and named options', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=enum(a, b, someOpt=true)
+      ITEM=a
+    `);
+    expect(g.configSchema.ITEM.isValid).toBe(false);
+    expect(g.configSchema.ITEM.errors[0].message).toContain('cannot mix');
+  });
+
+  it('rejects non-static option values with a clear error', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=string(matches=fallback(a, b))
+      ITEM=x
+    `);
+    expect(g.configSchema.ITEM.isValid).toBe(false);
+    expect(g.configSchema.ITEM.errors[0].message).toContain('must be a static value');
+  });
+
+  it('rejects nested type calls on scalar types', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=string(enum(a, b))
+      ITEM=x
+    `);
+    expect(g.configSchema.ITEM.isValid).toBe(false);
+    expect(g.configSchema.ITEM.errors[0].message).toContain('only supported as array/object element types');
+  });
+
+  it('still supports regex-like string patterns in options', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=string(matches=/^[A-Z]+$/)
+      GOOD=ABC
+      # @type=string(matches=/^[A-Z]+$/)
+      BAD=abc
+    `);
+    expect(g.configSchema.GOOD.isValid).toBe(true);
+    expect(g.configSchema.BAD.isValid).toBe(false);
+  });
+});

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -482,6 +482,21 @@ describe('array data type', () => {
       expect(g.configSchema.ITEM.isValid).toBe(false);
     });
 
+    it('enforces isLength (exact element count)', async () => {
+      const good = await loadAndResolve(outdent`
+        # @type=array(string, isLength=2)
+        ITEM=[a, b]
+      `);
+      expect(good.configSchema.ITEM.isValid).toBe(true);
+
+      const bad = await loadAndResolve(outdent`
+        # @type=array(string, isLength=2)
+        ITEM=[a, b, c]
+      `);
+      expect(bad.configSchema.ITEM.isValid).toBe(false);
+      expect(bad.configSchema.ITEM.validationErrors?.[0]?.message).toContain('exactly 2');
+    });
+
     it('enforces unique elements', async () => {
       const g = await loadAndResolve(outdent`
         # @type=array(string, unique=true)
@@ -932,6 +947,7 @@ describe('@type option validation error paths', () => {
     ['array(string, separator="")', 'separator must be a non-empty string'],
     ['array(string, format=yaml)', 'format must be "separator" or "json"'],
     ['array(string, minLength=abc)', 'minLength must be a number'],
+    ['array(string, isLength=abc)', 'isLength must be a number'],
     ['array(string, unique=maybe)', 'unique must be a boolean'],
     ['array(string, number)', 'single element type argument'],
     ['object(string, number)', 'single value type argument'],

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -647,7 +647,7 @@ describe('object data type', () => {
   describe('key validation', () => {
     it('validates keys against an enum', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(url, keys=enum(us, eu))
+        # @type=object(url, keyType=enum(us, eu))
         REGIONS={us=https://us.example.com, eu=https://eu.example.com}
       `);
       expect(g.configSchema.REGIONS.isValid).toBe(true);
@@ -655,7 +655,7 @@ describe('object data type', () => {
 
     it('rejects keys not in the enum', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(url, keys=enum(us, eu))
+        # @type=object(url, keyType=enum(us, eu))
         REGIONS={us=https://us.example.com, apac=https://apac.example.com}
       `);
       expect(g.configSchema.REGIONS.isValid).toBe(false);
@@ -664,7 +664,7 @@ describe('object data type', () => {
 
     it('validates keys with a pattern via string type options', async () => {
       const g = await loadAndResolve(outdent`
-        # @type=object(string, keys=string(matches="[a-z]+"))
+        # @type=object(string, keyType=string(matches="[a-z]+"))
         ITEM={lower=ok, UPPER=bad}
       `);
       expect(g.configSchema.ITEM.isValid).toBe(false);
@@ -689,6 +689,48 @@ describe('object data type', () => {
       `);
       expect(g.configSchema.ITEM.isValid).toBe(true);
       expect(g.configSchema.ITEM.resolvedValue).toEqual({});
+    });
+
+    it('enforces entriesMinLength', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=object(string, entriesMinLength=2)
+        ITEM={only=one}
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      expect(g.configSchema.ITEM.validationErrors?.[0]?.message).toContain('at least 2');
+    });
+
+    it('enforces entriesMaxLength', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=object(string, entriesMaxLength=1)
+        ITEM={a=1, b=2}
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      expect(g.configSchema.ITEM.validationErrors?.[0]?.message).toContain('at most 1');
+    });
+
+    it('enforces entriesIsLength (exact entry count)', async () => {
+      const good = await loadAndResolve(outdent`
+        # @type=object(string, entriesIsLength=2)
+        ITEM={a=1, b=2}
+      `);
+      expect(good.configSchema.ITEM.isValid).toBe(true);
+
+      const bad = await loadAndResolve(outdent`
+        # @type=object(string, entriesIsLength=2)
+        ITEM={a=1}
+      `);
+      expect(bad.configSchema.ITEM.isValid).toBe(false);
+      expect(bad.configSchema.ITEM.validationErrors?.[0]?.message).toContain('exactly 2');
+    });
+
+    it('entry count options support dynamic values', async () => {
+      const g = await loadAndResolve(outdent`
+        STRICT=true
+        # @type=object(string, entriesMinLength=if($STRICT, 2, 0))
+        ITEM={only=one}
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
     });
   });
 
@@ -951,7 +993,9 @@ describe('@type option validation error paths', () => {
     ['array(string, unique=maybe)', 'unique must be a boolean'],
     ['array(string, number)', 'single element type argument'],
     ['object(string, number)', 'single value type argument'],
-    ['object(string, keys={a=b})', 'keys must be a type name or type call'],
+    ['object(string, keyType={a=b})', 'keyType must be a type name or type call'],
+    ['object(string, keys=enum(a, b))', 'unknown object option "keys"'],
+    ['object(string, entriesMinLength=abc)', 'entriesMinLength must be a number'],
   ] as const;
 
   for (const [spec, expectedError] of badSpecs) {

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -457,9 +457,20 @@ describe('array data type', () => {
   });
 
   describe('array options', () => {
-    it('allows empty arrays by default', async () => {
+    it('rejects empty arrays by default', async () => {
       const g = await loadAndResolve(outdent`
         # @type=array(string)
+        ITEM=[]
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      const err = g.configSchema.ITEM.validationErrors?.[0];
+      expect(err?.message).toContain('must not be empty');
+      expect(err?.tip).toContain('minLength=0');
+    });
+
+    it('allows empty arrays with explicit minLength=0', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=array(string, minLength=0)
         ITEM=[]
       `);
       expect(g.configSchema.ITEM.isValid).toBe(true);
@@ -682,9 +693,20 @@ describe('record data type', () => {
       expect(g.configSchema.ITEM.errors[0].message).toContain('whatever');
     });
 
-    it('allows empty objects', async () => {
+    it('rejects empty objects by default', async () => {
       const g = await loadAndResolve(outdent`
         # @type=record(string)
+        ITEM={}
+      `);
+      expect(g.configSchema.ITEM.isValid).toBe(false);
+      const err = g.configSchema.ITEM.validationErrors?.[0];
+      expect(err?.message).toContain('must not be empty');
+      expect(err?.tip).toContain('entriesMinLength=0');
+    });
+
+    it('allows empty objects with explicit entriesMinLength=0', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=record(string, entriesMinLength=0)
         ITEM={}
       `);
       expect(g.configSchema.ITEM.isValid).toBe(true);
@@ -973,13 +995,36 @@ describe('composite coercion error paths', () => {
     expect(msg).not.toContain('"b"');
   });
 
-  it('whitespace-only string coerces to an empty array', async () => {
+  it('empty/whitespace string input resolves to missing, never an empty array', async () => {
     const g = await loadAndResolve(outdent`
       # @type=array(string)
+      WHITESPACE=" "
+      # @type=array(string)
+      QUOTED_EMPTY=""
+    `);
+    expect(g.configSchema.WHITESPACE.isValid).toBe(true);
+    expect(g.configSchema.WHITESPACE.resolvedValue).toBe(undefined);
+    expect(g.configSchema.QUOTED_EMPTY.isValid).toBe(true);
+    expect(g.configSchema.QUOTED_EMPTY.resolvedValue).toBe(undefined);
+  });
+
+  it('required items reject empty/whitespace string input as missing', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      # @required
       ITEM=" "
     `);
+    expect(g.configSchema.ITEM.isValid).toBe(false);
+    expect(g.configSchema.ITEM.validationErrors?.[0]?.message).toContain('required but is currently empty');
+  });
+
+  it('required items accept an explicitly non-empty array', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=array(string)
+      # @required
+      ITEM=[a]
+    `);
     expect(g.configSchema.ITEM.isValid).toBe(true);
-    expect(g.configSchema.ITEM.resolvedValue).toEqual([]);
   });
 });
 
@@ -1177,7 +1222,7 @@ describe('enum members sourced from other items', () => {
 
   it('rejects an empty resolved member list', async () => {
     const g = await loadAndResolve(outdent`
-      # @type=array(string)
+      # @type=array(string, minLength=0)
       ALLOWED_MODES=[]
       # @type=enum($ALLOWED_MODES)
       APP_MODE=dev

--- a/packages/varlock/src/env-graph/test/type-generation.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation.test.ts
@@ -250,7 +250,7 @@ describe('type generation', () => {
           APP_MODES=[dev, staging]
           # @type=object(url)
           ENDPOINTS={api=https://example.com}
-          # @type=object(number, keys=enum(us, eu))
+          # @type=object(number, keyType=enum(us, eu))
           REGION_LIMITS={us=1}
           # @type=object
           FREEFORM={k=v}

--- a/packages/varlock/src/env-graph/test/type-generation.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation.test.ts
@@ -237,6 +237,36 @@ describe('type generation', () => {
       expect(infos.APP_ENV.dataType?.name).toBe('enum');
     });
 
+    test('array and object types generate recursive TS types', async () => {
+      const g = await loadGraph({
+        envFile: outdent`
+          # @defaultRequired=false
+          # ---
+          # @type=array(email)
+          ALLOWED_EMAILS=[a@example.com, b@example.com]
+          # @type=array(number)
+          SCORES=[1, 2, 3]
+          # @type=array(enum(dev, staging, prod))
+          APP_MODES=[dev, staging]
+          # @type=object(url)
+          ENDPOINTS={api=https://example.com}
+          # @type=object(number, keys=enum(us, eu))
+          REGION_LIMITS={us=1}
+          # @type=object
+          FREEFORM={k=v}
+        `,
+      });
+
+      const items = await collectTypeGenItems(g);
+      const src = await generateTsTypesSrc(resolveFieldTypes(items));
+      expect(src).toContain('ALLOWED_EMAILS?: string[];');
+      expect(src).toContain('SCORES?: number[];');
+      expect(src).toContain('APP_MODES?: ("dev" | "staging" | "prod")[];');
+      expect(src).toContain('ENDPOINTS?: Record<string, string>;');
+      expect(src).toContain('REGION_LIMITS?: Partial<Record<"us" | "eu", number>>;');
+      expect(src).toContain('FREEFORM?: Record<string, any>;');
+    });
+
     test('boolean type gets correct TypeGenInfo', async () => {
       const g = await loadGraph({
         envFile: outdent`

--- a/packages/varlock/src/env-graph/test/type-generation.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation.test.ts
@@ -248,11 +248,11 @@ describe('type generation', () => {
           SCORES=[1, 2, 3]
           # @type=array(enum(dev, staging, prod))
           APP_MODES=[dev, staging]
-          # @type=object(url)
+          # @type=record(url)
           ENDPOINTS={api=https://example.com}
-          # @type=object(number, keyType=enum(us, eu))
+          # @type=record(number, keyType=enum(us, eu))
           REGION_LIMITS={us=1}
-          # @type=object
+          # @type=record
           FREEFORM={k=v}
         `,
       });

--- a/packages/varlock/src/env-graph/test/type-generation.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation.test.ts
@@ -267,6 +267,27 @@ describe('type generation', () => {
       expect(src).toContain('FREEFORM?: Record<string, any>;');
     });
 
+    test('dynamic @type parts generate from the provisional (static) type', async () => {
+      const g = await loadGraph({
+        envFile: outdent`
+          # @defaultRequired=false
+          # ---
+          # @type=enum(dev, production)
+          APP_ENV=dev
+          # @type=if(eq($APP_ENV, production), url, string)
+          SERVICE_HOST=localhost:3000
+          # @type=string(minLength=if(eq($APP_ENV, production), 32, 8))
+          API_TOKEN=abcdefgh
+        `,
+      });
+
+      const items = await collectTypeGenItems(g);
+      const src = await generateTsTypesSrc(resolveFieldTypes(items));
+      // both candidates (url/string) generate string - output is env-independent
+      expect(src).toContain('SERVICE_HOST?: string;');
+      expect(src).toContain('API_TOKEN?: string;');
+    });
+
     test('boolean type gets correct TypeGenInfo', async () => {
       const g = await loadGraph({
         envFile: outdent`

--- a/packages/varlock/src/env-graph/test/type-generation/csharp.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation/csharp.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import outdent from 'outdent';
 
 import { generateCsharpEnvSrc } from '../../index';
-import { loadFixtureFields } from './helpers';
+import { COMPOSITE_TYPE_FIXTURE, loadFixtureFields } from './helpers';
 
 describe('generateCsharpEnvSrc', () => {
   test('emits a typed class, SensitiveKeys, and a System.Text.Json loader', async () => {
@@ -96,5 +96,11 @@ describe('generateCsharpEnvSrc', () => {
     expect(src).not.toContain('2faSecret');
     expect(src).toContain('Keys omitted from this typed module (not valid identifiers): _2FA_SECRET');
     expect(src).toContain('"_2FA_SECRET"');
+  });
+  test('composite (array/object) types surface as JsonElement', async () => {
+    const { fields } = await loadFixtureFields(COMPOSITE_TYPE_FIXTURE);
+    const src = generateCsharpEnvSrc(fields);
+    expect(src).toContain('public required JsonElement Hosts { get; init; }');
+    expect(src).toContain('public JsonElement Limits { get; init; }');
   });
 });

--- a/packages/varlock/src/env-graph/test/type-generation/go.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation/go.test.ts
@@ -3,7 +3,7 @@ import outdent from 'outdent';
 
 import { generateGoEnvSrc } from '../../index';
 import { resolveGoPackageName } from '../../lib/type-generation/emitters/go';
-import { loadFixtureFields } from './helpers';
+import { COMPOSITE_TYPE_FIXTURE, loadFixtureFields } from './helpers';
 
 describe('generateGoEnvSrc', () => {
   test('emits a buildable package with a struct, SensitiveKeys, and Load()', async () => {
@@ -108,5 +108,15 @@ describe('generateGoEnvSrc', () => {
     expect(src).not.toContain('My-key');
     expect(src).toContain('Keys omitted from this typed module (not valid identifiers): MY-KEY');
     expect(src).toContain('"MY-KEY": true');
+  });
+  test('composite (array/object) types map to slices and maps', async () => {
+    const { fields } = await loadFixtureFields(COMPOSITE_TYPE_FIXTURE);
+    const src = generateGoEnvSrc(fields);
+    expect(src).toMatch(/Hosts +\[\]string/);
+    // slices are already nilable — optionals get no pointer wrapping
+    expect(src).toMatch(/Scores +\[\]float64/);
+    expect(src).not.toContain('*[]float64');
+    expect(src).toMatch(/Modes +\[\]string/);
+    expect(src).toMatch(/Limits +map\[string\]float64/);
   });
 });

--- a/packages/varlock/src/env-graph/test/type-generation/helpers.ts
+++ b/packages/varlock/src/env-graph/test/type-generation/helpers.ts
@@ -69,7 +69,7 @@ export const COMPOSITE_TYPE_FIXTURE = outdent`
   SCORES=[1, 2]
   # @type=array(enum(dev, prod))
   MODES=[dev]
-  # @type=object(number)
+  # @type=record(number)
   LIMITS={a=1}
 `;
 

--- a/packages/varlock/src/env-graph/test/type-generation/helpers.ts
+++ b/packages/varlock/src/env-graph/test/type-generation/helpers.ts
@@ -59,6 +59,20 @@ export async function getTypeGenInfoMap(g: EnvGraph) {
   return infos;
 }
 
+/** Schema fixture covering composite (array/object) types across required/optional. */
+export const COMPOSITE_TYPE_FIXTURE = outdent`
+  # @defaultSensitive=false @defaultRequired=false
+  # ---
+  # @type=array(string)
+  HOSTS=[a.com, b.com]        # @required @public
+  # @type=array(number)
+  SCORES=[1, 2]
+  # @type=array(enum(dev, prod))
+  MODES=[dev]
+  # @type=object(number)
+  LIMITS={a=1}
+`;
+
 export async function loadFixtureFields(
   envFile = NON_STRING_TYPE_FIXTURE,
   opts?: { dataTypes?: Array<EnvGraphDataTypeFactory> },

--- a/packages/varlock/src/env-graph/test/type-generation/java.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation/java.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import outdent from 'outdent';
 
 import { generateJavaEnvSrc } from '../../index';
-import { loadFixtureFields } from './helpers';
+import { COMPOSITE_TYPE_FIXTURE, loadFixtureFields } from './helpers';
 
 describe('generateJavaEnvSrc', () => {
   test('emits a typed class, SENSITIVE_KEYS, and a Jackson-based loader', async () => {
@@ -94,5 +94,14 @@ describe('generateJavaEnvSrc', () => {
     expect(src).not.toContain('2faSecret');
     expect(src).toContain('Keys omitted from this typed module (not valid identifiers): _2FA_SECRET');
     expect(src).toContain('"_2FA_SECRET"');
+  });
+  test('composite (array/object) types map to List/Map with Jackson plumbing', async () => {
+    const { fields } = await loadFixtureFields(COMPOSITE_TYPE_FIXTURE);
+    const src = generateJavaEnvSrc(fields);
+    expect(src).toContain('public final List<Object> hosts;');
+    expect(src).toContain('public final Map<String, Object> limits;');
+    expect(src).toContain('import java.util.List;');
+    expect(src).toContain('private static final CollectionType LIST_TYPE');
+    expect(src).toContain('mapper.convertValue(hostsEntry.get("value"), LIST_TYPE)');
   });
 });

--- a/packages/varlock/src/env-graph/test/type-generation/php.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation/php.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import outdent from 'outdent';
 
 import { resolveFieldTypes, generatePhpEnvSrc } from '../../index';
-import { loadFixtureFields, loadGraph } from './helpers';
+import { COMPOSITE_TYPE_FIXTURE, loadFixtureFields, loadGraph } from './helpers';
 
 describe('generatePhpEnvSrc', () => {
   test('emits a typed readonly class, SENSITIVE_KEYS, and a loader', async () => {
@@ -115,5 +115,12 @@ describe('generatePhpEnvSrc', () => {
     expect(src).not.toContain('$MY-KEY');
     expect(src).toContain('Keys omitted from this typed module (not valid identifiers): MY-KEY');
     expect(src).toContain("SENSITIVE_KEYS = ['MY-KEY']");
+  });
+  test('composite (array/object) types map to array with @var refinements', async () => {
+    const { fields } = await loadFixtureFields(COMPOSITE_TYPE_FIXTURE);
+    const src = generatePhpEnvSrc(fields);
+    expect(src).toContain('@var array<int, string>');
+    expect(src).toContain('@var array<int, float>|null');
+    expect(src).toContain('@var array<string, float>|null');
   });
 });

--- a/packages/varlock/src/env-graph/test/type-generation/python.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation/python.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import outdent from 'outdent';
 
 import { resolveFieldTypes, generatePythonEnvSrc } from '../../index';
-import { loadFixtureFields, loadGraph } from './helpers';
+import { COMPOSITE_TYPE_FIXTURE, loadFixtureFields, loadGraph } from './helpers';
 
 describe('generatePythonEnvSrc', () => {
   test('emits a typed TypedDict, SENSITIVE_KEYS, and a loader', async () => {
@@ -92,5 +92,15 @@ describe('generatePythonEnvSrc', () => {
 
     // rendered as a `#` comment — a triple-quote in the text can't break the file
     expect(src).toContain('QUOTED: str  # value with """ quotes inside');
+  });
+  test('composite (array/object) types map to list/dict annotations', async () => {
+    const { fields } = await loadFixtureFields(COMPOSITE_TYPE_FIXTURE);
+    const src = generatePythonEnvSrc(fields);
+    expect(src).toContain('HOSTS: list[str]');
+    expect(src).toContain('SCORES: NotRequired[list[float]]');
+    expect(src).toContain('MODES: NotRequired[list[Literal["dev", "prod"]]]');
+    expect(src).toContain('LIMITS: NotRequired[dict[str, float]]');
+    // Literal only appears nested here — the import detection must still catch it
+    expect(src).toContain('from typing import Literal');
   });
 });

--- a/packages/varlock/src/env-graph/test/type-generation/rust.test.ts
+++ b/packages/varlock/src/env-graph/test/type-generation/rust.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import outdent from 'outdent';
 
 import { generateRustEnvSrc } from '../../index';
-import { loadFixtureFields } from './helpers';
+import { COMPOSITE_TYPE_FIXTURE, loadFixtureFields } from './helpers';
 
 describe('generateRustEnvSrc', () => {
   test('emits a serde struct, SENSITIVE_KEYS, and a loader', async () => {
@@ -89,5 +89,12 @@ describe('generateRustEnvSrc', () => {
     expect(src).not.toContain('rename = "MY-KEY"');
     expect(src).toContain('Keys omitted from this typed module (not valid identifiers): MY-KEY');
     expect(src).toContain('&["MY-KEY"]');
+  });
+  test('composite (array/object) types map to Vec and serde_json::Value', async () => {
+    const { fields } = await loadFixtureFields(COMPOSITE_TYPE_FIXTURE);
+    const src = generateRustEnvSrc(fields);
+    expect(src).toContain('pub hosts: Vec<String>,');
+    expect(src).toContain('pub scores: Option<Vec<f64>>,');
+    expect(src).toContain('pub limits: Option<serde_json::Value>,');
   });
 });

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -332,13 +332,6 @@ export function getPreInjectionProcessEnv(): Record<string, string | undefined> 
   return getEnvState().originalProcessEnv;
 }
 
-/** blob values lacking a precomputed `envStr`: undefined → '', objects/arrays → JSON, scalars → String */
-function stringifyEnvValueFallback(value: any): string {
-  if (value === undefined) return '';
-  if (typeof value === 'object' && value !== null) return JSON.stringify(value);
-  return String(value);
-}
-
 export function initVarlockEnv(opts?: {
   allowFail?: boolean,
 }) {
@@ -411,10 +404,8 @@ export function initVarlockEnv(opts?: {
       // when re-injecting into process.env, we treat undefined as empty string
       // this more closely matches expected behaviour from other .env loaders.
       // composite values (arrays/objects) carry their flat string form in `envStr`
-      // (their serialization depends on type settings that don't travel in the blob);
-      // a composite WITHOUT envStr (a blob from an older CLI) falls back to JSON so
-      // an object value never degrades to "[object Object]" (see #900)
-      process.env[itemKey] = item.envStr ?? stringifyEnvValueFallback(item.value);
+      // (their serialization depends on type settings that don't travel in the blob)
+      process.env[itemKey] = item.envStr ?? (item.value === undefined ? '' : String(item.value));
     }
   }
   envState.initialized = true;

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -38,19 +38,38 @@ function getRedactionState(): RedactionState {
   return (globalThis as any)[REDACTION_STATE_KEY];
 }
 
+/** collect every redactable string within a (possibly composite) sensitive value -
+ * for arrays/objects each string element registers individually, so leaking a single
+ * element (not just the whole serialized value) is still caught */
+function collectSensitiveStrings(value: any, collected: Array<string> = []): Array<string> {
+  if (isString(value) && value) {
+    collected.push(value as string);
+  } else if (Array.isArray(value)) {
+    for (const el of value) collectSensitiveStrings(el, collected);
+  } else if (value && typeof value === 'object') {
+    for (const key in value) collectSensitiveStrings(value[key], collected);
+  }
+  return collected;
+}
+
 export function resetRedactionMap(graph: SerializedEnvGraph) {
   const state = getRedactionState();
   // reset map of { [sensitive] => redacted }
   state.sensitiveSecretsMap = {};
   for (const itemKey in graph.config) {
     const item = graph.config[itemKey];
-    if (item.isSensitive && item.value && isString(item.value)) {
+    if (!item.isSensitive || !item.value) continue;
+    const sensitiveStrings = collectSensitiveStrings(item.value);
+    // the flat serialized form also registers (e.g. a JSON-encoded element may not
+    // match its raw form once escaped)
+    if (item.envStr) sensitiveStrings.push(item.envStr);
+    for (const sensitiveStr of sensitiveStrings) {
       // TODO: we want to respect masking settings from the schema (once added)
-      const redacted = redactString(item.value);
+      const redacted = redactString(sensitiveStr);
       // preventLeaks defaults to true; `@sensitive={preventLeaks=false}` opts the item
       // out of leak scanning while still keeping it redacted in logs
       if (redacted) {
-        state.sensitiveSecretsMap[item.value] = {
+        state.sensitiveSecretsMap[sensitiveStr] = {
           key: itemKey, redacted, preventLeaks: item.preventLeaks !== false,
         };
       }
@@ -378,13 +397,15 @@ export function initVarlockEnv(opts?: {
   }
 
   for (const itemKey in serializedEnvData.config) {
-    const itemValue = serializedEnvData.config[itemKey].value;
-    envValues[itemKey] = itemValue;
+    const item = serializedEnvData.config[itemKey];
+    envValues[itemKey] = item.value;
     if (setProcessEnv) {
       envState.injectedProcessEnvKeys?.push(itemKey);
       // when re-injecting into process.env, we treat undefined as empty string
-      // this more closely matches expected behaviour from other .env loaders
-      process.env[itemKey] = itemValue === undefined ? '' : String(itemValue);
+      // this more closely matches expected behaviour from other .env loaders.
+      // composite values (arrays/objects) carry their flat string form in `envStr`
+      // (their serialization depends on type settings that don't travel in the blob)
+      process.env[itemKey] = item.envStr ?? (item.value === undefined ? '' : String(item.value));
     }
   }
   envState.initialized = true;

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -332,6 +332,13 @@ export function getPreInjectionProcessEnv(): Record<string, string | undefined> 
   return getEnvState().originalProcessEnv;
 }
 
+/** blob values lacking a precomputed `envStr`: undefined → '', objects/arrays → JSON, scalars → String */
+function stringifyEnvValueFallback(value: any): string {
+  if (value === undefined) return '';
+  if (typeof value === 'object' && value !== null) return JSON.stringify(value);
+  return String(value);
+}
+
 export function initVarlockEnv(opts?: {
   allowFail?: boolean,
 }) {
@@ -404,8 +411,10 @@ export function initVarlockEnv(opts?: {
       // when re-injecting into process.env, we treat undefined as empty string
       // this more closely matches expected behaviour from other .env loaders.
       // composite values (arrays/objects) carry their flat string form in `envStr`
-      // (their serialization depends on type settings that don't travel in the blob)
-      process.env[itemKey] = item.envStr ?? (item.value === undefined ? '' : String(item.value));
+      // (their serialization depends on type settings that don't travel in the blob);
+      // a composite WITHOUT envStr (a blob from an older CLI) falls back to JSON so
+      // an object value never degrades to "[object Object]" (see #900)
+      process.env[itemKey] = item.envStr ?? stringifyEnvValueFallback(item.value);
     }
   }
   envState.initialized = true;

--- a/packages/vscode-plugin/src/intellisense-catalog.ts
+++ b/packages/vscode-plugin/src/intellisense-catalog.ts
@@ -347,7 +347,7 @@ export const DATA_TYPES: Array<DataTypeInfo> = [
     documentation: 'Example: `@type=array(email)` or `@type=array(enum(dev, staging, prod))`. Element type options go in a nested call: `array(email(normalize=true))`. Values can be native literals (`[a, b]`), JSON arrays, or separator-joined strings (default `,`).',
     insertText: 'array(${1|string,email,number,boolean,url,port,uuid|})',
     optionSnippets: [
-      { name: 'minLength', insertText: 'minLength=${1:1}', documentation: 'Minimum number of elements.' },
+      { name: 'minLength', insertText: 'minLength=${1:1}', documentation: 'Minimum number of elements (default 1; set 0 to allow an empty array).' },
       { name: 'maxLength', insertText: 'maxLength=${1:10}', documentation: 'Maximum number of elements.' },
       { name: 'isLength', insertText: 'isLength=${1:2}', documentation: 'Exact number of elements.' },
       { name: 'unique', insertText: 'unique=true', documentation: 'Reject duplicate elements.' },
@@ -362,7 +362,7 @@ export const DATA_TYPES: Array<DataTypeInfo> = [
     insertText: 'record(${1|string,url,number,boolean|})',
     optionSnippets: [
       { name: 'keyType', insertText: 'keyType=${1:enum(a, b)}', documentation: 'Type used to validate each key (e.g. enum, string(matches=...)).' },
-      { name: 'entriesMinLength', insertText: 'entriesMinLength=${1:1}', documentation: 'Minimum number of entries.' },
+      { name: 'entriesMinLength', insertText: 'entriesMinLength=${1:1}', documentation: 'Minimum number of entries (default 1; set 0 to allow an empty object).' },
       { name: 'entriesMaxLength', insertText: 'entriesMaxLength=${1:10}', documentation: 'Maximum number of entries.' },
       { name: 'entriesIsLength', insertText: 'entriesIsLength=${1:2}', documentation: 'Exact number of entries.' },
     ],

--- a/packages/vscode-plugin/src/intellisense-catalog.ts
+++ b/packages/vscode-plugin/src/intellisense-catalog.ts
@@ -358,9 +358,14 @@ export const DATA_TYPES: Array<DataTypeInfo> = [
   {
     name: 'object',
     summary: 'Object with typed values and optional key validation.',
-    documentation: 'Example: `@type=object(url)` validates every value as a url; `@type=object(url, keys=enum(us, eu))` also restricts keys. Bare `@type=object` accepts any object. Values can be native literals (`{k=v}`) or JSON objects; serializes to process.env as JSON.',
+    documentation: 'Example: `@type=object(url)` validates every value as a url; `@type=object(url, keyType=enum(us, eu))` also restricts keys. Bare `@type=object` accepts any object. Values can be native literals (`{k=v}`) or JSON objects; serializes to process.env as JSON.',
     insertText: 'object(${1|string,url,number,boolean|})',
-    optionSnippets: [{ name: 'keys', insertText: 'keys=${1:enum(a, b)}', documentation: 'Type used to validate each key (e.g. enum, string(matches=...)).' }],
+    optionSnippets: [
+      { name: 'keyType', insertText: 'keyType=${1:enum(a, b)}', documentation: 'Type used to validate each key (e.g. enum, string(matches=...)).' },
+      { name: 'entriesMinLength', insertText: 'entriesMinLength=${1:1}', documentation: 'Minimum number of entries.' },
+      { name: 'entriesMaxLength', insertText: 'entriesMaxLength=${1:10}', documentation: 'Maximum number of entries.' },
+      { name: 'entriesIsLength', insertText: 'entriesIsLength=${1:2}', documentation: 'Exact number of entries.' },
+    ],
   },
   {
     name: 'email',

--- a/packages/vscode-plugin/src/intellisense-catalog.ts
+++ b/packages/vscode-plugin/src/intellisense-catalog.ts
@@ -349,6 +349,7 @@ export const DATA_TYPES: Array<DataTypeInfo> = [
     optionSnippets: [
       { name: 'minLength', insertText: 'minLength=${1:1}', documentation: 'Minimum number of elements.' },
       { name: 'maxLength', insertText: 'maxLength=${1:10}', documentation: 'Maximum number of elements.' },
+      { name: 'isLength', insertText: 'isLength=${1:2}', documentation: 'Exact number of elements.' },
       { name: 'unique', insertText: 'unique=true', documentation: 'Reject duplicate elements.' },
       { name: 'separator', insertText: 'separator=${1:","}', documentation: 'Separator used to split string input and join output (default ",").' },
       { name: 'format', insertText: 'format=${1|separator,json|}', documentation: 'How the value serializes back into process.env (default separator-joined; json emits a JSON array).' },

--- a/packages/vscode-plugin/src/intellisense-catalog.ts
+++ b/packages/vscode-plugin/src/intellisense-catalog.ts
@@ -342,6 +342,26 @@ export const DATA_TYPES: Array<DataTypeInfo> = [
     insertText: 'enum(${1:development}, ${2:preview}, ${3:production})',
   },
   {
+    name: 'array',
+    summary: 'Array of values, each validated with an element type.',
+    documentation: 'Example: `@type=array(email)` or `@type=array(enum(dev, staging, prod))`. Element type options go in a nested call: `array(email(normalize=true))`. Values can be native literals (`[a, b]`), JSON arrays, or separator-joined strings (default `,`).',
+    insertText: 'array(${1|string,email,number,boolean,url,port,uuid|})',
+    optionSnippets: [
+      { name: 'minLength', insertText: 'minLength=${1:1}', documentation: 'Minimum number of elements.' },
+      { name: 'maxLength', insertText: 'maxLength=${1:10}', documentation: 'Maximum number of elements.' },
+      { name: 'unique', insertText: 'unique=true', documentation: 'Reject duplicate elements.' },
+      { name: 'separator', insertText: 'separator=${1:","}', documentation: 'Separator used to split string input and join output (default ",").' },
+      { name: 'format', insertText: 'format=${1|separator,json|}', documentation: 'How the value serializes back into process.env (default separator-joined; json emits a JSON array).' },
+    ],
+  },
+  {
+    name: 'object',
+    summary: 'Object with typed values and optional key validation.',
+    documentation: 'Example: `@type=object(url)` validates every value as a url; `@type=object(url, keys=enum(us, eu))` also restricts keys. Bare `@type=object` accepts any object. Values can be native literals (`{k=v}`) or JSON objects; serializes to process.env as JSON.',
+    insertText: 'object(${1|string,url,number,boolean|})',
+    optionSnippets: [{ name: 'keys', insertText: 'keys=${1:enum(a, b)}', documentation: 'Type used to validate each key (e.g. enum, string(matches=...)).' }],
+  },
+  {
     name: 'email',
     summary: 'Email address.',
     documentation: 'Example: `@type=email(normalize=true)`.',

--- a/packages/vscode-plugin/src/intellisense-catalog.ts
+++ b/packages/vscode-plugin/src/intellisense-catalog.ts
@@ -356,10 +356,10 @@ export const DATA_TYPES: Array<DataTypeInfo> = [
     ],
   },
   {
-    name: 'object',
-    summary: 'Object with typed values and optional key validation.',
-    documentation: 'Example: `@type=object(url)` validates every value as a url; `@type=object(url, keyType=enum(us, eu))` also restricts keys. Bare `@type=object` accepts any object. Values can be native literals (`{k=v}`) or JSON objects; serializes to process.env as JSON.',
-    insertText: 'object(${1|string,url,number,boolean|})',
+    name: 'record',
+    summary: 'Object (keyed record) with typed values and optional key validation.',
+    documentation: 'Example: `@type=record(url)` validates every value as a url; `@type=record(url, keyType=enum(us, eu))` also restricts keys. Bare `@type=record` accepts any object. Values can be native literals (`{k=v}`) or JSON objects; serializes to process.env as JSON.',
+    insertText: 'record(${1|string,url,number,boolean|})',
     optionSnippets: [
       { name: 'keyType', insertText: 'keyType=${1:enum(a, b)}', documentation: 'Type used to validate each key (e.g. enum, string(matches=...)).' },
       { name: 'entriesMinLength', insertText: 'entriesMinLength=${1:1}', documentation: 'Minimum number of entries.' },

--- a/smoke-tests/smoke-test-composite-vals/.env.schema
+++ b/smoke-tests/smoke-test-composite-vals/.env.schema
@@ -1,0 +1,25 @@
+# @defaultRequired=false @defaultSensitive=false
+# ---
+# @type=enum(dev, production)
+APP_ENV=dev
+
+# @type=array(email)
+ALLOWED_EMAILS=[admin@example.com, support@example.com]
+
+# @type=array(number, separator=";")
+SCORES=[10, 20]
+
+# @type=object(url)
+ENDPOINTS={api=https://api.example.com}
+
+UNTYPED_LIST=[a, b]
+
+# @type=array(email, minLength=if(eq($APP_ENV, production), 1, 0))
+ALERT_EMAILS=[]
+
+# @type=if(eq($APP_ENV, production), url, string)
+SERVICE_HOST="not a url"
+
+# @type=array(string)
+# @sensitive
+SECRET_TOKENS=[tok-alpha-1234567, tok-beta-7654321]

--- a/smoke-tests/smoke-test-composite-vals/.env.schema
+++ b/smoke-tests/smoke-test-composite-vals/.env.schema
@@ -9,7 +9,7 @@ ALLOWED_EMAILS=[admin@example.com, support@example.com]
 # @type=array(number, separator=";")
 SCORES=[10, 20]
 
-# @type=object(url)
+# @type=record(url)
 ENDPOINTS={api=https://api.example.com}
 
 UNTYPED_LIST=[a, b]

--- a/smoke-tests/tests/composite-values.test.ts
+++ b/smoke-tests/tests/composite-values.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from 'vitest';
+import { varlockLoad, varlockRun, runVarlock } from '../helpers/run-varlock.js';
+
+const CWD = 'smoke-test-composite-vals';
+
+describe('composite (array/object) values', () => {
+  test('load --format json outputs real arrays and objects', () => {
+    const result = varlockLoad({ cwd: CWD, format: 'json' });
+    expect(result.exitCode).toBe(0);
+    const vars = JSON.parse(result.stdout);
+    expect(vars.ALLOWED_EMAILS).toEqual(['admin@example.com', 'support@example.com']);
+    expect(vars.SCORES).toEqual([10, 20]);
+    expect(vars.ENDPOINTS).toEqual({ api: 'https://api.example.com' });
+    // untyped array literal infers an array type
+    expect(vars.UNTYPED_LIST).toEqual(['a', 'b']);
+  });
+
+  test('load --format env outputs flat string forms', () => {
+    const result = varlockLoad({ cwd: CWD, format: 'env' });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('ALLOWED_EMAILS="admin@example.com,support@example.com"');
+    // custom separator respected on output
+    expect(result.stdout).toContain('SCORES="10;20"');
+    // objects serialize as JSON (quotes escaped in env format)
+    expect(result.stdout).toContain('ENDPOINTS="{\\"api\\":\\"https://api.example.com\\"}"');
+  });
+
+  test('run injects flat strings into the child process env', () => {
+    const result = varlockRun([
+      'node',
+      '-e',
+      'console.log([process.env.ALLOWED_EMAILS, process.env.SCORES, process.env.ENDPOINTS].join("\\n"))',
+    ], { cwd: CWD });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('admin@example.com,support@example.com');
+    expect(result.stdout).toContain('10;20');
+    expect(result.stdout).toContain('{"api":"https://api.example.com"}');
+  });
+
+  test('a real env var override re-parses through the separator', () => {
+    const result = varlockRun(
+      ['node', '-e', 'console.log(process.env.SCORES)'],
+      { cwd: CWD, env: { SCORES: '1;2;3' } },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('1;2;3');
+  });
+
+  test('a real env var override failing element validation errors', () => {
+    const result = varlockLoad({ cwd: CWD, format: 'json' });
+    expect(result.exitCode).toBe(0);
+    const bad = runVarlock(['load'], { cwd: CWD, env: { ALLOWED_EMAILS: 'not-an-email, two@example.com' } });
+    expect(bad.exitCode).not.toBe(0);
+    expect(bad.output).toContain('[0]');
+  });
+});
+
+describe('dynamic @type parts', () => {
+  test('relaxed constraints outside production', () => {
+    const result = varlockLoad({ cwd: CWD });
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('strict constraints kick in when APP_ENV=production', () => {
+    const result = runVarlock(['load'], { cwd: CWD, env: { APP_ENV: 'production' } });
+    expect(result.exitCode).not.toBe(0);
+    // empty ALERT_EMAILS violates the now-active minLength=1
+    expect(result.output).toContain('ALERT_EMAILS');
+    // SERVICE_HOST is now validated as a url
+    expect(result.output).toContain('SERVICE_HOST');
+  });
+});
+
+describe('sensitive composite redaction (end to end)', () => {
+  test('leaking a single element of a sensitive array gets redacted in child output', () => {
+    const result = varlockRun(
+      ['node', '-e', 'console.log("leak attempt:", "tok-beta-7654321")'],
+      { cwd: CWD },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('leak attempt:');
+    expect(result.stdout).not.toContain('tok-beta-7654321');
+  });
+});


### PR DESCRIPTION
Supersedes #843, rebuilt on current main (the emitter refactor in #892 made that branch conflict anyway). Also supersedes #912 / fixes #900: every injection site it patched (run, proxy, load env format, runtime re-injection) now flows through type-owned serialization, and `simple-object` serializes as JSON.

## What

Adds first-class array and object values for config items:

```env-spec
# @type=array(email)
ALLOWED_EMAILS=[admin@example.com, support@example.com]

# @type=array(enum(dev, staging, prod))
APP_MODES=[dev, staging]

# @type=record(url, keyType=enum(us, eu))
REGION_ENDPOINTS={us=https://us.example.com, eu=https://eu.example.com}
```

- Parser: `[a, b]` / `{k=v}` literals are now valid config item values; `${REF}` expansion works inside elements. Values starting with `{`/`[` that do not parse as literals (e.g. JSON with `:` pairs) still fall back to strings.
- `array(elementType, ...)`: per-element coercion/validation with indexed errors (all bad elements reported, not just the first). Options: `separator` (default `","`), `format=separator|json`, `minLength`, `maxLength`, `isLength`, `unique`. Element type options go in a nested call: `array(email(normalize=true))`.
- `record(valuesType, keyType=...)`: validates every value with the values type and every key with the `keyType` type (enum, string patterns, etc.). Entry count options: `entriesMinLength` / `entriesMaxLength` / `entriesIsLength`. Named `record` (zod/TS convention for a homogeneous keyed map), reserving `object` for a possible future per-key shape type; `@type=object` errors with a tip, and bare `record` subsumes `simple-object`.
- Three input forms per array: native literal, JSON string, separator-joined string, so real env var overrides (`HOSTS=a.com,b.com`) work with no extra config.
- Symmetric serialization out: `process.env` gets the separator-joined form by default (JSON for objects, nested composites, or `format=json`); an element containing the separator is a validation error instead of a corrupt round-trip. The blob carries the flat form as `envStr` for runtime re-injection.
- Redaction: sensitive composite values register each string element individually, so leaking one element of a secret list is still caught.
- Codegen: recursive `CoercedType` (`arrayOf` / `recordOf`) wired through all 7 emitters (TS `string[]` / `Partial<Record<...>>`, Go slices/maps, Rust `Vec<T>`, Python `list[...]`/`dict[...]`, PHP `@var` refinements, Java `List`/`Map` + Jackson plumbing, C# `JsonElement`).
- Untyped literal values infer their composite type (same principle as `123` inferring number), including scalar element types.
- `@type` parsing unified into `type-decorator.ts` with one arg-handling convention for every type call (composite and scalar): strict option validation, clear errors for mixed positional/named args, non-static option values, and typos (instead of opaque throws or silent drops). The decorator opts out of resolver conversion via a declarative `skipValueResolver` flag.

## Notable differences from #843

- Element options use nested calls (`array(email(normalize=true))`) instead of flat forwarding, so unknown array options can be rejected loudly.
- Output defaults to separator-joined (matching the input separator) instead of always-JSON.
- Empty composites are invalid by default via `minLength`/`entriesMinLength` defaulting to 1 (same strict posture as the original `allowEmpty=false`, but the opt-out is the existing `minLength=0` knob instead of a new flag). Empty or whitespace-only string input on a composite item resolves to `undefined` (missing) rather than becoming an empty container or a type-lying `''`.
- Objects are included, with key validation.


## Dynamic @type parts

Type option values can be resolver expressions, and the whole type can resolve to a type name, so validation can vary per environment or based on other items:

```env-spec
# @type=string(minLength=if(eq($APP_ENV, production), 32, 8))
API_TOKEN=

# @type=if(eq($APP_ENV, production), url, string)
SERVICE_HOST=localhost:3000

# enum members sourced from another item - a referenced array spreads its elements
# @type=array(string)
ALLOWED_MODES=[dev, staging, prod]
# @type=enum($ALLOWED_MODES)
APP_MODE=dev
```

Built as a two-phase plan: a deterministic provisional instance (static parts only / first static candidate) feeds type generation, and the final instance is built at resolution time after the deferred resolvers run (sharing the item dependency graph). Dynamic parts may vary validation but never generated types: static candidate names are checked for coercedType agreement at load time (`if($X, number, string)` is rejected), and the resolved instance is re-verified against the provisional one at resolution time (covers opaque expressions). A dynamic enum generates a plain `string` (membership is unknown until resolution), so its members must resolve to strings; the guard accepts that widening recursively (works for `array(enum($MODES))` too).







