### PR TITLE
Route Pullfrog reviews to GPT Sol on Azure

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -29,3 +29,12 @@ jobs:
         uses: pullfrog/pullfrog@v0
         with:
           prompt: ${{ inputs.prompt }}
+        env:
+          # Review with GPT Sol via our Azure Foundry deployment instead of the
+          # default Anthropic route. AZURE_API_KEY comes from the Pullfrog
+          # dashboard; these two are set here so they stay readable in run logs
+          # (dashboard-stored values get registered as GitHub Actions log masks).
+          # The Azure deployment must be named exactly `gpt-5.6-sol`: the
+          # @ai-sdk/azure provider uses the model id as the deployment name.
+          AZURE_RESOURCE_NAME: pullfrog-resource
+          PULLFROG_MODEL: azure/gpt-5.6-sol


### PR DESCRIPTION
Points the Pullfrog action at our Azure Foundry deployment so PR reviews run on a non-Anthropic model, since most of our day-to-day work is already on Claude.

## How it works

Pullfrog has no Codex-CLI agent and no Azure support of its own, but two existing behaviors make this work without any fork:

- `resolveModel` passes a slashed, non-curated value through unchanged as a raw models.dev specifier, so `azure/gpt-5.6-sol` reaches OpenCode as-is.
- The BYOK gate is `opencode models` output rather than a hardcoded allowlist, and models.dev ships a real `azure` provider (`AZURE_RESOURCE_NAME` + `AZURE_API_KEY`, `@ai-sdk/azure`) that carries `gpt-5.6-sol`.

`AZURE_API_KEY` is stored in the Pullfrog dashboard. The other two are set in the workflow deliberately: dashboard-stored values are passed to `core.setSecret()` regardless of key name, which would turn the resource name and model id into `***` throughout the run log.

## Requires

The Azure deployment must be named exactly `gpt-5.6-sol`, because `@ai-sdk/azure` uses the model id as the deployment name and that same string is the key the authorization gate checks.

## Notes

`PULLFROG_MODEL` applies to every run. For one-off comparisons against another model, use `--model=<slug>` in an `@pullfrog` comment instead.

A `» "azure/gpt-5.6-sol" is not a curated alias` line in the run log is expected, not a misconfiguration. Follow-up PRs to Pullfrog itself are planned to make this path first-class, including skipping log-masking for non-secret config values and an Azure setup validator with an actionable error.