### PR TITLE
Add `varlock flatten` command for monorepo Docker builds

### DIFF
--- a/.bumpy/distroless-plugin-install.md
+++ b/.bumpy/distroless-plugin-install.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+plugin auto-install now works in shell-less/distroless images (extracts tarballs natively instead of shelling out to `tar`)

--- a/.bumpy/distroless-plugin-install.md
+++ b/.bumpy/distroless-plugin-install.md
@@ -2,4 +2,4 @@
 varlock: patch
 ---
 
-plugin auto-install now works in shell-less/distroless images (extracts tarballs natively instead of shelling out to `tar`)
+plugins now work in shell-less/distroless images: tarballs extract natively (no `tar`/shell dependency), and `varlock flatten --vendor-plugins` downloads plugins into the output for a fully self-contained artifact

--- a/.bumpy/distroless-plugin-install.md
+++ b/.bumpy/distroless-plugin-install.md
@@ -2,4 +2,4 @@
 varlock: patch
 ---
 
-plugins now work in shell-less/distroless images: tarballs extract natively (no `tar`/shell dependency), and `varlock flatten --vendor-plugins` downloads plugins into the output for a fully self-contained artifact
+plugins now work in shell-less/distroless images: tarballs extract natively (no `tar`/shell dependency), and `varlock flatten --vendor-plugins` copies plugins into the output for a fully self-contained artifact

--- a/.bumpy/flatten-command.md
+++ b/.bumpy/flatten-command.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+New `varlock flatten` command: collapses the @import graph into a self-contained directory (rewriting import paths, pinning plugin versions) so a single package can be deployed without the rest of the monorepo, e.g. in Docker builds

--- a/packages/varlock-website/src/content/docs/guides/docker.mdx
+++ b/packages/varlock-website/src/content/docs/guides/docker.mdx
@@ -316,6 +316,26 @@ DATABASE_URL=op(op://prod/db/connection-string) # @sensitive
 
 In **Node-based images** where varlock is an npm dependency, install plugins in `package.json` and reference them without a version (or with a range for validation only). See the [Plugins guide](/guides/plugins/#plugin-installation) for details.
 
+### Distroless and shell-less base images
+
+Auto-install works in minimal base images (Google distroless, `scratch`-based, etc.) that have no shell and no `tar` binary. The standalone binary downloads and extracts pinned plugin versions itself, so official `@varlock/*` plugins resolve at runtime with no extra setup.
+
+Two things still need a shell or a pre-cache step somewhere in the build:
+
+- **Third-party (non-`@varlock`) plugins** require a one-time trust confirmation, which needs an interactive terminal. In a non-interactive build, pre-cache them in a stage that has a shell and copy the cache across. Pin the cache location with `XDG_CONFIG_HOME` so both stages agree:
+
+  ```dockerfile title="Dockerfile (excerpt)"
+  ENV XDG_CONFIG_HOME=/varlock-config
+
+  # builder stage: pre-cache the plugin into $XDG_CONFIG_HOME/varlock/plugins-cache
+  RUN varlock install-plugin my-plugin@1.2.3
+
+  # final stage: reuse the populated cache (set the same XDG_CONFIG_HOME here too)
+  COPY --from=builder /varlock-config /varlock-config
+  ```
+
+- **Offline / air-gapped images** with no npm access: pre-cache the same way, since auto-install fetches from the npm registry at runtime.
+
 :::caution[Plugin cache in CI/containers]
 Ephemeral containers often run in memory cache mode. If your job invokes varlock multiple times and plugin fetches are slow, set [`_VARLOCK_CACHE_KEY`](/guides/caching/#disk-caching-in-ci-with-_varlock_cache_key) as a CI secret. See the [Caching guide](/guides/caching/) for details.
 :::

--- a/packages/varlock-website/src/content/docs/guides/docker.mdx
+++ b/packages/varlock-website/src/content/docs/guides/docker.mdx
@@ -237,9 +237,48 @@ In a monorepo, `.env.schema` often uses [`@import()`](/guides/import/) to pull s
 
 When Docker's build context is limited to `apps/web/`, those imported files are **not** in the context, so `varlock load` fails with missing file errors.
 
-### Workaround: copy imported files explicitly
+### `varlock flatten`
 
-Until a dedicated **`varlock flatten`** command ships (to inline the import graph into a local directory for Docker builds), copy every file the import graph needs:
+[`varlock flatten`](/reference/cli-commands/#flatten) collapses the whole import graph into one self-contained directory (default `.env-flat/`) and rewrites the `@import` paths, so the package's env files no longer reach outside the package:
+
+```bash
+cd apps/web && varlock flatten
+```
+
+The output directory contains rewritten copies of the package's own env files at its root, plus everything they import mirrored under `.env-imports/`. It is position-independent: copy its **contents** over your app directory (replacing the originals, whose imports still point outside) and `varlock load` / `varlock run` work with nothing else present.
+
+The most common flow runs `flatten` in the **builder stage** of a multi-stage build, while the full monorepo is still around, then overlays the output in the final stage:
+
+```dockerfile title="Dockerfile: multi-stage with flatten"
+# builder stage has the full monorepo
+FROM node:22-slim AS builder
+WORKDIR /repo
+COPY . .
+RUN npm install
+RUN cd apps/web && npx varlock flatten
+RUN cd apps/web && npm run build
+
+FROM node:22-slim
+COPY --from=ghcr.io/dmno-dev/varlock:1.6.0 /usr/local/bin/varlock /usr/local/bin/varlock
+WORKDIR /app
+COPY --from=builder /repo/apps/web /app
+# overlay the flattened env files over the originals
+COPY --from=builder /repo/apps/web/.env-flat/ /app/
+ENTRYPOINT ["varlock", "run", "--"]
+CMD ["node", "dist/server.js"]
+```
+
+You can also run `flatten` on the host or in CI before `docker build`, when the build context is limited to the package directory. It never resolves values or executes plugins, so it needs no secrets wherever it runs. Add the output directory to `.gitignore` (and make sure `.dockerignore` does not exclude it).
+
+A few behaviors worth knowing (see the [command reference](/reference/cli-commands/#flatten) for the full list):
+
+- `.env.local` / `.env.[env].local` files are **skipped by default**, so machine-local secrets don't end up in image layers. Use `--include-local` if you really want them.
+- Conditionally-enabled imports (`enabled=`) are copied too, with their conditions preserved, since production may enable imports your build machine doesn't.
+- `@plugin()` declarations in copied files get pinned to the installed version, so the standalone binary can [auto-install them](/guides/plugins/) in the container without the sibling package's `node_modules`.
+
+### Alternative: copy imported files explicitly
+
+If you prefer not to add a build step, copy every file the import graph needs:
 
 ```dockerfile title="Dockerfile: monorepo env files"
 # Build from repo root: docker build -f apps/web/Dockerfile .
@@ -255,10 +294,6 @@ RUN varlock load
 ```
 
 Alternatively, set the build context to the **monorepo root** and use `docker build -f apps/web/Dockerfile .` so all import paths resolve naturally, at the cost of a larger context and slower builds.
-
-:::note[Coming soon]
-A planned `varlock flatten` command will automate inlining imported env files for Docker builds. Until then, explicit `COPY` lines or a root build context are the supported approaches.
-:::
 
 ## Plugins in containers
 
@@ -403,7 +438,7 @@ For cloud deployments, prefer [service account tokens](/guides/plugins/) or [OID
 
 ### Missing `@import` files
 
-See [Monorepos and partial build context](#monorepos-and-partial-build-context). The error usually lists a path outside your Docker build context. Add explicit `COPY` instructions or widen the context to the monorepo root.
+See [Monorepos and partial build context](#monorepos-and-partial-build-context). The error usually lists a path outside your Docker build context. Run [`varlock flatten`](/reference/cli-commands/#flatten) while the full monorepo is available, add explicit `COPY` instructions, or widen the context to the monorepo root.
 
 ### Wrong environment loaded
 

--- a/packages/varlock-website/src/content/docs/guides/docker.mdx
+++ b/packages/varlock-website/src/content/docs/guides/docker.mdx
@@ -320,21 +320,35 @@ In **Node-based images** where varlock is an npm dependency, install plugins in 
 
 Auto-install works in minimal base images (Google distroless, `scratch`-based, etc.) that have no shell and no `tar` binary. The standalone binary downloads and extracts pinned plugin versions itself, so official `@varlock/*` plugins resolve at runtime with no extra setup.
 
-Two things still need a shell or a pre-cache step somewhere in the build:
+Runtime auto-install still has two limits: **third-party (non-`@varlock`) plugins** need a one-time trust confirmation (an interactive terminal), and any auto-install needs **network access to npm** at container start. For a fully self-contained image that has neither, vendor the plugins at build time.
 
-- **Third-party (non-`@varlock`) plugins** require a one-time trust confirmation, which needs an interactive terminal. In a non-interactive build, pre-cache them in a stage that has a shell and copy the cache across. Pin the cache location with `XDG_CONFIG_HOME` so both stages agree:
+#### Vendor plugins with `flatten --vendor-plugins` (recommended)
 
-  ```dockerfile title="Dockerfile (excerpt)"
-  ENV XDG_CONFIG_HOME=/varlock-config
+If you already use [`varlock flatten`](/reference/cli-commands/#flatten) for a monorepo build, add `--vendor-plugins`. It copies each `@plugin()` package into the output (`.env-plugins/`) and rewrites the declarations to local paths. Plugins already in your `node_modules` are copied directly (no network); anything not installed is downloaded. The flattened directory then resolves with **no runtime npm fetch, no shell, and no trust prompt**:
 
-  # builder stage: pre-cache the plugin into $XDG_CONFIG_HOME/varlock/plugins-cache
-  RUN varlock install-plugin my-plugin@1.2.3
+```dockerfile title="Dockerfile (excerpt)"
+# builder stage (has the full monorepo + network)
+RUN cd packages/api && varlock flatten --vendor-plugins
 
-  # final stage: reuse the populated cache (set the same XDG_CONFIG_HOME here too)
-  COPY --from=builder /varlock-config /varlock-config
-  ```
+# final distroless stage
+COPY --from=builder /repo/packages/api/.env-flat/ /app/
+```
 
-- **Offline / air-gapped images** with no npm access: pre-cache the same way, since auto-install fetches from the npm registry at runtime.
+This is the most complete option: it covers third-party plugins and offline runtimes, which runtime auto-install cannot.
+
+#### Or pre-cache with `install-plugin`
+
+Without flatten, pre-cache plugins in a stage that has a shell and copy the cache across. Pin the cache location with `XDG_CONFIG_HOME` so both stages agree:
+
+```dockerfile title="Dockerfile (excerpt)"
+ENV XDG_CONFIG_HOME=/varlock-config
+
+# builder stage: pre-cache the plugin into $XDG_CONFIG_HOME/varlock/plugins-cache
+RUN varlock install-plugin my-plugin@1.2.3
+
+# final stage: reuse the populated cache (set the same XDG_CONFIG_HOME here too)
+COPY --from=builder /varlock-config /varlock-config
+```
 
 :::caution[Plugin cache in CI/containers]
 Ephemeral containers often run in memory cache mode. If your job invokes varlock multiple times and plugin fetches are slow, set [`_VARLOCK_CACHE_KEY`](/guides/caching/#disk-caching-in-ci-with-_varlock_cache_key) as a CI secret. See the [Caching guide](/guides/caching/) for details.

--- a/packages/varlock-website/src/content/docs/guides/monorepos.mdx
+++ b/packages/varlock-website/src/content/docs/guides/monorepos.mdx
@@ -137,4 +137,4 @@ Container images often copy a single app directory, not the whole monorepo. If y
 
 The [Docker guide](/guides/docker/) covers the official image, multi-stage copies of the varlock binary, and running `varlock run` as your container entrypoint.
 
-Today you may need to copy imported env files explicitly in your Dockerfile (mirroring the import tree). A planned **`varlock flatten`** command will collapse an import graph into local files for slim Docker contexts. See the [Docker guide](/guides/docker/#monorepos-and-partial-build-context).
+Run [`varlock flatten`](/reference/cli-commands/#flatten) while the full monorepo is available (e.g. in the builder stage of a multi-stage build) to collapse the import graph into a self-contained directory that travels with the package. See the [Docker guide](/guides/docker/#monorepos-and-partial-build-context) for the full workflow.

--- a/packages/varlock-website/src/content/docs/guides/plugins.mdx
+++ b/packages/varlock-website/src/content/docs/guides/plugins.mdx
@@ -53,10 +53,19 @@ When using the standalone binary (no `package.json` present), you must specify a
 When downloading a third-party (non-`@varlock/*`) plugin for the first time, Varlock will prompt you to confirm before downloading. Once confirmed and cached, subsequent runs will not re-prompt. You can also install the plugin via your `package.json` to skip the prompt entirely.
 :::
 
+### Local plugins
+
+You can point `@plugin()` at a local path instead of an npm package, either a single file or a package directory:
+
+```env-spec title=".env.schema"
+# @plugin(./my-plugin.js)   # single file
+# @plugin(../shared/plugin/) # package directory (trailing slash)
+```
+
+Local plugins must be **self-contained**: a single built file, or a package that bundles its dependencies. Varlock loads a plugin from its file directly and does not install anything for it, so a plugin that relies on separate `node_modules` dependencies will fail to load once it is moved away from where those dependencies live (for example in a compiled binary, or in the output of [`varlock flatten`](/reference/cli-commands/#flatten)). If you author a plugin with dependencies, bundle it into a single file first. The official `@varlock/*` plugins are each a single bundled file.
+
 {/*
 INFO TO ADD LATER
-- local single file
-- local path (monorepo)
 - https url
 - git
 - generic npm/jsr

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -679,6 +679,41 @@ varlock codegen -p ./envs -p ./overrides
 </div>
 
 <div>
+### `varlock flatten` ||flatten||
+
+Copies every env file reachable via [`@import()`](/guides/import/) into one self-contained directory and rewrites the `@import` paths. Use it when only part of a monorepo is available at runtime, most commonly the final stage of a Docker build. See [the Docker guide](/guides/docker/#monorepos-and-partial-build-context) for the full workflow.
+
+Values are never resolved and plugins are never executed: this is a purely structural transform, safe to run in CI without secrets.
+
+Details of the transform:
+- Files imported from outside the package are mirrored under `.env-imports/` inside the output directory, preserving their workspace-relative paths, so relative imports between copied files keep working.
+- Imports that are conditionally disabled (via `enabled=`) are still copied, with the condition preserved, since a different environment may enable them at runtime.
+- `.env.local` and `.env.[env].local` files are skipped by default (use `--include-local` to include them).
+- `@plugin()` declarations in copied files get their versions pinned to whatever is currently installed, so varlock can [auto-install them](/guides/plugins/) where the original package's `node_modules` is not available. Plugins declared via a local path are copied into the output.
+- Imports pointing outside the workspace root (including `~/` home-directory imports) are left untouched with a warning.
+
+```bash
+varlock flatten [options]
+```
+
+**Options:**
+- `--out-dir <path>`: Output directory, relative to the current directory (default `.env-flat`)
+- `--include-local`: Include `.env.local` / `.env.*.local` files (excluded by default)
+
+**Examples:**
+```bash
+# Flatten env files from the current directory into .env-flat/
+varlock flatten
+
+# Custom output location
+varlock flatten --out-dir dist/env
+```
+
+The output directory is a generated artifact: add it to `.gitignore`, and rerun `flatten` whenever your env files change.
+
+</div>
+
+<div>
 ### `varlock telemetry` ||telemetry||
 
 Opts in/out of anonymous usage analytics. This command creates/updates a configuration file at `$XDG_CONFIG_HOME/varlock/config.json` (defaults to `~/.config/varlock/config.json`) saving your preference.

--- a/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli-commands.mdx
@@ -683,13 +683,14 @@ varlock codegen -p ./envs -p ./overrides
 
 Copies every env file reachable via [`@import()`](/guides/import/) into one self-contained directory and rewrites the `@import` paths. Use it when only part of a monorepo is available at runtime, most commonly the final stage of a Docker build. See [the Docker guide](/guides/docker/#monorepos-and-partial-build-context) for the full workflow.
 
-Values are never resolved and plugins are never executed: this is a purely structural transform, safe to run in CI without secrets.
+By default, values are never resolved and plugins are never executed: this is a purely structural transform, safe to run in CI without secrets. (`--vendor-plugins` copies plugin code into the output, but still never resolves values.)
 
 Details of the transform:
 - Files imported from outside the package are mirrored under `.env-imports/` inside the output directory, preserving their workspace-relative paths, so relative imports between copied files keep working.
 - Imports that are conditionally disabled (via `enabled=`) are still copied, with the condition preserved, since a different environment may enable them at runtime.
 - `.env.local` and `.env.[env].local` files are skipped by default (use `--include-local` to include them).
 - `@plugin()` declarations in copied files get their versions pinned to whatever is currently installed, so varlock can [auto-install them](/guides/plugins/) where the original package's `node_modules` is not available. Plugins declared via a local path are copied into the output.
+- With `--vendor-plugins`, npm `@plugin()` packages are copied into `.env-plugins/` (from your `node_modules`, downloading only any that are not installed) and the declarations are rewritten to local paths, so the output resolves with no runtime install. This is the way to run plugins in shell-less, offline, or distroless images. See [plugins in containers](/guides/docker/#distroless-and-shell-less-base-images).
 - Imports pointing outside the workspace root (including `~/` home-directory imports) are left untouched with a warning.
 
 ```bash
@@ -699,6 +700,7 @@ varlock flatten [options]
 **Options:**
 - `--out-dir <path>`: Output directory, relative to the current directory (default `.env-flat`)
 - `--include-local`: Include `.env.local` / `.env.*.local` files (excluded by default)
+- `--vendor-plugins`: Copy npm plugins into the output so no runtime install is needed. Uses the copy in your `node_modules`, downloading only any that are not installed
 
 **Examples:**
 ```bash
@@ -707,6 +709,9 @@ varlock flatten
 
 # Custom output location
 varlock flatten --out-dir dist/env
+
+# Also vendor plugins for a self-contained, distroless-ready output
+varlock flatten --vendor-plugins
 ```
 
 The output directory is a generated artifact: add it to `.gitignore`, and rerun `flatten` whenever your env files change.

--- a/packages/varlock/src/cli/cli-executable.ts
+++ b/packages/varlock/src/cli/cli-executable.ts
@@ -26,6 +26,7 @@ import { commandSpec as revealCommandSpec } from './commands/reveal.command';
 import { commandSpec as helpCommandSpec } from './commands/help.command';
 import { commandSpec as telemetryCommandSpec } from './commands/telemetry.command';
 import { commandSpec as explainCommandSpec } from './commands/explain.command';
+import { commandSpec as flattenCommandSpec } from './commands/flatten.command';
 import { commandSpec as scanCommandSpec } from './commands/scan.command';
 import { commandSpec as codegenCommandSpec } from './commands/codegen.command';
 import { commandSpec as typegenCommandSpec } from './commands/typegen.command';
@@ -70,6 +71,7 @@ subCommands.set('lock', buildLazyCommand(lockCommandSpec, async () => await impo
 subCommands.set('reveal', buildLazyCommand(revealCommandSpec, async () => await import('./commands/reveal.command')));
 // subCommands.set('doctor', buildLazyCommand(doctorCommandSpec, async () => await import('./commands/doctor.command')));
 subCommands.set('explain', buildLazyCommand(explainCommandSpec, async () => await import('./commands/explain.command')));
+subCommands.set('flatten', buildLazyCommand(flattenCommandSpec, async () => await import('./commands/flatten.command')));
 subCommands.set('help', buildLazyCommand(helpCommandSpec, async () => await import('./commands/help.command')));
 subCommands.set('telemetry', buildLazyCommand(telemetryCommandSpec, async () => await import('./commands/telemetry.command')));
 subCommands.set('scan', buildLazyCommand(scanCommandSpec, async () => await import('./commands/scan.command')));

--- a/packages/varlock/src/cli/commands/flatten.command.ts
+++ b/packages/varlock/src/cli/commands/flatten.command.ts
@@ -1,0 +1,95 @@
+import { define } from 'gunshi';
+import path from 'node:path';
+import ansis from 'ansis';
+
+import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
+import { CliExitError } from '../helpers/exit-error';
+import { flattenEnvFiles, FlattenError } from '../../lib/flatten';
+import { detectWorkspaceInfo } from '../../lib/workspace-utils';
+
+export const commandSpec = define({
+  name: 'flatten',
+  description: 'Copy env files imported from outside this package into a self-contained directory, rewriting @import paths',
+  args: {
+    'out-dir': {
+      type: 'string',
+      description: 'Output directory (relative to cwd unless absolute)',
+      default: '.env-flat',
+    },
+    'include-local': {
+      type: 'boolean',
+      description: 'Include .env.local / .env.*.local files (excluded by default)',
+      default: false,
+    },
+  },
+  examples: `
+In a monorepo, a package's env files may @import files from sibling packages or the
+workspace root. Those files are not available in contexts where only the package itself
+is present, like the final stage of a Docker build.
+
+\`varlock flatten\` copies everything reachable via @import into one self-contained
+directory and rewrites the @import paths, so that directory can travel with the package.
+Values are never resolved - this is a purely structural transform, safe to run in CI.
+
+Examples:
+  varlock flatten                    # flatten env files from the current directory into .env-flat/
+  varlock flatten --out-dir dist/env # custom output location
+  varlock flatten --include-local    # also include .env.local files (careful - these often hold secrets)
+
+Typical Dockerfile usage (builder stage has the full monorepo):
+  RUN cd packages/api && varlock flatten
+  # final stage:
+  COPY --from=builder /repo/packages/api /app
+  COPY --from=builder /repo/packages/api/.env-flat/ /app/
+`.trim(),
+});
+
+export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
+  const packageDir = process.cwd();
+  const workspaceInfo = detectWorkspaceInfo({ cwd: packageDir });
+  const workspaceRootPath = workspaceInfo?.rootPath || packageDir;
+
+  if (!workspaceInfo) {
+    console.log(ansis.yellow('No workspace root detected (no lockfile found) - imports reaching outside the current directory cannot be flattened'));
+  }
+
+  let result;
+  try {
+    result = await flattenEnvFiles({
+      packageDir,
+      workspaceRootPath,
+      outDir: String(ctx.values['out-dir']),
+      includeLocal: !!ctx.values['include-local'],
+    });
+  } catch (err) {
+    if (err instanceof FlattenError) throw new CliExitError(err.message);
+    throw err;
+  }
+
+  const relOutDir = path.relative(packageDir, result.outDir) || '.';
+
+  console.log(`Flattened ${result.copiedFiles.length} file${result.copiedFiles.length === 1 ? '' : 's'} into ${ansis.bold(relOutDir)}/`);
+  for (const { src } of result.copiedFiles) {
+    console.log(ansis.gray(`  ${path.relative(packageDir, src)}`));
+  }
+
+  if (result.pinnedPlugins.length) {
+    console.log('\nPinned plugin versions (so they can auto-install without the original package present):');
+    for (const p of result.pinnedPlugins) {
+      console.log(ansis.gray(`  ${p.moduleName}@${p.version}`));
+    }
+  }
+
+  if (result.skippedLocalFiles.length) {
+    console.log(`\nSkipped ${result.skippedLocalFiles.length} local env file${result.skippedLocalFiles.length === 1 ? '' : 's'} (use --include-local to include)`);
+  }
+
+  if (result.warnings.length) {
+    console.log('');
+    for (const warning of result.warnings) {
+      console.log(`${ansis.yellow('⚠')} ${warning}`);
+    }
+  }
+
+  console.log(ansis.gray(`\nAdd ${relOutDir}/ to your .gitignore - it is a generated artifact.`));
+};

--- a/packages/varlock/src/cli/commands/flatten.command.ts
+++ b/packages/varlock/src/cli/commands/flatten.command.ts
@@ -21,6 +21,11 @@ export const commandSpec = define({
       description: 'Include .env.local / .env.*.local files (excluded by default)',
       default: false,
     },
+    'vendor-plugins': {
+      type: 'boolean',
+      description: 'Copy npm plugins into the output so no runtime install is needed (for shell-less/offline/distroless runtimes). Uses the installed copy, downloading only if absent',
+      default: false,
+    },
   },
   examples: `
 In a monorepo, a package's env files may @import files from sibling packages or the
@@ -35,6 +40,7 @@ Examples:
   varlock flatten                    # flatten env files from the current directory into .env-flat/
   varlock flatten --out-dir dist/env # custom output location
   varlock flatten --include-local    # also include .env.local files (careful - these often hold secrets)
+  varlock flatten --vendor-plugins   # also download npm plugins into the output (self-contained, no runtime install)
 
 Typical Dockerfile usage (builder stage has the full monorepo):
   RUN cd packages/api && varlock flatten
@@ -60,6 +66,7 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
       workspaceRootPath,
       outDir: String(ctx.values['out-dir']),
       includeLocal: !!ctx.values['include-local'],
+      vendorPlugins: !!ctx.values['vendor-plugins'],
     });
   } catch (err) {
     if (err instanceof FlattenError) throw new CliExitError(err.message);
@@ -76,6 +83,13 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   if (result.pinnedPlugins.length) {
     console.log('\nPinned plugin versions (so they can auto-install without the original package present):');
     for (const p of result.pinnedPlugins) {
+      console.log(ansis.gray(`  ${p.moduleName}@${p.version}`));
+    }
+  }
+
+  if (result.vendoredPlugins.length) {
+    console.log(`\nVendored ${result.vendoredPlugins.length} plugin${result.vendoredPlugins.length === 1 ? '' : 's'} into ${ansis.bold(`${relOutDir}/.env-plugins`)}/ (no runtime install needed):`);
+    for (const p of result.vendoredPlugins) {
       console.log(ansis.gray(`  ${p.moduleName}@${p.version}`));
     }
   }

--- a/packages/varlock/src/cli/commands/flatten.command.ts
+++ b/packages/varlock/src/cli/commands/flatten.command.ts
@@ -40,7 +40,7 @@ Examples:
   varlock flatten                    # flatten env files from the current directory into .env-flat/
   varlock flatten --out-dir dist/env # custom output location
   varlock flatten --include-local    # also include .env.local files (careful - these often hold secrets)
-  varlock flatten --vendor-plugins   # also download npm plugins into the output (self-contained, no runtime install)
+  varlock flatten --vendor-plugins   # also copy npm plugins into the output (self-contained, no runtime install)
 
 Typical Dockerfile usage (builder stage has the full monorepo):
   RUN cd packages/api && varlock flatten

--- a/packages/varlock/src/env-graph/lib/plugins.ts
+++ b/packages/varlock/src/env-graph/lib/plugins.ts
@@ -1,9 +1,7 @@
 /// <reference path="../../globals.d.ts" />
 import path from 'node:path';
-import { exec as execCb } from 'node:child_process';
 import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
-import { promisify } from 'node:util';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import crypto from 'node:crypto';
@@ -20,6 +18,7 @@ import type { CacheStoreLike } from '../../lib/cache/cache-store';
 import { parseTtl } from '../../lib/cache/ttl-parser';
 import { resolveCacheTtl } from '../../lib/cache/resolve-cache-ttl';
 import { confirm } from '../../cli/helpers/prompts';
+import { extractTarball } from '../../lib/extract-tarball';
 
 
 import { FileBasedDataSource, type EnvGraphDataSource } from './data-source';
@@ -551,7 +550,6 @@ async function isPluginCached(url: string): Promise<boolean> {
 }
 
 async function downloadPlugin(url: string) {
-  const exec = promisify(execCb);
   const cacheDir = path.join(getUserVarlockDir(), 'plugins-cache');
   const indexPath = path.join(cacheDir, 'index.json');
   await fs.mkdir(cacheDir, { recursive: true });
@@ -588,10 +586,12 @@ async function downloadPlugin(url: string) {
     }).on('error', reject);
   });
 
-  // Extract tgz to a temp folder
+  // Extract tgz to a temp folder. We extract natively (zlib + a small tar
+  // reader) rather than shelling out to `tar`, so plugin auto-install works in
+  // minimal/distroless images that have neither a shell nor a `tar` binary.
   const tmpExtractDir = path.join(cacheDir, `tmp-extract-${crypto.randomBytes(8).toString('hex')}`);
   await fs.mkdir(tmpExtractDir);
-  await exec(`tar -xzf ${tmpTgz} -C ${tmpExtractDir}`);
+  await extractTarball(tmpTgz, tmpExtractDir);
 
   // Find package.json (assume in package/ or root)
   let pkgJsonPath = path.join(tmpExtractDir, 'package', 'package.json');

--- a/packages/varlock/src/lib/extract-tarball.ts
+++ b/packages/varlock/src/lib/extract-tarball.ts
@@ -1,0 +1,158 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import zlib from 'node:zlib';
+
+/**
+ * Native extraction of a gzipped tarball (`.tgz`), with no dependency on a
+ * `tar` binary or a shell to spawn one.
+ *
+ * This exists so plugin auto-install works in minimal/distroless container
+ * images that ship neither `/bin/sh` nor `tar`. `node:zlib` is available in
+ * both Node and Bun (including the compiled SEA binary), so this runs
+ * everywhere varlock does.
+ *
+ * We only support the subset of the tar format that npm-published tarballs
+ * actually use: regular files and directories, plus PAX / GNU long-name
+ * extended headers so deeply-nested paths still extract correctly. Symlinks,
+ * hardlinks, and device nodes are skipped.
+ */
+
+const BLOCK_SIZE = 512;
+
+/** Read a NUL-terminated (or field-length-bounded) ASCII string from a header field. */
+function readString(block: Buffer, offset: number, length: number): string {
+  const raw = block.subarray(offset, offset + length);
+  const nul = raw.indexOf(0);
+  return raw.toString('utf-8', 0, nul === -1 ? length : nul);
+}
+
+/**
+ * Read a tar numeric field. Standard tar stores these as NUL/space-terminated
+ * octal ASCII. GNU tar uses base-256 (high bit of the first byte set) for
+ * values too large for the octal field; we handle that too, just in case.
+ */
+function readNumeric(block: Buffer, offset: number, length: number): number {
+  const first = block[offset];
+  if (first >= 0x80) {
+    // GNU base-256 encoding: high bit of the first byte is a flag, not a value bit
+    let value = first - 0x80;
+    for (let i = 1; i < length; i++) {
+      value = (value * 256) + block[offset + i];
+    }
+    return value;
+  }
+  const str = readString(block, offset, length).trim();
+  if (!str) return 0;
+  const parsed = parseInt(str, 8);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+/** Parse PAX extended-header records ("<len> key=value\n") into a key/value map. */
+function parsePaxRecords(data: Buffer): Record<string, string> {
+  const records: Record<string, string> = {};
+  let pos = 0;
+  const text = data.toString('utf-8');
+  while (pos < text.length) {
+    const spaceIdx = text.indexOf(' ', pos);
+    if (spaceIdx === -1) break;
+    const len = parseInt(text.slice(pos, spaceIdx), 10);
+    if (Number.isNaN(len) || len <= 0) break;
+    const record = text.slice(spaceIdx + 1, pos + len - 1); // drop trailing "\n"
+    const eq = record.indexOf('=');
+    if (eq !== -1) {
+      records[record.slice(0, eq)] = record.slice(eq + 1);
+    }
+    pos += len;
+  }
+  return records;
+}
+
+/**
+ * Resolve an entry path against the destination directory, refusing anything
+ * that would escape it (absolute paths, `..` traversal). Mirrors what `tar`
+ * does by default and blocks tarball path-traversal attacks.
+ */
+function safeJoin(destDir: string, entryName: string): string | undefined {
+  // strip a leading slash the way tar does, then normalize
+  const normalized = entryName.replace(/^\/+/, '');
+  const target = path.resolve(destDir, normalized);
+  const rel = path.relative(destDir, target);
+  if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) return undefined;
+  return target;
+}
+
+/** Extract a gzipped tar buffer into `destDir`. */
+export async function extractTarballBuffer(tgzBuffer: Buffer, destDir: string): Promise<void> {
+  const buf = zlib.gunzipSync(tgzBuffer);
+
+  await fs.mkdir(destDir, { recursive: true });
+
+  // overrides carried from a preceding PAX / GNU long-name header to the next entry
+  let nextPath: string | undefined;
+  let nextSize: number | undefined;
+
+  let offset = 0;
+  while (offset + BLOCK_SIZE <= buf.length) {
+    const header = buf.subarray(offset, offset + BLOCK_SIZE);
+
+    // two consecutive zero blocks mark end-of-archive; a single one is enough to stop
+    if (header.every((b) => b === 0)) break;
+
+    offset += BLOCK_SIZE;
+
+    const rawName = readString(header, 0, 100);
+    const size = readNumeric(header, 124, 12);
+    const typeflag = header[156] === 0 ? '0' : String.fromCharCode(header[156]);
+    const prefix = readString(header, 345, 155);
+
+    const dataStart = offset;
+    const dataEnd = dataStart + size;
+    // advance past the data, rounded up to the next block boundary
+    offset += Math.ceil(size / BLOCK_SIZE) * BLOCK_SIZE;
+
+    // PAX extended header (per-file 'x' or global 'g') — records apply to the next entry
+    if (typeflag === 'x' || typeflag === 'g') {
+      const records = parsePaxRecords(buf.subarray(dataStart, dataEnd));
+      if (records.path !== undefined) nextPath = records.path;
+      if (records.size !== undefined) nextSize = parseInt(records.size, 10);
+      continue;
+    }
+
+    // GNU long name / long link — data holds the full path for the next entry
+    if (typeflag === 'L') {
+      nextPath = buf.subarray(dataStart, dataEnd).toString('utf-8').replace(/\0+$/, '');
+      continue;
+    }
+    if (typeflag === 'K') {
+      continue; // long linkname — only relevant to links, which we skip anyway
+    }
+
+    const entryName = nextPath ?? (prefix ? `${prefix}/${rawName}` : rawName);
+    const entrySize = nextSize ?? size;
+    nextPath = undefined;
+    nextSize = undefined;
+
+    if (!entryName) continue;
+
+    // directory
+    if (typeflag === '5' || entryName.endsWith('/')) {
+      const dir = safeJoin(destDir, entryName);
+      if (dir) await fs.mkdir(dir, { recursive: true });
+      continue;
+    }
+
+    // regular file ('0' or legacy '\0'); skip links/devices/etc.
+    if (typeflag === '0' || typeflag === '7') {
+      const target = safeJoin(destDir, entryName);
+      if (!target) continue; // refuse path traversal
+      await fs.mkdir(path.dirname(target), { recursive: true });
+      await fs.writeFile(target, buf.subarray(dataStart, dataStart + entrySize));
+    }
+  }
+}
+
+/** Extract a gzipped tarball file at `tgzPath` into `destDir`. */
+export async function extractTarball(tgzPath: string, destDir: string): Promise<void> {
+  const tgzBuffer = await fs.readFile(tgzPath);
+  await extractTarballBuffer(tgzBuffer, destDir);
+}

--- a/packages/varlock/src/lib/extract-tarball.ts
+++ b/packages/varlock/src/lib/extract-tarball.ts
@@ -110,7 +110,7 @@ export async function extractTarballBuffer(tgzBuffer: Buffer, destDir: string): 
     // advance past the data, rounded up to the next block boundary
     offset += Math.ceil(size / BLOCK_SIZE) * BLOCK_SIZE;
 
-    // PAX extended header (per-file 'x' or global 'g') — records apply to the next entry
+    // PAX extended header (per-file 'x' or global 'g') - records apply to the next entry
     if (typeflag === 'x' || typeflag === 'g') {
       const records = parsePaxRecords(buf.subarray(dataStart, dataEnd));
       if (records.path !== undefined) nextPath = records.path;
@@ -118,13 +118,13 @@ export async function extractTarballBuffer(tgzBuffer: Buffer, destDir: string): 
       continue;
     }
 
-    // GNU long name / long link — data holds the full path for the next entry
+    // GNU long name / long link - data holds the full path for the next entry
     if (typeflag === 'L') {
       nextPath = buf.subarray(dataStart, dataEnd).toString('utf-8').replace(/\0+$/, '');
       continue;
     }
     if (typeflag === 'K') {
-      continue; // long linkname — only relevant to links, which we skip anyway
+      continue; // long linkname - only relevant to links, which we skip anyway
     }
 
     const entryName = nextPath ?? (prefix ? `${prefix}/${rawName}` : rawName);

--- a/packages/varlock/src/lib/flatten.ts
+++ b/packages/varlock/src/lib/flatten.ts
@@ -1,0 +1,393 @@
+import fsSync from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import semver from 'semver';
+import {
+  parseEnvSpecDotEnvFile,
+  ParsedEnvSpecFile,
+  ParsedEnvSpecDecorator,
+  ParsedEnvSpecFunctionArgs,
+  ParsedEnvSpecStaticValue,
+  ParsedEnvSpecKeyValuePair,
+} from '@env-spec/parser';
+import { tryCatch } from '@env-spec/utils/try-catch';
+import { pathExists } from '@env-spec/utils/fs-utils';
+
+/**
+ * `varlock flatten` support - copies every env file reachable via @import into a
+ * self-contained output directory and rewrites the @import paths, so a single
+ * package can be deployed (e.g. into a Docker image) without the rest of the
+ * monorepo being present at runtime.
+ *
+ * Layout of the output dir:
+ * - files inside the package keep their package-relative position at the output root
+ * - files outside the package (but inside the workspace) mirror their
+ *   workspace-relative position under `.env-imports/`
+ *
+ * Because both mappings preserve directory structure, relative imports between
+ * two copied files stay valid, and rewrites are simple relative-path math.
+ *
+ * Values are never resolved and plugins are never executed - this is a purely
+ * structural transform. Files that need no rewrites are copied byte-for-byte.
+ */
+
+const IMPORTS_DIR_NAME = '.env-imports';
+
+export class FlattenError extends Error {}
+
+export type FlattenResult = {
+  outDir: string;
+  /** files written to the output dir (absolute src -> absolute dest) */
+  copiedFiles: Array<{ src: string, dest: string }>;
+  /** local (gitignored-style) env files that were skipped */
+  skippedLocalFiles: Array<string>;
+  /** npm plugins that had their version pinned in rewritten files */
+  pinnedPlugins: Array<{ moduleName: string, version: string, filePath: string }>;
+  warnings: Array<string>;
+};
+
+export type FlattenOptions = {
+  /** the package directory whose env files are being flattened (defaults to cwd) */
+  packageDir: string;
+  /** workspace/monorepo root - imports outside of it cannot be flattened */
+  workspaceRootPath: string;
+  /** output directory, relative to packageDir unless absolute (default `.env-flat`) */
+  outDir?: string;
+  /** include .env.local / .env.*.local files (default false - they usually hold machine-local secrets) */
+  includeLocal?: boolean;
+};
+
+function isEnvFileName(name: string) {
+  return name === '.env' || name.startsWith('.env.');
+}
+function isLocalEnvFileName(name: string) {
+  return name === '.env.local' || (name.startsWith('.env.') && name.endsWith('.local'));
+}
+
+/** relative path in posix form (import paths always use forward slashes) */
+function relativeImportPath(fromDir: string, toPath: string) {
+  const rel = path.relative(fromDir, toPath).split(path.sep).join('/');
+  return (rel.startsWith('./') || rel.startsWith('../')) ? rel : `./${rel}`;
+}
+
+function getFnArgs(dec: ParsedEnvSpecDecorator) {
+  if (dec.isBareFnCall && dec.data.value instanceof ParsedEnvSpecFunctionArgs) {
+    return dec.data.value;
+  }
+}
+
+function getStaticKwarg(args: ParsedEnvSpecFunctionArgs, key: string) {
+  for (const val of args.values) {
+    if (val instanceof ParsedEnvSpecKeyValuePair && val.key === key) {
+      if (val.value instanceof ParsedEnvSpecStaticValue) return val.value.value;
+      return undefined; // dynamic (fn call) - value unknown at flatten time
+    }
+  }
+  return undefined;
+}
+
+function makeStaticPathValue(newPath: string, quote?: '"' | "'" | '`') {
+  if (quote) {
+    return new ParsedEnvSpecStaticValue({ rawValue: `${quote}${newPath}${quote}`, quote });
+  }
+  return new ParsedEnvSpecStaticValue({ rawValue: newPath });
+}
+
+/** walk up from `fromDir` (stopping at workspaceRoot) looking for node_modules/<moduleName> */
+async function findInstalledPluginVersion(
+  moduleName: string,
+  fromDir: string,
+  workspaceRootPath: string,
+): Promise<string | undefined> {
+  let currentDir = fromDir;
+  while (currentDir) {
+    const candidatePath = path.join(currentDir, 'node_modules', moduleName, 'package.json');
+    if (await pathExists(candidatePath)) {
+      const packageJson = await tryCatch(
+        async () => JSON.parse(await fs.readFile(candidatePath, 'utf8')),
+        () => undefined,
+      );
+      if (packageJson?.version) return packageJson.version as string;
+    }
+    if (currentDir === workspaceRootPath) break;
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) break;
+    currentDir = parentDir;
+  }
+  return undefined;
+}
+
+export async function flattenEnvFiles(opts: FlattenOptions): Promise<FlattenResult> {
+  const packageDir = path.resolve(opts.packageDir);
+  const workspaceRootPath = path.resolve(opts.workspaceRootPath);
+  const outDir = path.resolve(packageDir, opts.outDir || '.env-flat');
+  const includeLocal = !!opts.includeLocal;
+
+  if (outDir === packageDir || packageDir.startsWith(outDir + path.sep)) {
+    throw new FlattenError('flatten output directory cannot contain the package directory');
+  }
+
+  const result: FlattenResult = {
+    outDir,
+    copiedFiles: [],
+    skippedLocalFiles: [],
+    pinnedPlugins: [],
+    warnings: [],
+  };
+
+  // src abs path -> dest abs path, for everything already handled (also breaks import cycles)
+  const processedFiles = new Map<string, string>();
+  const processedDirs = new Set<string>();
+  // dest -> src, to detect the (unlikely) case of two sources mapping to the same output path
+  const claimedDests = new Map<string, string>();
+
+  function relLabel(absPath: string) {
+    const rel = path.relative(packageDir, absPath);
+    return rel.startsWith('..') ? absPath : rel;
+  }
+
+  /** maps a source path to its output location; undefined = not flattenable (outside the workspace) */
+  function getDestPath(srcAbs: string): string | undefined {
+    const relFromPackage = path.relative(packageDir, srcAbs);
+    if (relFromPackage && !relFromPackage.startsWith('..') && !path.isAbsolute(relFromPackage)) {
+      return path.join(outDir, relFromPackage);
+    }
+    const relFromRoot = path.relative(workspaceRootPath, srcAbs);
+    if (!relFromRoot.startsWith('..') && !path.isAbsolute(relFromRoot)) {
+      return path.join(outDir, IMPORTS_DIR_NAME, relFromRoot);
+    }
+    return undefined;
+  }
+
+  function claimDest(destAbs: string, srcAbs: string) {
+    const existingClaim = claimedDests.get(destAbs);
+    if (existingClaim && existingClaim !== srcAbs) {
+      throw new FlattenError(
+        `flatten output collision: both "${existingClaim}" and "${srcAbs}" map to "${destAbs}"`,
+      );
+    }
+    claimedDests.set(destAbs, srcAbs);
+  }
+
+  /** copy a local-path plugin source (single file or self-contained package dir) into the output */
+  async function copyPluginSource(pluginAbs: string, destAbs: string) {
+    if (processedFiles.has(pluginAbs)) return;
+    processedFiles.set(pluginAbs, destAbs);
+    claimDest(destAbs, pluginAbs);
+    await fs.mkdir(path.dirname(destAbs), { recursive: true });
+    await fs.cp(pluginAbs, destAbs, { recursive: true });
+    result.copiedFiles.push({ src: pluginAbs, dest: destAbs });
+  }
+
+  async function rewriteImportDecorator(
+    dec: ParsedEnvSpecDecorator,
+    srcAbs: string,
+    destAbs: string,
+  ): Promise<boolean> {
+    const args = getFnArgs(dec);
+    if (!args || !args.values.length) return false;
+    const pathArg = args.values[0];
+    // dynamic import paths are a load-time error anyway - nothing to rewrite
+    if (!(pathArg instanceof ParsedEnvSpecStaticValue)) return false;
+    const importPathStr = String(pathArg.value ?? '');
+    if (!importPathStr) return false;
+
+    const isDirImport = importPathStr.endsWith('/');
+
+    let targetAbs: string | undefined;
+    if (importPathStr.startsWith('./') || importPathStr.startsWith('../')) {
+      targetAbs = path.resolve(path.dirname(srcAbs), importPathStr);
+    } else if (importPathStr === '~' || importPathStr.startsWith('~/')) {
+      targetAbs = path.join(os.homedir(), importPathStr.slice(1));
+    } else if (importPathStr.startsWith('/')) {
+      targetAbs = path.resolve(importPathStr);
+    } else {
+      // http(s):// and npm: imports are not supported by the loader yet
+      return false;
+    }
+
+    const target = targetAbs;
+    const destTarget = getDestPath(target);
+    if (!destTarget) {
+      result.warnings.push(
+        `@import(${importPathStr}) in ${relLabel(srcAbs)} points outside the workspace root and was left untouched - it must exist at that same path wherever the flattened output is used`,
+      );
+      return false;
+    }
+
+    const allowMissing = getStaticKwarg(args, 'allowMissing') === true;
+    const fsStat = await tryCatch(async () => fs.stat(target), () => undefined);
+    if (!fsStat) {
+      if (!allowMissing) {
+        result.warnings.push(`@import(${importPathStr}) in ${relLabel(srcAbs)} does not exist - decorator was rewritten but nothing was copied`);
+      }
+    } else if (isDirImport) {
+      // eslint-disable-next-line no-use-before-define
+      if (fsStat.isDirectory()) await processDirectory(target);
+    } else if (fsStat.isFile()) {
+      const fileName = path.basename(target);
+      if (isLocalEnvFileName(fileName) && !includeLocal) {
+        result.skippedLocalFiles.push(target);
+        result.warnings.push(
+          `@import(${importPathStr}) in ${relLabel(srcAbs)} targets a local env file, which is excluded by default (rerun with --include-local to include it)`,
+        );
+      } else {
+        // eslint-disable-next-line no-use-before-define
+        await processEnvFile(target);
+      }
+    }
+
+    let newImportPath = relativeImportPath(path.dirname(destAbs), destTarget);
+    if (isDirImport) newImportPath += '/';
+    if (newImportPath === importPathStr) return false;
+    args.data.values[0] = makeStaticPathValue(newImportPath, pathArg.data.quote);
+    return true;
+  }
+
+  async function rewritePluginDecorator(
+    dec: ParsedEnvSpecDecorator,
+    srcAbs: string,
+    destAbs: string,
+  ): Promise<boolean> {
+    const args = getFnArgs(dec);
+    if (!args || !args.values.length) return false;
+    const sourceArg = args.values[0];
+    if (!(sourceArg instanceof ParsedEnvSpecStaticValue)) return false;
+    const sourceDescriptor = String(sourceArg.value ?? '');
+    if (!sourceDescriptor) return false;
+
+    // local path plugin - copy the source (plugins are self-contained) and rewrite the path
+    if (sourceDescriptor.startsWith('./') || sourceDescriptor.startsWith('../') || sourceDescriptor.startsWith('/')) {
+      const pluginAbs = path.resolve(path.dirname(srcAbs), sourceDescriptor);
+      const destPlugin = getDestPath(pluginAbs);
+      if (!destPlugin) {
+        result.warnings.push(
+          `@plugin(${sourceDescriptor}) in ${relLabel(srcAbs)} points outside the workspace root and was left untouched`,
+        );
+        return false;
+      }
+      if (!(await pathExists(pluginAbs))) {
+        result.warnings.push(`@plugin(${sourceDescriptor}) in ${relLabel(srcAbs)} does not exist - left untouched`);
+        return false;
+      }
+      await copyPluginSource(pluginAbs, destPlugin);
+      const newPluginPath = relativeImportPath(path.dirname(destAbs), destPlugin);
+      if (newPluginPath === sourceDescriptor) return false;
+      args.data.values[0] = makeStaticPathValue(newPluginPath, sourceArg.data.quote);
+      return true;
+    }
+
+    // other protocols are not supported by the plugin loader yet
+    if (/^(https?|npm|jsr|git):/.test(sourceDescriptor)) return false;
+
+    // npm plugin declared in a file that lives inside the package - it resolves from the
+    // package's own node_modules at runtime, so leave it alone
+    const relFromPackage = path.relative(packageDir, srcAbs);
+    if (!relFromPackage.startsWith('..') && !path.isAbsolute(relFromPackage)) return false;
+
+    // npm plugin declared in an imported external file - after flattening it can no longer
+    // resolve from the original package's node_modules, so pin the version that is installed
+    // there now; at runtime varlock can then auto-download it if it is not installed locally
+    const atLocation = sourceDescriptor.indexOf('@', 1);
+    const moduleName = atLocation === -1 ? sourceDescriptor : sourceDescriptor.slice(0, atLocation);
+    const versionDescriptor = atLocation === -1 ? undefined : sourceDescriptor.slice(atLocation + 1);
+    if (versionDescriptor && semver.valid(versionDescriptor)) return false; // already pinned
+
+    const installedVersion = await findInstalledPluginVersion(moduleName, path.dirname(srcAbs), workspaceRootPath);
+    if (!installedVersion) {
+      result.warnings.push(
+        `@plugin(${sourceDescriptor}) in ${relLabel(srcAbs)} could not be resolved to pin a version - install the plugin in this package or pin an exact version manually`,
+      );
+      return false;
+    }
+    if (versionDescriptor && !semver.satisfies(installedVersion, versionDescriptor)) {
+      result.warnings.push(
+        `@plugin(${sourceDescriptor}) in ${relLabel(srcAbs)} - installed version ${installedVersion} does not satisfy the declared range, left untouched`,
+      );
+      return false;
+    }
+    args.data.values[0] = makeStaticPathValue(`${moduleName}@${installedVersion}`, sourceArg.data.quote);
+    result.pinnedPlugins.push({ moduleName, version: installedVersion, filePath: srcAbs });
+    return true;
+  }
+
+  async function processEnvFile(srcAbs: string): Promise<void> {
+    if (processedFiles.has(srcAbs)) return;
+    const destAbs = getDestPath(srcAbs);
+    if (!destAbs) return; // callers only pass mappable paths, but guard anyway
+    processedFiles.set(srcAbs, destAbs); // set before recursing - breaks import cycles
+    claimDest(destAbs, srcAbs);
+
+    const rawContents = await fs.readFile(srcAbs, 'utf8');
+    let parsedFile: ParsedEnvSpecFile | undefined;
+    try {
+      parsedFile = parseEnvSpecDotEnvFile(rawContents);
+    } catch {
+      parsedFile = undefined;
+    }
+
+    let modified = false;
+    if (parsedFile) {
+      // note: root decorators only - @import/@plugin are only valid in the file header
+      for (const dec of parsedFile.decoratorsArray) {
+        if (dec.name === 'import') {
+          modified = (await rewriteImportDecorator(dec, srcAbs, destAbs)) || modified;
+        } else if (dec.name === 'plugin') {
+          modified = (await rewritePluginDecorator(dec, srcAbs, destAbs)) || modified;
+        }
+      }
+    } else {
+      result.warnings.push(`${relLabel(srcAbs)} could not be parsed - copied as-is without processing imports`);
+    }
+
+    await fs.mkdir(path.dirname(destAbs), { recursive: true });
+    if (parsedFile && modified) {
+      let serialized = parsedFile.toString();
+      if (rawContents.endsWith('\n') && !serialized.endsWith('\n')) serialized += '\n';
+      await fs.writeFile(destAbs, serialized, 'utf8');
+    } else {
+      // untouched files are copied byte-for-byte
+      await fs.copyFile(srcAbs, destAbs);
+    }
+    result.copiedFiles.push({ src: srcAbs, dest: destAbs });
+  }
+
+  /** copy all env files in an imported directory (directory imports load top-level .env.* files only) */
+  async function processDirectory(dirAbs: string): Promise<void> {
+    if (processedDirs.has(dirAbs)) return;
+    processedDirs.add(dirAbs);
+    const entries = await fs.readdir(dirAbs, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile() || !isEnvFileName(entry.name)) continue;
+      if (isLocalEnvFileName(entry.name) && !includeLocal) {
+        result.skippedLocalFiles.push(path.join(dirAbs, entry.name));
+        continue;
+      }
+      await processEnvFile(path.join(dirAbs, entry.name));
+    }
+  }
+
+  // start fresh on every run
+  if (fsSync.existsSync(outDir)) {
+    await fs.rm(outDir, { recursive: true, force: true });
+  }
+
+  // process the package's own env files - everything else is reached via imports
+  const packageEntries = await fs.readdir(packageDir, { withFileTypes: true });
+  let foundAnyEnvFile = false;
+  for (const entry of packageEntries) {
+    if (!entry.isFile() || !isEnvFileName(entry.name)) continue;
+    foundAnyEnvFile = true;
+    if (isLocalEnvFileName(entry.name) && !includeLocal) {
+      result.skippedLocalFiles.push(path.join(packageDir, entry.name));
+      continue;
+    }
+    await processEnvFile(path.join(packageDir, entry.name));
+  }
+  if (!foundAnyEnvFile) {
+    throw new FlattenError(`no .env files found in ${packageDir}`);
+  }
+
+  return result;
+}

--- a/packages/varlock/src/lib/flatten.ts
+++ b/packages/varlock/src/lib/flatten.ts
@@ -13,6 +13,7 @@ import {
 } from '@env-spec/parser';
 import { tryCatch } from '@env-spec/utils/try-catch';
 import { pathExists } from '@env-spec/utils/fs-utils';
+import { downloadPluginToCache } from '../env-graph/lib/plugins';
 
 /**
  * `varlock flatten` support - copies every env file reachable via @import into a
@@ -33,6 +34,7 @@ import { pathExists } from '@env-spec/utils/fs-utils';
  */
 
 const IMPORTS_DIR_NAME = '.env-imports';
+const PLUGINS_DIR_NAME = '.env-plugins';
 
 export class FlattenError extends Error {}
 
@@ -42,8 +44,10 @@ export type FlattenResult = {
   copiedFiles: Array<{ src: string, dest: string }>;
   /** local (gitignored-style) env files that were skipped */
   skippedLocalFiles: Array<string>;
-  /** npm plugins that had their version pinned in rewritten files */
+  /** npm plugins that had their version pinned in rewritten files (auto-installed at runtime) */
   pinnedPlugins: Array<{ moduleName: string, version: string, filePath: string }>;
+  /** npm plugins that were downloaded and vendored into the output dir (--vendor-plugins) */
+  vendoredPlugins: Array<{ moduleName: string, version: string, dest: string }>;
   warnings: Array<string>;
 };
 
@@ -56,7 +60,21 @@ export type FlattenOptions = {
   outDir?: string;
   /** include .env.local / .env.*.local files (default false - they usually hold machine-local secrets) */
   includeLocal?: boolean;
+  /**
+   * Copy npm `@plugin()` packages into the output dir, rewriting the declarations to local
+   * paths. Makes the artifact fully self-contained: no runtime npm fetch, and works in
+   * shell-less/offline/distroless runtimes. Prefers the copy already installed in node_modules
+   * (no network); only downloads from npm when a plugin is not installed locally. When false
+   * (default), npm plugins are only version-pinned for runtime auto-install.
+   */
+  vendorPlugins?: boolean;
 };
+
+/** stable, filesystem-safe directory name for a vendored plugin (e.g. `varlock-infisical-plugin_2.1.0`) */
+function vendoredPluginDirName(moduleName: string, version: string) {
+  const safeName = moduleName.replaceAll('/', '-').replaceAll('@', '');
+  return `${safeName}_${version}`;
+}
 
 function isEnvFileName(name: string) {
   return name === '.env' || name.startsWith('.env.');
@@ -95,20 +113,21 @@ function makeStaticPathValue(newPath: string, quote?: '"' | "'" | '`') {
 }
 
 /** walk up from `fromDir` (stopping at workspaceRoot) looking for node_modules/<moduleName> */
-async function findInstalledPluginVersion(
+async function findInstalledPlugin(
   moduleName: string,
   fromDir: string,
   workspaceRootPath: string,
-): Promise<string | undefined> {
+): Promise<{ version: string, dir: string } | undefined> {
   let currentDir = fromDir;
   while (currentDir) {
-    const candidatePath = path.join(currentDir, 'node_modules', moduleName, 'package.json');
+    const pluginDir = path.join(currentDir, 'node_modules', moduleName);
+    const candidatePath = path.join(pluginDir, 'package.json');
     if (await pathExists(candidatePath)) {
       const packageJson = await tryCatch(
         async () => JSON.parse(await fs.readFile(candidatePath, 'utf8')),
         () => undefined,
       );
-      if (packageJson?.version) return packageJson.version as string;
+      if (packageJson?.version) return { version: packageJson.version as string, dir: pluginDir };
     }
     if (currentDir === workspaceRootPath) break;
     const parentDir = path.dirname(currentDir);
@@ -123,6 +142,7 @@ export async function flattenEnvFiles(opts: FlattenOptions): Promise<FlattenResu
   const workspaceRootPath = path.resolve(opts.workspaceRootPath);
   const outDir = path.resolve(packageDir, opts.outDir || '.env-flat');
   const includeLocal = !!opts.includeLocal;
+  const vendorPlugins = !!opts.vendorPlugins;
 
   if (outDir === packageDir || packageDir.startsWith(outDir + path.sep)) {
     throw new FlattenError('flatten output directory cannot contain the package directory');
@@ -133,8 +153,12 @@ export async function flattenEnvFiles(opts: FlattenOptions): Promise<FlattenResu
     copiedFiles: [],
     skippedLocalFiles: [],
     pinnedPlugins: [],
+    vendoredPlugins: [],
     warnings: [],
   };
+
+  // dedupe downloads: `${moduleName}@${version}` -> absolute dest plugin dir
+  const vendoredPluginDirs = new Map<string, string>();
 
   // src abs path -> dest abs path, for everything already handled (also breaks import cycles)
   const processedFiles = new Map<string, string>();
@@ -178,6 +202,43 @@ export async function flattenEnvFiles(opts: FlattenOptions): Promise<FlattenResu
     await fs.mkdir(path.dirname(destAbs), { recursive: true });
     await fs.cp(pluginAbs, destAbs, { recursive: true });
     result.copiedFiles.push({ src: pluginAbs, dest: destAbs });
+  }
+
+  /**
+   * Copy an npm plugin at an exact version into the output's plugins dir. Prefers the copy
+   * already installed in `node_modules` (`localDir`, no network); only downloads from npm when
+   * the plugin is not installed locally. Copies each module@version only once per run.
+   */
+  async function vendorNpmPlugin(moduleName: string, version: string, localDir?: string): Promise<string> {
+    const cacheKey = `${moduleName}@${version}`;
+    const cached = vendoredPluginDirs.get(cacheKey);
+    if (cached) return cached;
+
+    const destPluginDir = path.join(outDir, PLUGINS_DIR_NAME, vendoredPluginDirName(moduleName, version));
+    // dereference: the installed entry may be a symlink (pnpm store, workspace link) - copy the
+    // real files so the output stays self-contained. Falls back to downloading (native extract,
+    // no shell) when the plugin is not present in node_modules.
+    const sourceDir = localDir ?? await downloadPluginToCache(moduleName, version);
+    await fs.rm(destPluginDir, { recursive: true, force: true });
+    await fs.mkdir(path.dirname(destPluginDir), { recursive: true });
+    await fs.cp(sourceDir, destPluginDir, { recursive: true, dereference: true });
+
+    // warn if the vendored package pulls in runtime deps that aren't bundled - those won't
+    // travel with the tarball (varlock plugins are expected to bundle their dependencies)
+    const vendoredPkgJson = await tryCatch(
+      async () => JSON.parse(await fs.readFile(path.join(destPluginDir, 'package.json'), 'utf8')),
+      () => undefined,
+    );
+    if (vendoredPkgJson?.dependencies && Object.keys(vendoredPkgJson.dependencies).length) {
+      result.warnings.push(
+        `@plugin(${cacheKey}) declares runtime dependencies that are not bundled into the package - `
+        + 'they will be missing from the vendored copy. Only self-contained plugins can be vendored.',
+      );
+    }
+
+    vendoredPluginDirs.set(cacheKey, destPluginDir);
+    result.vendoredPlugins.push({ moduleName, version, dest: destPluginDir });
+    return destPluginDir;
   }
 
   async function rewriteImportDecorator(
@@ -281,34 +342,85 @@ export async function flattenEnvFiles(opts: FlattenOptions): Promise<FlattenResu
     // other protocols are not supported by the plugin loader yet
     if (/^(https?|npm|jsr|git):/.test(sourceDescriptor)) return false;
 
+    const atLocation = sourceDescriptor.indexOf('@', 1);
+    const moduleName = atLocation === -1 ? sourceDescriptor : sourceDescriptor.slice(0, atLocation);
+    const versionDescriptor = atLocation === -1 ? undefined : sourceDescriptor.slice(atLocation + 1);
+    const relFromPackage = path.relative(packageDir, srcAbs);
+    const isPackageInternal = !relFromPackage.startsWith('..') && !path.isAbsolute(relFromPackage);
+
+    // resolve the concrete version to use: an already-pinned exact version, otherwise the
+    // version installed in node_modules (works for bare names and semver ranges alike)
+    const pinnedExact = versionDescriptor && semver.valid(versionDescriptor) ? versionDescriptor : undefined;
+
+    if (vendorPlugins) {
+      // vendor every npm plugin (package-internal included) so the artifact needs no node_modules
+      // and no runtime npm fetch - rewrite the declaration to point at the copied local package
+      const installed = await findInstalledPlugin(moduleName, path.dirname(srcAbs), workspaceRootPath);
+
+      // prefer copying the installed package (no network); only fall back to downloading when the
+      // resolved version is not what is installed locally (or nothing is installed at all)
+      let version: string | undefined;
+      let localDir: string | undefined;
+      if (pinnedExact) {
+        version = pinnedExact;
+        if (installed?.version === pinnedExact) localDir = installed.dir;
+      } else if (installed) {
+        if (versionDescriptor && !semver.satisfies(installed.version, versionDescriptor)) {
+          result.warnings.push(
+            `@plugin(${sourceDescriptor}) in ${relLabel(srcAbs)} - installed version ${installed.version} does not satisfy the declared range, left untouched`,
+          );
+          return false;
+        }
+        version = installed.version;
+        localDir = installed.dir;
+      }
+      if (!version) {
+        result.warnings.push(
+          `@plugin(${sourceDescriptor}) in ${relLabel(srcAbs)} could not be resolved to a concrete version to vendor - install the plugin or pin an exact version`,
+        );
+        return false;
+      }
+
+      let destPluginDir: string;
+      try {
+        destPluginDir = await vendorNpmPlugin(moduleName, version, localDir);
+      } catch (err) {
+        result.warnings.push(
+          `@plugin(${sourceDescriptor}) in ${relLabel(srcAbs)} could not be vendored: ${(err as Error).message}`,
+        );
+        return false;
+      }
+      args.data.values[0] = makeStaticPathValue(
+        relativeImportPath(path.dirname(destAbs), destPluginDir),
+        sourceArg.data.quote,
+      );
+      return true;
+    }
+
     // npm plugin declared in a file that lives inside the package - it resolves from the
     // package's own node_modules at runtime, so leave it alone
-    const relFromPackage = path.relative(packageDir, srcAbs);
-    if (!relFromPackage.startsWith('..') && !path.isAbsolute(relFromPackage)) return false;
+    if (isPackageInternal) return false;
 
     // npm plugin declared in an imported external file - after flattening it can no longer
     // resolve from the original package's node_modules, so pin the version that is installed
     // there now; at runtime varlock can then auto-download it if it is not installed locally
-    const atLocation = sourceDescriptor.indexOf('@', 1);
-    const moduleName = atLocation === -1 ? sourceDescriptor : sourceDescriptor.slice(0, atLocation);
-    const versionDescriptor = atLocation === -1 ? undefined : sourceDescriptor.slice(atLocation + 1);
-    if (versionDescriptor && semver.valid(versionDescriptor)) return false; // already pinned
+    if (pinnedExact) return false; // already pinned
 
-    const installedVersion = await findInstalledPluginVersion(moduleName, path.dirname(srcAbs), workspaceRootPath);
-    if (!installedVersion) {
+    const installed = await findInstalledPlugin(moduleName, path.dirname(srcAbs), workspaceRootPath);
+    if (!installed) {
       result.warnings.push(
         `@plugin(${sourceDescriptor}) in ${relLabel(srcAbs)} could not be resolved to pin a version - install the plugin in this package or pin an exact version manually`,
       );
       return false;
     }
-    if (versionDescriptor && !semver.satisfies(installedVersion, versionDescriptor)) {
+    if (versionDescriptor && !semver.satisfies(installed.version, versionDescriptor)) {
       result.warnings.push(
-        `@plugin(${sourceDescriptor}) in ${relLabel(srcAbs)} - installed version ${installedVersion} does not satisfy the declared range, left untouched`,
+        `@plugin(${sourceDescriptor}) in ${relLabel(srcAbs)} - installed version ${installed.version} does not satisfy the declared range, left untouched`,
       );
       return false;
     }
-    args.data.values[0] = makeStaticPathValue(`${moduleName}@${installedVersion}`, sourceArg.data.quote);
-    result.pinnedPlugins.push({ moduleName, version: installedVersion, filePath: srcAbs });
+    args.data.values[0] = makeStaticPathValue(`${moduleName}@${installed.version}`, sourceArg.data.quote);
+    result.pinnedPlugins.push({ moduleName, version: installed.version, filePath: srcAbs });
     return true;
   }
 

--- a/packages/varlock/src/lib/flatten.ts
+++ b/packages/varlock/src/lib/flatten.ts
@@ -194,13 +194,34 @@ export async function flattenEnvFiles(opts: FlattenOptions): Promise<FlattenResu
     claimedDests.set(destAbs, srcAbs);
   }
 
+  /**
+   * Warn if a copied/vendored plugin package declares runtime `dependencies`. Those live in
+   * `node_modules` and do not travel with the copied package, so the plugin would fail to load
+   * from the flattened output. Plugins are expected to be self-contained (a single built file,
+   * or a package that bundles its dependencies). No-op for single-file plugins (no package.json).
+   */
+  async function warnIfUnbundledDeps(pkgDir: string, label: string) {
+    const pkgJson = await tryCatch(
+      async () => JSON.parse(await fs.readFile(path.join(pkgDir, 'package.json'), 'utf8')),
+      () => undefined,
+    );
+    if (pkgJson?.dependencies && Object.keys(pkgJson.dependencies).length) {
+      result.warnings.push(
+        `${label} declares runtime dependencies that are not bundled into the package - they will `
+        + 'be missing from the flattened copy. Plugins must be self-contained (a single built file, '
+        + 'or a package that bundles its dependencies).',
+      );
+    }
+  }
+
   /** copy a local-path plugin source (single file or self-contained package dir) into the output */
-  async function copyPluginSource(pluginAbs: string, destAbs: string) {
+  async function copyPluginSource(pluginAbs: string, destAbs: string, label: string) {
     if (processedFiles.has(pluginAbs)) return;
     processedFiles.set(pluginAbs, destAbs);
     claimDest(destAbs, pluginAbs);
     await fs.mkdir(path.dirname(destAbs), { recursive: true });
-    await fs.cp(pluginAbs, destAbs, { recursive: true });
+    await fs.cp(pluginAbs, destAbs, { recursive: true, dereference: true });
+    await warnIfUnbundledDeps(destAbs, label);
     result.copiedFiles.push({ src: pluginAbs, dest: destAbs });
   }
 
@@ -223,18 +244,7 @@ export async function flattenEnvFiles(opts: FlattenOptions): Promise<FlattenResu
     await fs.mkdir(path.dirname(destPluginDir), { recursive: true });
     await fs.cp(sourceDir, destPluginDir, { recursive: true, dereference: true });
 
-    // warn if the vendored package pulls in runtime deps that aren't bundled - those won't
-    // travel with the tarball (varlock plugins are expected to bundle their dependencies)
-    const vendoredPkgJson = await tryCatch(
-      async () => JSON.parse(await fs.readFile(path.join(destPluginDir, 'package.json'), 'utf8')),
-      () => undefined,
-    );
-    if (vendoredPkgJson?.dependencies && Object.keys(vendoredPkgJson.dependencies).length) {
-      result.warnings.push(
-        `@plugin(${cacheKey}) declares runtime dependencies that are not bundled into the package - `
-        + 'they will be missing from the vendored copy. Only self-contained plugins can be vendored.',
-      );
-    }
+    await warnIfUnbundledDeps(destPluginDir, `@plugin(${cacheKey})`);
 
     vendoredPluginDirs.set(cacheKey, destPluginDir);
     result.vendoredPlugins.push({ moduleName, version, dest: destPluginDir });
@@ -332,7 +342,7 @@ export async function flattenEnvFiles(opts: FlattenOptions): Promise<FlattenResu
         result.warnings.push(`@plugin(${sourceDescriptor}) in ${relLabel(srcAbs)} does not exist - left untouched`);
         return false;
       }
-      await copyPluginSource(pluginAbs, destPlugin);
+      await copyPluginSource(pluginAbs, destPlugin, `@plugin(${sourceDescriptor}) in ${relLabel(srcAbs)}`);
       const newPluginPath = relativeImportPath(path.dirname(destAbs), destPlugin);
       if (newPluginPath === sourceDescriptor) return false;
       args.data.values[0] = makeStaticPathValue(newPluginPath, sourceArg.data.quote);

--- a/packages/varlock/src/lib/test/extract-tarball.test.ts
+++ b/packages/varlock/src/lib/test/extract-tarball.test.ts
@@ -1,0 +1,173 @@
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs/promises';
+import zlib from 'node:zlib';
+import {
+  describe, it, expect, afterEach,
+} from 'vitest';
+import { extractTarballBuffer } from '../extract-tarball';
+
+const BLOCK = 512;
+
+/** Build a single 512-byte ustar header block for the given entry. */
+function makeHeader(name: string, size: number, typeflag: string, prefix = ''): Buffer {
+  const block = Buffer.alloc(BLOCK);
+  block.write(name, 0, 100, 'utf-8');
+  block.write('0000644', 100, 8, 'utf-8'); // mode
+  block.write('0000000', 108, 8, 'utf-8'); // uid
+  block.write('0000000', 116, 8, 'utf-8'); // gid
+  block.write(size.toString(8).padStart(11, '0'), 124, 12, 'utf-8'); // size (octal)
+  block.write('00000000000', 136, 12, 'utf-8'); // mtime
+  block.write(typeflag, 156, 1, 'utf-8');
+  block.write('ustar\0', 257, 6, 'utf-8');
+  block.write('00', 263, 2, 'utf-8');
+  if (prefix) block.write(prefix, 345, 155, 'utf-8');
+
+  // checksum: sum of all bytes with the checksum field treated as spaces
+  block.write('        ', 148, 8, 'utf-8');
+  let sum = 0;
+  for (const b of block) sum += b;
+  block.write(`${sum.toString(8).padStart(6, '0')}\0 `, 148, 8, 'utf-8');
+  return block;
+}
+
+/** Pad a data buffer up to the next 512-byte boundary. */
+function padToBlock(data: Buffer): Buffer {
+  const rem = data.length % BLOCK;
+  if (rem === 0) return data;
+  return Buffer.concat([data, Buffer.alloc(BLOCK - rem)]);
+}
+
+type TarEntry = { name: string, content?: string, typeflag?: string, prefix?: string };
+
+/** Assemble a set of entries into a raw (uncompressed) tar buffer. */
+function makeTar(entries: Array<TarEntry | Buffer>): Buffer {
+  const parts: Array<Buffer> = [];
+  for (const entry of entries) {
+    if (Buffer.isBuffer(entry)) {
+      parts.push(entry); // pre-built header + data (for PAX/GNU cases)
+      continue;
+    }
+    const content = entry.content ?? '';
+    const data = Buffer.from(content, 'utf-8');
+    parts.push(makeHeader(entry.name, entry.typeflag === '5' ? 0 : data.length, entry.typeflag ?? '0', entry.prefix));
+    if (entry.typeflag !== '5' && data.length) parts.push(padToBlock(data));
+  }
+  parts.push(Buffer.alloc(BLOCK * 2)); // end-of-archive
+  return Buffer.concat(parts);
+}
+
+/** Build a PAX extended-header block plus its data, followed by the real entry. */
+function makePaxEntry(paxRecords: Record<string, string>, realName: string, content: string): Buffer {
+  const recordsText = Object.entries(paxRecords).map(([k, v]) => {
+    const body = ` ${k}=${v}\n`;
+    // record length includes the digits of the length itself
+    let len = body.length + 1;
+    len = body.length + String(len).length;
+    // iterate to a fixed point (length digits can change the count)
+    while (String(len).length + body.length !== len) len = String(len).length + body.length;
+    return `${len}${body}`;
+  }).join('');
+  const paxData = Buffer.from(recordsText, 'utf-8');
+  const paxHeader = makeHeader('PaxHeader', paxData.length, 'x');
+  const data = Buffer.from(content, 'utf-8');
+  const fileHeader = makeHeader(realName, data.length, '0');
+  return Buffer.concat([paxHeader, padToBlock(paxData), fileHeader, padToBlock(data)]);
+}
+
+function gzip(buf: Buffer): Buffer {
+  return zlib.gzipSync(buf);
+}
+
+const tmpDirs: Array<string> = [];
+async function makeTmpDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'varlock-tar-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tmpDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
+});
+
+describe('extractTarballBuffer', () => {
+  it('extracts regular files with the package/ prefix like npm tarballs', async () => {
+    const dest = await makeTmpDir();
+    const tar = makeTar([
+      { name: 'package/package.json', content: '{"name":"my-plugin"}' },
+      { name: 'package/dist/plugin.js', content: 'module.exports = {};' },
+    ]);
+    await extractTarballBuffer(gzip(tar), dest);
+
+    expect(await fs.readFile(path.join(dest, 'package/package.json'), 'utf-8')).toBe('{"name":"my-plugin"}');
+    expect(await fs.readFile(path.join(dest, 'package/dist/plugin.js'), 'utf-8')).toBe('module.exports = {};');
+  });
+
+  it('creates nested directories from directory entries', async () => {
+    const dest = await makeTmpDir();
+    const tar = makeTar([
+      { name: 'package/nested/deep/', typeflag: '5' },
+      { name: 'package/nested/deep/file.txt', content: 'hi' },
+    ]);
+    await extractTarballBuffer(gzip(tar), dest);
+    expect(await fs.readFile(path.join(dest, 'package/nested/deep/file.txt'), 'utf-8')).toBe('hi');
+  });
+
+  it('honors the ustar prefix field for long paths', async () => {
+    const dest = await makeTmpDir();
+    const tar = makeTar([{ name: 'file.js', prefix: 'package/some/long/prefixed/path', content: 'x' }]);
+    await extractTarballBuffer(gzip(tar), dest);
+    expect(await fs.readFile(path.join(dest, 'package/some/long/prefixed/path/file.js'), 'utf-8')).toBe('x');
+  });
+
+  it('applies a PAX path override to the following entry', async () => {
+    const dest = await makeTmpDir();
+    const longPath = `package/${'a'.repeat(120)}/deep.js`;
+    const tar = makeTar([makePaxEntry({ path: longPath }, 'IGNORED_SHORT_NAME', 'pax-content')]);
+    await extractTarballBuffer(gzip(tar), dest);
+    expect(await fs.readFile(path.join(dest, longPath), 'utf-8')).toBe('pax-content');
+  });
+
+  it('applies a GNU long-name (L) header to the following entry', async () => {
+    const dest = await makeTmpDir();
+    const longPath = `package/${'b'.repeat(130)}/gnu.js`;
+    const nameData = Buffer.from(`${longPath}\0`, 'utf-8');
+    const gnuHeader = makeHeader('././@LongLink', nameData.length, 'L');
+    const content = Buffer.from('gnu-content', 'utf-8');
+    const fileHeader = makeHeader('IGNORED', content.length, '0');
+    const tar = makeTar([Buffer.concat([gnuHeader, padToBlock(nameData), fileHeader, padToBlock(content)])]);
+    await extractTarballBuffer(gzip(tar), dest);
+    expect(await fs.readFile(path.join(dest, longPath), 'utf-8')).toBe('gnu-content');
+  });
+
+  it('refuses path traversal outside the destination', async () => {
+    const dest = await makeTmpDir();
+    const tar = makeTar([
+      { name: '../escape.js', content: 'evil' },
+      { name: 'package/ok.js', content: 'good' },
+    ]);
+    await extractTarballBuffer(gzip(tar), dest);
+
+    // the traversal entry is skipped, the safe one still extracts
+    await expect(fs.readFile(path.join(dest, '../escape.js'), 'utf-8')).rejects.toThrow();
+    expect(await fs.readFile(path.join(dest, 'package/ok.js'), 'utf-8')).toBe('good');
+  });
+
+  it('strips a leading slash rather than writing to an absolute path', async () => {
+    const dest = await makeTmpDir();
+    const tar = makeTar([{ name: '/package/abs.js', content: 'rooted' }]);
+    await extractTarballBuffer(gzip(tar), dest);
+    expect(await fs.readFile(path.join(dest, 'package/abs.js'), 'utf-8')).toBe('rooted');
+  });
+
+  it('skips symlink entries without failing', async () => {
+    const dest = await makeTmpDir();
+    const tar = makeTar([
+      { name: 'package/link', typeflag: '2' }, // symlink typeflag
+      { name: 'package/real.js', content: 'real' },
+    ]);
+    await extractTarballBuffer(gzip(tar), dest);
+    await expect(fs.stat(path.join(dest, 'package/link'))).rejects.toThrow();
+    expect(await fs.readFile(path.join(dest, 'package/real.js'), 'utf-8')).toBe('real');
+  });
+});

--- a/packages/varlock/src/lib/test/flatten.test.ts
+++ b/packages/varlock/src/lib/test/flatten.test.ts
@@ -1,0 +1,313 @@
+import {
+  describe, test, expect, beforeEach, afterEach,
+} from 'vitest';
+import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import outdent from 'outdent';
+import { flattenEnvFiles, FlattenError } from '../flatten';
+import { EnvGraph, DirectoryDataSource } from '../../env-graph';
+
+let baseDir: string;
+let workspaceDir: string;
+
+beforeEach(async () => {
+  baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'varlock-flatten-test-'));
+  workspaceDir = path.join(baseDir, 'repo');
+  await fs.mkdir(workspaceDir);
+});
+afterEach(async () => {
+  await fs.rm(baseDir, { recursive: true, force: true });
+});
+
+async function writeTree(files: Record<string, string>, rootDir?: string) {
+  for (const [relPath, contents] of Object.entries(files)) {
+    const fullPath = path.join(rootDir || workspaceDir, relPath);
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    await fs.writeFile(fullPath, contents, 'utf8');
+  }
+}
+
+async function readOut(outDir: string, relPath: string) {
+  return await fs.readFile(path.join(outDir, relPath), 'utf8');
+}
+
+async function loadValues(dir: string) {
+  const g = new EnvGraph();
+  await g.setRootDataSource(new DirectoryDataSource(dir));
+  await g.finishLoad();
+  const sourceErrors = g.sortedDataSources.flatMap((s) => s.errors.filter((e) => !e.isWarning));
+  expect(sourceErrors, `expected no load errors, got: ${sourceErrors.map((e) => e.message).join(', ')}`).toEqual([]);
+  await g.resolveEnvValues();
+  const values: Record<string, any> = {};
+  for (const key of Object.keys(g.configSchema)) {
+    values[key] = g.configSchema[key].resolvedValue;
+  }
+  return values;
+}
+
+const API_DIR = 'packages/api';
+
+function apiFlatten(opts?: { outDir?: string, includeLocal?: boolean }) {
+  return flattenEnvFiles({
+    packageDir: path.join(workspaceDir, API_DIR),
+    workspaceRootPath: workspaceDir,
+    ...opts,
+  });
+}
+
+describe('flattenEnvFiles', () => {
+  test('copies external imports, rewrites paths, and output resolves identically', async () => {
+    // .env.common has intentionally quirky formatting to check byte-for-byte copying
+    const commonContents = outdent`
+      # @import(./.env.common2)  # trailing comment
+      # ---
+
+      # a comment   with   weird spacing
+      SIB_COMMON=from-sib
+
+
+      SIB_COMMON_TWO="quoted value"
+    `;
+    await writeTree({
+      '.env.shared': 'ROOT_SHARED=from-root\n',
+      'packages/shared/.env.common': commonContents,
+      'packages/shared/.env.common2': 'SIB_COMMON2=from-sib2\n',
+      [`${API_DIR}/.env.schema`]: outdent`
+        # @import(../../.env.shared)
+        # @import(../shared/.env.common)
+        # ---
+        API_ITEM=api-value
+      `,
+      [`${API_DIR}/.env.local`]: 'LOCAL_ONLY=nope\n',
+    });
+
+    const result = await apiFlatten();
+
+    // rewritten schema
+    const schemaOut = await readOut(result.outDir, '.env.schema');
+    expect(schemaOut).toContain('@import(./.env-imports/.env.shared)');
+    expect(schemaOut).toContain('@import(./.env-imports/packages/shared/.env.common)');
+    expect(schemaOut).toContain('API_ITEM=api-value');
+
+    // imported files mirrored by workspace-relative path; untouched files are byte-identical
+    expect(await readOut(result.outDir, '.env-imports/.env.shared')).toBe('ROOT_SHARED=from-root\n');
+    expect(await readOut(result.outDir, '.env-imports/packages/shared/.env.common')).toBe(commonContents);
+    expect(await readOut(result.outDir, '.env-imports/packages/shared/.env.common2')).toBe('SIB_COMMON2=from-sib2\n');
+
+    // local file skipped
+    expect(fsSync.existsSync(path.join(result.outDir, '.env.local'))).toBe(false);
+    expect(result.skippedLocalFiles).toEqual([path.join(workspaceDir, API_DIR, '.env.local')]);
+
+    expect(result.warnings).toEqual([]);
+
+    // flattened output loads standalone and resolves the same values
+    expect(await loadValues(result.outDir)).toEqual({
+      API_ITEM: 'api-value',
+      ROOT_SHARED: 'from-root',
+      SIB_COMMON: 'from-sib',
+      SIB_COMMON_TWO: 'quoted value',
+      SIB_COMMON2: 'from-sib2',
+    });
+  });
+
+  test('includeLocal copies local files', async () => {
+    await writeTree({
+      [`${API_DIR}/.env.schema`]: 'API_ITEM=api-value\n',
+      [`${API_DIR}/.env.local`]: 'LOCAL_ONLY=yep\n',
+    });
+    const result = await apiFlatten({ includeLocal: true });
+    expect(await readOut(result.outDir, '.env.local')).toBe('LOCAL_ONLY=yep\n');
+    expect(result.skippedLocalFiles).toEqual([]);
+  });
+
+  test('copies conditionally-enabled imports and preserves the enabled condition', async () => {
+    await writeTree({
+      '.env.prodonly': 'PROD_ONLY=1\n',
+      [`${API_DIR}/.env.schema`]: outdent`
+        # @import(../../.env.prodonly, enabled=eq($APP_ENV, "production"))
+        # ---
+        APP_ENV=dev
+      `,
+    });
+    const result = await apiFlatten();
+    const schemaOut = await readOut(result.outDir, '.env.schema');
+    expect(schemaOut).toContain('@import(./.env-imports/.env.prodonly, enabled=eq($APP_ENV, "production"))');
+    expect(await readOut(result.outDir, '.env-imports/.env.prodonly')).toBe('PROD_ONLY=1\n');
+  });
+
+  test('directory imports are copied (excluding local files) and keep their trailing slash', async () => {
+    await writeTree({
+      'envs/.env.one': 'ONE=1\n',
+      'envs/.env.local': 'TWO=2\n',
+      'envs/not-an-env-file.txt': 'ignore me\n',
+      [`${API_DIR}/.env.schema`]: outdent`
+        # @import(../../envs/)
+        # ---
+        API_ITEM=api-value
+      `,
+    });
+    const result = await apiFlatten();
+    const schemaOut = await readOut(result.outDir, '.env.schema');
+    expect(schemaOut).toContain('@import(./.env-imports/envs/)');
+    expect(await readOut(result.outDir, '.env-imports/envs/.env.one')).toBe('ONE=1\n');
+    expect(fsSync.existsSync(path.join(result.outDir, '.env-imports/envs/.env.local'))).toBe(false);
+    expect(fsSync.existsSync(path.join(result.outDir, '.env-imports/envs/not-an-env-file.txt'))).toBe(false);
+    expect(result.skippedLocalFiles).toEqual([path.join(workspaceDir, 'envs/.env.local')]);
+  });
+
+  test('pins npm plugin versions in external files, leaves package-internal plugins untouched', async () => {
+    await writeTree({
+      'node_modules/@varlock/fake-plugin/package.json': JSON.stringify({ name: '@varlock/fake-plugin', version: '1.2.3' }),
+      '.env.shared': outdent`
+        # @plugin(@varlock/fake-plugin)
+        # ---
+        ROOT_SHARED=from-root
+      `,
+      [`${API_DIR}/.env.schema`]: outdent`
+        # @plugin(@varlock/internal-plugin)
+        # @import(../../.env.shared)
+        # ---
+        API_ITEM=api-value
+      `,
+    });
+    const result = await apiFlatten();
+
+    const sharedOut = await readOut(result.outDir, '.env-imports/.env.shared');
+    expect(sharedOut).toContain('@plugin(@varlock/fake-plugin@1.2.3)');
+
+    // internal plugin decorator resolves from the package's own node_modules at runtime - untouched
+    const schemaOut = await readOut(result.outDir, '.env.schema');
+    expect(schemaOut).toContain('@plugin(@varlock/internal-plugin)');
+    expect(schemaOut).not.toContain('internal-plugin@');
+
+    expect(result.pinnedPlugins).toEqual([
+      {
+        moduleName: '@varlock/fake-plugin',
+        version: '1.2.3',
+        filePath: path.join(workspaceDir, '.env.shared'),
+      },
+    ]);
+  });
+
+  test('warns when an external plugin cannot be resolved for pinning', async () => {
+    await writeTree({
+      '.env.shared': outdent`
+        # @plugin(@varlock/missing-plugin)
+        # ---
+        ROOT_SHARED=from-root
+      `,
+      [`${API_DIR}/.env.schema`]: outdent`
+        # @import(../../.env.shared)
+        # ---
+        API_ITEM=api-value
+      `,
+    });
+    const result = await apiFlatten();
+    expect(result.warnings.some((w) => w.includes('@varlock/missing-plugin'))).toBe(true);
+    // left untouched
+    expect(await readOut(result.outDir, '.env-imports/.env.shared')).toContain('@plugin(@varlock/missing-plugin)');
+  });
+
+  test('vendors local-path plugins and rewrites their paths across the package boundary', async () => {
+    await writeTree({
+      'shared-plugin.js': 'export default {};\n',
+      [`${API_DIR}/.env.schema`]: outdent`
+        # @plugin(../../shared-plugin.js)
+        # ---
+        API_ITEM=api-value
+      `,
+    });
+    const result = await apiFlatten();
+    const schemaOut = await readOut(result.outDir, '.env.schema');
+    expect(schemaOut).toContain('@plugin(./.env-imports/shared-plugin.js)');
+    expect(await readOut(result.outDir, '.env-imports/shared-plugin.js')).toBe('export default {};\n');
+  });
+
+  test('handles circular imports without hanging', async () => {
+    await writeTree({
+      '.env.a': outdent`
+        # @import(./.env.b)
+        # ---
+        A=1
+      `,
+      '.env.b': outdent`
+        # @import(./.env.a)
+        # ---
+        B=1
+      `,
+      [`${API_DIR}/.env.schema`]: outdent`
+        # @import(../../.env.a)
+        # ---
+        API_ITEM=api-value
+      `,
+    });
+    const result = await apiFlatten();
+    // both copied once, their mutual (sibling-relative) imports unchanged
+    expect(await readOut(result.outDir, '.env-imports/.env.a')).toContain('@import(./.env.b)');
+    expect(await readOut(result.outDir, '.env-imports/.env.b')).toContain('@import(./.env.a)');
+    expect(result.copiedFiles.filter((f) => f.src.endsWith('.env.a')).length).toBe(1);
+  });
+
+  test('allowMissing imports are rewritten silently; missing imports warn', async () => {
+    await writeTree({
+      [`${API_DIR}/.env.schema`]: outdent`
+        # @import(../../.env.optional, allowMissing=true)
+        # @import(../../.env.gone)
+        # ---
+        API_ITEM=api-value
+      `,
+    });
+    const result = await apiFlatten();
+    const schemaOut = await readOut(result.outDir, '.env.schema');
+    expect(schemaOut).toContain('@import(./.env-imports/.env.optional, allowMissing=true)');
+    expect(schemaOut).toContain('@import(./.env-imports/.env.gone)');
+    expect(result.warnings.filter((w) => w.includes('.env.optional'))).toEqual([]);
+    expect(result.warnings.some((w) => w.includes('.env.gone') && w.includes('does not exist'))).toBe(true);
+  });
+
+  test('imports pointing outside the workspace root are left untouched with a warning', async () => {
+    await writeTree({ '.env.outside': 'OUTSIDE=1\n' }, baseDir);
+    await writeTree({
+      [`${API_DIR}/.env.schema`]: outdent`
+        # @import(../../../.env.outside)
+        # ---
+        API_ITEM=api-value
+      `,
+    });
+    const result = await apiFlatten();
+    const schemaOut = await readOut(result.outDir, '.env.schema');
+    expect(schemaOut).toContain('@import(../../../.env.outside)');
+    expect(result.warnings.some((w) => w.includes('outside the workspace root'))).toBe(true);
+  });
+
+  test('errors when no env files are found', async () => {
+    await fs.mkdir(path.join(workspaceDir, API_DIR), { recursive: true });
+    await expect(apiFlatten()).rejects.toThrow(FlattenError);
+  });
+
+  test('errors when the output dir would contain the package dir', async () => {
+    await writeTree({ [`${API_DIR}/.env.schema`]: 'API_ITEM=1\n' });
+    await expect(apiFlatten({ outDir: '../..' })).rejects.toThrow(FlattenError);
+  });
+
+  test('rerunning flatten replaces stale output', async () => {
+    await writeTree({
+      '.env.shared': 'ROOT_SHARED=old\n',
+      [`${API_DIR}/.env.schema`]: outdent`
+        # @import(../../.env.shared)
+        # ---
+        API_ITEM=api-value
+      `,
+    });
+    await apiFlatten();
+    // remove the import and rerun - previously copied file should be gone
+    await writeTree({
+      [`${API_DIR}/.env.schema`]: 'API_ITEM=api-value\n',
+    });
+    const result = await apiFlatten();
+    expect(fsSync.existsSync(path.join(result.outDir, '.env-imports'))).toBe(false);
+    expect(await readOut(result.outDir, '.env.schema')).toBe('API_ITEM=api-value\n');
+  });
+});

--- a/packages/varlock/src/lib/test/flatten.test.ts
+++ b/packages/varlock/src/lib/test/flatten.test.ts
@@ -1,5 +1,5 @@
 import {
-  describe, test, expect, beforeEach, afterEach,
+  describe, test, expect, beforeEach, afterEach, vi,
 } from 'vitest';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
@@ -8,6 +8,14 @@ import os from 'node:os';
 import outdent from 'outdent';
 import { flattenEnvFiles, FlattenError } from '../flatten';
 import { EnvGraph, DirectoryDataSource } from '../../env-graph';
+import { downloadPluginToCache } from '../../env-graph/lib/plugins';
+
+// vendoring downloads plugins from npm - stub the download so tests stay offline.
+// The stub materializes a fake extracted plugin package that flatten then copies.
+vi.mock('../../env-graph/lib/plugins', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../env-graph/lib/plugins')>();
+  return { ...actual, downloadPluginToCache: vi.fn() };
+});
 
 let baseDir: string;
 let workspaceDir: string;
@@ -49,12 +57,51 @@ async function loadValues(dir: string) {
 
 const API_DIR = 'packages/api';
 
-function apiFlatten(opts?: { outDir?: string, includeLocal?: boolean }) {
+function apiFlatten(opts?: { outDir?: string, includeLocal?: boolean, vendorPlugins?: boolean }) {
   return flattenEnvFiles({
     packageDir: path.join(workspaceDir, API_DIR),
     workspaceRootPath: workspaceDir,
     ...opts,
   });
+}
+
+/** write a realistic self-contained installed plugin package under node_modules */
+async function writeInstalledPlugin(
+  moduleName: string,
+  version: string,
+  extraPkgFields: Record<string, any> = {},
+  atDir = workspaceDir,
+) {
+  const pluginDir = path.join(atDir, 'node_modules', moduleName);
+  await fs.mkdir(path.join(pluginDir, 'dist'), { recursive: true });
+  await fs.writeFile(
+    path.join(pluginDir, 'package.json'),
+    JSON.stringify({
+      name: moduleName, version, exports: { './plugin': './dist/plugin.cjs' }, ...extraPkgFields,
+    }),
+  );
+  await fs.writeFile(path.join(pluginDir, 'dist', 'plugin.cjs'), `// installed ${moduleName}@${version}\n`);
+  return pluginDir;
+}
+
+/**
+ * Make `downloadPluginToCache` (the network fallback) return a freshly-created fake extracted
+ * plugin package, so the download path has real bytes to copy without touching the network.
+ * Returns the spy so tests can assert whether the fallback was used.
+ */
+function stubPluginDownload() {
+  const spy = vi.mocked(downloadPluginToCache);
+  spy.mockImplementation(async (moduleName: string, version: string) => {
+    const cacheDir = path.join(baseDir, 'fake-cache', `${moduleName.replaceAll('/', '-')}-${version}`);
+    await fs.mkdir(path.join(cacheDir, 'dist'), { recursive: true });
+    await fs.writeFile(
+      path.join(cacheDir, 'package.json'),
+      JSON.stringify({ name: moduleName, version, exports: { './plugin': './dist/plugin.cjs' } }),
+    );
+    await fs.writeFile(path.join(cacheDir, 'dist', 'plugin.cjs'), `// downloaded ${moduleName}@${version}\n`);
+    return cacheDir;
+  });
+  return spy;
 }
 
 describe('flattenEnvFiles', () => {
@@ -223,6 +270,168 @@ describe('flattenEnvFiles', () => {
     const schemaOut = await readOut(result.outDir, '.env.schema');
     expect(schemaOut).toContain('@plugin(./.env-imports/shared-plugin.js)');
     expect(await readOut(result.outDir, '.env-imports/shared-plugin.js')).toBe('export default {};\n');
+  });
+
+  describe('--vendor-plugins', () => {
+    afterEach(() => vi.mocked(downloadPluginToCache).mockReset());
+
+    test('copies the installed package (no download) and rewrites to a local path', async () => {
+      const spy = stubPluginDownload();
+      await writeInstalledPlugin('@varlock/fake-plugin', '1.2.3');
+      await writeTree({
+        '.env.shared': outdent`
+          # @plugin(@varlock/fake-plugin)
+          # ---
+          ROOT_SHARED=from-root
+        `,
+        [`${API_DIR}/.env.schema`]: outdent`
+          # @import(../../.env.shared)
+          # ---
+          API_ITEM=api-value
+        `,
+      });
+
+      const result = await apiFlatten({ vendorPlugins: true });
+
+      // installed locally, so it was copied - never downloaded
+      expect(spy).not.toHaveBeenCalled();
+
+      // the external file now points at the vendored local package, not an npm descriptor
+      const sharedOut = await readOut(result.outDir, '.env-imports/.env.shared');
+      expect(sharedOut).toContain('@plugin(../.env-plugins/varlock-fake-plugin_1.2.3)');
+      expect(sharedOut).not.toContain('@varlock/fake-plugin@');
+
+      // the installed package bytes were copied into the output
+      const vendoredPkg = await readOut(result.outDir, '.env-plugins/varlock-fake-plugin_1.2.3/package.json');
+      expect(JSON.parse(vendoredPkg).name).toBe('@varlock/fake-plugin');
+      expect(await readOut(result.outDir, '.env-plugins/varlock-fake-plugin_1.2.3/dist/plugin.cjs')).toContain('installed @varlock/fake-plugin@1.2.3');
+
+      expect(result.vendoredPlugins).toEqual([expect.objectContaining({ moduleName: '@varlock/fake-plugin', version: '1.2.3' })]);
+      expect(result.pinnedPlugins).toEqual([]);
+    });
+
+    test('follows symlinked installs (pnpm store / workspace links)', async () => {
+      // real package lives elsewhere; node_modules entry is a symlink to it, like pnpm/workspaces
+      const realPkgDir = path.join(baseDir, 'store', 'fake-plugin');
+      await fs.mkdir(path.join(realPkgDir, 'dist'), { recursive: true });
+      await fs.writeFile(path.join(realPkgDir, 'package.json'), JSON.stringify({ name: '@varlock/fake-plugin', version: '4.0.0', exports: { './plugin': './dist/plugin.cjs' } }));
+      await fs.writeFile(path.join(realPkgDir, 'dist', 'plugin.cjs'), '// symlinked build\n');
+      const nmScope = path.join(workspaceDir, 'node_modules', '@varlock');
+      await fs.mkdir(nmScope, { recursive: true });
+      await fs.symlink(realPkgDir, path.join(nmScope, 'fake-plugin'), 'dir');
+
+      await writeTree({
+        [`${API_DIR}/.env.schema`]: outdent`
+          # @plugin(@varlock/fake-plugin)
+          # ---
+          API_ITEM=api-value
+        `,
+      });
+
+      const result = await apiFlatten({ vendorPlugins: true });
+      // real files copied through the symlink, not a dangling link
+      const vendoredPlugin = path.join(result.outDir, '.env-plugins/varlock-fake-plugin_4.0.0/dist/plugin.cjs');
+      expect((await fs.lstat(vendoredPlugin)).isSymbolicLink()).toBe(false);
+      expect(await fs.readFile(vendoredPlugin, 'utf8')).toContain('symlinked build');
+    });
+
+    test('also vendors package-internal npm plugins (no node_modules at runtime)', async () => {
+      stubPluginDownload();
+      await writeInstalledPlugin('@varlock/internal-plugin', '2.0.0');
+      await writeTree({
+        [`${API_DIR}/.env.schema`]: outdent`
+          # @plugin(@varlock/internal-plugin)
+          # ---
+          API_ITEM=api-value
+        `,
+      });
+
+      const result = await apiFlatten({ vendorPlugins: true });
+
+      const schemaOut = await readOut(result.outDir, '.env.schema');
+      expect(schemaOut).toContain('@plugin(./.env-plugins/varlock-internal-plugin_2.0.0)');
+      expect(result.vendoredPlugins).toHaveLength(1);
+    });
+
+    test('downloads as a fallback when the pinned exact version is not installed', async () => {
+      const spy = stubPluginDownload();
+      await writeTree({
+        [`${API_DIR}/.env.schema`]: outdent`
+          # @plugin(@varlock/fake-plugin@3.1.0)
+          # ---
+          API_ITEM=api-value
+        `,
+      });
+
+      const result = await apiFlatten({ vendorPlugins: true });
+      expect(spy).toHaveBeenCalledWith('@varlock/fake-plugin', '3.1.0');
+      expect(await readOut(result.outDir, '.env-plugins/varlock-fake-plugin_3.1.0/dist/plugin.cjs')).toContain('downloaded @varlock/fake-plugin@3.1.0');
+      expect(result.vendoredPlugins).toEqual([expect.objectContaining({ moduleName: '@varlock/fake-plugin', version: '3.1.0' })]);
+    });
+
+    test('downloads when the installed version does not match a pinned exact version', async () => {
+      const spy = stubPluginDownload();
+      await writeInstalledPlugin('@varlock/fake-plugin', '1.0.0'); // installed != pinned
+      await writeTree({
+        [`${API_DIR}/.env.schema`]: '# @plugin(@varlock/fake-plugin@3.1.0)\n# ---\nAPI_ITEM=x\n',
+      });
+
+      const result = await apiFlatten({ vendorPlugins: true });
+      expect(spy).toHaveBeenCalledWith('@varlock/fake-plugin', '3.1.0');
+      expect(result.vendoredPlugins).toEqual([expect.objectContaining({ version: '3.1.0' })]);
+    });
+
+    test('copies each module@version only once when referenced from multiple files', async () => {
+      const spy = stubPluginDownload();
+      await writeInstalledPlugin('@varlock/fake-plugin', '1.2.3');
+      await writeTree({
+        '.env.shared': '# @plugin(@varlock/fake-plugin)\n# ---\nROOT_SHARED=x\n',
+        '.env.other': '# @plugin(@varlock/fake-plugin)\n# ---\nOTHER=y\n',
+        [`${API_DIR}/.env.schema`]: outdent`
+          # @import(../../.env.shared)
+          # @import(../../.env.other)
+          # ---
+          API_ITEM=api-value
+        `,
+      });
+
+      const result = await apiFlatten({ vendorPlugins: true });
+      expect(spy).not.toHaveBeenCalled();
+      expect(result.vendoredPlugins).toHaveLength(1);
+    });
+
+    test('warns when a vendored plugin has unbundled runtime dependencies', async () => {
+      stubPluginDownload();
+      await writeInstalledPlugin('@varlock/fake-plugin', '1.0.0', { dependencies: { 'some-dep': '^1.0.0' } });
+      await writeTree({
+        [`${API_DIR}/.env.schema`]: outdent`
+          # @plugin(@varlock/fake-plugin)
+          # ---
+          API_ITEM=api-value
+        `,
+      });
+
+      const result = await apiFlatten({ vendorPlugins: true });
+      expect(result.warnings.some((w) => w.includes('not bundled'))).toBe(true);
+    });
+
+    test('warns and skips when no concrete version can be resolved', async () => {
+      const spy = stubPluginDownload();
+      await writeTree({
+        [`${API_DIR}/.env.schema`]: outdent`
+          # @plugin(@varlock/unresolvable-plugin)
+          # ---
+          API_ITEM=api-value
+        `,
+      });
+
+      const result = await apiFlatten({ vendorPlugins: true });
+      expect(spy).not.toHaveBeenCalled();
+      expect(result.vendoredPlugins).toEqual([]);
+      expect(result.warnings.some((w) => w.includes('unresolvable-plugin'))).toBe(true);
+      // left untouched
+      expect(await readOut(result.outDir, '.env.schema')).toContain('@plugin(@varlock/unresolvable-plugin)');
+    });
   });
 
   test('handles circular imports without hanging', async () => {

--- a/packages/varlock/src/lib/test/flatten.test.ts
+++ b/packages/varlock/src/lib/test/flatten.test.ts
@@ -272,6 +272,33 @@ describe('flattenEnvFiles', () => {
     expect(await readOut(result.outDir, '.env-imports/shared-plugin.js')).toBe('export default {};\n');
   });
 
+  test('warns when a copied local package plugin declares unbundled dependencies', async () => {
+    await writeTree({
+      'my-plugin/package.json': JSON.stringify({
+        name: 'my-plugin', version: '1.0.0', exports: { './plugin': './plugin.js' }, dependencies: { 'some-dep': '^1.0.0' },
+      }),
+      'my-plugin/plugin.js': 'module.exports = {};\n',
+      [`${API_DIR}/.env.schema`]: outdent`
+        # @plugin(../../my-plugin/)
+        # ---
+        API_ITEM=api-value
+      `,
+    });
+    const result = await apiFlatten();
+    // still copied and rewritten, but flags the dependency gap
+    expect(await readOut(result.outDir, '.env-imports/my-plugin/package.json')).toContain('my-plugin');
+    expect(result.warnings.some((w) => w.includes('not bundled'))).toBe(true);
+  });
+
+  test('does not warn for a self-contained single-file local plugin', async () => {
+    await writeTree({
+      'plugin.js': 'module.exports = {};\n',
+      [`${API_DIR}/.env.schema`]: '# @plugin(../../plugin.js)\n# ---\nAPI_ITEM=x\n',
+    });
+    const result = await apiFlatten();
+    expect(result.warnings.some((w) => w.includes('not bundled'))).toBe(false);
+  });
+
   describe('--vendor-plugins', () => {
     afterEach(() => vi.mocked(downloadPluginToCache).mockReset());
 


### PR DESCRIPTION
## What

New `varlock flatten` command that collapses a package's `@import` graph into one self-contained directory (default `.env-flat/`), so the package can be deployed without the rest of the monorepo present, most commonly in the final stage of a Docker build.

## How it works

- Files imported from outside the package are mirrored under `.env-imports/` by workspace-relative path, and `@import` paths are rewritten. Because both the package's own files and the imports preserve their directory structure, relative imports between copied files stay valid, and the output is position-independent.
- Purely structural by default: values are never resolved and plugins are never executed, so it is safe to run in CI without secrets. Untouched files are copied byte-for-byte; only files with rewrites are reserialized (round-trip-faithful AST).
- Conditionally-enabled imports (`enabled=`) are still copied with their conditions preserved, since production may enable imports the build machine does not.
- `.env.local` / `.env.*.local` files are skipped by default (opt back in with `--include-local`) so machine-local secrets stay out of image layers.
- `@plugin()` declarations in copied external files get pinned to the currently installed version, letting the standalone binary auto-install them where the sibling's `node_modules` is gone. Local-path plugins are vendored into the output. Package-internal plugin declarations are left untouched.
- Imports pointing outside the workspace root warn and are left as-is.

## Plugins in shell-less / distroless images

Two changes so pinned plugins actually work in minimal runtime images:

- **Native tarball extraction.** Plugin auto-install previously shelled out to `tar` (`exec("tar -xzf ...")`), which spawns `/bin/sh`. Distroless images have neither a shell nor `tar`, so `varlock load` in the final stage failed with `spawn /bin/sh ENOENT`. Extraction is now native (`zlib` + a small tar reader that runs in both Node and the compiled Bun binary), so official `@varlock/*` plugins auto-install at runtime with no extra setup. Verified byte-for-byte against system `tar`, and end-to-end in the compiled binary with an empty `PATH` + fresh cache.
- **`flatten --vendor-plugins`.** Copies each npm `@plugin()` package into the output (`.env-plugins/`), rewriting the declarations to local paths. It uses the copy already in your `node_modules` (no network), downloading only plugins that are not installed locally. The flattened directory then resolves with no runtime npm fetch, no shell, and no trust prompt. This is the only option that also covers third-party plugins and offline/air-gapped runtimes, which runtime auto-install cannot. Package-internal npm plugins are vendored too under this flag, since a distroless runtime has no `node_modules` to resolve from.

## Why not resolve-and-bake

Resolving values at flatten time would bake secrets into the artifact. This keeps runtime resolution (`varlock run` in the container) working exactly as before; only the file layout changes. `--vendor-plugins` copies plugin *code* at build time but still never resolves values.

Docs: Docker guide rewritten around the new command (it was previously documented as "coming soon"), with a "Distroless and shell-less base images" section covering both fixes, plus a CLI reference entry and monorepos guide update.

