### PR TITLE
Reclaim orphaned cache locks via owner liveness

### DIFF
--- a/.bumpy/cache-lock-liveness.md
+++ b/.bumpy/cache-lock-liveness.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Cache locks left behind by an interrupted run are now reclaimed immediately instead of stalling later runs for several minutes and hiding the real error. `varlock cache clear` also clears locks.

--- a/packages/varlock-website/src/content/docs/guides/caching.mdx
+++ b/packages/varlock-website/src/content/docs/guides/caching.mdx
@@ -68,6 +68,14 @@ A few things to keep in mind:
 - The disk cache is per-OS-user and shared across all projects. This is intentional - projects often share config - but it means any env file you load can read and write it, so treat untrusted repos accordingly.
 - With the file-based encryption fallback, the decryption key sits on the same disk as the cache, so encryption is obfuscation-only (see warning above).
 
+## Concurrent runs
+
+When several varlock processes start at once (a turbo or nx pipeline, or a monorepo dev script), they coordinate through the disk cache so a value is only fetched once. The first process to need a given value fetches it while the others wait, then read the result from the cache. This is what keeps ten parallel tasks from triggering ten API calls, or ten biometric prompts, for the same secret.
+
+Coordination uses per-value lock directories under `~/.config/varlock/cache/`. If a process is killed while holding one (Ctrl+C at a password or biometric prompt, for example), the leftover lock is detected and reclaimed by the next run, so this is normally invisible.
+
+A lock can outlive its owner in one case: a cache directory shared between machines through a synced home directory, where varlock cannot tell whether the owning process is still running. `varlock cache clear --yes` removes lock directories along with entries.
+
 ## Per-invocation CLI controls
 
 [`varlock load`](/reference/cli-commands/#load), [`varlock run`](/reference/cli-commands/#run), and [`varlock printenv`](/reference/cli-commands/#printenv) support:
@@ -98,6 +106,16 @@ Notes:
 
 - If you used a custom `key`, that key may intentionally pin the cache entry.
 - Run with `--clear-cache` or clear entries via `varlock cache clear`.
+
+### "Timed out waiting for cache lock"
+
+A lock directory is being held and could not be reclaimed. Check whether another varlock process is genuinely running and still working. If none is, clear the locks:
+
+```bash
+varlock cache clear --yes
+```
+
+This is expected to be rare. Locks left behind by an interrupted run are reclaimed automatically on the next run.
 
 ### "`varlock cache` shows nothing, but caching seems active"
 

--- a/packages/varlock/src/cli/commands/cache.command.ts
+++ b/packages/varlock/src/cli/commands/cache.command.ts
@@ -191,12 +191,13 @@ const clearCommand = define({
     }
 
     try {
+      // a full clear also drops lock dirs. locks go first: clearing entries
+      // itself takes the file lock, and a wedged lock is often exactly why the
+      // user is running this command
+      if (!pluginName) store.clearLocks();
       const count = pluginName
         ? await store.clearByPrefix(`plugin:${pluginName}:`)
         : await store.clearAll();
-      // a full clear also drops lock dirs — clearing the cache is what users
-      // reach for when a lock is wedged, so it must actually unwedge it
-      if (!pluginName) store.clearLocks();
       console.log(`  Cleared ${count} ${target}`);
     } catch (err) {
       console.error(ansis.red(`Failed to clear ${target}: ${err instanceof Error ? err.message : err}`));
@@ -280,8 +281,8 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async () => {
         initialValue: false,
       });
       if (isCancel(confirmed) || !confirmed) continue;
-      const count = await store.clearAll();
       store.clearLocks();
+      const count = await store.clearAll();
       console.log(`  Cleared ${count} entries`);
       return;
     }

--- a/packages/varlock/src/cli/commands/cache.command.ts
+++ b/packages/varlock/src/cli/commands/cache.command.ts
@@ -194,6 +194,9 @@ const clearCommand = define({
       const count = pluginName
         ? await store.clearByPrefix(`plugin:${pluginName}:`)
         : await store.clearAll();
+      // a full clear also drops lock dirs — clearing the cache is what users
+      // reach for when a lock is wedged, so it must actually unwedge it
+      if (!pluginName) store.clearLocks();
       console.log(`  Cleared ${count} ${target}`);
     } catch (err) {
       console.error(ansis.red(`Failed to clear ${target}: ${err instanceof Error ? err.message : err}`));
@@ -278,6 +281,7 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async () => {
       });
       if (isCancel(confirmed) || !confirmed) continue;
       const count = await store.clearAll();
+      store.clearLocks();
       console.log(`  Cleared ${count} entries`);
       return;
     }

--- a/packages/varlock/src/env-graph/lib/loader.ts
+++ b/packages/varlock/src/env-graph/lib/loader.ts
@@ -49,7 +49,7 @@ export async function loadEnvGraph(opts?: {
       }
     }
     for (const store of diskStores) {
-      // locks are cleared unconditionally — a run interrupted before its first
+      // locks are cleared unconditionally: a run interrupted before its first
       // write leaves a lock dir behind with no cache file to gate on
       store.clearLocks();
       if (fs.existsSync(store.getFilePath())) await store.clearAll();

--- a/packages/varlock/src/env-graph/lib/loader.ts
+++ b/packages/varlock/src/env-graph/lib/loader.ts
@@ -49,6 +49,9 @@ export async function loadEnvGraph(opts?: {
       }
     }
     for (const store of diskStores) {
+      // locks are cleared unconditionally — a run interrupted before its first
+      // write leaves a lock dir behind with no cache file to gate on
+      store.clearLocks();
       if (fs.existsSync(store.getFilePath())) await store.clearAll();
     }
   }

--- a/packages/varlock/src/lib/cache/cache-lock-crossproc.test.ts
+++ b/packages/varlock/src/lib/cache/cache-lock-crossproc.test.ts
@@ -61,7 +61,7 @@ describe.runIf(hasBun)('orphaned lock left by a killed process', () => {
     fs.writeFileSync(holderScript, `
       import { CacheStore } from ${JSON.stringify(path.join(thisDir, 'cache-store.ts'))};
       const store = new CacheStore();
-      // never resolves — stands in for a hung API call or an unanswered prompt
+      // never resolves, stands in for a hung API call or an unanswered prompt
       store.getOrSet(${JSON.stringify(CACHE_KEY)}, 60_000, () => new Promise(() => {})).catch(() => {});
       setInterval(() => {}, 1_000);
     `);

--- a/packages/varlock/src/lib/cache/cache-lock-crossproc.test.ts
+++ b/packages/varlock/src/lib/cache/cache-lock-crossproc.test.ts
@@ -1,0 +1,174 @@
+import {
+  describe, it, expect, beforeEach, afterEach,
+} from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+
+/**
+ * End-to-end check of the scenario from the bug report: a varlock process is
+ * killed mid-resolution while holding a cache key lock, and the next run must
+ * not inherit a multi-minute stall.
+ *
+ * This deliberately uses a real child process rather than a fabricated lock
+ * dir, so the owner metadata is written by the same code path that reads it.
+ */
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const CACHE_KEY = 'plugin:test:crossproc';
+
+const hasBun = spawnSync('bun', ['--version'], { encoding: 'utf-8' }).status === 0;
+
+let tempHome: string;
+let child: ChildProcess | undefined;
+
+beforeEach(() => {
+  tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'varlock-xproc-'));
+});
+
+afterEach(() => {
+  if (child && child.exitCode === null) child.kill('SIGKILL');
+  child = undefined;
+  fs.rmSync(tempHome, { recursive: true, force: true });
+});
+
+function keyLockPath(): string {
+  const hash = createHash('sha256').update(CACHE_KEY).digest('hex');
+  return path.join(tempHome, 'varlock', 'cache', 'varlock-default.json.keylocks', `${hash}.lock`);
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+/** Wait until the child has actually taken the lock (owner metadata present). */
+async function waitForLockHeld(timeoutMs = 20_000): Promise<void> {
+  const ownerFile = path.join(keyLockPath(), 'owner.json');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(ownerFile)) return;
+    await sleep(25);
+  }
+  throw new Error('child never acquired the lock');
+}
+
+describe.runIf(hasBun)('orphaned lock left by a killed process', () => {
+  it('is reclaimed immediately, surfacing the real producer error', async () => {
+    const holderScript = path.join(tempHome, 'holder.ts');
+    fs.writeFileSync(holderScript, `
+      import { CacheStore } from ${JSON.stringify(path.join(thisDir, 'cache-store.ts'))};
+      const store = new CacheStore();
+      // never resolves — stands in for a hung API call or an unanswered prompt
+      store.getOrSet(${JSON.stringify(CACHE_KEY)}, 60_000, () => new Promise(() => {})).catch(() => {});
+      setInterval(() => {}, 1_000);
+    `);
+
+    child = spawn('bun', ['run', holderScript], {
+      env: { ...process.env, XDG_CONFIG_HOME: tempHome },
+      stdio: 'ignore',
+    });
+
+    await waitForLockHeld();
+
+    // hard kill: no exit handler runs, so the lock dir is left behind
+    child.kill('SIGKILL');
+    await sleep(200);
+    expect(fs.existsSync(keyLockPath())).toBe(true);
+
+    // a fresh process must now reclaim it rather than waiting out the deadline
+    const runnerScript = path.join(tempHome, 'runner.ts');
+    fs.writeFileSync(runnerScript, `
+      import { CacheStore } from ${JSON.stringify(path.join(thisDir, 'cache-store.ts'))};
+      const store = new CacheStore();
+      store.getOrSet(${JSON.stringify(CACHE_KEY)}, 60_000, () => {
+        throw new Error('awsParam(): Parameter "/test/x" not found');
+      }).then(
+        () => { console.log('UNEXPECTED_SUCCESS'); },
+        (err) => { console.log('ERR:' + err.message); },
+      );
+    `);
+
+    const start = Date.now();
+    const result = spawnSync('bun', ['run', runnerScript], {
+      env: { ...process.env, XDG_CONFIG_HOME: tempHome },
+      encoding: 'utf-8',
+      timeout: 30_000,
+    });
+    const elapsed = Date.now() - start;
+
+    expect(result.stdout).toContain('Parameter "/test/x" not found');
+    expect(result.stdout).not.toContain('Timed out waiting for cache lock');
+    // before liveness detection this blocked for the full 5 minute deadline
+    expect(elapsed).toBeLessThan(20_000);
+  }, 60_000);
+
+  it('is released on SIGINT, and the signal still terminates the process', async () => {
+    const holderScript = path.join(tempHome, 'holder.ts');
+    fs.writeFileSync(holderScript, `
+      import { CacheStore } from ${JSON.stringify(path.join(thisDir, 'cache-store.ts'))};
+      const store = new CacheStore();
+      store.getOrSet(${JSON.stringify(CACHE_KEY)}, 60_000, () => new Promise(() => {})).catch(() => {});
+      setInterval(() => {}, 1_000);
+    `);
+
+    child = spawn('bun', ['run', holderScript], {
+      env: { ...process.env, XDG_CONFIG_HOME: tempHome },
+      stdio: 'ignore',
+    });
+
+    await waitForLockHeld();
+
+    const exited = new Promise<{ code: number | null; signal: string | null }>((resolve) => {
+      child!.on('exit', (code, signal) => resolve({ code, signal }));
+    });
+    child.kill('SIGINT');
+    const outcome = await exited;
+
+    // the lock is gone rather than left for liveness detection to clean up
+    expect(fs.existsSync(keyLockPath())).toBe(false);
+    // and Ctrl+C still ends the process (re-raised, not swallowed)
+    expect(outcome.signal === 'SIGINT' || outcome.code === 130).toBe(true);
+  }, 60_000);
+
+  it('is left alone while its owner is still alive', async () => {
+    const holderScript = path.join(tempHome, 'holder.ts');
+    fs.writeFileSync(holderScript, `
+      import { CacheStore } from ${JSON.stringify(path.join(thisDir, 'cache-store.ts'))};
+      const store = new CacheStore();
+      store.getOrSet(${JSON.stringify(CACHE_KEY)}, 60_000, () => new Promise(() => {})).catch(() => {});
+      setInterval(() => {}, 1_000);
+    `);
+
+    child = spawn('bun', ['run', holderScript], {
+      env: { ...process.env, XDG_CONFIG_HOME: tempHome },
+      stdio: 'ignore',
+    });
+
+    await waitForLockHeld();
+    const ownerBefore = fs.readFileSync(path.join(keyLockPath(), 'owner.json'), 'utf-8');
+
+    // a second process must wait on the live holder, not steal from it
+    const waiterScript = path.join(tempHome, 'waiter.ts');
+    fs.writeFileSync(waiterScript, `
+      import { CacheStore } from ${JSON.stringify(path.join(thisDir, 'cache-store.ts'))};
+      const store = new CacheStore();
+      store.getOrSet(${JSON.stringify(CACHE_KEY)}, 60_000, () => 'STOLE_IT').catch(() => {});
+      setInterval(() => {}, 1_000);
+    `);
+    const waiter = spawn('bun', ['run', waiterScript], {
+      env: { ...process.env, XDG_CONFIG_HOME: tempHome },
+      stdio: 'ignore',
+    });
+
+    try {
+      await sleep(3_000);
+      // the original owner still holds it
+      expect(fs.readFileSync(path.join(keyLockPath(), 'owner.json'), 'utf-8')).toBe(ownerBefore);
+    } finally {
+      waiter.kill('SIGKILL');
+    }
+  }, 60_000);
+});

--- a/packages/varlock/src/lib/cache/cache-lock.test.ts
+++ b/packages/varlock/src/lib/cache/cache-lock.test.ts
@@ -1,0 +1,238 @@
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createHash } from 'node:crypto';
+import { CacheStore, withDirLock } from './cache-store';
+
+// mock localEncrypt to avoid needing real encryption keys
+vi.mock('../local-encrypt', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  ensureKey: vi.fn(async () => {}),
+  encryptValue: vi.fn(async (value: string) => `encrypted:${value}`),
+  decryptValue: vi.fn(async (value: string) => value.replace('encrypted:', '')),
+}));
+
+let tempDir: string;
+vi.mock('../user-config-dir', () => ({
+  getUserVarlockDir: () => tempDir,
+}));
+
+/** short opts so the backstop deadline is reachable in a test */
+const FAST = {
+  waitMs: 5, timeoutMs: 300, staleMs: 10_000,
+};
+
+let lockPath: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'varlock-lock-test-'));
+  lockPath = path.join(tempDir, 'locks', 'test.lock');
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+/** Fabricate a held lock dir owned by `pid` (defaults to a pid that is gone). */
+function plantLock(opts: { pid?: number; host?: string; withOwner?: boolean } = {}) {
+  fs.mkdirSync(lockPath, { recursive: true, mode: 0o700 });
+  if (opts.withOwner === false) return;
+  fs.writeFileSync(
+    path.join(lockPath, 'owner.json'),
+    JSON.stringify({
+      pid: opts.pid ?? 999_999_999,
+      host: opts.host ?? os.hostname(),
+      token: 'planted-token',
+    }),
+  );
+}
+
+describe('withDirLock', () => {
+  it('steals a lock owned by a dead process immediately', async () => {
+    plantLock({ pid: 999_999_999 });
+
+    const start = Date.now();
+    const ran = await withDirLock(lockPath, FAST, () => 'ran');
+
+    expect(ran).toBe('ran');
+    // must not have waited out the deadline
+    expect(Date.now() - start).toBeLessThan(FAST.timeoutMs);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('waits for a lock owned by a live process rather than stealing it', async () => {
+    // our own pid is alive by definition; a foreign token means it is not ours to release
+    plantLock({ pid: process.pid });
+    fs.writeFileSync(
+      path.join(lockPath, 'owner.json'),
+      JSON.stringify({ pid: process.pid, host: os.hostname(), token: 'someone-else' }),
+    );
+
+    const fn = vi.fn(() => 'ran');
+    await withDirLock(lockPath, { ...FAST, failOpen: true }, fn);
+
+    // it fell through to the fail-open backstop rather than stealing early
+    expect(fn).toHaveBeenCalledTimes(1);
+    // the live holder's lock was left intact
+    expect(fs.existsSync(lockPath)).toBe(true);
+  });
+
+  it('does not steal a lock owned by another host', async () => {
+    plantLock({ pid: 999_999_999, host: 'some-other-machine' });
+
+    const fn = vi.fn(() => 'ran');
+    await withDirLock(lockPath, { ...FAST, failOpen: true }, fn);
+
+    // liveness is undecidable off-host, so the lock survives until it goes stale
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('steals a lock left with no owner metadata once past the grace window', async () => {
+    plantLock({ withOwner: false });
+    // backdate past OWNER_GRACE_MS (5s)
+    const old = new Date(Date.now() - 30_000);
+    fs.utimesSync(lockPath, old, old);
+
+    const start = Date.now();
+    const ran = await withDirLock(lockPath, FAST, () => 'ran');
+
+    expect(ran).toBe('ran');
+    expect(Date.now() - start).toBeLessThan(FAST.timeoutMs);
+  });
+
+  it('fails open at the backstop instead of throwing', async () => {
+    plantLock({ pid: process.pid });
+    fs.writeFileSync(
+      path.join(lockPath, 'owner.json'),
+      JSON.stringify({ pid: process.pid, host: os.hostname(), token: 'someone-else' }),
+    );
+
+    const result = await withDirLock(lockPath, { ...FAST, failOpen: true }, () => 'produced anyway');
+    expect(result).toBe('produced anyway');
+  });
+
+  it('throws a message naming the remedy when fail-open is off', async () => {
+    plantLock({ pid: process.pid });
+    fs.writeFileSync(
+      path.join(lockPath, 'owner.json'),
+      JSON.stringify({ pid: process.pid, host: os.hostname(), token: 'someone-else' }),
+    );
+
+    await expect(withDirLock(lockPath, { ...FAST, failOpen: false }, () => 'x'))
+      .rejects.toThrow(/varlock cache clear/);
+  });
+
+  it('propagates producer errors and releases the lock', async () => {
+    await expect(withDirLock(lockPath, FAST, () => {
+      throw new Error('boom');
+    })).rejects.toThrow('boom');
+
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  describe('ownership', () => {
+    it('does not delete a lock that was stolen and re-acquired by someone else', async () => {
+      let observedInside = false;
+
+      await withDirLock(lockPath, FAST, async () => {
+        // simulate: this holder was judged stale, stolen, and a new owner took over
+        fs.rmSync(lockPath, { recursive: true, force: true });
+        fs.mkdirSync(lockPath, { recursive: true, mode: 0o700 });
+        fs.writeFileSync(
+          path.join(lockPath, 'owner.json'),
+          JSON.stringify({ pid: process.pid, host: os.hostname(), token: 'new-owner' }),
+        );
+        observedInside = true;
+      });
+
+      expect(observedInside).toBe(true);
+      // the new owner's lock must survive our release
+      expect(fs.existsSync(lockPath)).toBe(true);
+      const owner = JSON.parse(fs.readFileSync(path.join(lockPath, 'owner.json'), 'utf-8'));
+      expect(owner.token).toBe('new-owner');
+    });
+
+    it('re-enters a lock it already holds instead of deadlocking', async () => {
+      const start = Date.now();
+      const inner = await withDirLock(lockPath, FAST, async () => (
+        // same lock path, from inside the critical section
+        withDirLock(lockPath, FAST, () => 'inner ran')
+      ));
+
+      expect(inner).toBe('inner ran');
+      expect(Date.now() - start).toBeLessThan(FAST.timeoutMs);
+      // the outer release still cleans up
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    it('records itself as owner while held', async () => {
+      await withDirLock(lockPath, FAST, () => {
+        const owner = JSON.parse(fs.readFileSync(path.join(lockPath, 'owner.json'), 'utf-8'));
+        expect(owner.pid).toBe(process.pid);
+        expect(owner.host).toBe(os.hostname());
+        expect(typeof owner.token).toBe('string');
+      });
+    });
+  });
+});
+
+describe('CacheStore key locks', () => {
+  const keyLockPathFor = (store: CacheStore, cacheKey: string) => path.join(
+    store.getKeyLocksPath(),
+    `${createHash('sha256').update(cacheKey).digest('hex')}.lock`,
+  );
+
+  it('surfaces the real producer error instead of a lock timeout when a lock is orphaned', async () => {
+    const store = new CacheStore();
+    const cacheKey = 'plugin:test:orphaned';
+    // an interrupted run left a lock behind, owned by a process that is gone
+    const orphan = keyLockPathFor(store, cacheKey);
+    fs.mkdirSync(orphan, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(
+      path.join(orphan, 'owner.json'),
+      JSON.stringify({ pid: 999_999_999, host: os.hostname(), token: 'gone' }),
+    );
+
+    const start = Date.now();
+    await expect(store.getOrSet(cacheKey, 60_000, () => {
+      throw new Error('awsParam(): Parameter "/test/x" not found');
+    })).rejects.toThrow('Parameter "/test/x" not found');
+
+    // the whole point: this used to block for 5 minutes
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  it('still deduplicates concurrent producers for the same key', async () => {
+    const store = new CacheStore();
+    const producer = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 30);
+      });
+      return 'shared-value';
+    });
+
+    const [a, b] = await Promise.all([
+      store.getOrSet('plugin:test:race', 60_000, producer),
+      store.getOrSet('plugin:test:race', 60_000, producer),
+    ]);
+
+    expect(producer).toHaveBeenCalledTimes(1);
+    expect(a?.value).toBe('shared-value');
+    expect(b?.value).toBe('shared-value');
+  });
+
+  it('clearLocks removes orphaned key locks', async () => {
+    const store = new CacheStore();
+    const orphan = keyLockPathFor(store, 'plugin:test:whatever');
+    fs.mkdirSync(orphan, { recursive: true, mode: 0o700 });
+    expect(fs.existsSync(orphan)).toBe(true);
+
+    store.clearLocks();
+
+    expect(fs.existsSync(store.getKeyLocksPath())).toBe(false);
+  });
+});

--- a/packages/varlock/src/lib/cache/cache-store.ts
+++ b/packages/varlock/src/lib/cache/cache-store.ts
@@ -1,5 +1,7 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHash, randomBytes } from 'node:crypto';
 import { getUserVarlockDir } from '../user-config-dir';
 import * as localEncrypt from '../local-encrypt';
@@ -8,7 +10,246 @@ import { createDebug } from '../debug';
 const debug = createDebug('varlock:cache');
 
 const FILE_LOCK_OPTS = { waitMs: 25, timeoutMs: 5_000, staleMs: 30_000 };
-const KEY_LOCK_OPTS = { waitMs: 50, timeoutMs: 5 * 60_000, staleMs: 10 * 60_000 };
+/**
+ * The key lock serializes the producer (an API call, a biometric unlock, a CLI
+ * prompt) across processes, so waiting is normal and the deadline is only a
+ * backstop for a holder that is alive but wedged. Orphaned locks are handled by
+ * liveness detection, not by this timeout.
+ */
+const KEY_LOCK_OPTS = {
+  waitMs: 50, timeoutMs: 5 * 60_000, staleMs: 10 * 60_000, failOpen: true,
+};
+
+/** Metadata written into a lock dir identifying its owner */
+const LOCK_OWNER_FILE = 'owner.json';
+/**
+ * How long after creation a lock dir may lack owner metadata before we treat it
+ * as an orphan. Covers the sub-millisecond gap between `mkdir` and writing the
+ * owner file, and locks left by varlock versions predating owner metadata.
+ */
+const OWNER_GRACE_MS = 5_000;
+
+const sleep = (ms: number) => new Promise<void>((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+type LockOwner = { pid: number; host: string; token: string };
+
+type LockOpts = { waitMs: number; timeoutMs: number; staleMs: number; failOpen?: boolean };
+
+/** Lock dirs currently held by this process, released on interrupt/exit */
+const heldLocks = new Map<string, string>();
+let cleanupRegistered = false;
+
+/**
+ * Lock dirs held by the *current async call stack*.
+ *
+ * Distinguishes a re-entrant call (nested inside the critical section, so it
+ * already owns the lock) from a concurrent sibling in the same process (which
+ * must still wait). A process-global set cannot tell those apart.
+ */
+const lockContext = new AsyncLocalStorage<ReadonlySet<string>>();
+
+function readLockOwner(lockPath: string): LockOwner | undefined {
+  try {
+    const raw = fs.readFileSync(path.join(lockPath, LOCK_OWNER_FILE), 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.pid !== 'number' || typeof parsed?.host !== 'string' || typeof parsed?.token !== 'string') {
+      return undefined;
+    }
+    return parsed as LockOwner;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Whether the process that owns a lock is still running.
+ *
+ * Only decidable for locks owned on this host. A recycled pid reads as alive,
+ * which fails safe: we keep waiting and fall back to the mtime staleness check.
+ */
+function isLockOwnerAlive(owner: LockOwner): boolean {
+  if (owner.host !== os.hostname()) return true;
+  if (owner.pid === process.pid) return true;
+  try {
+    process.kill(owner.pid, 0);
+    return true;
+  } catch (err: any) {
+    // EPERM means the process exists but belongs to another user
+    return err?.code === 'EPERM';
+  }
+}
+
+/** Atomically discard a lock dir. Only one racing waiter can win the rename. */
+function stealLock(lockPath: string): void {
+  const graveyard = `${lockPath}.stale.${process.pid}.${randomBytes(4).toString('hex')}`;
+  fs.renameSync(lockPath, graveyard);
+  fs.rmSync(graveyard, { recursive: true, force: true });
+}
+
+/**
+ * Release a lock dir, but only if this process still owns it.
+ *
+ * Without the token check a holder that was (correctly) judged stale and stolen
+ * from would delete the *new* owner's lock on its way out, letting two
+ * processes run the same producer concurrently.
+ */
+function releaseLock(lockPath: string, token: string | undefined): void {
+  try {
+    if (token !== undefined) {
+      const owner = readLockOwner(lockPath);
+      if (owner && owner.token !== token) {
+        debug('not releasing %s — lock was stolen by pid %d', lockPath, owner.pid);
+        return;
+      }
+    }
+    stealLock(lockPath);
+  } catch {
+    // already gone, or another process won a concurrent steal
+  } finally {
+    heldLocks.delete(lockPath);
+  }
+}
+
+/**
+ * Best-effort release of every lock this process holds.
+ *
+ * Ctrl+C at a biometric or password prompt is the common way locks get
+ * orphaned, and the prompt-owning CLI often inherits stdin, so the signal hits
+ * the whole process group.
+ */
+function registerLockCleanup(): void {
+  if (cleanupRegistered) return;
+  cleanupRegistered = true;
+  const releaseAll = () => {
+    for (const [lockPath, token] of [...heldLocks]) releaseLock(lockPath, token);
+  };
+  process.on('exit', releaseAll);
+
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGQUIT'] as const) {
+    // `once`, then re-raise: attaching any listener suppresses Node's default
+    // termination, so we hand the signal back rather than picking an exit code.
+    // Deliberately does not exit on its own — `varlock run` installs its own
+    // forwarders, and racing them would break child signal delivery.
+    process.once(signal, () => {
+      releaseAll();
+      if (process.listenerCount(signal) === 0) {
+        process.kill(process.pid, signal);
+      }
+    });
+  }
+}
+
+/**
+ * Cross-process mutual exclusion via atomic `mkdir` of a lock directory.
+ *
+ * A lock is considered abandoned when its owning process is gone (checked via
+ * pid liveness), falling back to an mtime staleness window when ownership
+ * can't be determined. Held locks have their mtime refreshed periodically so a
+ * slow holder is not treated as stale.
+ *
+ * @internal exported so lock semantics can be tested with short timeouts
+ */
+export async function withDirLock<T>(
+  lockPath: string,
+  opts: LockOpts,
+  fn: () => Promise<T> | T,
+): Promise<T> {
+  // already held further up this call stack — e.g. `cache(key="x", cache(key="x", …))`,
+  // or a plugin whose producer re-enters the same key. Mutual exclusion is
+  // already satisfied, so proceed rather than self-deadlocking until the deadline.
+  const outerHeld = lockContext.getStore();
+  if (outerHeld?.has(lockPath)) {
+    debug('re-entering lock %s already held by this call stack', lockPath);
+    return await fn();
+  }
+
+  const token = randomBytes(16).toString('hex');
+  const deadline = Date.now() + opts.timeoutMs;
+  let acquired = false;
+
+  while (true) {
+    try {
+      fs.mkdirSync(lockPath, { mode: 0o700 });
+      acquired = true;
+      break;
+    } catch (err: any) {
+      if (err?.code === 'ENOENT') {
+        // parent dir missing — create it (0700: keys can leak secret topology) and retry
+        fs.mkdirSync(path.dirname(lockPath), { recursive: true, mode: 0o700 });
+        continue;
+      }
+      if (err?.code !== 'EEXIST') {
+        throw err;
+      }
+      try {
+        const owner = readLockOwner(lockPath);
+        const stat = fs.statSync(lockPath);
+        const ageMs = Date.now() - stat.mtimeMs;
+        if (owner ? !isLockOwnerAlive(owner) : ageMs > OWNER_GRACE_MS) {
+          debug('stealing abandoned lock %s (owner pid %s)', lockPath, owner?.pid ?? 'unknown');
+          stealLock(lockPath);
+          continue;
+        }
+        if (ageMs > opts.staleMs) {
+          debug('stealing stale lock %s', lockPath);
+          stealLock(lockPath);
+          continue;
+        }
+      } catch {
+        // lock disappeared or another waiter won the steal; retry
+      }
+      if (Date.now() >= deadline) {
+        if (!opts.failOpen) {
+          throw new Error(
+            `Timed out waiting for cache lock at ${lockPath}\n`
+            + 'If no other varlock process is running this lock may be orphaned — '
+            + 'run `varlock cache clear --yes` or delete the path above.',
+          );
+        }
+        // a lock problem must never become a resolution failure — the worst case
+        // of proceeding is duplicated work, which is what the lock optimizes away
+        debug('lock %s timed out — proceeding without it', lockPath);
+        return await fn();
+      }
+      await sleep(opts.waitMs);
+    }
+  }
+
+  let ownerWritten = false;
+  try {
+    fs.writeFileSync(
+      path.join(lockPath, LOCK_OWNER_FILE),
+      JSON.stringify({ pid: process.pid, host: os.hostname(), token } satisfies LockOwner),
+      { encoding: 'utf-8', mode: 0o600 },
+    );
+    ownerWritten = true;
+    heldLocks.set(lockPath, token);
+    registerLockCleanup();
+  } catch {
+    // without owner metadata the lock still works, it just can't be identified
+  }
+
+  // refresh mtime while held so long operations don't get their lock stolen
+  const touchTimer = setInterval(() => {
+    try {
+      const now = new Date();
+      fs.utimesSync(lockPath, now, now);
+    } catch {
+      // lock dir gone (stolen/removed) — nothing useful to do
+    }
+  }, Math.max(1_000, Math.floor(opts.staleMs / 3)));
+  touchTimer.unref?.();
+
+  const nestedHeld = new Set(outerHeld ?? []).add(lockPath);
+  try {
+    return await lockContext.run(nestedHeld, async () => fn());
+  } finally {
+    clearInterval(touchTimer);
+    if (acquired) releaseLock(lockPath, ownerWritten ? token : undefined);
+  }
+}
 
 export const MAX_CACHE_KEY_LENGTH = 2_048;
 /** "forever" TTLs are stored as a concrete far-future expiry (~100 years) */
@@ -85,77 +326,6 @@ export function assertValidCacheKey(key: string, label = 'cache key'): void {
   }
 }
 
-const sleep = (ms: number) => new Promise<void>((resolve) => {
-  setTimeout(resolve, ms);
-});
-
-/**
- * Cross-process mutual exclusion via atomic `mkdir` of a lock directory.
- *
- * Stale locks are stolen via an atomic rename (so two waiters cannot both
- * "remove and acquire"), and held locks have their mtime refreshed
- * periodically so a long-running holder is not treated as stale.
- */
-async function withDirLock<T>(
-  lockPath: string,
-  opts: { waitMs: number; timeoutMs: number; staleMs: number },
-  fn: () => Promise<T> | T,
-): Promise<T> {
-  const deadline = Date.now() + opts.timeoutMs;
-  while (true) {
-    try {
-      fs.mkdirSync(lockPath, { mode: 0o700 });
-      break;
-    } catch (err: any) {
-      if (err?.code === 'ENOENT') {
-        // parent dir missing — create it (0700: keys can leak secret topology) and retry
-        fs.mkdirSync(path.dirname(lockPath), { recursive: true, mode: 0o700 });
-        continue;
-      }
-      if (err?.code !== 'EEXIST') {
-        throw err;
-      }
-      try {
-        const stat = fs.statSync(lockPath);
-        if (Date.now() - stat.mtimeMs > opts.staleMs) {
-          // steal stale lock atomically — only one waiter can win the rename
-          const graveyard = `${lockPath}.stale.${process.pid}.${randomBytes(4).toString('hex')}`;
-          fs.renameSync(lockPath, graveyard);
-          fs.rmSync(graveyard, { recursive: true, force: true });
-          continue;
-        }
-      } catch {
-        // lock disappeared or another waiter won the steal; retry
-      }
-      if (Date.now() >= deadline) {
-        throw new Error(`Timed out waiting for cache lock at ${lockPath}`);
-      }
-      await sleep(opts.waitMs);
-    }
-  }
-
-  // refresh mtime while held so long operations don't get their lock stolen
-  const touchTimer = setInterval(() => {
-    try {
-      const now = new Date();
-      fs.utimesSync(lockPath, now, now);
-    } catch {
-      // lock dir gone (stolen/removed) — nothing useful to do
-    }
-  }, Math.max(1_000, Math.floor(opts.staleMs / 3)));
-  touchTimer.unref?.();
-
-  try {
-    return await fn();
-  } finally {
-    clearInterval(touchTimer);
-    try {
-      fs.rmSync(lockPath, { recursive: true, force: true });
-    } catch {
-      // lock cleanup failure is non-fatal
-    }
-  }
-}
 
 /**
  * JSON-file-based encrypted cache store.
@@ -382,6 +552,29 @@ export class CacheStore {
    */
   getFilePath(): string {
     return this.filePath;
+  }
+
+  /** Directory holding this store's per-key lock dirs. */
+  getKeyLocksPath(): string {
+    return `${this.filePath}.keylocks`;
+  }
+
+  /**
+   * Remove this store's lock dirs.
+   *
+   * Locks are normally self-healing (an abandoned lock is detected via owner
+   * liveness), but clearing them explicitly is the escape hatch when a lock
+   * survives that check — e.g. one left on a different machine via a synced
+   * home directory, where pid liveness can't be evaluated.
+   */
+  clearLocks(): void {
+    for (const target of [this.getKeyLocksPath(), `${this.filePath}.lock`]) {
+      try {
+        fs.rmSync(target, { recursive: true, force: true });
+      } catch (err) {
+        debug('failed to clear locks at %s: %O', target, err);
+      }
+    }
   }
 
   // -- internal --

--- a/packages/varlock/src/lib/cache/cache-store.ts
+++ b/packages/varlock/src/lib/cache/cache-store.ts
@@ -100,7 +100,7 @@ function releaseLock(lockPath: string, token: string | undefined): void {
     if (token !== undefined) {
       const owner = readLockOwner(lockPath);
       if (owner && owner.token !== token) {
-        debug('not releasing %s — lock was stolen by pid %d', lockPath, owner.pid);
+        debug('not releasing %s, lock was stolen by pid %d', lockPath, owner.pid);
         return;
       }
     }
@@ -130,14 +130,18 @@ function registerLockCleanup(): void {
   for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGQUIT'] as const) {
     // `once`, then re-raise: attaching any listener suppresses Node's default
     // termination, so we hand the signal back rather than picking an exit code.
-    // Deliberately does not exit on its own — `varlock run` installs its own
+    // Deliberately does not exit on its own: `varlock run` installs its own
     // forwarders, and racing them would break child signal delivery.
-    process.once(signal, () => {
-      releaseAll();
-      if (process.listenerCount(signal) === 0) {
-        process.kill(process.pid, signal);
-      }
-    });
+    try {
+      process.once(signal, () => {
+        releaseAll();
+        if (process.listenerCount(signal) === 0) {
+          process.kill(process.pid, signal);
+        }
+      });
+    } catch {
+      // some signals (e.g. SIGQUIT) can't be listened for on every platform
+    }
   }
 }
 
@@ -156,7 +160,7 @@ export async function withDirLock<T>(
   opts: LockOpts,
   fn: () => Promise<T> | T,
 ): Promise<T> {
-  // already held further up this call stack — e.g. `cache(key="x", cache(key="x", …))`,
+  // already held further up this call stack, e.g. `cache(key="x", cache(key="x", …))`,
   // or a plugin whose producer re-enters the same key. Mutual exclusion is
   // already satisfied, so proceed rather than self-deadlocking until the deadline.
   const outerHeld = lockContext.getStore();
@@ -204,13 +208,13 @@ export async function withDirLock<T>(
         if (!opts.failOpen) {
           throw new Error(
             `Timed out waiting for cache lock at ${lockPath}\n`
-            + 'If no other varlock process is running this lock may be orphaned — '
-            + 'run `varlock cache clear --yes` or delete the path above.',
+            + 'If no other varlock process is running this lock may be orphaned. '
+            + 'Run `varlock cache clear --yes` or delete the path above.',
           );
         }
-        // a lock problem must never become a resolution failure — the worst case
+        // a lock problem must never become a resolution failure: the worst case
         // of proceeding is duplicated work, which is what the lock optimizes away
-        debug('lock %s timed out — proceeding without it', lockPath);
+        debug('lock %s timed out, proceeding without it', lockPath);
         return await fn();
       }
       await sleep(opts.waitMs);
@@ -564,7 +568,7 @@ export class CacheStore {
    *
    * Locks are normally self-healing (an abandoned lock is detected via owner
    * liveness), but clearing them explicitly is the escape hatch when a lock
-   * survives that check — e.g. one left on a different machine via a synced
+   * survives that check, e.g. one left on a different machine via a synced
    * home directory, where pid liveness can't be evaluated.
    */
   clearLocks(): void {

--- a/packages/varlock/src/lib/local-encrypt/index.ts
+++ b/packages/varlock/src/lib/local-encrypt/index.ts
@@ -10,7 +10,7 @@
  *   4. File-based (pure JS) — universal fallback, no native binary needed
  */
 
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import { resolveNativeBinary } from './binary-resolver';
 import { DaemonClient } from './daemon-client';
@@ -280,6 +280,69 @@ function runNativeBinary(args: Array<string>, opts?: { timeout?: number; sensiti
   return output;
 }
 
+/**
+ * Spawn the native binary asynchronously, writing `input` to its stdin and
+ * resolving with its stdout.
+ *
+ * Async rather than `spawnSync` because this runs on the cache write path,
+ * inside the cache key lock. A blocking spawn there stalls every other
+ * concurrent item resolution in the process, and would freeze the lock's
+ * liveness heartbeat so a busy holder looks dead to other processes.
+ */
+function spawnNativeBinaryAsync(
+  binaryPath: string,
+  args: Array<string>,
+  opts: { input: string; timeout?: number },
+): Promise<string> {
+  const timeoutMs = opts.timeout ?? 30_000;
+  return new Promise((resolve, reject) => {
+    debug(`spawnNativeBinaryAsync: ${binaryPath} ${redactDataArg(args).join(' ')}`);
+    const proc = spawn(binaryPath, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    // held in an object so `finish` can clear a timer declared after it
+    const pending: { timer?: ReturnType<typeof setTimeout> } = {};
+
+    const finish = (err?: Error, out?: string) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(pending.timer);
+      if (err) reject(err);
+      else resolve(out ?? '');
+    };
+
+    pending.timer = setTimeout(() => {
+      proc.kill('SIGKILL');
+      finish(new Error(`Native binary timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    proc.stdout.setEncoding('utf-8');
+    proc.stderr.setEncoding('utf-8');
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    proc.on('error', (err) => finish(err));
+    proc.on('close', (code) => {
+      // the binary reports failures as JSON on stdout, so a non-zero exit with
+      // output is still handed back for the caller to parse
+      if (!stdout.trim()) {
+        finish(new Error(`Native binary exited with code ${code}${stderr.trim() ? `: ${stderr.trim()}` : ''}`));
+        return;
+      }
+      finish(undefined, stdout);
+    });
+    proc.stdin.on('error', () => {
+      // the child can exit before we finish writing — EPIPE here is not useful
+      debug('spawnNativeBinaryAsync: stdin write failed (child already exited)');
+    });
+    proc.stdin.end(opts.input);
+  });
+}
+
 function runNativeBinaryJson<T = Record<string, unknown>>(
   args: Array<string>,
   opts?: { timeout?: number; sensitiveOutput?: boolean },
@@ -441,13 +504,11 @@ export async function encryptValue(plaintext: string, keyId: string = DEFAULT_KE
   const binaryPath = resolveNativeBinary();
   if (!binaryPath) throw new Error('Native binary not found');
 
-  const proc = spawnSync(binaryPath, ['encrypt', '--key-id', keyId, '--data-stdin'], {
+  const stdout = await spawnNativeBinaryAsync(binaryPath, ['encrypt', '--key-id', keyId, '--data-stdin'], {
     input: b64Input,
-    encoding: 'utf-8',
     timeout: 30_000,
   });
-  if (proc.error) throw proc.error;
-  const result = JSON.parse(proc.stdout.trim());
+  const result = JSON.parse(stdout.trim());
   if (result.error) throw new Error(result.error);
   return result.ciphertext;
 }

--- a/packages/varlock/src/lib/local-encrypt/index.ts
+++ b/packages/varlock/src/lib/local-encrypt/index.ts
@@ -336,7 +336,7 @@ function spawnNativeBinaryAsync(
       finish(undefined, stdout);
     });
     proc.stdin.on('error', () => {
-      // the child can exit before we finish writing — EPIPE here is not useful
+      // the child can exit before we finish writing, EPIPE here is not useful
       debug('spawnNativeBinaryAsync: stdin write failed (child already exited)');
     });
     proc.stdin.end(opts.input);


### PR DESCRIPTION
Fixes #941.

## The bug

A cache key lock left behind by an interrupted run (Ctrl+C at a biometric or password prompt, a killed shell) blocked every later run resolving the same key for the full 5 minute deadline, then failed with a generic `Timed out waiting for cache lock` that replaced the real error. In the reported case that hid an `awsParam(): Parameter "..." not found`.

This is in varlock core (`CacheStore.getOrSet`), not the AWS plugin, so it affects the 11 plugins that use `cacheTtl` plus the core `cache()` resolver.

## The fix

Lock dirs now record their owner (`pid`, `host`, `token`). A lock whose owner process is gone is reclaimed immediately, so the underlying error surfaces right away.

A **live** holder is still waited on, with no shortened timeout. That matters: the lock exists so that parallel task runners (turbo, nx) make one API call and show one biometric prompt per value instead of N. Shortening the deadline would have reintroduced exactly that. Timing out is now only a backstop for a holder that is alive but wedged, and it falls back to running the producer rather than failing the load.

Locks with no owner metadata (existing orphans, older versions) are reclaimed after a short grace window.

## Also fixed

- **Exclusion bug:** release now verifies the lock's token is still ours. Previously a holder that was correctly judged stale and stolen from would delete the *new* owner's lock on its way out, letting two processes run the same producer.
- **Re-entrancy:** a nested call on the same key proceeds instead of self-deadlocking. Tracked via `AsyncLocalStorage`, so concurrent siblings in the same process still dedupe (a process-global set conflates the two, which the existing dedupe test caught).
- **Signal cleanup:** held locks are released on SIGINT/SIGTERM/SIGHUP/SIGQUIT, using `once` + re-raise so `varlock run`'s signal forwarding and exit codes are unaffected.
- **`varlock cache clear` / `--clear-cache` now remove lock dirs**, and no longer skip when the cache file does not exist yet. Previously the obvious remedy silently did nothing.
- **Native encrypt is no longer `spawnSync`.** It ran inside the key lock, blocking concurrent item resolution and freezing the liveness heartbeat, which would have made a busy holder look dead.
- Lock timeout message names the remedy.

## Testing

`cache-lock.test.ts` covers liveness stealing, off-host locks, ownership tokens, fail-open, and re-entrancy. `cache-lock-crossproc.test.ts` spawns real child processes: one is SIGKILLed mid-lock to reproduce the actual bug, one verifies a live holder is not stolen from, and one verifies SIGINT both releases the lock and still terminates the process.

Verified the tests fail without the fix: disabling the liveness check fails exactly 3 tests and nothing else; disabling the re-entrancy short-circuit fails exactly 1.

## Docs

Added a "Concurrent runs" section and a troubleshooting entry to the caching guide.