### PR TITLE
Fix non-minimal DER serial numbers in proxy MITM certs

### DIFF
--- a/.bumpy/fix-cert-serial-padding.md
+++ b/.bumpy/fix-cert-serial-padding.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Fix proxy MITM certs that occasionally failed to load due to a non-minimal DER serial number

--- a/packages/varlock/src/proxy/cert-authority.test.ts
+++ b/packages/varlock/src/proxy/cert-authority.test.ts
@@ -34,6 +34,38 @@ describe('cert-authority (in-memory CA)', () => {
     expect(leafCert.subject).toContain('api.example.com');
   });
 
+  test('serial numbers are minimally encoded DER INTEGERs', async () => {
+    // A random serial starting with 0x00 followed by a byte with a clear top bit
+    // is a non-minimal INTEGER; OpenSSL rejects it with ASN1_R_ILLEGAL_PADDING,
+    // so roughly 1 in 512 minted certs used to be unloadable. Force that byte
+    // pattern instead of relying on chance.
+    const realGetRandomValues = crypto.getRandomValues.bind(crypto);
+    const patched = (array: any) => {
+      const filled = realGetRandomValues(array);
+      // 16 bytes is the serial; leave key material alone.
+      if (filled.length === 16) {
+        filled[0] = 0x00;
+        filled[1] = 0x01;
+      }
+      return filled;
+    };
+
+    (crypto as any).getRandomValues = patched;
+    let ca: Awaited<ReturnType<typeof createEphemeralCa>>;
+    let leaf: Awaited<ReturnType<typeof createHostCert>>;
+    try {
+      ca = await createEphemeralCa();
+      leaf = await createHostCert(ca, 'api.example.com');
+    } finally {
+      (crypto as any).getRandomValues = realGetRandomValues;
+    }
+
+    expect(() => tls.createSecureContext({ cert: ca.certPem })).not.toThrow();
+    expect(() => tls.createSecureContext({ key: leaf.keyPem, cert: leaf.certPem })).not.toThrow();
+    // The leading zero was dropped, not preserved.
+    expect(new x509.X509Certificate(leaf.certPem).serialNumber).not.toMatch(/^00/);
+  });
+
   test('emits PEM material and keeps no private key in the public CA cert', async () => {
     const ca = await createEphemeralCa();
     const leaf = await createHostCert(ca, 'api.example.com');

--- a/packages/varlock/src/proxy/cert-authority.ts
+++ b/packages/varlock/src/proxy/cert-authority.ts
@@ -85,16 +85,26 @@ function commonNameDn(value: string): Name {
   ]);
 }
 
-/** Random positive 16-byte serial number as an ASN.1 INTEGER-ready ArrayBuffer. */
-function generateSerialNumber(): ArrayBuffer {
-  const serial = cryptoApi.getRandomValues(new Uint8Array(16));
-  // A leading bit of 1 would encode as a negative INTEGER; prepend a zero byte.
-  if (serial[0] > 0x7F) {
-    const prefixed = new Uint8Array(serial.length + 1);
-    prefixed.set(serial, 1);
+// Strip leading zero bytes, then prepend one back if the top bit is set, so the
+// value encodes as a positive, minimally-encoded DER INTEGER. Both halves
+// matter: a leading 0x00 followed by a byte with a clear top bit is non-minimal
+// and strict parsers (OpenSSL raises ASN1_R_ILLEGAL_PADDING) reject the cert.
+function trimToPositiveInteger(input: Uint8Array): ArrayBuffer {
+  let bytes = input;
+  let i = 0;
+  while (i < bytes.length - 1 && bytes[i] === 0) i++;
+  bytes = bytes.slice(i);
+  if (bytes[0] > 0x7F) {
+    const prefixed = new Uint8Array(bytes.length + 1);
+    prefixed.set(bytes, 1);
     return prefixed.buffer;
   }
-  return serial.buffer as ArrayBuffer;
+  return bytes.buffer as ArrayBuffer;
+}
+
+/** Random positive 16-byte serial number as an ASN.1 INTEGER-ready ArrayBuffer. */
+function generateSerialNumber(): ArrayBuffer {
+  return trimToPositiveInteger(cryptoApi.getRandomValues(new Uint8Array(16)));
 }
 
 function extension(extnID: string, critical: boolean, value: unknown): Extension {
@@ -110,21 +120,6 @@ function pemEncode(label: string, der: ArrayBuffer): string {
 async function exportPrivateKeyPem(key: CryptoKey): Promise<string> {
   const pkcs8 = await cryptoApi.subtle.exportKey('pkcs8', key);
   return pemEncode('PRIVATE KEY', pkcs8);
-}
-
-// Strip leading zero bytes, then prepend one back if the top bit is set, so the
-// value encodes as a positive DER INTEGER.
-function trimToPositiveInteger(input: Uint8Array): ArrayBuffer {
-  let bytes = input;
-  let i = 0;
-  while (i < bytes.length - 1 && bytes[i] === 0) i++;
-  bytes = bytes.slice(i);
-  if (bytes[0] > 0x7F) {
-    const prefixed = new Uint8Array(bytes.length + 1);
-    prefixed.set(bytes, 1);
-    return prefixed.buffer;
-  }
-  return bytes.buffer as ArrayBuffer;
 }
 
 /** Convert a raw WebCrypto ECDSA signature (r||s) to a DER-encoded ECDSA-Sig-Value. */


### PR DESCRIPTION
`generateSerialNumber()` in the proxy's in-memory CA prepended a zero byte when the top bit of the random serial was set, but never stripped an *existing* leading `0x00`. When the first random byte was `0x00` and the second had a clear top bit, the serial encoded as a non-minimal DER INTEGER, which OpenSSL rejects with `ASN1_R_ILLEGAL_PADDING`. The cert then fails to load at all.

Odds are ~1 in 512 per minted cert, so this is a real runtime bug: occasionally a leaf cert the proxy mints for a host is rejected by the client. It also showed up as intermittent CI failures in `proxy-tls.test.ts`, where a bad upstream cert in `beforeAll` takes out 10 of the 11 tests. That is what failed the 1.14.0 release run on main, and it had flaked on two other main pushes recently.

Fix reuses the existing `trimToPositiveInteger()` helper (already correct for ECDSA signature r/s values) so serials are always minimally encoded.

The added test stubs `getRandomValues` to force the bad byte pattern rather than relying on a 1-in-512 chance; it reproduces the exact CI error without the fix.