### PR TITLE
Report varlock/auto-load failures to error trackers

### DIFF
--- a/.bumpy/auto-load-error-hook.md
+++ b/.bumpy/auto-load-error-hook.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+Report load failures to error trackers. `varlock/auto-load` can now throw the load error (instead of exiting silently) so a reporter like Sentry can capture it. Opt in with a `globalThis._varlockOnLoadError` hook (called with the error and the values that did resolve), or set `_VARLOCK_THROW_ON_LOAD_ERROR=1` when a reporter is already initialized. Default behavior is unchanged.

--- a/packages/varlock-website/src/content/docs/integrations/javascript.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/javascript.mdx
@@ -31,6 +31,41 @@ const FROM_PROCESS_ENV = process.env.MY_CONFIG_ITEM; // 🆗 still works
 If you are using [`dotenv`](https://www.npmjs.com/package/dotenv), or a package you are using is using it under the hood, you can swap in varlock using your package manager's override feature. See the [migrate from dotenv](/guides/migrate-from-dotenv) guide for more information.
 :::
 
+### Reporting load failures
+
+When validation fails, `varlock/auto-load` writes the error to `stderr` and exits with a non-zero code. Because it exits during module import, an error reporter like Sentry may never see the failure. You can opt in to having auto-load **throw** the error instead of exiting, so a reporter can pick it up. This is never enabled automatically, so nothing changes for apps that do not opt in.
+
+**If your reporter is already initialized before varlock loads** (for example Sentry started via `node --import ./instrument.mjs`, with its DSN in a real environment variable), set `_VARLOCK_THROW_ON_LOAD_ERROR=1`. auto-load then throws instead of exiting, and the reporter's existing `uncaughtException` handler catches it. Make sure the reporter is imported before varlock:
+
+```js title="index.js"
+import './instrument.js'; // initializes Sentry (registers its handler)
+import 'varlock/auto-load';
+```
+
+**If the DSN itself comes from varlock, or you init your reporter in app code,** set a `globalThis._varlockOnLoadError` hook. It is called with the error and a map of the values that did resolve (so you can read `SENTRY_DSN` even though the overall load failed):
+
+```js title="varlock-error-hook.js"
+import * as Sentry from '@sentry/node';
+
+globalThis._varlockOnLoadError = (err, env) => {
+  Sentry.init({ dsn: env.SENTRY_DSN });
+  Sentry.captureException(err);
+  return Sentry.close(2000); // return the promise; auto-load exits once it settles
+};
+```
+
+```js title="index.js"
+import './varlock-error-hook.js'; // must be imported BEFORE auto-load
+import 'varlock/auto-load';
+```
+
+Two things to keep in mind:
+
+- The hook must be registered **before** `varlock/auto-load` is imported. ES modules hoist all `import` statements, so register the hook via its own side-effect import placed above the auto-load import, not with an inline call between imports.
+- Reporting is best-effort. auto-load does not `await` your hook (that would change how env is injected), so it gives async work a short window and then forces the process to exit. Return a promise from the hook and auto-load will exit as soon as it settles.
+
+Only resolved values are available to the hook, so this does not help with `.env` **parse or schema errors**, where resolution is skipped entirely. To report those, the DSN must come from a real environment variable and be picked up by an already-initialized reporter.
+
 
 ## Boot via `varlock run`
 

--- a/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
+++ b/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
@@ -44,6 +44,10 @@ Fallback for the [`--filter`](/reference/cli-commands/#filtering-items) flag on 
 _VARLOCK_FILTER="#billing" varlock load --format json
 ```
 
+### `_VARLOCK_THROW_ON_LOAD_ERROR`
+
+When set (`1` / `true`), [`varlock/auto-load`](/integrations/javascript/#reporting-load-failures) throws the error on a load failure instead of exiting, so an already-initialized error tracker (e.g. Sentry) can capture it via its `uncaughtException` handler. Setting a `globalThis._varlockOnLoadError` hook enables the same throw behavior. See [Reporting load failures](/integrations/javascript/#reporting-load-failures).
+
 {/*
   Intentionally NOT documented for end users; internal/testing only.
   Kept here (and in VARLOCK_CONFIG_ENV_VARS with internal:true) for maintainer reference.

--- a/packages/varlock/src/auto-load.ts
+++ b/packages/varlock/src/auto-load.ts
@@ -80,37 +80,45 @@ try {
   // import ordered above `import 'varlock/auto-load'`, not an inline call.
   const onLoadError = (globalThis as any)._varlockOnLoadError;
   const hasHook = typeof onLoadError === 'function';
-  const throwEnabled = hasHook || !!process.env._VARLOCK_THROW_ON_LOAD_ERROR;
 
-  if (throwEnabled) {
-    // We can't `await` here without making auto-load async, which would change env-injection
-    // ordering (see note above about running synchronously). So reporting is best-effort:
-    // give any async work a bounded window, then guarantee the process still exits.
-    setTimeout(() => process.exit(exitCode), 2000).unref();
-
-    if (hasHook) {
-      // If nothing else would keep the event loop alive after we throw (no pre-registered
-      // uncaughtException handler, e.g. Sentry's), add a no-op one so Node doesn't perform its
-      // default immediate-exit and cut off the hook's async reporting. `once` keeps our global
-      // footprint minimal: it only neutralizes the throw below.
-      if (process.listenerCount('uncaughtException') === 0) {
-        process.once('uncaughtException', () => {
-          // no-op: keep the loop alive; the timer/hook-promise below drives the exit
-        });
-      }
-      try {
-        const result = onLoadError(err, getPartialResolvedEnv(err));
-        // Exit as soon as the hook settles (observing the promise, not awaiting it).
-        if (result && typeof result.then === 'function') {
-          result.then(() => process.exit(exitCode), () => process.exit(exitCode));
-        }
-      } catch {
-        // a broken hook must never mask the original load failure
-      }
+  if (hasHook) {
+    // Call the hook with the error and whatever values did resolve, then guarantee a non-zero
+    // exit. We can't `await` here without making auto-load async (which would change env-injection
+    // ordering — see note above about running synchronously), so we observe the returned promise
+    // instead: exit as soon as it settles, bounded by a timer, and let it flush before then.
+    let result: unknown;
+    try {
+      result = onLoadError(err, getPartialResolvedEnv(err));
+    } catch {
+      // a broken hook must never mask the original load failure
     }
 
-    // Throw so downstream code never runs with invalid/missing env. A registered
-    // uncaughtException handler (e.g. Sentry's) catches this and can flush; the timer bounds it.
+    if (result && typeof (result as any).then === 'function') {
+      // Async hook: keep the process alive until it settles (or a 2s bound), then exit non-zero.
+      // Throw so downstream code never runs with invalid env; a no-op uncaughtException handler
+      // (added only if nothing else would catch it) stops Node's immediate crash-exit so the
+      // promise/timer below drives the exit code. The timer is intentionally NOT unref'd — it must
+      // hold the loop open so the process can't drain and exit 0 before we report.
+      setTimeout(() => process.exit(exitCode), 2000);
+      (result as Promise<unknown>).then(() => process.exit(exitCode), () => process.exit(exitCode));
+      if (process.listenerCount('uncaughtException') === 0) {
+        process.once('uncaughtException', () => {
+          // no-op: keep the loop alive; the promise/timer above drives the exit
+        });
+      }
+      throw err;
+    }
+
+    // Sync hook: reporting is already done, so exit now. This also aborts downstream, and keeps
+    // the exit code correct (a thrown error swallowed by a no-op handler would exit 0).
+    process.exit(exitCode);
+  }
+
+  if (process.env._VARLOCK_THROW_ON_LOAD_ERROR) {
+    // No hook, but a tracker is already initialized (e.g. Sentry via `--import`). Throw so its
+    // uncaughtException handler captures the failure. Bound the flush and guarantee exit; if no
+    // handler is actually registered, Node's default behavior exits non-zero anyway.
+    setTimeout(() => process.exit(exitCode), 2000).unref();
     throw err;
   }
 

--- a/packages/varlock/src/auto-load.ts
+++ b/packages/varlock/src/auto-load.ts
@@ -11,6 +11,26 @@ import { patchGlobalResponse } from './runtime/patch-response';
 // so we call out to the CLI using execSync
 // this also isolates the varlock loading process from the end user process
 
+/**
+ * Build a plain `{ KEY: value }` map of the values that DID resolve, for the load-error hook.
+ * On a validation failure (as opposed to a parse/schema error) the CLI still emits the fully
+ * serialized graph to stdout, so items unrelated to the failure have real resolved values here
+ * (e.g. a SENTRY_DSN needed to report the failure itself). Best-effort — returns `{}` if the
+ * failure produced no parseable output.
+ */
+function getPartialResolvedEnv(err: unknown): Record<string, unknown> {
+  const stdout = err instanceof VarlockExecError ? err.stdout : undefined;
+  if (!stdout) return {};
+  try {
+    const parsed = JSON.parse(stdout);
+    const env: Record<string, unknown> = {};
+    for (const key in parsed?.config) env[key] = parsed.config[key]?.value;
+    return env;
+  } catch {
+    return {};
+  }
+}
+
 try {
   const { stdout } = execSyncVarlock('load --format json-full --compact', {
     fullResult: true,
@@ -43,7 +63,59 @@ try {
     // eslint-disable-next-line no-console
     console.error(err);
   }
-  process.exit((err as any).exitCode ?? 1);
+  const exitCode = (err as any).exitCode ?? 1;
+
+  // By default we exit here (fail-fast). Apps can instead have auto-load THROW the error, so an
+  // error tracker can report the load failure rather than the process dying silently. This is
+  // opt-in, never inferred from the mere presence of some unrelated uncaughtException handler:
+  //
+  //  1. Set a `globalThis._varlockOnLoadError` hook — called with the error and the values that
+  //     did resolve (e.g. a SENTRY_DSN needed to report the failure).
+  //  2. Set `_VARLOCK_THROW_ON_LOAD_ERROR=1` — for when a tracker is already initialized with its
+  //     own uncaughtException handler (e.g. Sentry via `--import`), so the throw lands there.
+  //
+  // Single-underscore prefixes (`_varlock*`, `_VARLOCK_*`) mark user-controllable behavior;
+  // double-underscore `__varlock*` globals are set by varlock itself. The hook must be set BEFORE
+  // this module is imported — ESM hoists all `import` statements, so register it via a side-effect
+  // import ordered above `import 'varlock/auto-load'`, not an inline call.
+  const onLoadError = (globalThis as any)._varlockOnLoadError;
+  const hasHook = typeof onLoadError === 'function';
+  const throwEnabled = hasHook || !!process.env._VARLOCK_THROW_ON_LOAD_ERROR;
+
+  if (throwEnabled) {
+    // We can't `await` here without making auto-load async, which would change env-injection
+    // ordering (see note above about running synchronously). So reporting is best-effort:
+    // give any async work a bounded window, then guarantee the process still exits.
+    setTimeout(() => process.exit(exitCode), 2000).unref();
+
+    if (hasHook) {
+      // If nothing else would keep the event loop alive after we throw (no pre-registered
+      // uncaughtException handler, e.g. Sentry's), add a no-op one so Node doesn't perform its
+      // default immediate-exit and cut off the hook's async reporting. `once` keeps our global
+      // footprint minimal: it only neutralizes the throw below.
+      if (process.listenerCount('uncaughtException') === 0) {
+        process.once('uncaughtException', () => {
+          // no-op: keep the loop alive; the timer/hook-promise below drives the exit
+        });
+      }
+      try {
+        const result = onLoadError(err, getPartialResolvedEnv(err));
+        // Exit as soon as the hook settles (observing the promise, not awaiting it).
+        if (result && typeof result.then === 'function') {
+          result.then(() => process.exit(exitCode), () => process.exit(exitCode));
+        }
+      } catch {
+        // a broken hook must never mask the original load failure
+      }
+    }
+
+    // Throw so downstream code never runs with invalid/missing env. A registered
+    // uncaughtException handler (e.g. Sentry's) catches this and can flush; the timer bounds it.
+    throw err;
+  }
+
+  // Default: preserve the original fail-fast behavior exactly.
+  process.exit(exitCode);
 }
 
 // initialize varlock and patch globals as necessary

--- a/packages/varlock/src/env-graph/lib/reserved-vars.ts
+++ b/packages/varlock/src/env-graph/lib/reserved-vars.ts
@@ -42,6 +42,10 @@ export const VARLOCK_CONFIG_ENV_VARS: Array<ReservedVarInfo> = [
     description: 'Fallback for the `--filter` flag on `varlock load`/`run`, for use when a CLI flag can\'t easily be passed (e.g. a wrapper script, CI config, or build-time integration). The `--filter` flag takes precedence when both are set.',
   },
   {
+    name: '_VARLOCK_THROW_ON_LOAD_ERROR',
+    description: 'When set (`1`/`true`), `varlock/auto-load` throws the error on a load failure instead of exiting, so an already-initialized error tracker (e.g. Sentry) can capture it. Setting a `globalThis._varlockOnLoadError` hook enables the same throw behavior.',
+  },
+  {
     name: '_VARLOCK_FORCE_FILE_ENCRYPTION_FALLBACK',
     description: 'Forces the file-based local encryption fallback instead of the native binary. Intended for testing/debugging.',
     internal: true,

--- a/smoke-tests/smoke-test-auto-load-error/.env.schema
+++ b/smoke-tests/smoke-test-auto-load-error/.env.schema
@@ -1,0 +1,8 @@
+# @defaultSensitive=false
+# ---
+
+# resolves fine even though the overall load fails — must reach the error hook
+SENTRY_DSN=https://example@sentry.io/123
+
+# @required
+REQUIRED_THING=

--- a/smoke-tests/smoke-test-auto-load-error/app-hook-async.mjs
+++ b/smoke-tests/smoke-test-auto-load-error/app-hook-async.mjs
@@ -1,0 +1,3 @@
+import './register-hook-async.mjs'; // sets an async globalThis._varlockOnLoadError before auto-load
+import 'varlock/auto-load';
+console.log('DOWNSTREAM_RAN'); // should never print on a load failure

--- a/smoke-tests/smoke-test-auto-load-error/app-hook.mjs
+++ b/smoke-tests/smoke-test-auto-load-error/app-hook.mjs
@@ -1,0 +1,3 @@
+import './register-hook.mjs'; // must be imported before auto-load (sets globalThis._varlockOnLoadError)
+import 'varlock/auto-load';
+console.log('DOWNSTREAM_RAN'); // should never print on a load failure

--- a/smoke-tests/smoke-test-auto-load-error/app-plain.mjs
+++ b/smoke-tests/smoke-test-auto-load-error/app-plain.mjs
@@ -1,0 +1,2 @@
+import 'varlock/auto-load';
+console.log('DOWNSTREAM_RAN'); // should never print on a load failure

--- a/smoke-tests/smoke-test-auto-load-error/instrument.mjs
+++ b/smoke-tests/smoke-test-auto-load-error/instrument.mjs
@@ -1,0 +1,6 @@
+// Emulates an error tracker initialized via `node --import` (e.g. Sentry): registers an
+// uncaughtException handler before the app (and varlock) load. Reports, then exits.
+process.on('uncaughtException', (err) => {
+  console.log(`HANDLER_CAUGHT msg=${err?.message ?? err}`);
+  process.exit(1);
+});

--- a/smoke-tests/smoke-test-auto-load-error/register-hook-async.mjs
+++ b/smoke-tests/smoke-test-auto-load-error/register-hook-async.mjs
@@ -1,0 +1,10 @@
+// Async variant of the load-error hook: returns a promise (simulating Sentry's flush).
+// auto-load must keep the process alive until it settles, then still exit non-zero.
+globalThis._varlockOnLoadError = (err, env) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      console.log(`HOOK_FIRED_ASYNC dsn=${env.SENTRY_DSN} msg=${err?.message ?? err}`);
+      resolve();
+    }, 50);
+  });
+};

--- a/smoke-tests/smoke-test-auto-load-error/register-hook.mjs
+++ b/smoke-tests/smoke-test-auto-load-error/register-hook.mjs
@@ -1,0 +1,5 @@
+// Side-effect import: registers the load-error hook BEFORE auto-load runs.
+// Ordered above `import 'varlock/auto-load'` so ESM import hoisting can't run auto-load first.
+globalThis._varlockOnLoadError = (err, env) => {
+  console.log(`HOOK_FIRED dsn=${env.SENTRY_DSN} msg=${err?.message ?? err}`);
+};

--- a/smoke-tests/tests/auto-load-error.test.ts
+++ b/smoke-tests/tests/auto-load-error.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+// End-to-end tests for how `varlock/auto-load` handles a load failure: by default it exits
+// (fail-fast), but apps can opt in to having it THROW so an error tracker (e.g. Sentry) can
+// report the failure — via a `globalThis._varlockOnLoadError` hook or `_VARLOCK_THROW_ON_LOAD_ERROR`.
+// The scenario's `.env.schema` has a `@required` item left empty, so every run below fails to load
+// unless `REQUIRED_THING` is provided.
+
+const SCENARIO_DIR = join(import.meta.dirname, '..', 'smoke-test-auto-load-error');
+
+function runNode(
+  script: string,
+  opts: { importModule?: string; env?: Record<string, string> } = {},
+) {
+  const args: Array<string> = [];
+  if (opts.importModule) args.push('--import', opts.importModule);
+  args.push(script);
+
+  // Start from a copy of the env with the test-relevant knobs cleared, so an inherited value
+  // (e.g. in CI) can't accidentally satisfy the schema or flip the opt-in.
+  const env: Record<string, string | undefined> = { ...process.env };
+  delete env.REQUIRED_THING;
+  delete env._VARLOCK_THROW_ON_LOAD_ERROR;
+  Object.assign(env, opts.env);
+
+  const result = spawnSync(process.execPath, args, {
+    cwd: SCENARIO_DIR,
+    env: env as NodeJS.ProcessEnv,
+    encoding: 'utf-8',
+  });
+  return {
+    exitCode: result.status ?? 1,
+    output: (result.stdout ?? '') + (result.stderr ?? ''),
+  };
+}
+
+describe('varlock/auto-load load-failure reporting', () => {
+  test('default: exits non-zero without throwing or reporting, and downstream never runs', () => {
+    const { exitCode, output } = runNode('app-plain.mjs');
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('Configuration is currently invalid');
+    expect(output).not.toContain('HOOK_FIRED');
+    expect(output).not.toContain('DOWNSTREAM_RAN');
+  });
+
+  test('sync hook: fires with the resolved values, exits non-zero, downstream never runs', () => {
+    const { exitCode, output } = runNode('app-hook.mjs');
+    // regression guard: a synchronous hook must still exit non-zero (a thrown error swallowed by
+    // the keep-alive handler would otherwise let the loop drain and exit 0)
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('HOOK_FIRED');
+    expect(output).toContain('dsn=https://example@sentry.io/123');
+    expect(output).not.toContain('DOWNSTREAM_RAN');
+  });
+
+  test('async hook: waits for the returned promise, then exits non-zero', () => {
+    const { exitCode, output } = runNode('app-hook-async.mjs');
+    expect(exitCode).not.toBe(0);
+    // the async hook only logs after its (simulated flush) promise settles
+    expect(output).toContain('HOOK_FIRED_ASYNC');
+    expect(output).toContain('dsn=https://example@sentry.io/123');
+    expect(output).not.toContain('DOWNSTREAM_RAN');
+  });
+
+  test('_VARLOCK_THROW_ON_LOAD_ERROR: throw is caught by a preloaded uncaughtException handler', () => {
+    const { exitCode, output } = runNode('app-plain.mjs', {
+      importModule: './instrument.mjs',
+      env: { _VARLOCK_THROW_ON_LOAD_ERROR: '1' },
+    });
+    expect(exitCode).not.toBe(0);
+    expect(output).toContain('HANDLER_CAUGHT');
+    expect(output).not.toContain('DOWNSTREAM_RAN');
+  });
+
+  test('a preloaded uncaughtException handler alone (no opt-in) does NOT trigger the throw', () => {
+    const { exitCode, output } = runNode('app-plain.mjs', {
+      importModule: './instrument.mjs',
+    });
+    expect(exitCode).not.toBe(0);
+    // without the flag, auto-load exits rather than throwing, so the handler never sees anything
+    expect(output).not.toContain('HANDLER_CAUGHT');
+    expect(output).not.toContain('DOWNSTREAM_RAN');
+  });
+
+  test('success: env is injected, downstream runs, and the hook is not called', () => {
+    const { exitCode, output } = runNode('app-hook.mjs', { env: { REQUIRED_THING: 'ok' } });
+    expect(exitCode).toBe(0);
+    expect(output).toContain('DOWNSTREAM_RAN');
+    expect(output).not.toContain('HOOK_FIRED');
+  });
+});


### PR DESCRIPTION
## Problem

When `varlock/auto-load` validation fails, it writes the error to stderr and calls `process.exit()` during module import. An error tracker like Sentry never sees the failure: auto-load never throws (so no `uncaughtException` handler fires), and `process.exit()` would kill Sentry's async flush anyway. The process just dies with a non-zero code and nothing is reported.

## Change

auto-load can now **throw** the load error instead of exiting, so a reporter can capture it. It is **opt-in** and never inferred from the mere presence of an unrelated `uncaughtException` handler, so default behavior is unchanged.

Two ways to opt in:

- **`globalThis._varlockOnLoadError` hook** — called with the error and a map of the values that *did* resolve (so a `SENTRY_DSN` managed by varlock is available to init the reporter at failure time). Register it via a side-effect import ordered above `import 'varlock/auto-load'` (ESM hoists imports). auto-load stays synchronous and does not `await` the hook; reporting is best-effort with a bounded window, and if the hook returns a promise auto-load exits as soon as it settles.
- **`_VARLOCK_THROW_ON_LOAD_ERROR=1`** — for when a reporter is already initialized before varlock (e.g. Sentry via `--import`, DSN in a real env var). auto-load throws and the reporter's existing handler catches it.

When neither is set, auto-load exits exactly as before.

## Limitation

Only resolved values are available to the hook, so this covers **validation** failures, not `.env` parse/schema errors (resolution is skipped there). For those, the DSN must come from a real env var and be picked up by an already-initialized reporter.

## Testing

Verified against a built package with a deliberately-failing schema:

- Hook set → hook fires with the resolved `SENTRY_DSN`, captures + flushes, downstream never runs, exit 1
- Sentry-style handler + `_VARLOCK_THROW_ON_LOAD_ERROR=1` → handler catches + flushes, exit 1
- Sentry-style handler, **no** flag → exits quietly, handler untouched (no behavior change)
- No hook / no flag → quiet exit 1 (unchanged)
- Success path → env injected, downstream runs, exit 0

Docs updated in `integrations/javascript.mdx`.