### PR TITLE
Fix refs in @cache decorator values resolving as undefined

### DIFF
--- a/.bumpy/cache-decorator-refs.md
+++ b/.bumpy/cache-decorator-refs.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Fix refs in the `@cache` root decorator value (e.g. `@cache=if($USE_CACHE, "memory", "disabled")`) silently resolving as undefined

--- a/packages/varlock-website/src/content/docs/guides/caching.mdx
+++ b/packages/varlock-website/src/content/docs/guides/caching.mdx
@@ -11,7 +11,7 @@ Rather than caching environment variable values, it is a general key-value store
 
 Plugins have access to cache helpers that can be used to avoid repeated network round trips, or to hold short-lived tokens. They will usually expose params (like `cacheTtl`) to let the user opt into caching. This still respects global cache mode and CLI flags. Each plugin can decide how to cache things and it will often depend on the shape of the external API.
 
-`cacheTtl` can be set dynamically, for example `cacheTtl=forEnv(dev, "1h")` to cache only in development. Setting it to `false` (or an empty string) disables caching for that plugin instance.
+`cacheTtl` can be set dynamically, for example `cacheTtl=if(forEnv(dev), "1h")` to cache only in development. Setting it to `false` (or an empty string) disables caching for that plugin instance.
 
 ## Common `cache()` use case: stable generated values
 

--- a/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
+++ b/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
@@ -288,7 +288,7 @@ SESSION_SECRET=cache(randomHex(32))
 
 ```env-spec
 # dynamic - only use disk caching in development
-# @cache=forEnv(dev, "disk")
+# @cache=if(forEnv(dev), "disk")
 # ---
 ```
 

--- a/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
+++ b/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
@@ -278,7 +278,7 @@ Sets global cache mode for [`cache()`](/reference/functions/#cache) and plugin c
 - `disabled`: disable caching globally
 - `auto` (default): uses `disk` when a native encryption backend is available outside CI; otherwise uses `disk` encrypted with `_VARLOCK_CACHE_KEY` if that env var is set, falling back to `memory` (see the [Caching guide](/guides/caching/))
 
-The value can also be set dynamically with a function, for example to change cache mode per environment. A function that resolves to no value falls back to `auto`.
+The value can also be set dynamically with a function, for example to change cache mode per environment, and it can reference other config items. A function that resolves to no value falls back to `auto`.
 
 ```env-spec
 # @cache=memory
@@ -290,6 +290,13 @@ SESSION_SECRET=cache(randomHex(32))
 # dynamic - only use disk caching in development
 # @cache=forEnv(dev, "disk")
 # ---
+```
+
+```env-spec
+# dynamic - based on another config item
+# @cache=if($USE_CACHE, "memory", "disabled")
+# ---
+USE_CACHE=true
 ```
 
 :::note

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -507,6 +507,16 @@ export class EnvGraph {
     // when @plugin decorators execute below.
     const cacheDec = this.getRootDec('cache');
     if (cacheDec) {
+      // @cache is resolved before config items, so any refs in its value
+      // (e.g. if($USE_CACHE, "memory", "disabled")) must be early-resolved first,
+      // same as @disable does in finishInit. A missing ref is surfaced by the
+      // resolver itself when the decorator resolves below.
+      if (cacheDec.decValueResolver) {
+        for (const depKey of cacheDec.decValueResolver.deps) {
+          const depItem = this.configSchema[depKey];
+          if (depItem) await depItem.earlyResolve();
+        }
+      }
       const cacheSetting = await cacheDec.resolve();
       let cacheMode: 'auto' | 'memory' | 'disk' | 'disabled' = 'auto';
       if (cacheSetting === 'auto' || cacheSetting === 'memory' || cacheSetting === 'disk' || cacheSetting === 'disabled') {

--- a/packages/varlock/src/env-graph/lib/resolver.ts
+++ b/packages/varlock/src/env-graph/lib/resolver.ts
@@ -225,6 +225,10 @@ export class Resolver {
     const depItem = this.envGraph?.configSchema[key];
     if (!depItem) throw new Error(`Referenced item "${key}" not found`);
     if (!depItem.isValid) throw new Error(`Referenced item "${key}" is not valid`);
+    // a valid-but-unresolved dep means the calling context forgot to resolve deps
+    // first (see earlyResolve / resolveEnvValues); returning resolvedValue here
+    // would silently produce undefined instead of the item's actual value
+    if (!depItem.isResolved) throw new Error(`Referenced item "${key}" has not been resolved yet`);
     return depItem.resolvedValue;
   }
 }

--- a/packages/varlock/src/env-graph/test/cache-resolver.test.ts
+++ b/packages/varlock/src/env-graph/test/cache-resolver.test.ts
@@ -231,6 +231,110 @@ describe('cache() resolver', () => {
       expect(g.configSchema.A.resolvedValue).toBeDefined();
     });
 
+    it('supports refs in the @cache value via if()', async () => {
+      // @cache is resolved before config items, so its ref deps ($USE_MEM here)
+      // must be early-resolved; previously they silently read as undefined
+      const g = new EnvGraph();
+      g.registerResolver(RandomResolver);
+      const source = new DotEnvFileDataSource('.env.schema', {
+        overrideContents: outdent`
+          # @defaultRequired=false
+          # @cache=if($USE_MEM, "memory", "disabled")
+          # ---
+          USE_MEM=true
+          A=cache(random(), ttl="1h")
+        `,
+      });
+      await g.setRootDataSource(source);
+      await g.finishLoad();
+      await g.resolveEnvValues();
+      expect(g._cacheStore).toBeInstanceOf(InMemoryCacheStore);
+      expect(g.configSchema.A.resolvedValue).toBeDefined();
+    });
+
+    it('supports refs in the @cache value via eq()', async () => {
+      const loadWithTarget = async (targetVal: string) => {
+        const g = new EnvGraph();
+        g.registerResolver(RandomResolver);
+        const source = new DotEnvFileDataSource('.env.schema', {
+          overrideContents: outdent`
+            # @defaultRequired=false
+            # @cache=if(eq($TARGET, "local"), "memory", "disabled")
+            # ---
+            TARGET=${targetVal}
+            A=cache(random(), ttl="1h")
+          `,
+        });
+        await g.setRootDataSource(source);
+        await g.finishLoad();
+        await g.resolveEnvValues();
+        return g;
+      };
+
+      const gLocal = await loadWithTarget('local');
+      expect(gLocal._cacheStore).toBeInstanceOf(InMemoryCacheStore);
+
+      const gOther = await loadWithTarget('ci');
+      expect(gOther._skipCacheMode).toBe(true);
+      expect(gOther._cacheStore).toBeUndefined();
+    });
+
+    it('supports a bare ref as the @cache value', async () => {
+      const g = new EnvGraph();
+      g.registerResolver(RandomResolver);
+      const source = new DotEnvFileDataSource('.env.schema', {
+        overrideContents: outdent`
+          # @defaultRequired=false
+          # @cache=$CACHE_MODE
+          # ---
+          CACHE_MODE=memory
+          A=cache(random(), ttl="1h")
+        `,
+      });
+      await g.setRootDataSource(source);
+      await g.finishLoad();
+      await g.resolveEnvValues();
+      expect(g._cacheStore).toBeInstanceOf(InMemoryCacheStore);
+    });
+
+    it('supports forEnv() inside the @cache value', async () => {
+      const g = new EnvGraph();
+      g.registerResolver(RandomResolver);
+      const source = new DotEnvFileDataSource('.env.schema', {
+        overrideContents: outdent`
+          # @defaultRequired=false
+          # @envFlag=APP_ENV
+          # @cache=if(forEnv(production), "disabled", "memory")
+          # ---
+          APP_ENV=production
+          A=cache(random(), ttl="1h")
+        `,
+      });
+      await g.setRootDataSource(source);
+      await g.finishLoad();
+      await g.resolveEnvValues();
+      expect(g._skipCacheMode).toBe(true);
+      expect(g._cacheStore).toBeUndefined();
+    });
+
+    it('errors when a @cache ref points at a non-existent item', async () => {
+      const g = new EnvGraph();
+      g.registerResolver(RandomResolver);
+      const source = new DotEnvFileDataSource('.env.schema', {
+        overrideContents: outdent`
+          # @defaultRequired=false
+          # @cache=if($NOPE, "memory", "disabled")
+          # ---
+          A=random()
+        `,
+      });
+      await g.setRootDataSource(source);
+      await g.finishLoad();
+      const cacheDec = g.getRootDec('cache');
+      expect(cacheDec).toBeDefined();
+      expect(cacheDec!.errors.some((e) => e.message.includes('invalid dependency: NOPE'))).toBe(true);
+    });
+
     it('errors when dynamic @cache resolves to an invalid value', async () => {
       const g = new EnvGraph();
       g.registerResolver(RandomResolver);

--- a/packages/varlock/src/env-graph/test/resolvers.test.ts
+++ b/packages/varlock/src/env-graph/test/resolvers.test.ts
@@ -218,6 +218,25 @@ describe('ref()', functionValueTests({
   },
 }));
 
+describe('ref() unresolved dependency guard', () => {
+  it('errors loudly if resolved before its dependency (instead of silently returning undefined)', async () => {
+    const g = new EnvGraph();
+    const testDataSource = new DotEnvFileDataSource('.env.schema', {
+      overrideContents: outdent`
+        # @defaultRequired=false
+        # ---
+        OTHER=otherval
+        ITEM=ref(OTHER)
+      `,
+    });
+    await g.setRootDataSource(testDataSource);
+    await g.finishLoad();
+    // simulate a buggy calling context that resolves ITEM without resolving its deps first
+    await g.configSchema.ITEM.resolve();
+    expect(g.configSchema.ITEM.resolutionError?.message).toContain('has not been resolved yet');
+  });
+});
+
 describe('regex()', functionValueTests({
   'error - regex used as value': {
     input: 'ITEM=regex(.*)',


### PR DESCRIPTION
## What

Refs in the `@cache` root decorator value did not work. `@cache` is resolved early in `finishLoad()` (before config items) so plugin modules see the final cache setting, but a ref in its value (e.g. `@cache=if($USE_CACHE, "memory", "disabled")`) read the unresolved item's value as `undefined` and silently picked the wrong branch, with no error.

## Changes

- `EnvGraph.finishLoad()` now early-resolves the `@cache` decorator's dependencies before resolving it, using the same pattern as `@disable` in `finishInit()`.
- `Resolver.getDepValue()` now throws when the referenced item exists but has not been resolved yet, so any other calling context that forgets to resolve deps first fails loudly instead of silently producing `undefined`.
- Tests for `@cache` with `if($REF, ...)`, `if(eq($REF, ...))`, a bare `$REF`, `forEnv()`, and a ref to a non-existent item, plus a test pinning the new unresolved-dep guard.
- Docs: note in the `@cache` reference that the value can reference other config items, with an example.
- Docs: fix two broken `forEnv()` examples spotted in review. `forEnv()` treats every arg as an env name and returns a boolean, so `@cache=forEnv(dev, "disk")` and `cacheTtl=forEnv(dev, "1h")` never yield a value (verified: `@cache` errors with "resolved to an invalid value (true/false)" in every env). Both now use the working `if(forEnv(dev), ...)` form.