### PR TITLE
Fix varlock run OOM when child command is a bare PATH binary like node

### DIFF
--- a/.bumpy/fix-run-shebang-memory.md
+++ b/.bumpy/fix-run-shebang-memory.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Fix varlock run OOM when child command is a bare PATH binary like node (shebang probe no longer reads the whole file)

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ eslint-output.txt
 
 # vitest coverage output
 coverage/
+
+# local throwaway experiments
+scratch/

--- a/packages/varlock-website/src/content/docs/guides/docker.mdx
+++ b/packages/varlock-website/src/content/docs/guides/docker.mdx
@@ -46,6 +46,8 @@ CMD ["node", "dist/server.js"]
 
 Secrets are fetched when the container starts, not when the image is built.
 
+`varlock run` stays resident while your app runs (signal forwarding), so the container pays for two processes. That is usually fine once the CLI is a few tens of MiB. If you are on a very tight memory limit and only need env at boot, prefer resolve-then-`exec` so a single Node process remains: `eval "$(varlock load --format shell --compact)" && exec node dist/server.js`.
+
   </TabItem>
   <TabItem label="Build-time">
 

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -287,6 +287,8 @@ Note: When the `__VARLOCK_ENV` blob is omitted, framework integrations that rely
 This makes `varlock run` safe to use as a container `ENTRYPOINT` (including PID 1), so `docker stop` / pod termination reaches your app gracefully instead of waiting out the grace period and being `SIGKILL`ed.
 
 By default varlock forwards and then waits indefinitely for the child. It does **not** impose its own kill deadline, leaving that decision to the orchestrator or operator (a forwarded signal isn't always terminal, since many programs use `SIGHUP` to reload). If you want varlock to escalate to `SIGKILL` when the child hasn't exited within a grace period, set the `_VARLOCK_FORCE_KILL_TIMEOUT_MS` environment variable to a number of milliseconds.
+
+Because the parent stays alive, container memory is roughly **CLI process + child process**. For the leanest footprint when you only need env injection at boot (no long-lived parent), resolve once and replace the shell with your app: `eval "$(varlock load --format shell --compact)" && exec node dist/server.js`.
 :::
 
 </div>

--- a/packages/varlock/src/lib/exec.ts
+++ b/packages/varlock/src/lib/exec.ts
@@ -5,7 +5,7 @@ import {
   join, delimiter, extname, isAbsolute,
 } from 'node:path';
 import {
-  existsSync, statSync, readFileSync, accessSync, constants as fsConstants,
+  existsSync, statSync, openSync, readSync, closeSync, accessSync, constants as fsConstants,
 } from 'node:fs';
 
 interface ExecOptions {
@@ -87,16 +87,32 @@ function isExecutableOnWindows(filePath: string): boolean {
 }
 
 /**
- * Read shebang from file (first 150 bytes)
+ * Read shebang from file (first 150 bytes only).
+ *
+ * Must not use readFileSync on the whole file: `varlock run -- node ...` resolves
+ * bare `node` via PATH and probes candidates for a shebang. Reading a ~100MB+
+ * Node binary into a UTF-8 string spikes the parent to hundreds of MiB and can
+ * OOM 256Mi containers.
  */
 function readShebang(filePath: string): string | null {
+  let fd: number | undefined;
   try {
-    const fd = readFileSync(filePath, { encoding: 'utf8', flag: 'r' });
-    const first150 = fd.slice(0, 150);
+    fd = openSync(filePath, 'r');
+    const buf = Buffer.alloc(150);
+    const bytesRead = readSync(fd, buf, 0, 150, 0);
+    const first150 = buf.toString('utf8', 0, bytesRead);
     const match = first150.match(/^#!([^\r\n]+)/);
     return match ? match[1].trim() : null;
   } catch {
     return null;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // ignore close errors
+      }
+    }
   }
 }
 

--- a/packages/varlock/src/lib/test/exec.test.ts
+++ b/packages/varlock/src/lib/test/exec.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { Readable } from 'node:stream';
 import { stripVTControlCharacters } from 'node:util';
+import {
+  mkdtempSync, writeFileSync, chmodSync, rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { exec } from '../exec.js';
 
 /**
@@ -84,4 +89,38 @@ describe('exec', () => {
     // to avoid flakiness while still catching a premature resolve (e.g. <50ms).
     expect(elapsedMs).toBeGreaterThanOrEqual(200);
   });
+
+  it('should not read whole PATH binaries when probing shebangs', async () => {
+    // Regression: readShebang used readFileSync on the entire file. Resolving a
+    // bare command like `node` (~100MB+ binary) allocated hundreds of MiB.
+    if (process.platform === 'win32') return;
+
+    const dir = mkdtempSync(join(tmpdir(), 'varlock-shebang-'));
+    const binName = 'varlock-shebang-probe';
+    const binPath = join(dir, binName);
+    // Large file with a shebang script that exits before any padding is parsed.
+    // findCommand must probe this via readShebang without loading all 32 MiB.
+    const payload = Buffer.concat([
+      Buffer.from('#!/bin/sh\necho shebang-ok\nexit 0\n'),
+      Buffer.alloc(32 * 1024 * 1024, 0x00),
+    ]);
+    writeFileSync(binPath, payload);
+    chmodSync(binPath, 0o755);
+
+    const before = process.memoryUsage().rss;
+    const childProcess = exec(binName, [], {
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH || ''}` },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const stdoutData = childProcess.stdout ? streamToString(childProcess.stdout) : Promise.resolve('');
+    const result = await childProcess;
+    const after = process.memoryUsage().rss;
+    rmSync(dir, { recursive: true, force: true });
+
+    expect(result.exitCode).toBe(0);
+    expect((await stdoutData).trim()).toBe('shebang-ok');
+    // Allow some allocator noise, but must not retain anything like the 32MiB file
+    expect(after - before).toBeLessThan(8 * 1024 * 1024);
+  }, 15_000);
 });

--- a/smoke-tests/tests/run-memory.test.ts
+++ b/smoke-tests/tests/run-memory.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect } from 'vitest';
+import { spawn, spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { VARLOCK_CLI } from '../helpers/run-varlock.js';
+
+const SMOKE_TESTS_DIR = join(import.meta.dirname, '..');
+const BASIC_CWD = join(SMOKE_TESTS_DIR, 'smoke-test-basic');
+
+/** Child holds long enough for us to sample parent RSS after spawn/shebang resolve. */
+const HOLD_SCRIPT = "process.stdout.write('ready\\n'); setTimeout(() => {}, 8000)";
+
+/**
+ * Memory thresholds for the `varlock run` shebang-probe regression.
+ *
+ * Healthy parent RSS (tiny schema, no plugins): ~67 MiB macOS / ~81 MiB Linux slim.
+ * The bug (readShebang loading the whole Node binary) was ~318 MiB parent / ~230 MiB
+ * bare-vs-absolute delta. Tune these if CI baselines move; keep well above healthy
+ * and well below the known bug.
+ */
+const MAX_BARE_VS_ABSOLUTE_DELTA_MIB = 40;
+const MAX_BARE_NODE_PARENT_RSS_MIB = 150;
+
+const MAX_BARE_VS_ABSOLUTE_DELTA_KIB = MAX_BARE_VS_ABSOLUTE_DELTA_MIB * 1024;
+const MAX_BARE_NODE_PARENT_RSS_KIB = MAX_BARE_NODE_PARENT_RSS_MIB * 1024;
+
+function rssKiB(pid: number): number | null {
+  if (process.platform === 'linux') {
+    try {
+      const status = readFileSync(`/proc/${pid}/status`, 'utf8');
+      const match = status.match(/^VmRSS:\s+(\d+)/m);
+      return match ? Number(match[1]) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  const result = spawnSync('ps', ['-o', 'rss=', '-p', String(pid)], { encoding: 'utf8' });
+  if (result.status !== 0) return null;
+  const n = Number(result.stdout.trim());
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Run `varlock run -- <nodeBin> -e <HOLD_SCRIPT>`, wait for `ready`, sample the
+ * varlock parent RSS a few times, then SIGTERM and return the peak sample.
+ */
+function measureRunParentRssKiB(nodeBin: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const samples: Array<number> = [];
+    let output = '';
+    const handles: {
+      sampling?: ReturnType<typeof setInterval>;
+      timeout?: ReturnType<typeof setTimeout>;
+    } = {};
+
+    const child = spawn(
+      process.execPath,
+      [VARLOCK_CLI, 'run', '--', nodeBin, '-e', HOLD_SCRIPT],
+      {
+        cwd: BASIC_CWD,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, VARLOCK_TELEMETRY_DISABLED: '1' },
+      },
+    );
+
+    const finish = (err?: Error) => {
+      if (settled) return;
+      settled = true;
+      if (handles.sampling) clearInterval(handles.sampling);
+      if (handles.timeout) clearTimeout(handles.timeout);
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // already gone
+      }
+      if (err) {
+        reject(err);
+        return;
+      }
+      if (!samples.length) {
+        reject(new Error(`no RSS samples (output=${JSON.stringify(output)})`));
+        return;
+      }
+      resolve(Math.max(...samples));
+    };
+
+    handles.timeout = setTimeout(() => {
+      finish(new Error(`timed out waiting for ready (output=${JSON.stringify(output)})`));
+    }, 15_000);
+    handles.timeout.unref();
+
+    const startSampling = () => {
+      if (handles.sampling) return;
+      handles.sampling = setInterval(() => {
+        if (!child.pid) return;
+        const rss = rssKiB(child.pid);
+        if (rss != null) samples.push(rss);
+      }, 200);
+      // give a few samples after ready, then stop
+      setTimeout(() => finish(), 1500).unref();
+    };
+
+    const onData = (chunk: Buffer) => {
+      output += chunk.toString();
+      if (output.includes('ready')) startSampling();
+    };
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    child.on('error', (err) => finish(err));
+  });
+}
+
+function miB(kib: number) {
+  return Math.round((kib / 1024) * 10) / 10;
+}
+
+// RSS sampling needs POSIX `ps` or Linux /proc
+describe.skipIf(process.platform === 'win32')('varlock run memory footprint', () => {
+  test('bare PATH `node` does not inflate parent RSS vs absolute node path', async () => {
+    // Regression for readShebang reading the entire Node binary when resolving a
+    // bare PATH command. Absolute paths skip the probe; bare `node` used to load
+    // ~100MB+ into the parent and OOM 256Mi containers.
+    const which = spawnSync('which', ['node'], { encoding: 'utf8' });
+    expect(which.status, 'node must be on PATH for this regression').toBe(0);
+
+    const absoluteRss = await measureRunParentRssKiB(process.execPath);
+    const bareRss = await measureRunParentRssKiB('node');
+
+    const deltaKiB = bareRss - absoluteRss;
+    expect(
+      deltaKiB,
+      `bare node parent RSS (${miB(bareRss)} MiB) exceeded absolute `
+        + `(${miB(absoluteRss)} MiB) by ${miB(deltaKiB)} MiB `
+        + `(limit ${MAX_BARE_VS_ABSOLUTE_DELTA_MIB} MiB)`,
+    ).toBeLessThan(MAX_BARE_VS_ABSOLUTE_DELTA_KIB);
+
+    expect(
+      bareRss,
+      `bare node parent RSS ${miB(bareRss)} MiB exceeds `
+        + `${MAX_BARE_NODE_PARENT_RSS_MIB} MiB sanity ceiling`,
+    ).toBeLessThan(MAX_BARE_NODE_PARENT_RSS_KIB);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary
- Fix `varlock run` OOM when the child command is a bare PATH binary (e.g. `node`): shebang probing no longer `readFileSync`s the entire file (Node binaries are ~100MB+).
- Add a regression test that resolves a large PATH binary without retaining its size in RSS.
- Note in Docker / `run` docs that the parent stays resident (two processes), and mention load-then-`exec` for tighter memory limits.

## Context
Reported against containers using `varlock run -- node dist/main.mjs` under a 256Mi limit. Repro on `node:24-slim`: before ~278MiB cgroup (OOM at 256Mi); after ~46MiB (runs under 256Mi). Absolute child paths skipped the bug because `findCommand` does not shebang-probe them.

## Test plan
- [ ] `bun run --filter varlock test -- src/lib/test/exec.test.ts`
- [ ] `varlock run -- node -e 'console.log("ok")'` still works
- [ ] Optional: Docker `node:24-slim` with `--memory=256m` and bare `node` child no longer exits 137