### PR TITLE
Fix proxy certs for strict TLS verifiers + 1password windows support

### DIFF
--- a/.bumpy/1password-windows-inject.md
+++ b/.bumpy/1password-windows-inject.md
@@ -1,0 +1,5 @@
+---
+"@varlock/1password-plugin": patch
+---
+
+CLI batch reads now use op inject instead of op run -- env -0, fixing failures on Windows where no unix env binary exists

--- a/.bumpy/proxy-cert-strict-verifiers.md
+++ b/.bumpy/proxy-cert-strict-verifiers.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+proxy: minted MITM certs now include subject/authority key identifiers so strict TLS verifiers (python 3.13+ urllib/httpx defaults) accept them; Proxy-Authorization from clients is stripped instead of forwarded upstream

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -2,7 +2,7 @@ import {
   type Resolver, type PluginCacheAccessor, plugin, resolveCacheTtl,
 } from 'varlock/plugin-lib';
 
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { createDeferredPromise, type DeferredPromise } from '@env-spec/utils/defer';
 import { spawnAsync } from '@env-spec/utils/exec-helpers';
 import { Client, createClient } from '@1password/sdk';
@@ -20,6 +20,41 @@ const OP_ICON = 'simple-icons:1password';
 type OpAuthCompletedFn = (success: boolean) => void;
 
 const CLI_BATCH_READ_TIMEOUT = 50;
+
+/*
+  Batched CLI reads go through `op inject`: we feed it a template of
+  `KEY={{ op://ref }}` entries on stdin and it prints the template with refs
+  resolved, in a single authenticated call. Previously this used
+  `op run -- env -0`, but that depends on a unix `env` binary which does not
+  exist on windows (unless git's usr/bin happens to be on PATH).
+
+  Entries are joined with a random per-call separator string because secret
+  values can contain newlines, and `op inject` strips control characters
+  (e.g. \0, \x1e) from its output so a non-printable separator would be lost.
+*/
+function buildInjectTemplate(opReferences: Array<string>) {
+  const separator = `__VARLOCK_1P_SEP_${randomUUID()}__`;
+  const keyToRef: Record<string, string> = {};
+  let i = 1;
+  const template = opReferences.map((ref) => {
+    const key = `VARLOCK_1P_INJECT_${i++}`;
+    keyToRef[key] = ref;
+    return `${key}={{ ${ref} }}${separator}`;
+  }).join('');
+  return { template, separator, keyToRef };
+}
+
+/** Parse `op inject` output back into op-ref → value (dangling segments, e.g. a trailing newline, are ignored). */
+function parseInjectResult(result: string, separator: string, keyToRef: Record<string, string>) {
+  const valuesByRef: Record<string, string> = {};
+  for (const segment of result.split(separator)) {
+    const eqPos = segment.indexOf('=');
+    const key = segment.substring(0, eqPos);
+    if (!keyToRef[key]) continue;
+    valuesByRef[keyToRef[key]] = segment.substring(eqPos + 1);
+  }
+  return valuesByRef;
+}
 
 /*
   ! IMPORTANT INFO ON CLI APP AUTH
@@ -58,17 +93,11 @@ async function checkAppCliAuth(): Promise<OpAuthCompletedFn> {
 
 async function executeAppCliBatch(batchToExecute: NonNullable<typeof appAuthBatch>) {
   debug('execute op read batch (app auth)', Object.keys(batchToExecute));
-  const envMap = {} as Record<string, string>;
-  let i = 1;
-  Object.keys(batchToExecute).forEach((opReference) => {
-    envMap[`VARLOCK_1P_INJECT_${i++}`] = opReference;
-  });
+  const { template, separator, keyToRef } = buildInjectTemplate(Object.keys(batchToExecute));
   const startAt = new Date();
 
   const authCompletedFn = await checkAppCliAuth();
-  // `env -0` splits values by a null character instead of newlines
-  // because otherwise we'll have trouble dealing with values that contain newlines
-  await spawnAsync('op', `run --no-masking ${lockCliToOpAccount ? `--account ${lockCliToOpAccount} ` : ''}-- env -0`.split(' '), {
+  await spawnAsync('op', ['inject', ...lockCliToOpAccount ? ['--account', lockCliToOpAccount] : []], {
     env: {
       PATH: process.env.PATH!,
       ...process.env.USER && { USER: process.env.USER },
@@ -76,21 +105,16 @@ async function executeAppCliBatch(batchToExecute: NonNullable<typeof appAuthBatc
       ...process.env.XDG_CONFIG_HOME && { XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
       ...pickProxyEnv(),
       OP_BIOMETRIC_UNLOCK_ENABLED: 'true',
-      ...envMap,
     },
+    input: template,
   })
     .then((result) => {
       authCompletedFn?.(true);
       debug(`batched OP request took ${+new Date() - +startAt}ms`);
 
-      const lines = result.split('\0');
-      for (const line of lines) {
-        const eqPos = line.indexOf('=');
-        const key = line.substring(0, eqPos);
-        if (!envMap[key]) continue;
-        const val = line.substring(eqPos + 1);
-        const opRef = envMap[key];
-        batchToExecute[opRef].deferredPromises.forEach((p) => {
+      const valuesByRef = parseInjectResult(result, separator, keyToRef);
+      for (const [opRef, val] of Object.entries(valuesByRef)) {
+        batchToExecute[opRef]?.deferredPromises.forEach((p) => {
           p.resolve(val);
         });
       }
@@ -369,17 +393,11 @@ class OpPluginInstance {
   /** Executes the per-instance CLI read batch using `op run` with a service account token. */
   private async executeCliBatch(batchToExecute: NonNullable<typeof this.cliBatch>) {
     debug('execute op read batch (service account CLI)', Object.keys(batchToExecute));
-    const envMap = {} as Record<string, string>;
-    let i = 1;
-    Object.keys(batchToExecute).forEach((opReference) => {
-      envMap[`VARLOCK_1P_INJECT_${i++}`] = opReference;
-    });
+    const { template, separator, keyToRef } = buildInjectTemplate(Object.keys(batchToExecute));
     const startAt = new Date();
 
     const authCompletedFn = await this.checkCliAuth();
-    // `env -0` splits values by a null character instead of newlines
-    // because otherwise we'll have trouble dealing with values that contain newlines
-    await spawnAsync('op', `run --no-masking ${this.account ? `--account ${this.account} ` : ''}-- env -0`.split(' '), {
+    await spawnAsync('op', ['inject', ...this.account ? ['--account', this.account] : []], {
       env: {
         // have to pass a few things through at least path so it can find `op` and related config files
         PATH: process.env.PATH!,
@@ -393,24 +411,17 @@ class OpPluginInstance {
         // this setting actually just enables the CLI + Desktop App integration
         // which in some cases op has a hard time detecting via app setting
         OP_BIOMETRIC_UNLOCK_ENABLED: 'true',
-        ...envMap,
       },
+      input: template,
     })
       .then(async (result) => {
         authCompletedFn?.(true);
         debug(`batched OP request took ${+new Date() - +startAt}ms`);
 
-        const lines = result.split('\0');
-        for (const line of lines) {
-          const eqPos = line.indexOf('=');
-          const key = line.substring(0, eqPos);
-
-          if (!envMap[key]) continue;
-          const val = line.substring(eqPos + 1);
-          const opRef = envMap[key];
-
+        const valuesByRef = parseInjectResult(result, separator, keyToRef);
+        for (const [opRef, val] of Object.entries(valuesByRef)) {
           // resolve the deferred promises with the value
-          batchToExecute[opRef].deferredPromises.forEach((p) => {
+          batchToExecute[opRef]?.deferredPromises.forEach((p) => {
             p.resolve(val);
           });
         }

--- a/packages/plugins/1password/test/1password.test.ts
+++ b/packages/plugins/1password/test/1password.test.ts
@@ -232,6 +232,23 @@ describe('1password plugin', () => {
       expectValues: { SECRET: 'p@ss=w0rd&foo' },
     }));
 
+    test('handles multiline values (e.g. private keys)', opTest({
+      opConfig: {
+        responses: {
+          'op://vault/item/key': '-----BEGIN KEY-----\nline1\nline2\n-----END KEY-----',
+          'op://vault/item/other': 'single-line',
+        },
+      },
+      schema: outdent`
+        PRIVATE_KEY=op("op://vault/item/key")
+        OTHER=op("op://vault/item/other")
+      `,
+      expectValues: {
+        PRIVATE_KEY: '-----BEGIN KEY-----\nline1\nline2\n-----END KEY-----',
+        OTHER: 'single-line',
+      },
+    }));
+
     test('bad vault reference rejects that item and retries the rest', opTest({
       opConfig: {
         responses: { 'op://good-vault/item/field': 'good-value' },

--- a/packages/plugins/1password/test/fake-op.sh
+++ b/packages/plugins/1password/test/fake-op.sh
@@ -14,37 +14,33 @@ case "$1" in
   whoami)
     echo "Test User <test@example.com>"
     ;;
-  run)
-    # op run --no-masking [--account X] -- env -0
-    # Reads VARLOCK_1P_INJECT_* env vars, resolves op:// references from config,
-    # and outputs null-separated KEY=value pairs (like `env -0`).
+  inject)
+    # op inject [--account X]
+    # Reads a template from stdin, resolves {{ op://... }} references from
+    # config, and prints the substituted template. Mimics real op inject
+    # behavior: fails the whole batch on the first bad reference, strips
+    # control characters (except newline/tab) from output, and appends a
+    # trailing newline.
     node -e "
       const cfg = JSON.parse(require('fs').readFileSync('$CONFIG_FILE', 'utf-8'));
       const responses = cfg.responses || {};
       const errors = cfg.errors || {};
-      const refs = [];
+      const template = require('fs').readFileSync(0, 'utf-8');
 
-      for (const [key, ref] of Object.entries(process.env)) {
-        if (!key.startsWith('VARLOCK_1P_INJECT_')) continue;
-        refs.push({ key, ref });
-      }
+      const refs = [...template.matchAll(/\{\{\s*(op:\/\/[^}]+?)\s*\}\}/g)].map((m) => m[1]);
 
       // Check for errors first (real op fails entire batch on first error)
-      for (const { ref } of refs) {
+      for (const ref of refs) {
         if (errors[ref]) {
           process.stderr.write('[ERROR] 2024/01/01 00:00:00 ' + errors[ref] + '\n');
           process.exit(1);
         }
       }
 
-      // Output resolved values as null-separated pairs
-      const results = [];
-      for (const { key, ref } of refs) {
-        if (ref in responses) {
-          results.push(key + '=' + responses[ref]);
-        }
-      }
-      process.stdout.write(results.join('\0') + '\0');
+      const output = template.replace(/\{\{\s*(op:\/\/[^}]+?)\s*\}\}/g, (match, ref) => {
+        return ref in responses ? responses[ref] : match;
+      });
+      process.stdout.write(output.replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '') + '\n');
     "
     ;;
   environment)

--- a/packages/varlock-website/src/content/docs/guides/proxy.mdx
+++ b/packages/varlock-website/src/content/docs/guides/proxy.mdx
@@ -295,12 +295,16 @@ Sessions are durable records: they persist after the proxy stops (visible with `
 - **Proxy address:** `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` (and lowercase), with `NO_PROXY` excluding localhost.
 - **CA trust:** `NODE_EXTRA_CA_CERTS` (Node.js), `REQUESTS_CA_BUNDLE` (Python `requests`), `CURL_CA_BUNDLE` (curl), `GIT_SSL_CAINFO` (git), and `SSL_CERT_FILE` (OpenSSL-based tools).
 
+The proxy URL carries no credentials, and the proxy never asks clients for proxy authentication (no `407` challenges). Session scoping is enforced by the proxy itself, so clients with limited proxy-auth support (like Python's `urllib`) work with the plain `HTTPS_PROXY` url.
+
 The proxy uses an **ephemeral, in-memory certificate authority** generated per run; only its public certificate is written to a temp file for the child to trust. The CA private key and all per-host certificates never leave memory.
 
 **Stdout/stderr redaction** is decided per stream: a stream attached to an interactive terminal passes through raw (so TUIs like `claude` render correctly), while a piped or redirected stream is scrubbed of sensitive values, including the real values the proxy injects at the wire, in case an upstream response echoes one back. Override with `--redact-stdout` / `--no-redact-stdout`.
 
 :::note[Clients that don't read these env vars]
 Tools that ignore the standard proxy/CA environment variables (many GUI apps, browsers, and some language runtimes with their own trust stores) won't be transparently proxied. The target here is CLI tools and agents, which generally do respect them.
+
+One known offender: the Python that ships with macOS (`/usr/bin/python3`, built against Apple's LibreSSL) ignores `SSL_CERT_FILE`, so its `urllib` fails TLS verification against the proxy. Pythons from python.org, Homebrew, pyenv, or `uv` honor it. On the system Python, either use `requests` (which reads `REQUESTS_CA_BUNDLE`) or pass the bundle explicitly: `ssl.create_default_context(cafile=os.environ["SSL_CERT_FILE"])`.
 :::
 
 ### Pinning the port and CA location

--- a/packages/varlock/src/proxy/cert-authority.test.ts
+++ b/packages/varlock/src/proxy/cert-authority.test.ts
@@ -37,6 +37,26 @@ describe('cert-authority (in-memory CA)', () => {
     expect(leaf.keyPem).toContain('BEGIN PRIVATE KEY');
   });
 
+  test('CA and leaf carry key identifiers for strict verifiers', async () => {
+    // Python 3.13+ enables VERIFY_X509_STRICT by default, which rejects chains
+    // missing an SKI on the CA or an AKI on the leaf (RFC 5280). A regression
+    // here breaks every modern python client through the proxy.
+    const ca = await createEphemeralCa();
+    const leaf = await createHostCert(ca, 'api.example.com');
+
+    const caCert = new x509.X509Certificate(ca.certPem);
+    const leafCert = new x509.X509Certificate(leaf.certPem);
+
+    const caSki = caCert.getExtension(x509.SubjectKeyIdentifierExtension);
+    const leafSki = leafCert.getExtension(x509.SubjectKeyIdentifierExtension);
+    const leafAki = leafCert.getExtension(x509.AuthorityKeyIdentifierExtension);
+    expect(caSki).toBeTruthy();
+    expect(leafSki).toBeTruthy();
+    expect(leafAki).toBeTruthy();
+    // Chain building matches the leaf AKI to the CA SKI byte-for-byte.
+    expect(leafAki!.keyId).toBe(caSki!.keyId);
+  });
+
   test('a leaf does not verify against an unrelated CA', async () => {
     const ca = await createEphemeralCa();
     const otherCa = await createEphemeralCa();

--- a/packages/varlock/src/proxy/cert-authority.ts
+++ b/packages/varlock/src/proxy/cert-authority.ts
@@ -87,6 +87,9 @@ export async function createEphemeralCa(): Promise<EphemeralCa> {
       new x509.BasicConstraintsExtension(true, undefined, true),
       // eslint-disable-next-line no-bitwise -- combining KeyUsage flags is the intended bitmask API
       new x509.KeyUsagesExtension(x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign, true),
+      // RFC 5280 requires an SKI on CA certs; strict verifiers (python 3.13+
+      // sets VERIFY_X509_STRICT by default) reject chains without it.
+      await x509.SubjectKeyIdentifierExtension.create(keys.publicKey),
     ],
   });
 
@@ -114,6 +117,11 @@ export async function createHostCert(ca: EphemeralCa, host: string): Promise<Min
       // IP-literal hosts need an IP SAN (clients verify IPs against iPAddress,
       // not dNSName); hostnames use a DNS SAN.
       new x509.SubjectAlternativeNameExtension([{ type: isIP(host) ? 'ip' : 'dns', value: host }]),
+      // Strict verifiers (python 3.13+ sets VERIFY_X509_STRICT by default)
+      // require an AKI on non-self-issued certs; it must match the CA's SKI,
+      // which both being derived from the CA public key guarantees.
+      await x509.SubjectKeyIdentifierExtension.create(keys.publicKey),
+      await x509.AuthorityKeyIdentifierExtension.create(ca.cert.publicKey),
     ],
   });
 

--- a/packages/varlock/src/proxy/runtime-proxy.test.ts
+++ b/packages/varlock/src/proxy/runtime-proxy.test.ts
@@ -237,6 +237,40 @@ describe('startLocalProxyRuntime', () => {
     });
   });
 
+  test('strips Proxy-Authorization instead of forwarding it upstream (hop-by-hop)', async () => {
+    // A client with credentials in its proxy url (userinfo) sends
+    // Proxy-Authorization addressed to the proxy; the upstream must not see it.
+    let upstreamSawProxyAuth: string | undefined;
+    const upstream = http.createServer((req, res) => {
+      upstreamSawProxyAuth = req.headers['proxy-authorization'] as string | undefined;
+      res.statusCode = 200;
+      res.end('ok');
+    });
+    await new Promise<void>((resolve) => {
+      upstream.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = upstream.address();
+    if (!addr || typeof addr === 'string') throw new Error('Failed to start test upstream');
+
+    const runtime = await startLocalProxyRuntime({
+      managedItems: [],
+      rules: [{ domain: ['127.0.0.1'], itemKeys: [] }],
+      egressMode: 'permissive',
+    });
+
+    const res = await requestViaProxy(runtime.env.HTTP_PROXY!, `http://127.0.0.1:${addr.port}/`, {
+      'proxy-authorization': 'Basic c29tZXRva2VuOg==',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(upstreamSawProxyAuth).toBeUndefined();
+
+    await runtime.stop();
+    await new Promise<void>((resolve) => {
+      upstream.close(() => resolve());
+    });
+  });
+
   test('emits a blocked-egress activity in strict mode (no secrets in the activity)', async () => {
     const activities: Array<ProxyActivity> = [];
     const runtime = await startLocalProxyRuntime({

--- a/packages/varlock/src/proxy/runtime-proxy.ts
+++ b/packages/varlock/src/proxy/runtime-proxy.ts
@@ -833,6 +833,10 @@ export async function startLocalProxyRuntime({
     );
     delete upstreamHeaders['proxy-connection'];
     delete upstreamHeaders.connection;
+    // Hop-by-hop: addressed to this proxy, never the upstream. A client with
+    // credentials in its proxy url (e.g. a copied HTTPS_PROXY with userinfo)
+    // must not have them forwarded to the destination host.
+    delete upstreamHeaders['proxy-authorization'];
     if (t.upstreamHostHeader !== undefined) upstreamHeaders.host = t.upstreamHostHeader;
     if (rewrittenBody.byteLength !== body.byteLength) {
       upstreamHeaders['content-length'] = String(rewrittenBody.byteLength);

--- a/smoke-tests/smoke-test-proxy/.env.schema
+++ b/smoke-tests/smoke-test-proxy/.env.schema
@@ -1,0 +1,3 @@
+# @proxy(domain="example.com")
+# @sensitive
+API_KEY=sk-fake-proxy-smoke-value

--- a/smoke-tests/tests/proxy-python.test.ts
+++ b/smoke-tests/tests/proxy-python.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'vitest';
+import { execSync } from 'node:child_process';
+
+import { runVarlock } from '../helpers/run-varlock';
+import { hasBinary, runBinary } from '../helpers/run-varlock-binary';
+
+// End-to-end proof that a real Python client works through the credential
+// proxy with zero client-side setup: python picks up HTTPS_PROXY + SSL_CERT_FILE
+// from the injected env, opens a CONNECT tunnel, and verifies the minted MITM
+// leaf with STRICT verification. python 3.13+ enables VERIFY_X509_STRICT by
+// default, which rejects chains missing subject/authority key identifiers; we
+// force the flag so any CPython exercises the same check. The target
+// (example.com) matches the fixture's @proxy rule, so the request takes the
+// full MITM path (summary shows matched=1), not a passthrough tunnel.
+//
+// Apple's system python (LibreSSL build) ignores SSL_CERT_FILE and its strict
+// checks differ, so only an OpenSSL-backed python is meaningful here; skip
+// otherwise. CI runners (linux/macos/windows) all provide OpenSSL pythons.
+function findOpensslPython(): string | undefined {
+  // Versioned names cover macOS dev machines where plain python3 is Apple's
+  // LibreSSL build but a homebrew/pyenv python is also on PATH.
+  for (const cmd of ['python3', 'python', 'python3.14', 'python3.13', 'python3.12']) {
+    try {
+      const backend = execSync(`${cmd} -c "import ssl; print(ssl.OPENSSL_VERSION)"`, {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        encoding: 'utf-8',
+      });
+      if (backend.trim().startsWith('OpenSSL')) return cmd;
+    } catch {
+      // not installed / broken; try the next candidate
+    }
+  }
+  return undefined;
+}
+
+const PYTHON = findOpensslPython();
+// proxy run is not exercised on windows yet; scope the smoke test accordingly
+const SKIP = process.platform === 'win32' || !PYTHON;
+
+const PYTHON_CLIENT = `
+import ssl, urllib.request, urllib.error
+ctx = ssl.create_default_context()
+ctx.verify_flags |= ssl.VERIFY_X509_STRICT
+try:
+    r = urllib.request.urlopen('https://example.com/', timeout=30, context=ctx)
+    print('STATUS', r.status)
+except urllib.error.HTTPError as e:
+    print('STATUS', e.code)
+except urllib.error.URLError as e:
+    print('URLERROR', e.reason)
+`;
+
+describe('python through the credential proxy (strict TLS verification)', () => {
+  test.skipIf(SKIP)('urllib completes a strict-verified MITM request (installed CLI)', () => {
+    const result = runVarlock(
+      ['proxy', 'run', '--', PYTHON!, '-c', PYTHON_CLIENT],
+      { cwd: 'smoke-test-proxy' },
+    );
+
+    // A cert-chain failure surfaces as URLERROR (CERTIFICATE_VERIFY_FAILED),
+    // never a STATUS line. matched=1 in the session summary proves the request
+    // took the MITM path (rule matched), not a passthrough tunnel.
+    expect(result.output).toContain('STATUS 200');
+    expect(result.output).toContain('matched=1');
+  }, 120_000);
+
+  test.skipIf(SKIP || !hasBinary())('urllib completes a strict-verified MITM request (compiled binary)', () => {
+    // The bundled/compiled binary is the risky artifact for cert generation
+    // (module init order differs from bun run / vitest), so prove it there too.
+    const result = runBinary(
+      ['proxy', 'run', '--', PYTHON!, '-c', PYTHON_CLIENT],
+      { cwd: 'smoke-test-proxy' },
+    );
+
+    expect(result.output).toContain('STATUS 200');
+    expect(result.output).toContain('matched=1');
+  }, 120_000);
+});


### PR DESCRIPTION
Two fixes from user feedback on the proxy and 1password plugin.

## Proxy: minted MITM certs rejected by strict TLS verifiers

Python 3.13+ enables `VERIFY_X509_STRICT` by default, and our minted CA/leaf certs had no subject/authority key identifier extensions, so every modern python client (urllib and httpx alike) failed the TLS handshake with `Missing Authority Key Identifier`. The CA cert now carries an SKI and minted leaves carry SKI + AKI (derived from the CA public key so it byte-matches the CA's SKI).

Also in this area:
- Client-sent `Proxy-Authorization` is now stripped (hop-by-hop, addressed to the proxy) instead of forwarded to the destination host.
- New smoke test drives real python urllib (with strict verification forced) through `proxy run` via both the installed CLI and the compiled binary. Verified it catches the bug: it fails with the exact missing-AKI error against a pre-fix build. Skips on windows and on LibreSSL pythons (Apple's system python ignores `SSL_CERT_FILE`, now documented in the proxy guide along with the no-proxy-credentials design).

## 1password: CLI batch reads fail on windows

`op run -- env -0` depends on a unix `env` binary, which doesn't exist on windows unless git's usr/bin is on PATH. Batch reads now use `op inject` with a stdin template of `op://` refs instead: same single authenticated call (batching performance unchanged), no child binary at all, and `--no-masking` is no longer needed.

Template entries are joined with a random per-call sentinel string rather than `\0` because `op inject` strips control characters from its output (verified against the real CLI, and the fake-op test harness mimics this). Multiline secret values are covered by a new test. References also no longer appear in the child process env, only on the stdin pipe.