### PR TITLE
actually add --plain

### DIFF
--- a/.bumpy/fix-generate-key-plain.md
+++ b/.bumpy/fix-generate-key-plain.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Add --plain flag to generate-key for piping into platform CLIs

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -748,9 +748,13 @@ Generates a random 256-bit encryption key for use with `_VARLOCK_ENV_KEY`. This 
 
 ```bash
 varlock generate-key
+varlock generate-key --plain
 ```
 
-See the [Next.js](/integrations/nextjs/#encrypting-the-env-blob) and [Vite](/integrations/vite/#encrypting-the-env-blob) integration docs for setup instructions.
+**Flags:**
+- `--plain`: Print only the key (no surrounding help text). Useful for piping into platform CLIs, e.g. `varlock generate-key --plain | vercel env add _VARLOCK_ENV_KEY production --sensitive`.
+
+See the [encrypted deployments guide](/guides/encrypted-deployments/) and the [Next.js](/integrations/nextjs/#encrypting-the-env-blob) / [Vite](/integrations/vite/#encrypting-the-env-blob) integration docs for setup instructions.
 
 </div>
 

--- a/packages/varlock/src/cli/commands/generate-key.command.ts
+++ b/packages/varlock/src/cli/commands/generate-key.command.ts
@@ -6,11 +6,28 @@ import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 export const commandSpec = define({
   name: 'generate-key',
   description: 'Generate an encryption key for encrypting the env blob in deployments',
-  args: {},
+  args: {
+    plain: {
+      type: 'boolean',
+      description: 'Print only the key (for piping into other commands)',
+    },
+  },
+  examples: `
+Generates a random 256-bit hex key for \`_VARLOCK_ENV_KEY\`.
+
+Examples:
+  varlock generate-key              # Human-readable output
+  varlock generate-key --plain      # Key only, for piping
+  `.trim(),
 });
 
-export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async () => {
+export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   const key = randomBytes(32).toString('hex');
+
+  if (ctx.values.plain) {
+    console.log(key);
+    return;
+  }
 
   console.log('');
   console.log('Generated _VARLOCK_ENV_KEY:');

--- a/smoke-tests/tests/cli.test.ts
+++ b/smoke-tests/tests/cli.test.ts
@@ -162,6 +162,21 @@ describe('CLI Commands', () => {
     });
   });
 
+  describe('generate-key command', () => {
+    test('varlock generate-key prints a human-readable banner and key', () => {
+      const result = runVarlock(['generate-key']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Generated _VARLOCK_ENV_KEY');
+      expect(result.stdout).toMatch(/[0-9a-f]{64}/);
+    });
+
+    test('varlock generate-key --plain prints only the key', () => {
+      const result = runVarlock(['generate-key', '--plain']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/^[0-9a-f]{64}\n$/);
+    });
+  });
+
   describe('explain command', () => {
     test('varlock explain <key> resolves a config item', () => {
       const result = runVarlock(['explain', 'PUBLIC_VAR'], { cwd: 'smoke-test-basic' });


### PR DESCRIPTION
Changes:

- Added --plain to [generate-key.command.ts](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/packages/varlock/src/cli/commands/generate-key.command.ts): prints only the 64-char hex key (default output unchanged)
- Documented the flag in the CLI reference
- Smoke tests for default vs --plain output (both passing)
- Patch changeset: .bumpy/fix-generate-key-plain.md

Verified: varlock generate-key --plain exits 0 with a single hex key on stdout, suitable for piping into vercel env add / Netlify as the docs show.

closes: #921 