### PR TITLE
Stop exporting ENV from the varlock package root

### DIFF
--- a/.bumpy/env-export-only-from-subpath.md
+++ b/.bumpy/env-export-only-from-subpath.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+ENV is no longer exported from the package root; import it from `varlock/env` instead

--- a/packages/varlock/src/index.ts
+++ b/packages/varlock/src/index.ts
@@ -71,6 +71,5 @@ export const internal = {
 export { patchGlobalConsole } from './runtime/patch-console';
 export { patchGlobalServerResponse } from './runtime/patch-server-response';
 export { patchGlobalResponse } from './runtime/patch-response';
-export { ENV } from './runtime/env';
 export { createDebug, type Debugger } from './lib/debug';
 export type { SerializedEnvGraph };


### PR DESCRIPTION
`ENV` was exported from both `varlock` and `varlock/env`. Because both worked, IDE auto-import would frequently pick the core entry point, when apps should always be importing from `varlock/env`.

This removes the root export. `varlock/env` is unchanged.

Technically breaking, but marked as a patch: npm's default `^` range picks up minors anyway, so the version choice shields nobody, and the failure mode is loud (TS compile error, or `undefined` then a `TypeError` on first access in plain JS).

Worth revisiting later: moving more of the root exports behind a `varlock/internal` subpath.