### PR TITLE
add vaultToken() to HC vault plugin

### DIFF
--- a/.bumpy/vault-token-resolver.md
+++ b/.bumpy/vault-token-resolver.md
@@ -1,0 +1,5 @@
+---
+"@varlock/hashicorp-vault-plugin": minor
+---
+
+Add vaultToken() resolver to expose the authenticated Vault client token

--- a/bun.lock
+++ b/bun.lock
@@ -300,6 +300,7 @@
         "@env-spec/utils": "workspace:^",
         "@types/node": "catalog:",
         "ky": "catalog:",
+        "outdent": "catalog:",
         "tsup": "catalog:",
         "varlock": "workspace:^",
         "vitest": "catalog:",

--- a/packages/plugins/hashicorp-vault/README.md
+++ b/packages/plugins/hashicorp-vault/README.md
@@ -216,6 +216,30 @@ API_KEY=
 
 This fetches all keys from `secret/myapp/config` and maps them to matching item keys.
 
+### Exposing the client token
+
+Use `vaultToken()` when another tool needs the same Vault client token the plugin already authenticated with (for example OpenTofu OpenBao state encryption via `BAO_TOKEN`). The resolver returns the token from the active auth method and reuses the plugin's cached login.
+
+```env-spec title=".env.schema"
+# @plugin(@varlock/hashicorp-vault-plugin@2.0.0)
+# @initHcpVault(
+#   url=$BAO_ADDR,
+#   jwtRole=$VAULT_ROLE,
+#   jwtAuthPath="gitlab",
+#   oidcToken=$GITLAB_OIDC
+# )
+# ---
+
+# @sensitive
+BAO_TOKEN=vaultToken()
+```
+
+Mark the item `@sensitive`. If you also use `@type=vaultToken`, set `@internal=false` so the value is injected for consumers (the type defaults to `@internal`).
+
+Prefer a consumer-specific name like `BAO_TOKEN` over `VAULT_TOKEN` when `VAULT_TOKEN` is already an input to `@initHcpVault(token=$VAULT_TOKEN)`, which would create a dependency cycle.
+
+With multiple instances, pass the instance id: `vaultToken(prod)`.
+
 ---
 
 ## Reference
@@ -267,6 +291,19 @@ By default, the item key (variable name) is used as the JSON key to extract from
 **How paths work:**
 
 Vault KV v2 stores key/value pairs at a path. Given a path like `secret/myapp/config`, the plugin calls `GET /v1/secret/data/myapp/config` (the first path segment is the mount point, and `/data/` is inserted for the KV v2 API).
+
+#### `vaultToken()`
+
+Returns the Vault client token for an initialized plugin instance. Useful when another tool needs the same short-lived credential the plugin already obtained.
+
+Always treated as sensitive. Reuses the plugin's existing auth cache instead of logging in again.
+
+**Signatures:**
+
+- `vaultToken()` - Token from the default instance
+- `vaultToken(instanceId)` - Token from a named instance
+
+If you use `@type=vaultToken`, also set `@internal=false` so the value is injected. Do not assign `vaultToken()` to `VAULT_TOKEN` when that same item is passed as `@initHcpVault(token=$VAULT_TOKEN)` (dependency cycle). Prefer a consumer-specific name such as `BAO_TOKEN`.
 
 ### Data Types
 

--- a/packages/plugins/hashicorp-vault/package.json
+++ b/packages/plugins/hashicorp-vault/package.json
@@ -49,6 +49,7 @@
     "@env-spec/utils": "workspace:^",
     "@types/node": "catalog:",
     "ky": "catalog:",
+    "outdent": "catalog:",
     "tsup": "catalog:",
     "varlock": "workspace:^",
     "vitest": "catalog:"

--- a/packages/plugins/hashicorp-vault/src/plugin.ts
+++ b/packages/plugins/hashicorp-vault/src/plugin.ts
@@ -57,6 +57,8 @@ class VaultPluginInstance {
   private jwtAuthPath?: string;
   private oidcToken?: string;
   private cachedToken?: CachedToken;
+  /** in-flight login promise so concurrent callers share one auth request */
+  private loginInFlight?: Promise<string>;
   private secretCache = new Map<string, Promise<Record<string, any>>>();
   /** optional cache TTL - when set, resolved values are cached */
   cacheTtl?: string | number;
@@ -119,7 +121,7 @@ class VaultPluginInstance {
     return this._cacheKeyIdentity;
   }
 
-  private async getVaultToken(): Promise<string> {
+  async getVaultToken(): Promise<string> {
     // Check cached token (with 30s buffer)
     if (this.cachedToken && this.cachedToken.expiresAt > Date.now() + 30_000) {
       debug('Using cached Vault token');
@@ -132,14 +134,26 @@ class VaultPluginInstance {
       return this.token;
     }
 
+    // Share one in-flight AppRole/JWT login across concurrent callers
+    if (this.loginInFlight) {
+      debug('Awaiting in-flight Vault login');
+      return this.loginInFlight;
+    }
+
     // 2. AppRole auth
     if (this.roleId && this.secretId) {
-      return this.loginWithAppRole();
+      this.loginInFlight = this.loginWithAppRole().finally(() => {
+        this.loginInFlight = undefined;
+      });
+      return this.loginInFlight;
     }
 
     // 3. JWT/OIDC auth
     if (this.jwtRole) {
-      return this.loginWithJwt();
+      this.loginInFlight = this.loginWithJwt().finally(() => {
+        this.loginInFlight = undefined;
+      });
+      return this.loginInFlight;
     }
 
     // 4. Vault/OpenBao CLI token helper files
@@ -709,6 +723,55 @@ plugin.registerResolverFunction({
     }
 
     return await selectedInstance.getSecret(fullPath, jsonKey);
+  },
+});
+
+plugin.registerResolverFunction({
+  name: 'vaultToken',
+  label: 'HashiCorp Vault client token',
+  icon: VAULT_ICON,
+  impliesSensitive: true,
+  argsSchema: {
+    type: 'array',
+    arrayMaxLength: 1,
+  },
+  process() {
+    // Optional positional arg = instance id
+    let instanceId = '_default';
+    if (this.arrArgs?.length) {
+      if (!this.arrArgs[0].isStatic) {
+        throw new SchemaError('Expected instance id to be a static value');
+      }
+      instanceId = String(this.arrArgs[0].staticValue);
+    }
+
+    if (!Object.values(pluginInstances).length) {
+      throw new SchemaError('No Vault plugin instances found', {
+        tip: 'Initialize at least one Vault instance using the @initHcpVault() root decorator',
+      });
+    }
+
+    const selectedInstance = pluginInstances[instanceId];
+    if (!selectedInstance) {
+      if (instanceId === '_default') {
+        throw new SchemaError('Vault plugin instance (without id) not found', {
+          tip: [
+            'Either remove the `id` param from your @initHcpVault call',
+            'or use `vaultToken(id)` to select an instance by id',
+            `Possible ids are: ${Object.keys(pluginInstances).join(', ')}`,
+          ].join('\n'),
+        });
+      } else {
+        throw new SchemaError(`Vault plugin instance id "${instanceId}" not found`, {
+          tip: [`Valid ids are: ${Object.keys(pluginInstances).join(', ')}`].join('\n'),
+        });
+      }
+    }
+
+    return { instanceId };
+  },
+  async resolve({ instanceId }) {
+    return pluginInstances[instanceId].getVaultToken();
   },
 });
 

--- a/packages/plugins/hashicorp-vault/test/hashicorp-vault.test.ts
+++ b/packages/plugins/hashicorp-vault/test/hashicorp-vault.test.ts
@@ -1,0 +1,249 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  describe, expect, test,
+} from 'vitest';
+import outdent from 'outdent';
+import { pluginTest } from 'varlock/test-helpers';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PLUGIN_PATH = path.join(__dirname, '..');
+
+type FakeVaultApi = {
+  url: string;
+  requests: Array<{ method?: string; url?: string; vaultToken?: string }>;
+  close: () => Promise<void>;
+};
+
+async function startFakeVaultApi(opts?: {
+  clientToken?: string;
+  leaseDuration?: number;
+}): Promise<FakeVaultApi> {
+  const clientToken = opts?.clientToken ?? 'hvs.fake-client-token';
+  const leaseDuration = opts?.leaseDuration ?? 3600;
+  const requests: FakeVaultApi['requests'] = [];
+
+  const server = http.createServer((req, res) => {
+    const requestUrl = new URL(req.url || '/', 'http://127.0.0.1');
+    requests.push({
+      method: req.method,
+      url: requestUrl.pathname,
+      vaultToken: req.headers['x-vault-token'] as string | undefined,
+    });
+
+    const sendJson = (statusCode: number, body: Record<string, unknown>) => {
+      res.writeHead(statusCode, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(body));
+    };
+
+    if (req.method === 'POST' && requestUrl.pathname === '/v1/auth/approle/login') {
+      sendJson(200, {
+        auth: {
+          client_token: clientToken,
+          lease_duration: leaseDuration,
+        },
+      });
+      return;
+    }
+
+    if (req.method === 'POST' && requestUrl.pathname === '/v1/auth/jwt/login') {
+      sendJson(200, {
+        auth: {
+          client_token: clientToken,
+          lease_duration: leaseDuration,
+        },
+      });
+      return;
+    }
+
+    if (req.method === 'POST' && requestUrl.pathname === '/v1/auth/gitlab/login') {
+      sendJson(200, {
+        auth: {
+          client_token: clientToken,
+          lease_duration: leaseDuration,
+        },
+      });
+      return;
+    }
+
+    sendJson(404, {
+      errors: [`${requestUrl.pathname} not found`],
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const address = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () => new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    }),
+  };
+}
+
+describe('hashicorp-vault vaultToken()', () => {
+  test('returns an explicitly configured token', async () => {
+    await pluginTest({
+      injectValues: {
+        VAULT_ADDR: 'http://127.0.0.1:8200',
+        VAULT_TOKEN: 'hvs.explicit-token',
+      },
+      schema: outdent`
+        # @plugin(${PLUGIN_PATH})
+        # @initHcpVault(url=$VAULT_ADDR, token=$VAULT_TOKEN)
+        # ---
+        VAULT_ADDR=
+        # @type=vaultToken
+        VAULT_TOKEN=
+        # @sensitive
+        BAO_TOKEN=vaultToken()
+      `,
+      expectValues: { BAO_TOKEN: 'hvs.explicit-token' },
+      expectSensitive: { BAO_TOKEN: true },
+    })();
+  });
+
+  test('returns AppRole client token and reuses the cached login', async () => {
+    const api = await startFakeVaultApi({ clientToken: 'hvs.approle-token' });
+    try {
+      await pluginTest({
+        injectValues: {
+          VAULT_ADDR: api.url,
+          VAULT_ROLE_ID: 'role-id',
+          VAULT_SECRET_ID: 'secret-id',
+        },
+        schema: outdent`
+          # @plugin(${PLUGIN_PATH})
+          # @initHcpVault(url=$VAULT_ADDR, roleId=$VAULT_ROLE_ID, secretId=$VAULT_SECRET_ID)
+          # ---
+          VAULT_ADDR=
+          VAULT_ROLE_ID=
+          # @sensitive @internal
+          VAULT_SECRET_ID=
+          # @sensitive
+          TOKEN_A=vaultToken()
+          # @sensitive
+          TOKEN_B=vaultToken()
+        `,
+        expectValues: {
+          TOKEN_A: 'hvs.approle-token',
+          TOKEN_B: 'hvs.approle-token',
+        },
+      })();
+
+      const loginRequests = api.requests.filter((r) => r.url === '/v1/auth/approle/login');
+      expect(loginRequests).toHaveLength(1);
+    } finally {
+      await api.close();
+    }
+  });
+
+  test('returns JWT client token', async () => {
+    const api = await startFakeVaultApi({ clientToken: 'hvs.jwt-token' });
+    try {
+      await pluginTest({
+        injectValues: {
+          VAULT_ADDR: api.url,
+          GITLAB_OIDC: 'fake-oidc-jwt',
+        },
+        schema: outdent`
+          # @plugin(${PLUGIN_PATH})
+          # @initHcpVault(url=$VAULT_ADDR, jwtRole=ci-role, jwtAuthPath="gitlab", oidcToken=$GITLAB_OIDC)
+          # ---
+          VAULT_ADDR=
+          # @sensitive @internal
+          GITLAB_OIDC=
+          # @sensitive
+          BAO_TOKEN=vaultToken()
+        `,
+        expectValues: { BAO_TOKEN: 'hvs.jwt-token' },
+      })();
+
+      expect(api.requests).toContainEqual(expect.objectContaining({
+        method: 'POST',
+        url: '/v1/auth/gitlab/login',
+      }));
+    } finally {
+      await api.close();
+    }
+  });
+
+  test('selects a named instance by id', async () => {
+    await pluginTest({
+      injectValues: {
+        VAULT_ADDR: 'http://127.0.0.1:8200',
+        DEV_TOKEN: 'hvs.dev-token',
+        PROD_TOKEN: 'hvs.prod-token',
+      },
+      schema: outdent`
+        # @plugin(${PLUGIN_PATH})
+        # @initHcpVault(id=dev, url=$VAULT_ADDR, token=$DEV_TOKEN)
+        # @initHcpVault(id=prod, url=$VAULT_ADDR, token=$PROD_TOKEN)
+        # ---
+        VAULT_ADDR=
+        # @type=vaultToken
+        DEV_TOKEN=
+        # @type=vaultToken
+        PROD_TOKEN=
+        # @sensitive
+        DEV_CLIENT=vaultToken(dev)
+        # @sensitive
+        PROD_CLIENT=vaultToken(prod)
+      `,
+      expectValues: {
+        DEV_CLIENT: 'hvs.dev-token',
+        PROD_CLIENT: 'hvs.prod-token',
+      },
+    })();
+  });
+
+  test('unknown instance id produces an error', pluginTest({
+    injectValues: {
+      VAULT_ADDR: 'http://127.0.0.1:8200',
+      VAULT_TOKEN: 'hvs.explicit-token',
+    },
+    schema: outdent`
+      # @plugin(${PLUGIN_PATH})
+      # @initHcpVault(url=$VAULT_ADDR, token=$VAULT_TOKEN)
+      # ---
+      VAULT_ADDR=
+      # @type=vaultToken
+      VAULT_TOKEN=
+      BAO_TOKEN=vaultToken(missing)
+    `,
+    expectValues: { BAO_TOKEN: Error },
+  }));
+
+  test('no init produces an error', pluginTest({
+    schema: outdent`
+      # @plugin(${PLUGIN_PATH})
+      # ---
+      BAO_TOKEN=vaultToken()
+    `,
+    expectValues: { BAO_TOKEN: Error },
+  }));
+
+  test('implies sensitive even when defaultSensitive is false', pluginTest({
+    injectValues: {
+      VAULT_ADDR: 'http://127.0.0.1:8200',
+      VAULT_TOKEN: 'hvs.explicit-token',
+    },
+    schema: outdent`
+      # @plugin(${PLUGIN_PATH})
+      # @defaultSensitive=false
+      # @initHcpVault(url=$VAULT_ADDR, token=$VAULT_TOKEN)
+      # ---
+      VAULT_ADDR=
+      # @type=vaultToken
+      VAULT_TOKEN=
+      BAO_TOKEN=vaultToken()
+    `,
+    expectSensitive: { BAO_TOKEN: true },
+  }));
+});

--- a/packages/plugins/hashicorp-vault/vitest.config.ts
+++ b/packages/plugins/hashicorp-vault/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    conditions: ['ts-src'],
+  },
+  define: {
+    __VARLOCK_BUILD_TYPE__: JSON.stringify('test'),
+    __VARLOCK_SEA_BUILD__: 'false',
+  },
+});

--- a/packages/varlock-website/src/content/docs/plugins/hashicorp-vault.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/hashicorp-vault.mdx
@@ -241,6 +241,33 @@ API_KEY=
 
 This fetches all keys stored at `secret/myapp/config` and maps them to matching item keys. Only items declared in your schema will be populated; any extra keys in the Vault secret are ignored.
 
+### Exposing the client token
+
+Use `vaultToken()` when another tool needs the same Vault client token the plugin already authenticated with (for example OpenTofu OpenBao state encryption via `BAO_TOKEN`). The resolver returns the token from the active auth method (explicit token, AppRole, JWT/OIDC, or CLI file) and reuses the plugin's cached login instead of authenticating again.
+
+```env-spec title=".env.schema"
+# @plugin(@varlock/hashicorp-vault-plugin@2.0.0)
+# @initHcpVault(
+#   url=$BAO_ADDR,
+#   jwtRole=$VAULT_ROLE,
+#   jwtAuthPath="gitlab",
+#   oidcToken=$GITLAB_OIDC
+# )
+# ---
+
+# @sensitive
+BAO_TOKEN=vaultToken()
+
+# @sensitive
+BAO_TOKEN_PROD=vaultToken(prod)
+```
+
+Mark the item `@sensitive`. If you also use `@type=vaultToken`, set `@internal=false` so the value is injected for consumers (the type defaults to `@internal`).
+
+Prefer a consumer-specific name like `BAO_TOKEN` over `VAULT_TOKEN` when `VAULT_TOKEN` is already an input to `@initHcpVault(token=$VAULT_TOKEN)`, which would create a dependency cycle.
+
+With multiple instances, pass the instance id: `vaultToken(prod)`.
+
 ---
 
 ## Vault Setup
@@ -426,6 +453,28 @@ DB_CONFIG=vaultSecret("secret/db/config", raw=true)
 # With instance ID
 PROD_SECRET=vaultSecret(prod, "secret/api/keys")
 ```
+</div>
+
+<div>
+#### `vaultToken()`
+
+Returns the Vault client token for an initialized plugin instance. Useful when another tool (for example OpenTofu OpenBao state encryption) needs the same short-lived credential the plugin already obtained.
+
+Always treated as sensitive. Reuses the plugin's existing auth cache (explicit token, AppRole, JWT/OIDC, or CLI file) instead of logging in again.
+
+**Array args:**
+- `instanceId` (optional): instance identifier when multiple plugin instances are initialized
+
+```env-spec /vaultToken\\(.*\\)/
+# @sensitive
+BAO_TOKEN=vaultToken()
+
+# With instance ID
+# @sensitive
+BAO_TOKEN_PROD=vaultToken(prod)
+```
+
+If you use `@type=vaultToken`, also set `@internal=false` so the value is injected. Do not assign `vaultToken()` to `VAULT_TOKEN` when that same item is passed as `@initHcpVault(token=$VAULT_TOKEN)` (dependency cycle). Prefer a consumer-specific name such as `BAO_TOKEN`.
 </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Add `vaultToken()` / `vaultToken(id)` to the HashiCorp Vault plugin so callers can reuse the authenticated client token (explicit, AppRole, JWT/OIDC, or CLI file) without a second login
- Always treats the result as sensitive; docs cover the OpenTofu/`BAO_TOKEN` use case and the `VAULT_TOKEN` dependency-cycle pitfall
- Closes #926

## Test plan
- [ ] `bun run --filter @varlock/hashicorp-vault-plugin build && bun run --filter @varlock/hashicorp-vault-plugin test -- --run`
- [ ] Confirm `BAO_TOKEN=vaultToken()` resolves after JWT/AppRole auth and reuses a single login
- [ ] Confirm `vaultToken(prod)` selects a named instance
- [ ] Confirm unknown/missing instance fails clearly