### PR TITLE
fix vscode plugin re: multiple instances of multi-line init calls

### DIFF
--- a/.bumpy/vscode-multiline-init-diagnostics.md
+++ b/.bumpy/vscode-multiline-init-diagnostics.md
@@ -1,0 +1,5 @@
+---
+env-spec-language: patch
+---
+
+Fix false "can only be used once" diagnostic for multiline plugin init decorators (e.g. `@initInfisical(`)

--- a/packages/vscode-plugin/src/diagnostics-core.ts
+++ b/packages/vscode-plugin/src/diagnostics-core.ts
@@ -215,13 +215,16 @@ export function getDecoratorOccurrences(lineText: string, lineNumber: number) {
   for (const match of decoratorComment.matchAll(DECORATOR_PATTERN)) {
     const name = match[1];
     const start = decoratorCommentStart + (match.index ?? 0);
-    const suffix = match[0].slice(name.length + 1);
+    // Prefer text after `@name` over the regex capture: DECORATOR_PATTERN only
+    // matches a closed `(...)` on the same line, so multiline `@initFoo(` would
+    // otherwise look like a bare (non-repeatable) decorator.
+    const afterName = decoratorComment.slice((match.index ?? 0) + name.length + 1);
     occurrences.push({
       name,
       line: lineNumber,
       start,
       end: start + match[0].length,
-      isFunctionCall: suffix.startsWith('('),
+      isFunctionCall: afterName.startsWith('('),
     });
   }
 

--- a/packages/vscode-plugin/test/diagnostics-core.test.ts
+++ b/packages/vscode-plugin/test/diagnostics-core.test.ts
@@ -27,6 +27,29 @@ describe('diagnostics-core', () => {
     ).toBe(false);
   });
 
+  // Plugin inits (@initInfisical, @initOp, etc.) are not in the intellisense
+  // catalog, so repeatability depends on detecting `@name(` even when `)` is
+  // on a later line. One representative covers all of them.
+  it('treats multiline open-paren decorator calls as function calls', () => {
+    expect(getDecoratorOccurrences('# @initInfisical(', 0)).toEqual([
+      {
+        name: 'initInfisical',
+        line: 0,
+        start: 2,
+        end: 16,
+        isFunctionCall: true,
+      },
+    ]);
+
+    const diagnostics = createDecoratorDiagnostics([
+      ...getDecoratorOccurrences('# @initInfisical(', 0),
+      ...getDecoratorOccurrences('# @initInfisical(', 1),
+    ]);
+    expect(
+      diagnostics.some((diagnostic) => diagnostic.message.includes('@initInfisical')),
+    ).toBe(false);
+  });
+
   it('flags incompatible decorator pairs inline', () => {
     const diagnostics = createDecoratorDiagnostics(
       getDecoratorOccurrences('# @required @optional @sensitive @public', 0),


### PR DESCRIPTION
## Summary
- Fix a VS Code false positive where multiple multiline plugin init decorators (e.g. `@initInfisical(`) were reported as `@… can only be used once in the same decorator block`
- Open-paren function calls are now detected even when the closing `)` is on a later line, matching how the CLI already treats repeatable init decorators

## Test plan
- [ ] Open a `.env` with two multiline `@initInfisical(` blocks (different `id`s) and confirm no duplicate diagnostic
- [ ] Confirm single-line duplicate `@required @required` still flags
- [ ] `bun run --filter env-spec-language test`