### PR TITLE
1password: use op inject for CLI batch reads (windows fix)

### DIFF
--- a/.bumpy/1password-windows-inject.md
+++ b/.bumpy/1password-windows-inject.md
@@ -1,0 +1,5 @@
+---
+"@varlock/1password-plugin": patch
+---
+
+CLI batch reads now use op inject instead of op run -- env -0, fixing failures on Windows where no unix env binary exists

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -2,7 +2,7 @@ import {
   type Resolver, type PluginCacheAccessor, plugin, resolveCacheTtl,
 } from 'varlock/plugin-lib';
 
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { createDeferredPromise, type DeferredPromise } from '@env-spec/utils/defer';
 import { spawnAsync } from '@env-spec/utils/exec-helpers';
 import { Client, createClient } from '@1password/sdk';
@@ -20,6 +20,41 @@ const OP_ICON = 'simple-icons:1password';
 type OpAuthCompletedFn = (success: boolean) => void;
 
 const CLI_BATCH_READ_TIMEOUT = 50;
+
+/*
+  Batched CLI reads go through `op inject`: we feed it a template of
+  `KEY={{ op://ref }}` entries on stdin and it prints the template with refs
+  resolved, in a single authenticated call. Previously this used
+  `op run -- env -0`, but that depends on a unix `env` binary which does not
+  exist on windows (unless git's usr/bin happens to be on PATH).
+
+  Entries are joined with a random per-call separator string because secret
+  values can contain newlines, and `op inject` strips control characters
+  (e.g. \0, \x1e) from its output so a non-printable separator would be lost.
+*/
+function buildInjectTemplate(opReferences: Array<string>) {
+  const separator = `__VARLOCK_1P_SEP_${randomUUID()}__`;
+  const keyToRef: Record<string, string> = {};
+  let i = 1;
+  const template = opReferences.map((ref) => {
+    const key = `VARLOCK_1P_INJECT_${i++}`;
+    keyToRef[key] = ref;
+    return `${key}={{ ${ref} }}${separator}`;
+  }).join('');
+  return { template, separator, keyToRef };
+}
+
+/** Parse `op inject` output back into op-ref → value (dangling segments, e.g. a trailing newline, are ignored). */
+function parseInjectResult(result: string, separator: string, keyToRef: Record<string, string>) {
+  const valuesByRef: Record<string, string> = {};
+  for (const segment of result.split(separator)) {
+    const eqPos = segment.indexOf('=');
+    const key = segment.substring(0, eqPos);
+    if (!keyToRef[key]) continue;
+    valuesByRef[keyToRef[key]] = segment.substring(eqPos + 1);
+  }
+  return valuesByRef;
+}
 
 /*
   ! IMPORTANT INFO ON CLI APP AUTH
@@ -58,17 +93,11 @@ async function checkAppCliAuth(): Promise<OpAuthCompletedFn> {
 
 async function executeAppCliBatch(batchToExecute: NonNullable<typeof appAuthBatch>) {
   debug('execute op read batch (app auth)', Object.keys(batchToExecute));
-  const envMap = {} as Record<string, string>;
-  let i = 1;
-  Object.keys(batchToExecute).forEach((opReference) => {
-    envMap[`VARLOCK_1P_INJECT_${i++}`] = opReference;
-  });
+  const { template, separator, keyToRef } = buildInjectTemplate(Object.keys(batchToExecute));
   const startAt = new Date();
 
   const authCompletedFn = await checkAppCliAuth();
-  // `env -0` splits values by a null character instead of newlines
-  // because otherwise we'll have trouble dealing with values that contain newlines
-  await spawnAsync('op', `run --no-masking ${lockCliToOpAccount ? `--account ${lockCliToOpAccount} ` : ''}-- env -0`.split(' '), {
+  await spawnAsync('op', ['inject', ...lockCliToOpAccount ? ['--account', lockCliToOpAccount] : []], {
     env: {
       PATH: process.env.PATH!,
       ...process.env.USER && { USER: process.env.USER },
@@ -76,21 +105,16 @@ async function executeAppCliBatch(batchToExecute: NonNullable<typeof appAuthBatc
       ...process.env.XDG_CONFIG_HOME && { XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
       ...pickProxyEnv(),
       OP_BIOMETRIC_UNLOCK_ENABLED: 'true',
-      ...envMap,
     },
+    input: template,
   })
     .then((result) => {
       authCompletedFn?.(true);
       debug(`batched OP request took ${+new Date() - +startAt}ms`);
 
-      const lines = result.split('\0');
-      for (const line of lines) {
-        const eqPos = line.indexOf('=');
-        const key = line.substring(0, eqPos);
-        if (!envMap[key]) continue;
-        const val = line.substring(eqPos + 1);
-        const opRef = envMap[key];
-        batchToExecute[opRef].deferredPromises.forEach((p) => {
+      const valuesByRef = parseInjectResult(result, separator, keyToRef);
+      for (const [opRef, val] of Object.entries(valuesByRef)) {
+        batchToExecute[opRef]?.deferredPromises.forEach((p) => {
           p.resolve(val);
         });
       }
@@ -369,17 +393,11 @@ class OpPluginInstance {
   /** Executes the per-instance CLI read batch using `op run` with a service account token. */
   private async executeCliBatch(batchToExecute: NonNullable<typeof this.cliBatch>) {
     debug('execute op read batch (service account CLI)', Object.keys(batchToExecute));
-    const envMap = {} as Record<string, string>;
-    let i = 1;
-    Object.keys(batchToExecute).forEach((opReference) => {
-      envMap[`VARLOCK_1P_INJECT_${i++}`] = opReference;
-    });
+    const { template, separator, keyToRef } = buildInjectTemplate(Object.keys(batchToExecute));
     const startAt = new Date();
 
     const authCompletedFn = await this.checkCliAuth();
-    // `env -0` splits values by a null character instead of newlines
-    // because otherwise we'll have trouble dealing with values that contain newlines
-    await spawnAsync('op', `run --no-masking ${this.account ? `--account ${this.account} ` : ''}-- env -0`.split(' '), {
+    await spawnAsync('op', ['inject', ...this.account ? ['--account', this.account] : []], {
       env: {
         // have to pass a few things through at least path so it can find `op` and related config files
         PATH: process.env.PATH!,
@@ -393,24 +411,17 @@ class OpPluginInstance {
         // this setting actually just enables the CLI + Desktop App integration
         // which in some cases op has a hard time detecting via app setting
         OP_BIOMETRIC_UNLOCK_ENABLED: 'true',
-        ...envMap,
       },
+      input: template,
     })
       .then(async (result) => {
         authCompletedFn?.(true);
         debug(`batched OP request took ${+new Date() - +startAt}ms`);
 
-        const lines = result.split('\0');
-        for (const line of lines) {
-          const eqPos = line.indexOf('=');
-          const key = line.substring(0, eqPos);
-
-          if (!envMap[key]) continue;
-          const val = line.substring(eqPos + 1);
-          const opRef = envMap[key];
-
+        const valuesByRef = parseInjectResult(result, separator, keyToRef);
+        for (const [opRef, val] of Object.entries(valuesByRef)) {
           // resolve the deferred promises with the value
-          batchToExecute[opRef].deferredPromises.forEach((p) => {
+          batchToExecute[opRef]?.deferredPromises.forEach((p) => {
             p.resolve(val);
           });
         }

--- a/packages/plugins/1password/test/1password.test.ts
+++ b/packages/plugins/1password/test/1password.test.ts
@@ -232,6 +232,23 @@ describe('1password plugin', () => {
       expectValues: { SECRET: 'p@ss=w0rd&foo' },
     }));
 
+    test('handles multiline values (e.g. private keys)', opTest({
+      opConfig: {
+        responses: {
+          'op://vault/item/key': '-----BEGIN KEY-----\nline1\nline2\n-----END KEY-----',
+          'op://vault/item/other': 'single-line',
+        },
+      },
+      schema: outdent`
+        PRIVATE_KEY=op("op://vault/item/key")
+        OTHER=op("op://vault/item/other")
+      `,
+      expectValues: {
+        PRIVATE_KEY: '-----BEGIN KEY-----\nline1\nline2\n-----END KEY-----',
+        OTHER: 'single-line',
+      },
+    }));
+
     test('bad vault reference rejects that item and retries the rest', opTest({
       opConfig: {
         responses: { 'op://good-vault/item/field': 'good-value' },

--- a/packages/plugins/1password/test/fake-op.sh
+++ b/packages/plugins/1password/test/fake-op.sh
@@ -14,37 +14,33 @@ case "$1" in
   whoami)
     echo "Test User <test@example.com>"
     ;;
-  run)
-    # op run --no-masking [--account X] -- env -0
-    # Reads VARLOCK_1P_INJECT_* env vars, resolves op:// references from config,
-    # and outputs null-separated KEY=value pairs (like `env -0`).
+  inject)
+    # op inject [--account X]
+    # Reads a template from stdin, resolves {{ op://... }} references from
+    # config, and prints the substituted template. Mimics real op inject
+    # behavior: fails the whole batch on the first bad reference, strips
+    # control characters (except newline/tab) from output, and appends a
+    # trailing newline.
     node -e "
       const cfg = JSON.parse(require('fs').readFileSync('$CONFIG_FILE', 'utf-8'));
       const responses = cfg.responses || {};
       const errors = cfg.errors || {};
-      const refs = [];
+      const template = require('fs').readFileSync(0, 'utf-8');
 
-      for (const [key, ref] of Object.entries(process.env)) {
-        if (!key.startsWith('VARLOCK_1P_INJECT_')) continue;
-        refs.push({ key, ref });
-      }
+      const refs = [...template.matchAll(/\{\{\s*(op:\/\/[^}]+?)\s*\}\}/g)].map((m) => m[1]);
 
       // Check for errors first (real op fails entire batch on first error)
-      for (const { ref } of refs) {
+      for (const ref of refs) {
         if (errors[ref]) {
           process.stderr.write('[ERROR] 2024/01/01 00:00:00 ' + errors[ref] + '\n');
           process.exit(1);
         }
       }
 
-      // Output resolved values as null-separated pairs
-      const results = [];
-      for (const { key, ref } of refs) {
-        if (ref in responses) {
-          results.push(key + '=' + responses[ref]);
-        }
-      }
-      process.stdout.write(results.join('\0') + '\0');
+      const output = template.replace(/\{\{\s*(op:\/\/[^}]+?)\s*\}\}/g, (match, ref) => {
+        return ref in responses ? responses[ref] : match;
+      });
+      process.stdout.write(output.replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '') + '\n');
     "
     ;;
   environment)


### PR DESCRIPTION
`op run -- env -0` depends on a unix `env` binary, which doesn't exist on windows unless git's usr/bin is on PATH. Batch reads now use `op inject` with a stdin template of `op://` refs instead: same single authenticated call (batching performance unchanged), no child binary at all, and `--no-masking` is no longer needed.

Template entries are joined with a random per-call sentinel string rather than `\0` because `op inject` strips control characters from its output (verified against the real CLI, and the fake-op test harness mimics this). Multiline secret values are covered by a new test. References also no longer appear in the child process env, only on the stdin pipe.