### PR TITLE
Fix proxy MITM certs for strict TLS verifiers (python 3.13+)

### DIFF
--- a/.bumpy/proxy-cert-strict-verifiers.md
+++ b/.bumpy/proxy-cert-strict-verifiers.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+proxy: minted MITM certs now include subject/authority key identifiers so strict TLS verifiers (python 3.13+ urllib/httpx defaults) accept them; Proxy-Authorization from clients is stripped instead of forwarded upstream

--- a/.bumpy/proxy-cert-strict-verifiers.md
+++ b/.bumpy/proxy-cert-strict-verifiers.md
@@ -2,4 +2,4 @@
 varlock: patch
 ---
 
-proxy: minted MITM certs now include subject/authority key identifiers so strict TLS verifiers (python 3.13+ urllib/httpx defaults) accept them; Proxy-Authorization from clients is stripped instead of forwarded upstream
+proxy client compatibility fixes: minted MITM certs now include subject/authority key identifiers so strict TLS verifiers (python 3.13+ urllib/httpx defaults) accept them; the injected env now sets NODE_USE_ENV_PROXY=1 so Node's built-in fetch (node 24+) routes through the proxy instead of silently bypassing it, and DENO_CERT so Deno trusts the proxy CA; Proxy-Authorization from clients is stripped instead of forwarded upstream

--- a/packages/varlock-website/src/content/docs/guides/proxy.mdx
+++ b/packages/varlock-website/src/content/docs/guides/proxy.mdx
@@ -345,12 +345,32 @@ The proxy uses an **ephemeral, in-memory certificate authority** generated per r
 
 **Stdout/stderr redaction** is decided per stream: a stream attached to an interactive terminal passes through raw (so TUIs like `claude` render correctly), while a piped or redirected stream is scrubbed of sensitive values, including the real values the proxy injects at the wire, in case an upstream response echoes one back. Override with `--redact-stdout` / `--no-redact-stdout`.
 
-:::note[Clients that don't read these env vars]
-Tools that ignore the standard proxy/CA environment variables (many GUI apps, browsers, and some language runtimes with their own trust stores) won't be transparently proxied. The target here is CLI tools and agents, which generally do respect them.
+### Client compatibility
 
-One known offender: the Python that ships with macOS (`/usr/bin/python3`, built against Apple's LibreSSL) ignores `SSL_CERT_FILE`, so its `urllib` fails TLS verification against the proxy. Pythons from python.org, Homebrew, pyenv, or `uv` honor it. On the system Python, either use `requests` (which reads `REQUESTS_CA_BUNDLE`) or pass the bundle explicitly: `ssl.create_default_context(cafile=os.environ["SSL_CERT_FILE"])`.
+The proxy works with any client that honors the standard proxy and CA env vars above. Status of common clients:
 
-The same class of issue affects clients that verify TLS against the macOS system keychain instead of the CA env vars: Go programs on macOS (including CLIs like `gh` and `terraform`), .NET on macOS, macOS system Ruby, and Rust tools built with platform-verifier crates. These honor `HTTPS_PROXY` but reject the proxy's certificate. On Linux, Go and .NET read `SSL_CERT_FILE` and work. There is no env-var fix on macOS; run those tools outside the proxy or on Linux (e.g. `--sandbox=docker`).
+| Client | Works? | Notes |
+| --- | --- | --- |
+| curl, git, wget | yes | `--http2` is fine: ALPN negotiates down to HTTP/1.1 |
+| Python: python.org, Homebrew, pyenv, `uv` builds | yes | urllib, requests, and httpx all verified, including python 3.13+ strict verification |
+| Python: macOS system (`/usr/bin/python3`) | partial | proxied, but ignores `SSL_CERT_FILE` so urllib fails TLS verification; see workarounds below |
+| Node built-in `fetch` (Node 24+) | yes | via the injected `NODE_USE_ENV_PROXY=1` |
+| Node built-in `fetch` (Node < 24) | no | silently bypasses the proxy and sends placeholders directly upstream; use axios/got or Node 24+ |
+| Node axios, got | yes | implement env-proxy support themselves |
+| Bun `fetch` | yes | |
+| Deno | yes | via the injected `DENO_CERT` |
+| Go programs (incl. `gh`, `terraform`, `kubectl`) | Linux yes, macOS no | on macOS Go verifies against the system keychain and rejects the proxy CA |
+| .NET | Linux yes, macOS no | same system-keychain issue as Go |
+| Ruby | build-dependent | OpenSSL-linked builds work; macOS system Ruby has the same `SSL_CERT_FILE` issue as system Python |
+| Rust (reqwest etc.) | build-dependent | `native-tls`/OpenSSL backends honor `SSL_CERT_FILE`; `rustls` platform-verifier or bundled-roots builds reject the proxy CA |
+| JVM tools (java, gradle, maven) | no | the JVM ignores both the proxy and CA env vars on every platform; needs `-Dhttps.proxyHost`/`-Dhttps.proxyPort` and a custom truststore |
+| gRPC clients | no on matched hosts | gRPC requires HTTP/2 and the proxy's TLS interception is HTTP/1.1 only; hosts without a `@proxy` rule tunnel through untouched |
+| WebSockets (`wss://`) | no on matched hosts | upgrades through the interception path are unsupported; hosts without a `@proxy` rule tunnel through untouched |
+
+:::note[Workarounds]
+- **macOS system Python:** use `requests` (reads `REQUESTS_CA_BUNDLE`), or pass the bundle explicitly: `ssl.create_default_context(cafile=os.environ["SSL_CERT_FILE"])`. Pythons from python.org, Homebrew, pyenv, or `uv` need nothing.
+- **macOS system-keychain clients (Go, .NET, Rust platform verifiers):** these honor `HTTPS_PROXY` but verify TLS against the system keychain, which does not contain the proxy's ephemeral CA. There is no env-var fix; run those tools on Linux (e.g. [`--sandbox=docker`](/guides/sandboxing/), where they read `SSL_CERT_FILE`) or outside the proxy.
+- **GUI apps and browsers** generally ignore these env vars entirely; the target here is CLI tools and agents.
 :::
 
 ### Pinning the port and CA location
@@ -423,7 +443,8 @@ The proxy is a local, same-machine tool. Know what it does and doesn't cover bef
 - **Injection requires a verified public-TLS host.** Secrets are injected only onto connections whose TLS identity is verified against public CAs. The proxy refuses to inject over cleartext `http://` or into a self-signed/local upstream, by design.
 - **Default egress is not containment.** `egress=permissive` (the default) does not restrict where the agent can connect; it just never injects to unmatched hosts. Use `egress=strict` (and ideally a sandbox) if you want to constrain egress.
 - **Hot-reload is human-applied.** `proxy reload` (or pressing `r` in an interactive `proxy start`) re-resolves the schema and swaps the live policy; a reload requested from inside the proxied agent is refused and logged so the agent can't self-approve a schema edit. Availability follows [`@proxyConfig={reload=...}`](/reference/root-decorators/#proxyconfig) (default `auto`: on for an interactive daemon, off for headless or one-shot runs). But the agent-refusal is a self-reported signal, not authentication: an agent that strips its proxy markers (or runs out-of-tree) can still trigger a reload on a shared uid. A real out-of-band approver is planned to close this; until then, prefer a sandbox.
-- **Only proxy-aware clients are covered.** The child is pointed at the proxy via standard `HTTP(S)_PROXY` / CA env vars. A client that ignores those (or pins its own CA) bypasses the proxy entirely; it just won't get a working secret.
+- **Only proxy-aware clients are covered.** The child is pointed at the proxy via standard `HTTP(S)_PROXY` / CA env vars. A client that ignores those (or pins its own CA) bypasses the proxy entirely; it just won't get a working secret. See [client compatibility](#client-compatibility) for the status of common clients.
+- **TLS interception is HTTP/1.1 only.** Normal clients negotiate down via ALPN and work fine, but protocols that require HTTP/2 (gRPC) or a connection upgrade (WebSockets) are unsupported on hosts with a `@proxy` rule. Hosts without a rule tunnel through untouched.
 
 ## Reference
 

--- a/packages/varlock-website/src/content/docs/guides/proxy.mdx
+++ b/packages/varlock-website/src/content/docs/guides/proxy.mdx
@@ -336,7 +336,8 @@ Sessions are durable records: they persist after the proxy stops (visible with `
 `proxy run` (and `proxy env`) inject a standard set of environment variables into the child so common HTTP clients trust the proxy with no manual setup:
 
 - **Proxy address:** `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` (and lowercase), with `NO_PROXY` excluding localhost.
-- **CA trust:** `NODE_EXTRA_CA_CERTS` (Node.js), `REQUESTS_CA_BUNDLE` (Python `requests`), `CURL_CA_BUNDLE` (curl), `GIT_SSL_CAINFO` (git), and `SSL_CERT_FILE` (OpenSSL-based tools).
+- **CA trust:** `NODE_EXTRA_CA_CERTS` (Node.js), `REQUESTS_CA_BUNDLE` (Python `requests`), `CURL_CA_BUNDLE` (curl), `GIT_SSL_CAINFO` (git), `DENO_CERT` (Deno), and `SSL_CERT_FILE` (OpenSSL-based tools).
+- **Runtime opt-ins:** `NODE_USE_ENV_PROXY=1`, so Node's built-in `fetch` (Node 24+) routes through the proxy. Without it, `fetch` ignores the proxy env vars entirely and sends requests (with placeholder values) directly to the upstream. On older Node versions the flag is ignored and `fetch` still bypasses the proxy; use an env-proxy-aware client (axios, got) or Node 24+.
 
 The proxy URL carries no credentials, and the proxy never asks clients for proxy authentication (no `407` challenges). Session scoping is enforced by the proxy itself, so clients with limited proxy-auth support (like Python's `urllib`) work with the plain `HTTPS_PROXY` url.
 
@@ -348,6 +349,8 @@ The proxy uses an **ephemeral, in-memory certificate authority** generated per r
 Tools that ignore the standard proxy/CA environment variables (many GUI apps, browsers, and some language runtimes with their own trust stores) won't be transparently proxied. The target here is CLI tools and agents, which generally do respect them.
 
 One known offender: the Python that ships with macOS (`/usr/bin/python3`, built against Apple's LibreSSL) ignores `SSL_CERT_FILE`, so its `urllib` fails TLS verification against the proxy. Pythons from python.org, Homebrew, pyenv, or `uv` honor it. On the system Python, either use `requests` (which reads `REQUESTS_CA_BUNDLE`) or pass the bundle explicitly: `ssl.create_default_context(cafile=os.environ["SSL_CERT_FILE"])`.
+
+The same class of issue affects clients that verify TLS against the macOS system keychain instead of the CA env vars: Go programs on macOS (including CLIs like `gh` and `terraform`), .NET on macOS, macOS system Ruby, and Rust tools built with platform-verifier crates. These honor `HTTPS_PROXY` but reject the proxy's certificate. On Linux, Go and .NET read `SSL_CERT_FILE` and work. There is no env-var fix on macOS; run those tools outside the proxy or on Linux (e.g. `--sandbox=docker`).
 :::
 
 ### Pinning the port and CA location

--- a/packages/varlock-website/src/content/docs/guides/proxy.mdx
+++ b/packages/varlock-website/src/content/docs/guides/proxy.mdx
@@ -336,7 +336,7 @@ Sessions are durable records: they persist after the proxy stops (visible with `
 `proxy run` (and `proxy env`) inject a standard set of environment variables into the child so common HTTP clients trust the proxy with no manual setup:
 
 - **Proxy address:** `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` (and lowercase), with `NO_PROXY` excluding localhost.
-- **CA trust:** `NODE_EXTRA_CA_CERTS` (Node.js), `REQUESTS_CA_BUNDLE` (Python `requests`), `CURL_CA_BUNDLE` (curl), `GIT_SSL_CAINFO` (git), `DENO_CERT` (Deno), and `SSL_CERT_FILE` (OpenSSL-based tools).
+- **CA trust:** `NODE_EXTRA_CA_CERTS` (Node.js), `REQUESTS_CA_BUNDLE` (Python `requests`), `CURL_CA_BUNDLE` (curl), `GIT_SSL_CAINFO` (git), `CARGO_HTTP_CAINFO` (cargo), `DENO_CERT` (Deno), and `SSL_CERT_FILE` (OpenSSL-based tools).
 - **Runtime opt-ins:** `NODE_USE_ENV_PROXY=1`, so Node's built-in `fetch` (Node 24+) routes through the proxy. Without it, `fetch` ignores the proxy env vars entirely and sends requests (with placeholder values) directly to the upstream. On older Node versions the flag is ignored and `fetch` still bypasses the proxy; use an env-proxy-aware client (axios, got) or Node 24+.
 
 The proxy URL carries no credentials, and the proxy never asks clients for proxy authentication (no `407` challenges). Session scoping is enforced by the proxy itself, so clients with limited proxy-auth support (like Python's `urllib`) work with the plain `HTTPS_PROXY` url.

--- a/packages/varlock-website/src/content/docs/guides/proxy.mdx
+++ b/packages/varlock-website/src/content/docs/guides/proxy.mdx
@@ -338,12 +338,16 @@ Sessions are durable records: they persist after the proxy stops (visible with `
 - **Proxy address:** `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` (and lowercase), with `NO_PROXY` excluding localhost.
 - **CA trust:** `NODE_EXTRA_CA_CERTS` (Node.js), `REQUESTS_CA_BUNDLE` (Python `requests`), `CURL_CA_BUNDLE` (curl), `GIT_SSL_CAINFO` (git), and `SSL_CERT_FILE` (OpenSSL-based tools).
 
+The proxy URL carries no credentials, and the proxy never asks clients for proxy authentication (no `407` challenges). Session scoping is enforced by the proxy itself, so clients with limited proxy-auth support (like Python's `urllib`) work with the plain `HTTPS_PROXY` url.
+
 The proxy uses an **ephemeral, in-memory certificate authority** generated per run; only its public certificate is written to a temp file for the child to trust. The CA private key and all per-host certificates never leave memory.
 
 **Stdout/stderr redaction** is decided per stream: a stream attached to an interactive terminal passes through raw (so TUIs like `claude` render correctly), while a piped or redirected stream is scrubbed of sensitive values, including the real values the proxy injects at the wire, in case an upstream response echoes one back. Override with `--redact-stdout` / `--no-redact-stdout`.
 
 :::note[Clients that don't read these env vars]
 Tools that ignore the standard proxy/CA environment variables (many GUI apps, browsers, and some language runtimes with their own trust stores) won't be transparently proxied. The target here is CLI tools and agents, which generally do respect them.
+
+One known offender: the Python that ships with macOS (`/usr/bin/python3`, built against Apple's LibreSSL) ignores `SSL_CERT_FILE`, so its `urllib` fails TLS verification against the proxy. Pythons from python.org, Homebrew, pyenv, or `uv` honor it. On the system Python, either use `requests` (which reads `REQUESTS_CA_BUNDLE`) or pass the bundle explicitly: `ssl.create_default_context(cafile=os.environ["SSL_CERT_FILE"])`.
 :::
 
 ### Pinning the port and CA location

--- a/packages/varlock/src/proxy/cert-authority.test.ts
+++ b/packages/varlock/src/proxy/cert-authority.test.ts
@@ -44,6 +44,26 @@ describe('cert-authority (in-memory CA)', () => {
     expect(leaf.keyPem).toContain('BEGIN PRIVATE KEY');
   });
 
+  test('CA and leaf carry key identifiers for strict verifiers', async () => {
+    // Python 3.13+ enables VERIFY_X509_STRICT by default, which rejects chains
+    // missing an SKI on the CA or an AKI on the leaf (RFC 5280). A regression
+    // here breaks every modern python client through the proxy.
+    const ca = await createEphemeralCa();
+    const leaf = await createHostCert(ca, 'api.example.com');
+
+    const caCert = new x509.X509Certificate(ca.certPem);
+    const leafCert = new x509.X509Certificate(leaf.certPem);
+
+    const caSki = caCert.getExtension(x509.SubjectKeyIdentifierExtension);
+    const leafSki = leafCert.getExtension(x509.SubjectKeyIdentifierExtension);
+    const leafAki = leafCert.getExtension(x509.AuthorityKeyIdentifierExtension);
+    expect(caSki).toBeTruthy();
+    expect(leafSki).toBeTruthy();
+    expect(leafAki).toBeTruthy();
+    // Chain building matches the leaf AKI to the CA SKI byte-for-byte.
+    expect(leafAki!.keyId).toBe(caSki!.keyId);
+  });
+
   test('a leaf does not verify against an unrelated CA', async () => {
     const ca = await createEphemeralCa();
     const otherCa = await createEphemeralCa();

--- a/packages/varlock/src/proxy/cert-authority.ts
+++ b/packages/varlock/src/proxy/cert-authority.ts
@@ -10,6 +10,8 @@ import {
   KeyUsage, KeyUsageFlags, id_ce_keyUsage as OID_KEY_USAGE,
   ExtendedKeyUsage, id_ce_extKeyUsage as OID_EXT_KEY_USAGE, id_kp_serverAuth as OID_KP_SERVER_AUTH,
   SubjectAlternativeName, id_ce_subjectAltName as OID_SUBJECT_ALT_NAME, GeneralName,
+  SubjectKeyIdentifier, id_ce_subjectKeyIdentifier as OID_SUBJECT_KEY_IDENTIFIER,
+  AuthorityKeyIdentifier, KeyIdentifier, id_ce_authorityKeyIdentifier as OID_AUTHORITY_KEY_IDENTIFIER,
 } from '@peculiar/asn1-x509';
 import { ecdsaWithSHA256, ECDSASigValue } from '@peculiar/asn1-ecc';
 
@@ -51,6 +53,8 @@ export type EphemeralCa = {
   privateKey: CryptoKey;
   /** Issuer DN of the CA, reused as the issuer field of every minted leaf. */
   issuerName: Name;
+  /** The CA's subject key identifier, embedded as each minted leaf's AKI so chains build under strict verifiers. */
+  subjectKeyId: ArrayBuffer;
   certPem: string;
 };
 
@@ -151,11 +155,18 @@ async function subjectPublicKeyInfo(publicKey: CryptoKey): Promise<SubjectPublic
   return AsnConvert.parse(spki, SubjectPublicKeyInfo);
 }
 
+/** RFC 5280 method-1 key identifier: SHA-1 of the subjectPublicKey BIT STRING contents. */
+async function keyIdentifierFor(publicKey: CryptoKey): Promise<ArrayBuffer> {
+  const spki = await subjectPublicKeyInfo(publicKey);
+  return cryptoApi.subtle.digest('SHA-1', spki.subjectPublicKey);
+}
+
 /** Generate a fresh in-memory CA. Private key stays in memory; only the cert is exported. */
 export async function createEphemeralCa(): Promise<EphemeralCa> {
   const keys = await generateKeyPair();
   const { notBefore, notAfter } = validityWindow();
   const issuerName = commonNameDn('varlock-proxy-ca');
+  const subjectKeyId = await keyIdentifierFor(keys.publicKey);
 
   const tbs = new TBSCertificate({
     version: Version.v3,
@@ -169,11 +180,16 @@ export async function createEphemeralCa(): Promise<EphemeralCa> {
       extension(OID_BASIC_CONSTRAINTS, true, new BasicConstraints({ cA: true })),
       // eslint-disable-next-line no-bitwise -- combining KeyUsage flags is the intended bitmask API
       extension(OID_KEY_USAGE, true, new KeyUsage(KeyUsageFlags.keyCertSign | KeyUsageFlags.cRLSign)),
+      // RFC 5280 requires an SKI on CA certs; strict verifiers (python 3.13+
+      // sets VERIFY_X509_STRICT by default) reject chains without it.
+      extension(OID_SUBJECT_KEY_IDENTIFIER, false, new SubjectKeyIdentifier(subjectKeyId)),
     ]),
   });
 
   const certPem = await signCertificate(tbs, keys.privateKey);
-  return { privateKey: keys.privateKey, issuerName, certPem };
+  return {
+    privateKey: keys.privateKey, issuerName, subjectKeyId, certPem,
+  };
 }
 
 /** Mint a leaf cert for a host, signed by the CA. Both keys stay in memory. */
@@ -200,6 +216,13 @@ export async function createHostCert(ca: EphemeralCa, host: string): Promise<Min
       extension(OID_KEY_USAGE, true, new KeyUsage(KeyUsageFlags.digitalSignature)),
       extension(OID_EXT_KEY_USAGE, false, new ExtendedKeyUsage([OID_KP_SERVER_AUTH])),
       extension(OID_SUBJECT_ALT_NAME, false, new SubjectAlternativeName([sanEntry])),
+      // Strict verifiers (python 3.13+ sets VERIFY_X509_STRICT by default)
+      // require an AKI on non-self-issued certs matching the issuer's SKI, and
+      // recommend an SKI on every cert (RFC 5280).
+      extension(OID_SUBJECT_KEY_IDENTIFIER, false, new SubjectKeyIdentifier(await keyIdentifierFor(keys.publicKey))),
+      extension(OID_AUTHORITY_KEY_IDENTIFIER, false, new AuthorityKeyIdentifier({
+        keyIdentifier: new KeyIdentifier(ca.subjectKeyId),
+      })),
     ]),
   });
 

--- a/packages/varlock/src/proxy/runtime-proxy.test.ts
+++ b/packages/varlock/src/proxy/runtime-proxy.test.ts
@@ -374,6 +374,40 @@ describe('startLocalProxyRuntime', () => {
     });
   });
 
+  test('strips Proxy-Authorization instead of forwarding it upstream (hop-by-hop)', async () => {
+    // A client with credentials in its proxy url (userinfo) sends
+    // Proxy-Authorization addressed to the proxy; the upstream must not see it.
+    let upstreamSawProxyAuth: string | undefined;
+    const upstream = http.createServer((req, res) => {
+      upstreamSawProxyAuth = req.headers['proxy-authorization'] as string | undefined;
+      res.statusCode = 200;
+      res.end('ok');
+    });
+    await new Promise<void>((resolve) => {
+      upstream.listen(0, '127.0.0.1', () => resolve());
+    });
+    const addr = upstream.address();
+    if (!addr || typeof addr === 'string') throw new Error('Failed to start test upstream');
+
+    const runtime = await startLocalProxyRuntime({
+      managedItems: [],
+      rules: [{ domain: ['127.0.0.1'], itemKeys: [] }],
+      egressMode: 'permissive',
+    });
+
+    const res = await requestViaProxy(runtime.env.HTTP_PROXY!, `http://127.0.0.1:${addr.port}/`, {
+      'proxy-authorization': 'Basic c29tZXRva2VuOg==',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(upstreamSawProxyAuth).toBeUndefined();
+
+    await runtime.stop();
+    await new Promise<void>((resolve) => {
+      upstream.close(() => resolve());
+    });
+  });
+
   test('emits a blocked-egress activity in strict mode (no secrets in the activity)', async () => {
     const activities: Array<ProxyActivity> = [];
     const runtime = await startLocalProxyRuntime({

--- a/packages/varlock/src/proxy/runtime-proxy.test.ts
+++ b/packages/varlock/src/proxy/runtime-proxy.test.ts
@@ -251,6 +251,9 @@ describe('startLocalProxyRuntime', () => {
     expect(runtime.env.REQUESTS_CA_BUNDLE).toBeDefined();
     expect(runtime.env.CURL_CA_BUNDLE).toBeDefined();
     expect(runtime.env.GIT_SSL_CAINFO).toBeDefined();
+    expect(runtime.env.DENO_CERT).toBe(runtime.env.SSL_CERT_FILE);
+    // without this, node's built-in fetch silently bypasses the proxy (node >= 24)
+    expect(runtime.env.NODE_USE_ENV_PROXY).toBe('1');
 
     await runtime.stop();
   });

--- a/packages/varlock/src/proxy/runtime-proxy.ts
+++ b/packages/varlock/src/proxy/runtime-proxy.ts
@@ -1089,6 +1089,10 @@ export async function startLocalProxyRuntime({
     );
     delete upstreamHeaders['proxy-connection'];
     delete upstreamHeaders.connection;
+    // Hop-by-hop: addressed to this proxy, never the upstream. A client with
+    // credentials in its proxy url (e.g. a copied HTTPS_PROXY with userinfo)
+    // must not have them forwarded to the destination host.
+    delete upstreamHeaders['proxy-authorization'];
     if (t.upstreamHostHeader !== undefined) upstreamHeaders.host = t.upstreamHostHeader;
     if (rewrittenBody.byteLength !== body.byteLength) {
       upstreamHeaders['content-length'] = String(rewrittenBody.byteLength);

--- a/packages/varlock/src/proxy/runtime-proxy.ts
+++ b/packages/varlock/src/proxy/runtime-proxy.ts
@@ -1365,6 +1365,7 @@ export async function startLocalProxyRuntime({
       REQUESTS_CA_BUNDLE: combinedCaPath,
       CURL_CA_BUNDLE: combinedCaPath,
       GIT_SSL_CAINFO: combinedCaPath,
+      CARGO_HTTP_CAINFO: combinedCaPath,
       // Node's built-in fetch (undici) ignores HTTP(S)_PROXY unless this flag
       // is set (node >= 24; older nodes ignore the flag and still bypass).
       // Without it, fetch traffic silently goes DIRECT to the upstream,

--- a/packages/varlock/src/proxy/runtime-proxy.ts
+++ b/packages/varlock/src/proxy/runtime-proxy.ts
@@ -1365,6 +1365,14 @@ export async function startLocalProxyRuntime({
       REQUESTS_CA_BUNDLE: combinedCaPath,
       CURL_CA_BUNDLE: combinedCaPath,
       GIT_SSL_CAINFO: combinedCaPath,
+      // Node's built-in fetch (undici) ignores HTTP(S)_PROXY unless this flag
+      // is set (node >= 24; older nodes ignore the flag and still bypass).
+      // Without it, fetch traffic silently goes DIRECT to the upstream,
+      // skipping substitution and egress policy entirely.
+      NODE_USE_ENV_PROXY: '1',
+      // Deno honors HTTP(S)_PROXY but reads its CA trust from DENO_CERT,
+      // not SSL_CERT_FILE.
+      DENO_CERT: combinedCaPath,
     },
     setSessionEnvPayloadJson: (payloadJson, meta) => {
       sessionEnvPayloadJson = payloadJson;

--- a/packages/varlock/src/proxy/sandbox-docker.ts
+++ b/packages/varlock/src/proxy/sandbox-docker.ts
@@ -39,7 +39,7 @@ const PROXY_HOSTNAME = 'varlock-proxy';
 const FORWARDER_IMAGE = 'alpine/socat:1.8.0.0';
 
 /** CA-bundle env vars the proxy injects — all repoint to the in-guest mount. */
-const CA_PATH_ENV_VARS = ['NODE_EXTRA_CA_CERTS', 'SSL_CERT_FILE', 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE', 'GIT_SSL_CAINFO'];
+const CA_PATH_ENV_VARS = ['NODE_EXTRA_CA_CERTS', 'SSL_CERT_FILE', 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE', 'GIT_SSL_CAINFO', 'DENO_CERT'];
 /** Proxy-URL env vars — all repoint at the in-guest forwarder. */
 const PROXY_URL_ENV_VARS = ['HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'http_proxy', 'https_proxy', 'all_proxy'];
 

--- a/packages/varlock/src/proxy/sandbox-docker.ts
+++ b/packages/varlock/src/proxy/sandbox-docker.ts
@@ -39,7 +39,7 @@ const PROXY_HOSTNAME = 'varlock-proxy';
 const FORWARDER_IMAGE = 'alpine/socat:1.8.0.0';
 
 /** CA-bundle env vars the proxy injects — all repoint to the in-guest mount. */
-const CA_PATH_ENV_VARS = ['NODE_EXTRA_CA_CERTS', 'SSL_CERT_FILE', 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE', 'GIT_SSL_CAINFO', 'DENO_CERT'];
+const CA_PATH_ENV_VARS = ['NODE_EXTRA_CA_CERTS', 'SSL_CERT_FILE', 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE', 'GIT_SSL_CAINFO', 'CARGO_HTTP_CAINFO', 'DENO_CERT'];
 /** Proxy-URL env vars — all repoint at the in-guest forwarder. */
 const PROXY_URL_ENV_VARS = ['HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'http_proxy', 'https_proxy', 'all_proxy'];
 

--- a/smoke-tests/smoke-test-proxy/.env.schema
+++ b/smoke-tests/smoke-test-proxy/.env.schema
@@ -1,0 +1,3 @@
+# @proxy(domain="example.com")
+# @sensitive
+API_KEY=sk-fake-proxy-smoke-value

--- a/smoke-tests/tests/proxy-python.test.ts
+++ b/smoke-tests/tests/proxy-python.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'vitest';
+import { execSync } from 'node:child_process';
+
+import { runVarlock } from '../helpers/run-varlock';
+import { hasBinary, runBinary } from '../helpers/run-varlock-binary';
+
+// End-to-end proof that a real Python client works through the credential
+// proxy with zero client-side setup: python picks up HTTPS_PROXY + SSL_CERT_FILE
+// from the injected env, opens a CONNECT tunnel, and verifies the minted MITM
+// leaf with STRICT verification. python 3.13+ enables VERIFY_X509_STRICT by
+// default, which rejects chains missing subject/authority key identifiers; we
+// force the flag so any CPython exercises the same check. The target
+// (example.com) matches the fixture's @proxy rule, so the request takes the
+// full MITM path (summary shows matched=1), not a passthrough tunnel.
+//
+// Apple's system python (LibreSSL build) ignores SSL_CERT_FILE and its strict
+// checks differ, so only an OpenSSL-backed python is meaningful here; skip
+// otherwise. CI runners (linux/macos/windows) all provide OpenSSL pythons.
+function findOpensslPython(): string | undefined {
+  // Versioned names cover macOS dev machines where plain python3 is Apple's
+  // LibreSSL build but a homebrew/pyenv python is also on PATH.
+  for (const cmd of ['python3', 'python', 'python3.14', 'python3.13', 'python3.12']) {
+    try {
+      const backend = execSync(`${cmd} -c "import ssl; print(ssl.OPENSSL_VERSION)"`, {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        encoding: 'utf-8',
+      });
+      if (backend.trim().startsWith('OpenSSL')) return cmd;
+    } catch {
+      // not installed / broken; try the next candidate
+    }
+  }
+  return undefined;
+}
+
+const PYTHON = findOpensslPython();
+// proxy run is not exercised on windows yet; scope the smoke test accordingly
+const SKIP = process.platform === 'win32' || !PYTHON;
+
+const PYTHON_CLIENT = `
+import ssl, urllib.request, urllib.error
+ctx = ssl.create_default_context()
+ctx.verify_flags |= ssl.VERIFY_X509_STRICT
+try:
+    r = urllib.request.urlopen('https://example.com/', timeout=30, context=ctx)
+    print('STATUS', r.status)
+except urllib.error.HTTPError as e:
+    print('STATUS', e.code)
+except urllib.error.URLError as e:
+    print('URLERROR', e.reason)
+`;
+
+describe('python through the credential proxy (strict TLS verification)', () => {
+  test.skipIf(SKIP)('urllib completes a strict-verified MITM request (installed CLI)', () => {
+    const result = runVarlock(
+      ['proxy', 'run', '--', PYTHON!, '-c', PYTHON_CLIENT],
+      { cwd: 'smoke-test-proxy' },
+    );
+
+    // A cert-chain failure surfaces as URLERROR (CERTIFICATE_VERIFY_FAILED),
+    // never a STATUS line. matched=1 in the session summary proves the request
+    // took the MITM path (rule matched), not a passthrough tunnel.
+    expect(result.output).toContain('STATUS 200');
+    expect(result.output).toContain('matched=1');
+  }, 120_000);
+
+  test.skipIf(SKIP || !hasBinary())('urllib completes a strict-verified MITM request (compiled binary)', () => {
+    // The bundled/compiled binary is the risky artifact for cert generation
+    // (module init order differs from bun run / vitest), so prove it there too.
+    const result = runBinary(
+      ['proxy', 'run', '--', PYTHON!, '-c', PYTHON_CLIENT],
+      { cwd: 'smoke-test-proxy' },
+    );
+
+    expect(result.output).toContain('STATUS 200');
+    expect(result.output).toContain('matched=1');
+  }, 120_000);
+});


### PR DESCRIPTION
Client-compatibility fixes for the credential proxy, from user feedback plus a sweep of popular HTTP clients.

## Minted MITM certs rejected by strict TLS verifiers

Python 3.13+ enables `VERIFY_X509_STRICT` by default, and our minted CA/leaf certs had no subject/authority key identifier extensions, so every modern python client (urllib and httpx alike) failed the TLS handshake with `Missing Authority Key Identifier`. The CA cert now carries an SKI and minted leaves carry SKI + AKI (derived from the CA public key so it byte-matches the CA's SKI).

## Node's built-in fetch silently bypassed the proxy

undici ignores `HTTP(S)_PROXY` unless `NODE_USE_ENV_PROXY=1` (node 24+), so `fetch` traffic went directly upstream, skipping substitution and egress policy, with placeholder values in the requests. The injected proxy env now sets the flag (older nodes ignore it; documented). Also added `DENO_CERT` (Deno) and `CARGO_HTTP_CAINFO` (cargo) so those trust the proxy CA; the docker sandbox repoints it like the other CA path vars.

## Also

- Client-sent `Proxy-Authorization` is now stripped (hop-by-hop, addressed to the proxy) instead of forwarded to the destination host.
- New smoke test drives real python urllib (with strict verification forced) through `proxy run` via both the installed CLI and the compiled binary. Verified it catches the bug: it fails with the exact missing-AKI error against a pre-fix build. Skips on windows and on LibreSSL pythons.
- Docs: a consolidated client-compatibility matrix (node fetch by version, python by build, go/.NET by platform, JVM, gRPC, WebSockets) with a workarounds note, the no-proxy-credentials design note, and a new HTTP/1.1-only limitation bullet (gRPC / WebSocket upgrades unsupported on matched hosts).

