### PR TITLE
fix auditIgnore

### DIFF
--- a/.bumpy/fix-audit-ignore.md
+++ b/.bumpy/fix-audit-ignore.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+fix `varlock audit` ignoring `@auditIgnore` on schema items

--- a/packages/varlock/src/cli/commands/audit.command.ts
+++ b/packages/varlock/src/cli/commands/audit.command.ts
@@ -193,9 +193,10 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
     if (internallyReferenced.has(key)) continue;
 
     const item = envGraph.configSchema[key];
-    const itemDecorators = (item as any)?.decorators as Record<string, unknown> | undefined;
-    const isIgnored = (typeof item?.getDec === 'function' && (item.getDec('auditIgnore') as unknown) === true)
-      || (itemDecorators?.auditIgnore === true);
+    const auditIgnoreDec = typeof item?.getDec === 'function'
+      ? item.getDec('auditIgnore')
+      : undefined;
+    const isIgnored = auditIgnoreDec?.parsedDecorator.simplifiedValue === true;
     if (isIgnored) continue;
     unusedInSchema.push(key);
   }

--- a/packages/varlock/src/cli/commands/test/audit.command.test.ts
+++ b/packages/varlock/src/cli/commands/test/audit.command.test.ts
@@ -197,8 +197,9 @@ describe('audit command', () => {
     loadVarlockEnvGraphMock.mockResolvedValue({
       configSchema: {
         API_KEY: { getDec: vi.fn().mockReturnValue(undefined) },
-        IGNORED_UNUSED: { getDec: vi.fn().mockReturnValue(true) }, // # @auditIgnore
-        EXPLICIT_FALSE_UNUSED: { getDec: vi.fn().mockReturnValue(false) }, // # @auditIgnore=false
+        // getDec returns an ItemDecoratorInstance, not a bare boolean
+        IGNORED_UNUSED: { getDec: vi.fn().mockReturnValue({ parsedDecorator: { simplifiedValue: true } }) }, // # @auditIgnore
+        EXPLICIT_FALSE_UNUSED: { getDec: vi.fn().mockReturnValue({ parsedDecorator: { simplifiedValue: false } }) }, // # @auditIgnore=false
       },
       graphAdjacencyList: { API_KEY: [], IGNORED_UNUSED: [], EXPLICIT_FALSE_UNUSED: [] },
       sortedDataSources: [],


### PR DESCRIPTION
## Summary
- Fix `varlock audit` ignoring `@auditIgnore` / `@auditIgnore=true` on unused schema items ([#932](https://github.com/dmno-dev/varlock/issues/932))
- `getDec('auditIgnore')` returns an `ItemDecoratorInstance`; the command was comparing it to `true`, so ignored keys were never skipped
- Read `parsedDecorator.simplifiedValue` instead (same pattern as `@internal`), and update the unit test mocks to match the real return shape

## Test plan
- [ ] `bun run --filter varlock test -- src/cli/commands/test/audit.command.test.ts`
- [ ] Repro from #932: schema with `# @auditIgnore` / `# @auditIgnore=true` unused keys + a used key in code; `varlock audit` exits 0
- [ ] Confirm `# @auditIgnore=false` still reports as unused