### PR TITLE
Add native Python integration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -140,6 +140,23 @@ jobs:
             echo "::warning::Some Rust binary caches missing — will trigger rebuild"
           fi
 
+  # The native Python package (packages/varlock-python). Its own test suite is pure Python and
+  # stubs the CLI, so it runs independently of the JS build. The end-to-end checks against a
+  # real CLI live in the smoke-test suite.
+  python-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Run tests
+        working-directory: packages/varlock-python
+        # oldest and newest supported versions - the package has no dependencies, so the
+        # versions in between are not where breakage hides
+        run: |
+          uv run --frozen --python 3.9 pytest -q
+          uv run --frozen --python 3.13 pytest -q
+
   # Build + sign the macOS native binary if varlock is being released AND (source changed or cache missing)
   build-native-macos:
     needs: build-and-test

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,11 @@ eslint-output.txt
 # vitest coverage output
 coverage/
 
+# python
+__pycache__/
+*.egg-info/
+.venv/
+.pytest_cache/
+
 # local throwaway experiments
 scratch/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This is a monorepo managed with bun workspaces and Turborepo:
 - `packages/varlock-website` — docs site (Astro); docs content lives in `src/content/docs/`
 - `packages/vscode-plugin` — VSCode extension for @env-spec language support
 - `packages/integrations/*` — framework integrations (nextjs, vite, astro, ...)
+- `packages/varlock-python` — native Python integration, published to PyPI as `varlock` (not npm). Pure Python, no runtime deps; it shells out to the CLI the way `varlock/auto-load` does. Managed with `uv` (`uv run pytest`), not bun
 - `packages/utils`, `packages/plugins` — shared internals
 - `packages/varlock-docs-mcp` — docs MCP server for external varlock users; do **not** use it to look things up while working on this repo — read the docs source directly
 

--- a/bun.lock
+++ b/bun.lock
@@ -492,6 +492,10 @@
         "wrangler": "^4.93.0",
       },
     },
+    "packages/varlock-python": {
+      "name": "@varlock/python",
+      "version": "0.0.0",
+    },
     "packages/varlock-website": {
       "name": "@varlock/website",
       "version": "0.0.1",
@@ -1508,6 +1512,8 @@
     "@varlock/passbolt-plugin": ["@varlock/passbolt-plugin@workspace:packages/plugins/passbolt"],
 
     "@varlock/proton-pass-plugin": ["@varlock/proton-pass-plugin@workspace:packages/plugins/proton-pass"],
+
+    "@varlock/python": ["@varlock/python@workspace:packages/varlock-python"],
 
     "@varlock/tsconfig": ["@varlock/tsconfig@workspace:packages/tsconfig"],
 

--- a/packages/varlock-python/README.md
+++ b/packages/varlock-python/README.md
@@ -37,7 +37,17 @@ Reading a key that isn't in your schema raises `VarlockMissingKeyError` rather t
 varlock.reload()
 ```
 
-`repr(ENV)` masks values marked `@sensitive`, so echoing `env` in a cell won't write secrets into the saved notebook.
+### Redaction
+
+`load()` masks values marked `@sensitive` in `print()`, in `logging`, and in notebook cell output, so a secret does not end up saved in an `.ipynb` or a log file:
+
+```python
+print(f"token={env['API_KEY']}")     # token=sk▒▒▒▒▒
+print(varlock.reveal(env["API_KEY"]))  # 👁 sk-abc123 👁, shown on purpose
+varlock.scan_for_leaks(payload)      # raises VarlockLeakError naming the key
+```
+
+Only values that resolved to strings are masked. It is a safety net, not a guarantee: a stream captured before `load()` ran, a write to `sys.stdout.buffer`, or an object rendering a secret in its own `__str__` can still get through. Follows the schema's `@redactLogs` setting; override per call with `load(redact_logs=False)`.
 
 ### Scripts and servers
 
@@ -59,8 +69,10 @@ from varlock import ENV
 | `ENV` | The resolved env, a read-only mapping with attribute access |
 | `is_loaded()`, `is_running_under_varlock_run()` | State checks |
 | `get_settings()`, `get_sensitive_keys()` | Schema metadata |
+| `redact(obj)`, `reveal(value)`, `scan_for_leaks(value)` | Redaction primitives |
+| `install_redaction()`, `uninstall_redaction()` | Turn output redaction on or off |
 
-`load()` accepts `cwd`, `path`, `env`, `force`, `inject`, `on_error`, and `timeout`. See the docstrings.
+`load()` accepts `cwd`, `path`, `env`, `force`, `inject`, `redact_logs`, `on_error`, and `timeout`. See the docstrings.
 
 Set `VARLOCK_BIN` to an absolute path to skip CLI discovery.
 

--- a/packages/varlock-python/README.md
+++ b/packages/varlock-python/README.md
@@ -1,0 +1,75 @@
+# varlock (Python)
+
+Native Python integration for [varlock](https://varlock.dev): load and validate your `.env.schema` from inside a running Python process, with no wrapped launch.
+
+```bash
+pip install varlock
+```
+
+Requires the varlock CLI:
+
+```bash
+brew install dmno-dev/tap/varlock
+# or
+curl -sSfL https://varlock.dev/install.sh | sh -s
+```
+
+## Usage
+
+```python
+import varlock
+
+env = varlock.load()
+
+env["DATABASE_URL"]   # also env.DATABASE_URL
+env["PORT"]           # 5432, an int, not "5432"
+```
+
+`load()` resolves your schema by calling the varlock CLI, injects the resolved values into `os.environ`, and returns them coerced. When the process was started with `varlock run`, the values are already resolved, so `load()` reads them instead of resolving again. The same code works either way.
+
+Reading a key that isn't in your schema raises `VarlockMissingKeyError` rather than returning `None`.
+
+### Notebooks
+
+`load()` needs no wrapped launch, so it works in a Jupyter kernel started by VS Code or JupyterLab. After editing your schema or rotating a secret, re-resolve without restarting the kernel:
+
+```python
+varlock.reload()
+```
+
+`repr(ENV)` masks values marked `@sensitive`, so echoing `env` in a cell won't write secrets into the saved notebook.
+
+### Scripts and servers
+
+To fail fast at startup the way `varlock run` does, import the side-effect module as early as possible:
+
+```python
+import varlock.auto_load  # noqa: F401
+
+from varlock import ENV
+```
+
+## API
+
+| | |
+| --- | --- |
+| `load(**opts)` | Resolve (or adopt already-resolved values) and return `ENV` |
+| `reload(**opts)` | Re-resolve, ignoring what's loaded |
+| `unload()` | Forget values and restore every env var varlock set |
+| `ENV` | The resolved env, a read-only mapping with attribute access |
+| `is_loaded()`, `is_running_under_varlock_run()` | State checks |
+| `get_settings()`, `get_sensitive_keys()` | Schema metadata |
+
+`load()` accepts `cwd`, `path`, `env`, `force`, `inject`, `on_error`, and `timeout`. See the docstrings.
+
+Set `VARLOCK_BIN` to an absolute path to skip CLI discovery.
+
+## Development
+
+From this directory:
+
+```bash
+uv run pytest
+```
+
+Docs live in `packages/varlock-website/src/content/docs/integrations/`.

--- a/packages/varlock-python/README.md
+++ b/packages/varlock-python/README.md
@@ -37,6 +37,22 @@ Reading a key that isn't in your schema raises `VarlockMissingKeyError` rather t
 varlock.reload()
 ```
 
+### Types
+
+`load()` returns values typed as `Any`. Add `@generatePythonEnv(path=env.py)` to your schema and cast to the generated `Env` TypedDict to have a type checker verify them:
+
+```python
+from typing import cast
+
+import varlock
+from env import Env
+
+env = cast(Env, varlock.load())
+port = env["PORT"]     # int
+```
+
+The cast is a no-op at runtime, so this is still the live env object.
+
 ### Redaction
 
 `load()` masks values marked `@sensitive` in `print()`, in `logging`, and in notebook cell output, so a secret does not end up saved in an `.ipynb` or a log file:

--- a/packages/varlock-python/package.json
+++ b/packages/varlock-python/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@varlock/python",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Native Python integration for varlock (published to PyPI as `varlock`, not to npm)",
+  "scripts": {
+    "test:python": "uv run --frozen pytest",
+    "build:python": "uv build"
+  }
+}

--- a/packages/varlock-python/pyproject.toml
+++ b/packages/varlock-python/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "varlock"
+version = "0.1.0"
+description = "AI-safe .env files: load and validate your env schema from Python, no wrapped launch required"
+readme = "README.md"
+requires-python = ">=3.9"
+license = "MIT"
+authors = [{ name = "dmno-dev" }]
+keywords = [
+  "varlock",
+  "env",
+  "dotenv",
+  "environment variables",
+  "config",
+  "secrets",
+  "secret-management",
+  "jupyter",
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Software Development :: Libraries",
+  "Typing :: Typed",
+]
+# intentionally zero runtime dependencies - the package is a thin client of the varlock CLI
+dependencies = []
+
+[project.urls]
+Homepage = "https://varlock.dev"
+Documentation = "https://varlock.dev/integrations/python/"
+Repository = "https://github.com/dmno-dev/varlock"
+Issues = "https://github.com/dmno-dev/varlock/issues"
+
+[dependency-groups]
+dev = ["pytest>=8.0"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/varlock"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/varlock-python/src/varlock/__init__.py
+++ b/packages/varlock-python/src/varlock/__init__.py
@@ -132,6 +132,8 @@ def load(
         redact_logs = _state.settings.get("redactLogs") is not False
     if redact_logs:
         install_redaction()
+    else:
+        uninstall_redaction()
     return result
 
 

--- a/packages/varlock-python/src/varlock/__init__.py
+++ b/packages/varlock-python/src/varlock/__init__.py
@@ -20,14 +20,17 @@ import os
 import sys
 from typing import Any, Dict, FrozenSet, Optional, Sequence, Union
 
+from . import _patch
 from ._binary import BIN_PATH_ENV_VAR, clear_cache as clear_binary_cache, find_binary
 from ._blob import BLOB_ENV_VAR, RUN_FLAG_ENV_VAR, parse_blob
 from ._cli import PathArg, run_load
 from ._env import Env
+from ._redaction import redact, reveal, scan_for_leaks
 from ._runtime import state as _state
 from .errors import (
     VarlockBinaryNotFoundError,
     VarlockError,
+    VarlockLeakError,
     VarlockLoadError,
     VarlockMissingKeyError,
     VarlockNotLoadedError,
@@ -50,10 +53,16 @@ __all__ = [
     "is_running_under_varlock_run",
     "get_settings",
     "get_sensitive_keys",
+    "redact",
+    "reveal",
+    "scan_for_leaks",
+    "install_redaction",
+    "uninstall_redaction",
     "find_binary",
     "clear_binary_cache",
     "VarlockError",
     "VarlockBinaryNotFoundError",
+    "VarlockLeakError",
     "VarlockLoadError",
     "VarlockMissingKeyError",
     "VarlockNotLoadedError",
@@ -73,6 +82,7 @@ def load(
     env: Optional[str] = None,
     force: bool = False,
     inject: bool = True,
+    redact_logs: Optional[bool] = None,
     on_error: str = "raise",
     timeout: Optional[float] = None,
 ) -> Env:
@@ -93,6 +103,9 @@ def load(
         inject: Also set the resolved values as environment variables, so libraries reading
             ``os.environ`` and any subprocesses you spawn see them. Honors
             ``@disableProcessEnvInjection``.
+        redact_logs: Mask sensitive values in logs, ``print()`` output, and notebook cell
+            output. ``None`` (default) follows your schema's ``@redactLogs`` setting, which
+            is on unless you turned it off.
         on_error: ``"raise"`` (default) raises :class:`VarlockLoadError`. ``"exit"`` prints
             the CLI's error output and exits, matching what ``varlock run`` does. Prefer the
             default in notebooks and long-lived processes.
@@ -107,13 +120,19 @@ def load(
         VarlockBinaryNotFoundError: if the varlock CLI isn't installed.
     """
     try:
-        return _load(
+        result = _load(
             cwd=cwd, path=path, env=env, force=force, inject=inject, timeout=timeout
         )
     except VarlockError as err:
         if on_error == "exit":
             _exit_with(err)
         raise
+
+    if redact_logs is None:
+        redact_logs = _state.settings.get("redactLogs") is not False
+    if redact_logs:
+        install_redaction()
+    return result
 
 
 def _load(
@@ -170,8 +189,29 @@ def reload(**kwargs: Any) -> Env:
 
 
 def unload() -> None:
-    """Forget the loaded env and restore every environment variable varlock set."""
+    """Forget the loaded env, restore every environment variable varlock set, and stop
+    redacting."""
+    uninstall_redaction()
     _state.reset()
+
+
+def install_redaction() -> None:
+    """Mask sensitive values in output.
+
+    Covers `logging` (every logger and handler, including ones created later), ``print()``
+    via stdout and stderr, and notebook cell output. :func:`load` calls this for you unless
+    your schema sets ``@redactLogs=false``.
+
+    It is not foolproof, the same caveat the JS integration carries: a stream captured before
+    this ran, a write to ``sys.stdout.buffer``, or an object that renders a secret in its own
+    ``__str__`` can still get through. Only values that resolved to strings are masked.
+    """
+    _patch.patch_all()
+
+
+def uninstall_redaction() -> None:
+    """Stop masking sensitive values in output."""
+    _patch.unpatch_all()
 
 
 def is_loaded() -> bool:

--- a/packages/varlock-python/src/varlock/__init__.py
+++ b/packages/varlock-python/src/varlock/__init__.py
@@ -1,0 +1,223 @@
+"""varlock: AI-safe .env files.
+
+Resolve and validate your env schema from inside a running Python process, with no wrapped
+launch and no subprocess boilerplate::
+
+    import varlock
+
+    env = varlock.load()
+    env["DATABASE_URL"]
+
+The same call also works when the program was started with ``varlock run``: the values are
+already in the environment, so :func:`load` reads them instead of resolving again.
+
+See https://varlock.dev/integrations/python/
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Dict, FrozenSet, Optional, Sequence, Union
+
+from ._binary import BIN_PATH_ENV_VAR, clear_cache as clear_binary_cache, find_binary
+from ._blob import BLOB_ENV_VAR, RUN_FLAG_ENV_VAR, parse_blob
+from ._cli import PathArg, run_load
+from ._env import Env
+from ._runtime import state as _state
+from .errors import (
+    VarlockBinaryNotFoundError,
+    VarlockError,
+    VarlockLoadError,
+    VarlockMissingKeyError,
+    VarlockNotLoadedError,
+)
+
+try:  # pragma: no cover - depends on install method
+    from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+    __version__ = _pkg_version("varlock")
+except Exception:  # pragma: no cover
+    __version__ = "0.0.0+unknown"
+
+__all__ = [
+    "ENV",
+    "Env",
+    "load",
+    "reload",
+    "unload",
+    "is_loaded",
+    "is_running_under_varlock_run",
+    "get_settings",
+    "get_sensitive_keys",
+    "find_binary",
+    "clear_binary_cache",
+    "VarlockError",
+    "VarlockBinaryNotFoundError",
+    "VarlockLoadError",
+    "VarlockMissingKeyError",
+    "VarlockNotLoadedError",
+    "BIN_PATH_ENV_VAR",
+    "__version__",
+]
+
+#: The resolved env. Populated by :func:`load`, and automatically on import when the process
+#: was started with ``varlock run``.
+ENV = Env(_state)
+
+
+def load(
+    *,
+    cwd: Optional[PathArg] = None,
+    path: Optional[Union[PathArg, Sequence[PathArg]]] = None,
+    env: Optional[str] = None,
+    force: bool = False,
+    inject: bool = True,
+    on_error: str = "raise",
+    timeout: Optional[float] = None,
+) -> Env:
+    """Load, validate, and return the resolved env.
+
+    Cheap to call repeatedly: once values are loaded (or the process was started with
+    ``varlock run``) this returns the existing :data:`ENV` without doing any work. Use
+    ``force=True`` (or :func:`reload`) to resolve again.
+
+    Args:
+        cwd: Directory to resolve the schema from. Defaults to the current working directory,
+            which in a notebook is the directory the notebook lives in.
+        path: One or more `.env` files or directories to use as the entry point, matching the
+            CLI's ``--path``.
+        env: Environment name to load for, matching the CLI's ``--env``. Ignored if your
+            schema sets ``@currentEnv``.
+        force: Re-resolve even if values are already loaded.
+        inject: Also set the resolved values as environment variables, so libraries reading
+            ``os.environ`` and any subprocesses you spawn see them. Honors
+            ``@disableProcessEnvInjection``.
+        on_error: ``"raise"`` (default) raises :class:`VarlockLoadError`. ``"exit"`` prints
+            the CLI's error output and exits, matching what ``varlock run`` does. Prefer the
+            default in notebooks and long-lived processes.
+        timeout: Seconds to wait for the CLI. ``None`` (default) waits indefinitely, which
+            matters when a plugin needs you to approve a biometric prompt.
+
+    Returns:
+        The :data:`ENV` object.
+
+    Raises:
+        VarlockLoadError: if loading or validation failed.
+        VarlockBinaryNotFoundError: if the varlock CLI isn't installed.
+    """
+    try:
+        return _load(
+            cwd=cwd, path=path, env=env, force=force, inject=inject, timeout=timeout
+        )
+    except VarlockError as err:
+        if on_error == "exit":
+            _exit_with(err)
+        raise
+
+
+def _load(
+    *,
+    cwd: Optional[PathArg],
+    path: Optional[Union[PathArg, Sequence[PathArg]]],
+    env: Optional[str],
+    force: bool,
+    inject: bool,
+    timeout: Optional[float],
+) -> Env:
+    if not force:
+        if _state.initialized:
+            return ENV
+        # started via `varlock run` (or a previous load in this process): the values are
+        # already resolved and sitting in the environment, so don't resolve them again
+        blob = os.environ.get(BLOB_ENV_VAR)
+        if blob:
+            _state.init(parse_blob(blob), inject=inject)
+            return ENV
+
+    # hand the CLI the environment as it was before we injected anything, so a reload
+    # re-resolves against the caller's env rather than against our own values. Undone in a
+    # copy rather than in place, so a failed reload leaves what's loaded now untouched.
+    stdout = run_load(
+        version=__version__,
+        cwd=cwd,
+        path=path,
+        env=env,
+        timeout=timeout,
+        base_env=_state.clean_environ_copy(),
+    )
+    graph = parse_blob(stdout)
+    _state.init(graph, inject=inject)
+
+    # Publish the blob so subprocesses (and any generated env module) see the same values,
+    # matching `varlock run`. Skipped when values aren't being injected: that is the case
+    # where `@encryptInjectedEnv` would have the CLI encrypt the blob, and this package has no
+    # decryption, so keeping it in memory only is safer than writing plaintext.
+    if inject and not graph.settings.get("disableProcessEnvInjection"):
+        _state.set_env_var(BLOB_ENV_VAR, stdout)
+
+    return ENV
+
+
+def reload(**kwargs: Any) -> Env:
+    """Re-resolve everything, ignoring what's already loaded.
+
+    Use this after editing your schema or rotating a secret in a long-lived process such as a
+    notebook kernel. Accepts the same arguments as :func:`load`.
+    """
+    kwargs["force"] = True
+    return load(**kwargs)
+
+
+def unload() -> None:
+    """Forget the loaded env and restore every environment variable varlock set."""
+    _state.reset()
+
+
+def is_loaded() -> bool:
+    """Whether env values are currently loaded."""
+    return _state.initialized
+
+
+def is_running_under_varlock_run() -> bool:
+    """Whether this process was started with ``varlock run``."""
+    return bool(os.environ.get(RUN_FLAG_ENV_VAR))
+
+
+def get_settings() -> Dict[str, Any]:
+    """Varlock settings from the schema's root decorators (``redactLogs`` and friends)."""
+    return dict(_state.settings)
+
+
+def get_sensitive_keys() -> FrozenSet[str]:
+    """Keys whose values are marked ``@sensitive``."""
+    return _state.sensitive_keys
+
+
+def _exit_with(err: VarlockError) -> None:
+    # the CLI already formats its errors, so print that output rather than a Python traceback
+    detail = getattr(err, "stderr", "") or str(err)
+    if detail and not detail.endswith("\n"):
+        detail += "\n"
+    sys.stderr.write(detail)
+    raise SystemExit(getattr(err, "exit_code", 1))
+
+
+def _auto_init() -> None:
+    """Adopt an already-injected blob at import time.
+
+    Mirrors the JS runtime: when the process was started with ``varlock run`` the values are
+    right there, so ``from varlock import ENV`` works without an explicit load. Failures are
+    swallowed here (an encrypted or malformed blob), leaving a later explicit :func:`load` to
+    report the problem properly.
+    """
+    blob = os.environ.get(BLOB_ENV_VAR)
+    if not blob:
+        return
+    try:
+        _state.init(parse_blob(blob))
+    except VarlockError:
+        pass
+
+
+_auto_init()

--- a/packages/varlock-python/src/varlock/_binary.py
+++ b/packages/varlock-python/src/varlock/_binary.py
@@ -1,0 +1,132 @@
+"""Locating the varlock CLI binary.
+
+Mirrors the search the JS integration does in `exec-sync-varlock.ts`, with the standalone
+installer's locations added, since Python projects usually have no `node_modules` at all.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from .errors import VarlockBinaryNotFoundError
+
+#: Set this to an absolute path to skip discovery entirely.
+BIN_PATH_ENV_VAR = "VARLOCK_BIN"
+
+_IS_WINDOWS = sys.platform.startswith("win")
+
+# On Windows npm creates varlock.exe while pnpm only creates varlock.cmd (plus a shell script)
+_BIN_NAMES = ("varlock.exe", "varlock.cmd") if _IS_WINDOWS else ("varlock",)
+
+_INSTALL_HINT = (
+    "Install it with one of:\n"
+    "  brew install dmno-dev/tap/varlock\n"
+    "  curl -sSfL https://varlock.dev/install.sh | sh -s\n"
+    "or point VARLOCK_BIN at an existing binary.\n"
+    "See https://varlock.dev/getting-started/installation/"
+)
+
+# discovery hits the filesystem, so cache per starting directory
+_cache: dict = {}
+
+
+def _is_executable(path: Path) -> bool:
+    # .cmd/.bat shims are not marked executable on Windows, so only check existence there
+    if _IS_WINDOWS:
+        return path.is_file()
+    return path.is_file() and os.access(path, os.X_OK)
+
+
+def _standalone_install_dirs() -> List[Path]:
+    """Directories the standalone installer (install.sh / homebrew) writes to."""
+    dirs = []
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        dirs.append(Path(xdg) / "varlock" / "bin")
+    home = Path.home()
+    dirs.append(home / ".varlock" / "bin")
+    dirs.append(home / ".config" / "varlock" / "bin")
+    return dirs
+
+
+def _node_modules_dirs(start: Path) -> List[Path]:
+    """Walk up from `start` collecting every `node_modules/.bin` along the way.
+
+    Covers the case where a Python service lives inside a JS monorepo that installs varlock as
+    a package.json dependency. A `.bin` directory that exists without varlock in it is not the
+    end of the search: in a monorepo the root may have one while varlock is installed only in a
+    sub-package (and vice versa).
+    """
+    dirs = []
+    current = start
+    while True:
+        candidate = current / "node_modules" / ".bin"
+        if candidate.is_dir():
+            dirs.append(candidate)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return dirs
+
+
+def _candidate_dirs(start: Path) -> List[Path]:
+    return _standalone_install_dirs() + _node_modules_dirs(start)
+
+
+def find_binary(cwd: Optional[os.PathLike] = None, *, use_cache: bool = True) -> str:
+    """Return the path to the varlock CLI binary.
+
+    Search order: ``VARLOCK_BIN``, then ``PATH``, then the standalone install directories,
+    then any ``node_modules/.bin`` walking up from ``cwd``.
+
+    Raises:
+        VarlockBinaryNotFoundError: if no binary is found.
+    """
+    explicit = os.environ.get(BIN_PATH_ENV_VAR)
+    if explicit:
+        path = Path(explicit).expanduser()
+        if not _is_executable(path):
+            raise VarlockBinaryNotFoundError(
+                f"{BIN_PATH_ENV_VAR} is set to `{explicit}`, which is not an executable file",
+                [str(path)],
+            )
+        return str(path)
+
+    start = Path(cwd).resolve() if cwd else Path.cwd()
+    cache_key = str(start)
+    if use_cache and cache_key in _cache:
+        return _cache[cache_key]
+
+    searched: List[str] = []
+
+    on_path = shutil.which("varlock")
+    if on_path:
+        if use_cache:
+            _cache[cache_key] = on_path
+        return on_path
+    searched.append("PATH")
+
+    for directory in _candidate_dirs(start):
+        for name in _BIN_NAMES:
+            candidate = directory / name
+            searched.append(str(candidate))
+            if _is_executable(candidate):
+                resolved = str(candidate)
+                if use_cache:
+                    _cache[cache_key] = resolved
+                return resolved
+
+    raise VarlockBinaryNotFoundError(
+        f"Unable to find the varlock CLI.\n{_INSTALL_HINT}",
+        searched,
+    )
+
+
+def clear_cache() -> None:
+    """Forget cached binary lookups (useful after installing varlock mid-session)."""
+    _cache.clear()

--- a/packages/varlock-python/src/varlock/_blob.py
+++ b/packages/varlock-python/src/varlock/_blob.py
@@ -1,0 +1,145 @@
+"""Parsing the serialized env graph (the `__VARLOCK_ENV` blob)."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any, Dict, FrozenSet, List, Optional
+
+from .errors import VarlockLoadError
+
+#: Marks an encrypted blob. See `@encryptInjectedEnv`.
+ENCRYPTED_BLOB_PREFIX = "varlock:v1:"
+
+#: Set by `varlock run` in the child process.
+BLOB_ENV_VAR = "__VARLOCK_ENV"
+RUN_FLAG_ENV_VAR = "__VARLOCK_RUN"
+
+_ENCRYPTED_MSG = (
+    "__VARLOCK_ENV is encrypted and this package cannot decrypt it. "
+    "Disable @encryptInjectedEnv for processes that load env from Python."
+)
+
+
+def js_env_string(value: Any, env_str: Optional[str] = None) -> str:
+    """Serialize a resolved value the way varlock injects it into the environment.
+
+    Composite values (arrays/objects) carry their flat form in the blob as ``envStr``, since
+    re-deriving it needs type settings that don't travel in the blob. Everything else is
+    stringified the way the CLI does it, which is JS semantics: ``True`` becomes ``"true"``,
+    not ``"True"``.
+    """
+    if env_str is not None:
+        return env_str
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "NaN"
+        if math.isinf(value):
+            return "Infinity" if value > 0 else "-Infinity"
+        # JS prints whole floats without a trailing `.0`
+        if value.is_integer() and abs(value) < 1e21:
+            return str(int(value))
+        return repr(value)
+    if value is None:
+        return ""
+    return json.dumps(value)
+
+
+class LoadedGraph:
+    """The parts of a serialized env graph this package uses."""
+
+    __slots__ = (
+        "values",
+        "env_strings",
+        "declared_keys",
+        "sensitive_keys",
+        "settings",
+        "errors",
+        "raw",
+    )
+
+    def __init__(
+        self,
+        *,
+        values: Dict[str, Any],
+        env_strings: Dict[str, str],
+        declared_keys: List[str],
+        sensitive_keys: FrozenSet[str],
+        settings: Dict[str, Any],
+        errors: Optional[Dict[str, Any]],
+        raw: Dict[str, Any],
+    ) -> None:
+        self.values = values
+        self.env_strings = env_strings
+        self.declared_keys = declared_keys
+        self.sensitive_keys = sensitive_keys
+        self.settings = settings
+        self.errors = errors
+        self.raw = raw
+
+
+def parse_graph(data: Dict[str, Any]) -> LoadedGraph:
+    """Normalize an already-decoded serialized graph."""
+    config = data.get("config") or {}
+    values: Dict[str, Any] = {}
+    env_strings: Dict[str, str] = {}
+    declared_keys: List[str] = []
+    sensitive: List[str] = []
+
+    for key, entry in config.items():
+        declared_keys.append(key)
+        if entry.get("isSensitive"):
+            sensitive.append(key)
+        # unset optional items are serialized without a `value` at all, so a missing key here
+        # means "declared but has no value", which is distinct from a value of None
+        if "value" not in entry:
+            continue
+        value = entry["value"]
+        values[key] = value
+        env_strings[key] = js_env_string(value, entry.get("envStr"))
+
+    return LoadedGraph(
+        values=values,
+        env_strings=env_strings,
+        declared_keys=declared_keys,
+        sensitive_keys=frozenset(sensitive),
+        settings=data.get("settings") or {},
+        errors=data.get("errors"),
+        raw=data,
+    )
+
+
+def parse_blob(blob: str) -> LoadedGraph:
+    """Parse a raw `__VARLOCK_ENV` blob string."""
+    if blob.startswith(ENCRYPTED_BLOB_PREFIX):
+        raise VarlockLoadError(_ENCRYPTED_MSG)
+    try:
+        data = json.loads(blob)
+    except ValueError as err:
+        raise VarlockLoadError(f"Could not parse the __VARLOCK_ENV blob: {err}") from err
+    if not isinstance(data, dict):
+        raise VarlockLoadError("Expected the __VARLOCK_ENV blob to be a JSON object")
+    return parse_graph(data)
+
+
+def partial_values_from_stdout(stdout: str) -> Dict[str, Any]:
+    """Best-effort extraction of values from a failed load.
+
+    On a validation failure (as opposed to a schema/parse error) the CLI still writes the
+    serialized graph to stdout, so items unrelated to the failure have real values here. Used
+    to populate :attr:`VarlockLoadError.partial_values`.
+    """
+    if not stdout:
+        return {}
+    try:
+        data = json.loads(stdout)
+        config = data.get("config") or {}
+        return {key: entry.get("value") for key, entry in config.items()}
+    except Exception:
+        return {}

--- a/packages/varlock-python/src/varlock/_blob.py
+++ b/packages/varlock-python/src/varlock/_blob.py
@@ -59,6 +59,7 @@ class LoadedGraph:
         "env_strings",
         "declared_keys",
         "sensitive_keys",
+        "prevent_leaks",
         "settings",
         "errors",
         "raw",
@@ -71,6 +72,7 @@ class LoadedGraph:
         env_strings: Dict[str, str],
         declared_keys: List[str],
         sensitive_keys: FrozenSet[str],
+        prevent_leaks: Dict[str, bool],
         settings: Dict[str, Any],
         errors: Optional[Dict[str, Any]],
         raw: Dict[str, Any],
@@ -79,6 +81,7 @@ class LoadedGraph:
         self.env_strings = env_strings
         self.declared_keys = declared_keys
         self.sensitive_keys = sensitive_keys
+        self.prevent_leaks = prevent_leaks
         self.settings = settings
         self.errors = errors
         self.raw = raw
@@ -91,11 +94,14 @@ def parse_graph(data: Dict[str, Any]) -> LoadedGraph:
     env_strings: Dict[str, str] = {}
     declared_keys: List[str] = []
     sensitive: List[str] = []
+    prevent_leaks: Dict[str, bool] = {}
 
     for key, entry in config.items():
         declared_keys.append(key)
         if entry.get("isSensitive"):
             sensitive.append(key)
+            # only emitted when opted out via `@sensitive={preventLeaks=false}`
+            prevent_leaks[key] = entry.get("preventLeaks", True) is not False
         # unset optional items are serialized without a `value` at all, so a missing key here
         # means "declared but has no value", which is distinct from a value of None
         if "value" not in entry:
@@ -109,6 +115,7 @@ def parse_graph(data: Dict[str, Any]) -> LoadedGraph:
         env_strings=env_strings,
         declared_keys=declared_keys,
         sensitive_keys=frozenset(sensitive),
+        prevent_leaks=prevent_leaks,
         settings=data.get("settings") or {},
         errors=data.get("errors"),
         raw=data,

--- a/packages/varlock-python/src/varlock/_cli.py
+++ b/packages/varlock-python/src/varlock/_cli.py
@@ -1,0 +1,128 @@
+"""Calling the varlock CLI.
+
+The Python package resolves nothing itself. Like the JS integration's `auto-load`, it shells
+out to `varlock load --format json-full`, then parses the graph the CLI prints. Every plugin,
+cache, and resolver behavior therefore comes from the CLI you have installed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from ._binary import find_binary
+from ._blob import partial_values_from_stdout
+from .errors import VarlockLoadError
+
+PathArg = Union[str, os.PathLike]
+
+INTEGRATION_ENV_VAR = "__VARLOCK_INTEGRATION"
+
+
+def build_load_args(
+    *,
+    path: Optional[Union[PathArg, Sequence[PathArg]]] = None,
+    env: Optional[str] = None,
+    extra_args: Optional[Sequence[str]] = None,
+) -> List[str]:
+    args = ["load", "--format", "json-full", "--compact"]
+    if path is not None:
+        paths = [path] if isinstance(path, (str, os.PathLike)) else list(path)
+        for p in paths:
+            args += ["--path", os.fspath(p)]
+    if env is not None:
+        args += ["--env", env]
+    if extra_args:
+        args += list(extra_args)
+    return args
+
+
+def _child_env(version: str, base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    child = dict(os.environ if base_env is None else base_env)
+    # tells the CLI which integration invoked it (telemetry only)
+    child[INTEGRATION_ENV_VAR] = f"python@{version}"
+    return child
+
+
+def run_load(
+    *,
+    version: str,
+    cwd: Optional[PathArg] = None,
+    path: Optional[Union[PathArg, Sequence[PathArg]]] = None,
+    env: Optional[str] = None,
+    extra_args: Optional[Sequence[str]] = None,
+    timeout: Optional[float] = None,
+    base_env: Optional[Dict[str, str]] = None,
+) -> str:
+    """Run `varlock load` and return its stdout (the serialized graph as JSON).
+
+    Raises:
+        VarlockBinaryNotFoundError: if the CLI can't be found.
+        VarlockLoadError: if the CLI exits non-zero, or can't be run at all.
+    """
+    binary = find_binary(cwd)
+    args = build_load_args(path=path, env=env, extra_args=extra_args)
+
+    # pnpm creates a .cmd shim on Windows, which only runs through the shell
+    needs_shell = sys.platform.startswith("win") and binary.lower().endswith(".cmd")
+    command: Any = (
+        subprocess.list2cmdline([binary, *args]) if needs_shell else [binary, *args]
+    )
+
+    try:
+        result = subprocess.run(
+            command,
+            shell=needs_shell,
+            cwd=os.fspath(cwd) if cwd is not None else None,
+            env=_child_env(version, base_env),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as err:
+        raise VarlockLoadError(
+            f"`varlock load` timed out after {timeout}s",
+            stderr=_decode(err.stderr),
+            stdout=_decode(err.stdout),
+        ) from err
+    except OSError as err:
+        raise VarlockLoadError(f"Could not run the varlock CLI at `{binary}`: {err}") from err
+
+    stdout = _decode(result.stdout)
+    stderr = _decode(result.stderr)
+
+    if result.returncode != 0:
+        raise VarlockLoadError(
+            f"`varlock load` failed (exit code {result.returncode})",
+            stderr=stderr,
+            stdout=stdout,
+            exit_code=result.returncode,
+            errors=_errors_from_stdout(stdout),
+            partial_values=partial_values_from_stdout(stdout),
+        )
+
+    if not stdout.strip():
+        raise VarlockLoadError(
+            "`varlock load` produced no output", stderr=stderr, stdout=stdout
+        )
+
+    return stdout
+
+
+def _decode(raw: Optional[bytes]) -> str:
+    if not raw:
+        return ""
+    if isinstance(raw, str):
+        return raw
+    return raw.decode("utf-8", errors="replace")
+
+
+def _errors_from_stdout(stdout: str) -> Optional[Dict[str, Any]]:
+    try:
+        return json.loads(stdout).get("errors")
+    except Exception:
+        return None

--- a/packages/varlock-python/src/varlock/_cli.py
+++ b/packages/varlock-python/src/varlock/_cli.py
@@ -40,6 +40,49 @@ def build_load_args(
     return args
 
 
+def quote_for_cmd(arg: str) -> str:
+    """Quote a single argument for a Windows command line, always adding the quotes.
+
+    This is the MSVCRT quoting algorithm that `subprocess.list2cmdline` uses, except that it
+    quotes unconditionally. `list2cmdline` only quotes an argument containing whitespace,
+    which is not enough here: `cmd.exe` parses its own metacharacters (`&`, `|`, `<`, `>`,
+    `^`, parens) out of *unquoted* text before argument splitting ever happens, so
+    `--path a&b` would run `b` as a second command. Inside double quotes it treats them as
+    ordinary characters.
+    """
+    result = ['"']
+    backslashes = 0
+    for char in arg:
+        if char == "\\":
+            backslashes += 1
+            continue
+        if char == '"':
+            # a quote is escaped by a backslash, and every backslash before it doubles
+            result.append("\\" * (backslashes * 2 + 1))
+        else:
+            result.append("\\" * backslashes)
+        backslashes = 0
+        result.append(char)
+    # backslashes before the closing quote double, so they aren't read as escaping it
+    result.append("\\" * (backslashes * 2))
+    result.append('"')
+    return "".join(result)
+
+
+def build_cmd_shim_command(binary: str, args: Sequence[str], comspec: Optional[str] = None) -> str:
+    """Build the command line for running a `.cmd` shim through `cmd.exe`.
+
+    Uses the `cmd.exe /d /s /c "..."` form: `/s` makes cmd strip the outer quote pair and
+    take the rest verbatim, and every token inside is quoted individually, so a
+    metacharacter in a path or an argument stays literal. Handed to `subprocess` with
+    `shell=False` so this exact string reaches `CreateProcess`, rather than `shell=True`
+    building a `/c` line whose quote-stripping rules are far harder to reason about.
+    """
+    shell = comspec or os.environ.get("COMSPEC") or "cmd.exe"
+    inner = " ".join(quote_for_cmd(token) for token in (binary, *args))
+    return f'{quote_for_cmd(shell)} /d /s /c "{inner}"'
+
+
 def _child_env(version: str, base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     child = dict(os.environ if base_env is None else base_env)
     # tells the CLI which integration invoked it (telemetry only)
@@ -66,16 +109,17 @@ def run_load(
     binary = find_binary(cwd)
     args = build_load_args(path=path, env=env, extra_args=extra_args)
 
-    # pnpm creates a .cmd shim on Windows, which only runs through the shell
-    needs_shell = sys.platform.startswith("win") and binary.lower().endswith(".cmd")
+    # pnpm creates a .cmd shim on Windows, and a batch file can only be run by cmd.exe.
+    # Everything else is executed directly, with no shell involved at all.
+    is_cmd_shim = sys.platform.startswith("win") and binary.lower().endswith(".cmd")
     command: Any = (
-        subprocess.list2cmdline([binary, *args]) if needs_shell else [binary, *args]
+        build_cmd_shim_command(binary, args) if is_cmd_shim else [binary, *args]
     )
 
     try:
         result = subprocess.run(
             command,
-            shell=needs_shell,
+            shell=False,
             cwd=os.fspath(cwd) if cwd is not None else None,
             env=_child_env(version, base_env),
             stdout=subprocess.PIPE,

--- a/packages/varlock-python/src/varlock/_env.py
+++ b/packages/varlock-python/src/varlock/_env.py
@@ -82,6 +82,12 @@ class Env(Mapping):
         # makes `ENV.<TAB>` complete env keys in notebooks and REPLs
         return sorted(set(super().__dir__()) | set(self._state.values))
 
+    def _ipython_key_completions_(self):
+        # makes `ENV["<TAB>"]` complete env keys. IPython only infers keys for real `dict`
+        # instances, so a Mapping has to advertise them explicitly or subscript completion
+        # comes back empty.
+        return list(self._state.values)
+
     # -- display -------------------------------------------------------------------------
 
     def to_dict(self, *, redact_sensitive: bool = False) -> Dict[str, Any]:

--- a/packages/varlock-python/src/varlock/_env.py
+++ b/packages/varlock-python/src/varlock/_env.py
@@ -1,0 +1,138 @@
+"""The `ENV` object."""
+
+from __future__ import annotations
+
+import html
+from collections.abc import Mapping
+from typing import Any, Dict, Iterator
+
+from ._redact import redact_value
+from ._runtime import EnvState
+from .errors import VarlockMissingKeyError, VarlockNotLoadedError
+
+_NOT_LOADED_MSG = (
+    "varlock env has not been loaded yet.\n"
+    "Call varlock.load() first, or start your program with `varlock run -- <command>`."
+)
+
+
+class Env(Mapping):
+    """Resolved, coerced env values.
+
+    Behaves like a read-only mapping (``env["KEY"]``, ``in``, ``.get()``, ``dict(env)``) and
+    also allows attribute access (``env.KEY``) since that reads better in a notebook. Reading a
+    key that isn't in your schema raises :class:`VarlockMissingKeyError` rather than returning
+    ``None``, matching the JS ``ENV`` proxy.
+
+    Note that mapping methods (``get``, ``keys``, ``items``, ``values``) shadow same-named env
+    keys for attribute access only. Env keys are uppercase by convention, and ``env["get"]``
+    always works regardless.
+    """
+
+    __slots__ = ("_state",)
+
+    def __init__(self, state: EnvState) -> None:
+        self._state = state
+
+    # -- mapping protocol ----------------------------------------------------------------
+
+    def __getitem__(self, key: str) -> Any:
+        state = self._state
+        if not state.initialized:
+            raise VarlockNotLoadedError(_NOT_LOADED_MSG)
+        try:
+            return state.values[key]
+        except KeyError:
+            pass
+        # a declared key with no value is a different problem than a typo, so say which it is
+        if key in state.declared_keys:
+            raise VarlockMissingKeyError(
+                key,
+                f"`{key}` exists in your schema, but has no value in this environment",
+            ) from None
+        raise VarlockMissingKeyError(key) from None
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._state.values)
+
+    def __len__(self) -> int:
+        return len(self._state.values)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._state.values
+
+    # -- attribute access ----------------------------------------------------------------
+
+    def __getattr__(self, name: str) -> Any:
+        # Private and dunder names are probed by tooling (IPython display hooks, copy, pickle)
+        # and must answer with a plain AttributeError. Underscore-prefixed env keys are legal,
+        # so a real one still resolves.
+        if name.startswith("_"):
+            # copy/pickle can build an instance without __init__, leaving the slot unset;
+            # reading it below would then recurse back into __getattr__
+            if name == "_state":
+                raise AttributeError(name)
+            state = self._state
+            if state.initialized and name in state.values:
+                return state.values[name]
+            raise AttributeError(name)
+        return self[name]
+
+    def __dir__(self):
+        # makes `ENV.<TAB>` complete env keys in notebooks and REPLs
+        return sorted(set(super().__dir__()) | set(self._state.values))
+
+    # -- display -------------------------------------------------------------------------
+
+    def to_dict(self, *, redact_sensitive: bool = False) -> Dict[str, Any]:
+        """A plain dict of the resolved values.
+
+        Pass ``redact_sensitive=True`` to mask values marked ``@sensitive``, which is what you
+        want before printing or logging the whole thing.
+        """
+        if not redact_sensitive:
+            return dict(self._state.values)
+        sensitive = self._state.sensitive_keys
+        return {
+            key: (redact_value(value) if key in sensitive else value)
+            for key, value in self._state.values.items()
+        }
+
+    def __repr__(self) -> str:
+        if not self._state.initialized:
+            return "<varlock.Env (not loaded)>"
+        # never render sensitive values here: a notebook echoes the repr of the last
+        # expression in a cell, which would otherwise print every secret into the saved file
+        inner = ", ".join(
+            f"{key}={value!r}" for key, value in self.to_dict(redact_sensitive=True).items()
+        )
+        return f"<varlock.Env {inner}>"
+
+    def _repr_html_(self) -> str:
+        """Rendered by Jupyter in place of the repr."""
+        if not self._state.initialized:
+            return "<em>varlock.Env (not loaded)</em>"
+        sensitive = self._state.sensitive_keys
+        rows = []
+        for key, value in self.to_dict(redact_sensitive=True).items():
+            marker = " 🔐" if key in sensitive else ""
+            rows.append(
+                "<tr>"
+                f"<td style='text-align:left'><code>{html.escape(key)}</code>{marker}</td>"
+                f"<td style='text-align:left'><code>{html.escape(repr(value))}</code></td>"
+                "</tr>"
+            )
+        unset = [k for k in self._state.declared_keys if k not in self._state.values]
+        footer = (
+            f"<caption style='caption-side:bottom;text-align:left'>{len(unset)} declared "
+            "key(s) with no value in this environment</caption>"
+            if unset
+            else ""
+        )
+        return (
+            "<table>"
+            f"{footer}"
+            "<thead><tr><th style='text-align:left'>key</th>"
+            "<th style='text-align:left'>value</th></tr></thead>"
+            f"<tbody>{''.join(rows)}</tbody></table>"
+        )

--- a/packages/varlock-python/src/varlock/_patch.py
+++ b/packages/varlock-python/src/varlock/_patch.py
@@ -1,0 +1,236 @@
+"""Routing output through redaction.
+
+The JS runtime patches the console. Python has three separate places output escapes, so this
+covers all of them:
+
+- `logging`, via the record factory, which every logger and handler goes through no matter
+  when it was created
+- `print()`, via `builtins.print`, which resolves its stream at call time and so keeps working
+  when something replaces `sys.stdout` after this ran
+- direct `sys.stdout.write` / `sys.stderr.write` calls, via the stream objects themselves
+- notebook cell output, via IPython's display formatter, which does not go through stdout
+
+None of this is foolproof, the same caveat the JS integration carries. Code holding its own
+reference to a stream, writing to `sys.stdout.buffer`, or rendering a secret in an object's
+`__str__` after redaction has run will still get through.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import sys
+from typing import Any, Optional
+
+from ._redaction import redact
+
+_original_record_factory: Optional[Any] = None
+_original_print: Optional[Any] = None
+# stream name -> (stream object, original write, whether it already had its own `write`)
+_patched_streams: dict = {}
+_patched_formatter: Optional[Any] = None
+
+
+# -- logging -----------------------------------------------------------------------------
+
+
+def patch_logging() -> None:
+    """Redact every log record at creation.
+
+    Patching the record factory rather than adding a filter means it applies to every logger
+    and every handler, including ones created after this runs. A filter would only cover the
+    logger or handler it was attached to.
+    """
+    global _original_record_factory
+    if _original_record_factory is not None:
+        return
+    _original_record_factory = logging.getLogRecordFactory()
+
+    def factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
+        record = _original_record_factory(*args, **kwargs)
+        record.msg = redact(record.msg)
+        if record.args:
+            record.args = redact(record.args)
+        return record
+
+    factory._varlock_patched = True  # type: ignore[attr-defined]
+    logging.setLogRecordFactory(factory)
+
+
+def unpatch_logging() -> None:
+    global _original_record_factory
+    if _original_record_factory is None:
+        return
+    # someone may have installed their own factory on top of ours; restoring the old one
+    # would silently drop theirs
+    if getattr(logging.getLogRecordFactory(), "_varlock_patched", False):
+        logging.setLogRecordFactory(_original_record_factory)
+    _original_record_factory = None
+
+
+# -- stdout / stderr ---------------------------------------------------------------------
+
+
+def patch_print() -> None:
+    """Redact `print()`.
+
+    Wrapping the builtin rather than only the stream matters because `print` looks up
+    `sys.stdout` on every call, so this keeps working when a library (or a notebook kernel)
+    swaps the stream out after redaction was installed.
+    """
+    global _original_print
+    if _original_print is not None:
+        return
+    _original_print = builtins.print
+
+    def patched_print(*args: Any, **kwargs: Any) -> Any:
+        # print stringifies each argument anyway, so doing it here first loses nothing and
+        # lets a secret inside a dict or a dataclass be caught too
+        return _original_print(
+            *(redact(arg if isinstance(arg, str) else str(arg)) for arg in args), **kwargs
+        )
+
+    patched_print._varlock_patched = True  # type: ignore[attr-defined]
+    builtins.print = patched_print
+
+
+def unpatch_print() -> None:
+    global _original_print
+    if _original_print is None:
+        return
+    if getattr(builtins.print, "_varlock_patched", False):
+        builtins.print = _original_print
+    _original_print = None
+
+
+def patch_streams() -> None:
+    """Redact direct writes to `sys.stdout` / `sys.stderr`.
+
+    Calling this again after a stream has been replaced re-patches the new one, so
+    `install_redaction()` is the fix when something swapped a stream out from under us.
+    """
+    for name in ("stdout", "stderr"):
+        stream = getattr(sys, name, None)
+        if stream is None:
+            continue
+        patched = _patched_streams.get(name)
+        if patched is not None:
+            if patched[0] is stream:
+                continue
+            # the stream was replaced after we patched it; drop the stale record
+            _unpatch_stream(name)
+
+        original = getattr(stream, "write", None)
+        if original is None or getattr(original, "_varlock_patched", False):
+            continue
+
+        def make_write(orig: Any) -> Any:
+            def write(text: Any) -> Any:
+                return orig(redact(text) if isinstance(text, str) else text)
+
+            write._varlock_patched = True  # type: ignore[attr-defined]
+            return write
+
+        had_own_write = "write" in getattr(stream, "__dict__", {})
+        try:
+            stream.write = make_write(original)
+        except (AttributeError, TypeError):
+            # a stream that doesn't allow attribute assignment (some C-level objects)
+            continue
+        _patched_streams[name] = (stream, original, had_own_write)
+
+
+def _unpatch_stream(name: str) -> None:
+    patched = _patched_streams.pop(name, None)
+    if patched is None:
+        return
+    stream, original, had_own_write = patched
+    try:
+        if had_own_write:
+            stream.write = original
+        else:
+            del stream.write
+    except (AttributeError, TypeError):
+        pass
+
+
+def unpatch_streams() -> None:
+    for name in list(_patched_streams):
+        _unpatch_stream(name)
+
+
+# -- notebook cell output ----------------------------------------------------------------
+
+
+def _get_ipython() -> Optional[Any]:
+    try:
+        from IPython import get_ipython
+    except Exception:
+        return None
+    try:
+        return get_ipython()
+    except Exception:
+        return None
+
+
+def patch_ipython() -> None:
+    """Redact notebook cell output.
+
+    A cell's result is sent straight to the frontend through the display formatter rather
+    than through stdout, so this is the only thing that catches an echoed secret.
+    """
+    global _patched_formatter
+    if _patched_formatter is not None:
+        return
+    ipython = _get_ipython()
+    formatter = getattr(ipython, "display_formatter", None)
+    if formatter is None:
+        return
+    original = formatter.format
+    if getattr(original, "_varlock_patched", False):
+        return
+
+    def patched_format(obj: Any, *args: Any, **kwargs: Any):
+        data, metadata = original(obj, *args, **kwargs)
+        redacted = {
+            key: (redact(value) if isinstance(value, str) else value)
+            for key, value in data.items()
+        }
+        return redacted, metadata
+
+    patched_format._varlock_patched = True  # type: ignore[attr-defined]
+    formatter.format = patched_format
+    _patched_formatter = (formatter, original)
+
+
+def unpatch_ipython() -> None:
+    global _patched_formatter
+    if _patched_formatter is None:
+        return
+    formatter, original = _patched_formatter
+    try:
+        formatter.format = original
+    except (AttributeError, TypeError):
+        pass
+    _patched_formatter = None
+
+
+# -- all ---------------------------------------------------------------------------------
+
+
+def patch_all() -> None:
+    patch_logging()
+    patch_print()
+    patch_streams()
+    patch_ipython()
+
+
+def unpatch_all() -> None:
+    unpatch_logging()
+    unpatch_print()
+    unpatch_streams()
+    unpatch_ipython()
+
+
+def is_patched() -> bool:
+    return _original_record_factory is not None or _original_print is not None

--- a/packages/varlock-python/src/varlock/_patch.py
+++ b/packages/varlock-python/src/varlock/_patch.py
@@ -24,9 +24,9 @@ from typing import Any, Optional
 
 from ._redaction import redact
 
-_original_record_factory: Optional[Any] = None
-_original_print: Optional[Any] = None
-# stream name -> (stream object, original write, whether it already had its own `write`)
+_logging_patch: Optional[Any] = None
+_print_patch: Optional[Any] = None
+# stream name -> (stream object, original write, patched write, whether it had its own `write`)
 _patched_streams: dict = {}
 _patched_formatter: Optional[Any] = None
 
@@ -41,13 +41,13 @@ def patch_logging() -> None:
     and every handler, including ones created after this runs. A filter would only cover the
     logger or handler it was attached to.
     """
-    global _original_record_factory
-    if _original_record_factory is not None:
+    global _logging_patch
+    if _logging_patch is not None:
         return
-    _original_record_factory = logging.getLogRecordFactory()
+    original = logging.getLogRecordFactory()
 
     def factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
-        record = _original_record_factory(*args, **kwargs)
+        record = original(*args, **kwargs)
         record.msg = redact(record.msg)
         if record.args:
             record.args = redact(record.args)
@@ -55,17 +55,19 @@ def patch_logging() -> None:
 
     factory._varlock_patched = True  # type: ignore[attr-defined]
     logging.setLogRecordFactory(factory)
+    _logging_patch = (original, factory)
 
 
 def unpatch_logging() -> None:
-    global _original_record_factory
-    if _original_record_factory is None:
+    global _logging_patch
+    if _logging_patch is None:
         return
+    original, factory = _logging_patch
     # someone may have installed their own factory on top of ours; restoring the old one
     # would silently drop theirs
-    if getattr(logging.getLogRecordFactory(), "_varlock_patched", False):
-        logging.setLogRecordFactory(_original_record_factory)
-    _original_record_factory = None
+    if logging.getLogRecordFactory() is factory:
+        logging.setLogRecordFactory(original)
+    _logging_patch = None
 
 
 # -- stdout / stderr ---------------------------------------------------------------------
@@ -78,29 +80,31 @@ def patch_print() -> None:
     `sys.stdout` on every call, so this keeps working when a library (or a notebook kernel)
     swaps the stream out after redaction was installed.
     """
-    global _original_print
-    if _original_print is not None:
+    global _print_patch
+    if _print_patch is not None:
         return
-    _original_print = builtins.print
+    original = builtins.print
 
     def patched_print(*args: Any, **kwargs: Any) -> Any:
         # print stringifies each argument anyway, so doing it here first loses nothing and
         # lets a secret inside a dict or a dataclass be caught too
-        return _original_print(
+        return original(
             *(redact(arg if isinstance(arg, str) else str(arg)) for arg in args), **kwargs
         )
 
     patched_print._varlock_patched = True  # type: ignore[attr-defined]
     builtins.print = patched_print
+    _print_patch = (original, patched_print)
 
 
 def unpatch_print() -> None:
-    global _original_print
-    if _original_print is None:
+    global _print_patch
+    if _print_patch is None:
         return
-    if getattr(builtins.print, "_varlock_patched", False):
-        builtins.print = _original_print
-    _original_print = None
+    original, patched_print = _print_patch
+    if builtins.print is patched_print:
+        builtins.print = original
+    _print_patch = None
 
 
 def patch_streams() -> None:
@@ -137,19 +141,20 @@ def patch_streams() -> None:
         except (AttributeError, TypeError):
             # a stream that doesn't allow attribute assignment (some C-level objects)
             continue
-        _patched_streams[name] = (stream, original, had_own_write)
+        _patched_streams[name] = (stream, original, stream.write, had_own_write)
 
 
 def _unpatch_stream(name: str) -> None:
     patched = _patched_streams.pop(name, None)
     if patched is None:
         return
-    stream, original, had_own_write = patched
+    stream, original, patched_write, had_own_write = patched
     try:
-        if had_own_write:
-            stream.write = original
-        else:
-            del stream.write
+        if stream.write is patched_write:
+            if had_own_write:
+                stream.write = original
+            else:
+                del stream.write
     except (AttributeError, TypeError):
         pass
 
@@ -200,16 +205,17 @@ def patch_ipython() -> None:
 
     patched_format._varlock_patched = True  # type: ignore[attr-defined]
     formatter.format = patched_format
-    _patched_formatter = (formatter, original)
+    _patched_formatter = (formatter, original, patched_format)
 
 
 def unpatch_ipython() -> None:
     global _patched_formatter
     if _patched_formatter is None:
         return
-    formatter, original = _patched_formatter
+    formatter, original, patched_format = _patched_formatter
     try:
-        formatter.format = original
+        if formatter.format is patched_format:
+            formatter.format = original
     except (AttributeError, TypeError):
         pass
     _patched_formatter = None
@@ -233,4 +239,4 @@ def unpatch_all() -> None:
 
 
 def is_patched() -> bool:
-    return _original_record_factory is not None or _original_print is not None
+    return _logging_patch is not None or _print_patch is not None

--- a/packages/varlock-python/src/varlock/_redact.py
+++ b/packages/varlock-python/src/varlock/_redact.py
@@ -1,0 +1,37 @@
+"""Value masking.
+
+Mirrors `redactString` in the JS runtime so masked values look the same everywhere varlock
+shows them. Full log redaction (patching `logging` and `print`) is separate; this module only
+covers masking a single value, which is what `repr(ENV)` needs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+MASK_CHAR = "▒"
+
+
+def redact_string(value: str, *, mode: str = "show_first_2", hide_length: bool = True) -> str:
+    """Mask a string, e.g. ``"hunter2"`` -> ``"hu▒▒▒▒▒"``.
+
+    ``hide_length`` keeps the mask a fixed width so the output doesn't leak how long the
+    original value was.
+    """
+    if not value:
+        return value
+    hidden_length = 5 if hide_length else max(len(value) - 2, 0)
+    hidden = MASK_CHAR * hidden_length
+    if mode == "show_last_2":
+        return f"{hidden}{value[-2:]}"
+    if mode == "show_first_last":
+        return f"{value[:1]}{hidden}{value[-1:]}"
+    return f"{value[:2]}{hidden}"
+
+
+def redact_value(value: Any) -> str:
+    """Mask any resolved value for display, including non-strings."""
+    if isinstance(value, str):
+        return redact_string(value)
+    # composites and scalars alike: mask the rendered form rather than showing structure
+    return redact_string(str(value))

--- a/packages/varlock-python/src/varlock/_redaction.py
+++ b/packages/varlock-python/src/varlock/_redaction.py
@@ -1,0 +1,188 @@
+"""Finding and masking sensitive values in arbitrary data.
+
+Mirrors `resetRedactionMap` / `redactSensitiveConfig` / `scanForLeaks` in the JS runtime, so
+the same values are caught and masked identically in both languages.
+
+Only *string* values are registered for redaction, matching the JS runtime. A sensitive value
+that resolved to a number would otherwise have every occurrence of that number masked
+everywhere, which is far more disruptive than it is useful.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from ._blob import LoadedGraph
+from ._redact import redact_string
+from .errors import VarlockLeakError
+
+#: Wraps a value that was deliberately revealed, so redaction leaves it alone.
+UNMASK_STR = "👁"
+
+# deep structures are redacted recursively; the bound stops a cyclic object (which the JS
+# implementation hits as a JSON.stringify failure) from blowing the stack
+_MAX_DEPTH = 12
+
+
+class _Entry:
+    __slots__ = ("key", "masked", "prevent_leaks")
+
+    def __init__(self, key: str, masked: str, prevent_leaks: bool) -> None:
+        self.key = key
+        self.masked = masked
+        self.prevent_leaks = prevent_leaks
+
+
+class RedactionState:
+    def __init__(self) -> None:
+        self.sensitive: Dict[str, _Entry] = {}
+        self.pattern: Optional[re.Pattern] = None
+
+    @property
+    def active(self) -> bool:
+        return self.pattern is not None
+
+
+state = RedactionState()
+
+
+def _collect_strings(value: Any, collected: List[str], depth: int = 0) -> None:
+    """Every redactable string inside a (possibly composite) sensitive value.
+
+    Each string element of an array/object registers on its own, so leaking a single element
+    is caught, not just the whole serialized value.
+    """
+    if depth > _MAX_DEPTH:
+        return
+    if isinstance(value, str):
+        if value:
+            collected.append(value)
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        for item in value:
+            _collect_strings(item, collected, depth + 1)
+    elif isinstance(value, dict):
+        for item in value.values():
+            _collect_strings(item, collected, depth + 1)
+
+
+def reset(graph: LoadedGraph) -> None:
+    """Rebuild the redaction map from a freshly loaded graph."""
+    state.sensitive = {}
+    state.pattern = None
+
+    for key in graph.sensitive_keys:
+        if key not in graph.values:
+            continue
+        strings: List[str] = []
+        _collect_strings(graph.values[key], strings)
+        # the flat serialized form registers too: a JSON-encoded element may not match its
+        # raw form once escaped
+        env_str = graph.env_strings.get(key)
+        if env_str:
+            strings.append(env_str)
+        prevent_leaks = graph.prevent_leaks.get(key, True)
+        for sensitive_str in strings:
+            masked = redact_string(sensitive_str)
+            if masked:
+                state.sensitive[sensitive_str] = _Entry(key, masked, prevent_leaks)
+
+    if not state.sensitive:
+        return
+
+    # sort longest first so overlapping values match maximally
+    alternatives = "|".join(
+        re.escape(s) for s in sorted(state.sensitive, key=len, reverse=True)
+    )
+    state.pattern = re.compile(
+        f"({UNMASK_STR} )?({alternatives})( {UNMASK_STR})?"
+    )
+
+
+def clear() -> None:
+    state.sensitive = {}
+    state.pattern = None
+
+
+def _replace(match: "re.Match") -> str:
+    pre, value, post = match.group(1), match.group(2), match.group(3)
+    # both markers present means the value was deliberately revealed, so leave it as it is
+    if pre and post:
+        return match.group(0)
+    return state.sensitive[value].masked
+
+
+def redact(value: Any) -> Any:
+    """Mask every sensitive value found anywhere in `value`.
+
+    Strings are masked directly; lists, tuples, sets, and dicts are walked and rebuilt.
+    Anything else is returned unchanged. Must be called after values are loaded.
+    """
+    if not state.active:
+        return value
+    return _redact(value, 0)
+
+
+def _redact(value: Any, depth: int) -> Any:
+    if depth > _MAX_DEPTH:
+        return value
+    if isinstance(value, str):
+        return state.pattern.sub(_replace, value)
+    if isinstance(value, dict):
+        return {
+            _redact(k, depth + 1): _redact(v, depth + 1) for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact(item, depth + 1) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact(item, depth + 1) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return type(value)(_redact(item, depth + 1) for item in value)
+    return value
+
+
+def reveal(secret: str) -> str:
+    """Mark a sensitive value so redaction leaves it alone when it is printed.
+
+    Returns the value unchanged when redaction is not active.
+    """
+    if not state.active:
+        return secret
+    return f"{UNMASK_STR} {secret} {UNMASK_STR}"
+
+
+def scan_for_leaks(
+    value: Any, *, method: Optional[str] = None, file: Optional[str] = None
+) -> Any:
+    """Raise if `value` contains a sensitive value, otherwise return it unchanged.
+
+    Use it on anything about to leave your process (a response body, a file you are writing,
+    a payload headed for a third party). Items opted out with `@sensitive={preventLeaks=false}`
+    are skipped, though they are still masked in logs.
+    """
+    if not state.sensitive or value is None:
+        return value
+
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        text = bytes(value).decode("utf-8", errors="replace")
+    elif isinstance(value, str):
+        text = value
+    else:
+        return value
+
+    for sensitive_str, entry in state.sensitive.items():
+        if not entry.prevent_leaks:
+            continue
+        if sensitive_str in text:
+            location = "".join(
+                [
+                    f"\n> Scan method: {method}" if method else "",
+                    f"\n> File: {file}" if file else "",
+                ]
+            )
+            raise VarlockLeakError(
+                f"🚨 DETECTED LEAKED SENSITIVE CONFIG - {entry.key}"
+                f"\n> Config item key: {entry.key}{location}",
+                key=entry.key,
+            )
+    return value

--- a/packages/varlock-python/src/varlock/_runtime.py
+++ b/packages/varlock-python/src/varlock/_runtime.py
@@ -1,0 +1,106 @@
+"""Process-level env state.
+
+The JS equivalent is `runtime/env.ts`: hold the resolved values, inject them into the
+process environment, and let the same objects be re-initialized on reload. Values are mutated
+in place rather than replaced, so anything holding a reference to `ENV` sees a reload.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, FrozenSet, List, Optional
+
+from ._blob import BLOB_ENV_VAR, LoadedGraph
+
+
+class EnvState:
+    """Everything varlock knows about the currently loaded env."""
+
+    def __init__(self) -> None:
+        self.initialized = False
+        self.values: Dict[str, Any] = {}
+        self.env_strings: Dict[str, str] = {}
+        self.declared_keys: List[str] = []
+        self.sensitive_keys: FrozenSet[str] = frozenset()
+        self.settings: Dict[str, Any] = {}
+        self.errors: Optional[Dict[str, Any]] = None
+        # keys we wrote into os.environ -> the value they had before (None = was not set)
+        self._overwritten: Dict[str, Optional[str]] = {}
+
+    # -- os.environ bookkeeping ----------------------------------------------------------
+
+    def set_env_var(self, key: str, value: str) -> None:
+        """Set an environment variable, remembering what was there so it can be restored."""
+        if key not in self._overwritten:
+            self._overwritten[key] = os.environ.get(key)
+        os.environ[key] = value
+
+    def restore_environ(self) -> None:
+        """Undo every environment variable this package set."""
+        for key, previous in self._overwritten.items():
+            if previous is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = previous
+        self._overwritten.clear()
+
+    def clean_environ_copy(self) -> Dict[str, str]:
+        """A copy of the environment with this package's injection undone.
+
+        Used as the environment for the CLI when re-resolving, so it sees the environment as
+        it was rather than the values we put there. Copied rather than applied in place, so a
+        failed reload leaves the currently loaded values untouched.
+        """
+        clean = dict(os.environ)
+        for key, previous in self._overwritten.items():
+            if previous is None:
+                clean.pop(key, None)
+            else:
+                clean[key] = previous
+        return clean
+
+    @property
+    def injected_keys(self) -> List[str]:
+        return [k for k in self._overwritten if k != BLOB_ENV_VAR]
+
+    # -- (re)initialization --------------------------------------------------------------
+
+    def init(self, graph: LoadedGraph, *, inject: bool = True) -> None:
+        """Adopt a freshly loaded graph, replacing anything loaded before it."""
+        # drop the previous injection first, so keys that disappeared from the schema don't
+        # linger in os.environ after a reload
+        self.restore_environ()
+
+        # mutate in place - callers hold references to these objects
+        self.values.clear()
+        self.values.update(graph.values)
+        self.env_strings.clear()
+        self.env_strings.update(graph.env_strings)
+        self.settings.clear()
+        self.settings.update(graph.settings)
+        self.declared_keys = list(graph.declared_keys)
+        self.sensitive_keys = graph.sensitive_keys
+        self.errors = graph.errors
+
+        if inject and not self.settings.get("disableProcessEnvInjection"):
+            for key, env_str in graph.env_strings.items():
+                self.set_env_var(key, env_str)
+
+        self.initialized = True
+
+    def reset(self) -> None:
+        """Restore the environment and forget everything loaded."""
+        self.restore_environ()
+        self.values.clear()
+        self.env_strings.clear()
+        self.settings.clear()
+        self.declared_keys = []
+        self.sensitive_keys = frozenset()
+        self.errors = None
+        self.initialized = False
+
+
+#: Module-level singleton. Unlike the JS runtime (which stores state on `globalThis` because
+#: bundlers can produce several copies of the module), `sys.modules` already guarantees one
+#: instance per interpreter.
+state = EnvState()

--- a/packages/varlock-python/src/varlock/_runtime.py
+++ b/packages/varlock-python/src/varlock/_runtime.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 from typing import Any, Dict, FrozenSet, List, Optional
 
+from . import _redaction
 from ._blob import BLOB_ENV_VAR, LoadedGraph
 
 
@@ -82,6 +83,10 @@ class EnvState:
         self.sensitive_keys = graph.sensitive_keys
         self.errors = graph.errors
 
+        # rebuild what redaction matches against, so a reload stops masking values that are
+        # no longer current and starts masking the new ones
+        _redaction.reset(graph)
+
         if inject and not self.settings.get("disableProcessEnvInjection"):
             for key, env_str in graph.env_strings.items():
                 self.set_env_var(key, env_str)
@@ -98,6 +103,7 @@ class EnvState:
         self.sensitive_keys = frozenset()
         self.errors = None
         self.initialized = False
+        _redaction.clear()
 
 
 #: Module-level singleton. Unlike the JS runtime (which stores state on `globalThis` because

--- a/packages/varlock-python/src/varlock/auto_load.py
+++ b/packages/varlock-python/src/varlock/auto_load.py
@@ -1,0 +1,21 @@
+"""Load env as an import side effect, failing fast.
+
+The equivalent of ``import 'varlock/auto-load'`` in JS. Import this once, as early as
+possible, from a script or server entrypoint::
+
+    import varlock.auto_load  # noqa: F401
+
+    from varlock import ENV
+
+If loading fails, the CLI's error output is printed and the process exits non-zero, so nothing
+downstream runs with an invalid env.
+
+Prefer calling :func:`varlock.load` directly in notebooks and other long-lived sessions, where
+exiting the process is the wrong response to a schema typo.
+"""
+
+from __future__ import annotations
+
+from . import load
+
+load(on_error="exit")

--- a/packages/varlock-python/src/varlock/errors.py
+++ b/packages/varlock-python/src/varlock/errors.py
@@ -14,6 +14,7 @@ __all__ = [
     "VarlockLoadError",
     "VarlockNotLoadedError",
     "VarlockMissingKeyError",
+    "VarlockLeakError",
 ]
 
 
@@ -69,6 +70,15 @@ class VarlockLoadError(VarlockError):
 
 class VarlockNotLoadedError(VarlockError):
     """``ENV`` was accessed before any values were loaded."""
+
+
+class VarlockLeakError(VarlockError):
+    """A sensitive value was found in something on its way out of the process."""
+
+    def __init__(self, message: str, *, key: str) -> None:
+        super().__init__(message)
+        #: The config item whose value leaked.
+        self.key = key
 
 
 class VarlockMissingKeyError(VarlockError, KeyError, AttributeError):

--- a/packages/varlock-python/src/varlock/errors.py
+++ b/packages/varlock-python/src/varlock/errors.py
@@ -1,0 +1,87 @@
+"""Error types raised by varlock.
+
+All of them derive from :class:`VarlockError`, so ``except varlock.VarlockError`` catches
+everything this package raises.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+__all__ = [
+    "VarlockError",
+    "VarlockBinaryNotFoundError",
+    "VarlockLoadError",
+    "VarlockNotLoadedError",
+    "VarlockMissingKeyError",
+]
+
+
+class VarlockError(Exception):
+    """Base class for every error raised by varlock."""
+
+
+class VarlockBinaryNotFoundError(VarlockError):
+    """The varlock CLI could not be found.
+
+    The Python package resolves values by calling the CLI, so it has to be installed and
+    findable. :attr:`searched` lists every location that was checked.
+    """
+
+    def __init__(self, message: str, searched: Optional[list] = None) -> None:
+        super().__init__(message)
+        self.searched = searched or []
+
+
+class VarlockLoadError(VarlockError):
+    """Loading or validating the env schema failed.
+
+    :attr:`stderr` holds the CLI's own (already formatted) output, which is normally the most
+    useful thing to show a user. On a validation failure the CLI still emits the serialized
+    graph, so :attr:`partial_values` carries whichever values did resolve, and :attr:`errors`
+    carries the structured per-item and root errors.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        stderr: str = "",
+        stdout: str = "",
+        exit_code: int = 1,
+        errors: Optional[Dict[str, Any]] = None,
+        partial_values: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(message)
+        self.stderr = stderr
+        self.stdout = stdout
+        self.exit_code = exit_code
+        self.errors = errors
+        self.partial_values = partial_values or {}
+
+    def __str__(self) -> str:
+        # the CLI already formats its errors nicely, so lead with the message and append that
+        # output verbatim rather than re-wording it
+        base = super().__str__()
+        detail = self.stderr.strip()
+        return f"{base}\n\n{detail}" if detail else base
+
+
+class VarlockNotLoadedError(VarlockError):
+    """``ENV`` was accessed before any values were loaded."""
+
+
+class VarlockMissingKeyError(VarlockError, KeyError, AttributeError):
+    """A key that is not in your schema was read off ``ENV``.
+
+    Inherits from both :class:`KeyError` and :class:`AttributeError` so that ``env["NOPE"]``
+    and ``env.NOPE`` can each be caught the way the corresponding Python protocol implies.
+    """
+
+    def __init__(self, key: str, message: Optional[str] = None) -> None:
+        self.key = key
+        super().__init__(message or f"`{key}` does not exist in your env schema")
+
+    def __str__(self) -> str:
+        # KeyError.__str__ would wrap the message in quotes (repr of args[0])
+        return self.args[0] if self.args else ""

--- a/packages/varlock-python/tests/conftest.py
+++ b/packages/varlock-python/tests/conftest.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+
+import pytest
+
+import varlock
+from varlock import _binary
+
+SAMPLE_GRAPH = {
+    "settings": {},
+    "config": {
+        "APP_ENV": {"value": "development", "isSensitive": False},
+        "PORT": {"value": 8080, "isSensitive": False},
+        "DEBUG": {"value": True, "isSensitive": False},
+        "SECRET": {"value": "super-secret-value", "isSensitive": True},
+        "TAGS": {"value": ["a", "b"], "envStr": "a,b", "isSensitive": False},
+        # declared with no value - an unset optional item
+        "OPTIONAL_UNSET": {"isSensitive": False},
+    },
+}
+
+SAMPLE_BLOB = json.dumps(SAMPLE_GRAPH)
+
+
+@pytest.fixture(autouse=True)
+def clean_state(monkeypatch):
+    """Each test starts with nothing loaded and no varlock env vars set."""
+    varlock.unload()
+    for key in ("__VARLOCK_ENV", "__VARLOCK_RUN", _binary.BIN_PATH_ENV_VAR):
+        monkeypatch.delenv(key, raising=False)
+    _binary.clear_cache()
+    yield
+    varlock.unload()
+    _binary.clear_cache()
+
+
+@pytest.fixture
+def fake_cli(tmp_path, monkeypatch):
+    """Install a fake `varlock` binary and point VARLOCK_BIN at it.
+
+    The fake records the argv it was called with (in `argv.json` next to it) so tests can
+    assert on the flags the package passes.
+    """
+
+    def _install(*, stdout: str = SAMPLE_BLOB, stderr: str = "", exit_code: int = 0):
+        if sys.platform.startswith("win"):
+            pytest.skip("fake CLI fixture uses a POSIX shebang script")
+        argv_path = tmp_path / "argv.json"
+        script = tmp_path / "varlock"
+        script.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, sys\n"
+            f"json.dump(sys.argv[1:], open({str(argv_path)!r}, 'w'))\n"
+            f"sys.stdout.write({stdout!r})\n"
+            f"sys.stderr.write({stderr!r})\n"
+            f"sys.exit({exit_code})\n"
+        )
+        script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        monkeypatch.setenv(_binary.BIN_PATH_ENV_VAR, str(script))
+        return argv_path
+
+    return _install
+
+
+@pytest.fixture
+def recorded_argv():
+    def _read(argv_path) -> list:
+        return json.loads(argv_path.read_text())
+
+    return _read
+
+
+@pytest.fixture
+def loaded(monkeypatch):
+    """Env loaded from an already-injected blob, as if started by `varlock run`."""
+    monkeypatch.setenv("__VARLOCK_ENV", SAMPLE_BLOB)
+    return varlock.load()
+
+
+@pytest.fixture
+def env_snapshot():
+    """Capture os.environ so a test can assert it was fully restored."""
+    return dict(os.environ)

--- a/packages/varlock-python/tests/test_binary.py
+++ b/packages/varlock-python/tests/test_binary.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import stat
+import sys
+
+import pytest
+
+from varlock import VarlockBinaryNotFoundError, find_binary
+from varlock._binary import BIN_PATH_ENV_VAR
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="POSIX executable-bit behavior"
+)
+
+
+def _make_executable(path):
+    path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+    return path
+
+
+def test_explicit_path_wins(tmp_path, monkeypatch):
+    binary = _make_executable(tmp_path / "my-varlock")
+    monkeypatch.setenv(BIN_PATH_ENV_VAR, str(binary))
+    assert find_binary() == str(binary)
+
+
+def test_explicit_path_must_be_executable(tmp_path, monkeypatch):
+    not_executable = tmp_path / "varlock"
+    not_executable.write_text("")
+    monkeypatch.setenv(BIN_PATH_ENV_VAR, str(not_executable))
+    with pytest.raises(VarlockBinaryNotFoundError):
+        find_binary()
+
+
+def test_found_on_path(tmp_path, monkeypatch):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    binary = _make_executable(bin_dir / "varlock")
+    monkeypatch.setenv("PATH", str(bin_dir))
+    assert find_binary() == str(binary)
+
+
+def test_found_in_standalone_install_dir(tmp_path, monkeypatch):
+    install_dir = tmp_path / "xdg" / "varlock" / "bin"
+    install_dir.mkdir(parents=True)
+    binary = _make_executable(install_dir / "varlock")
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    assert find_binary() == str(binary)
+
+
+def test_found_by_walking_up_to_node_modules(tmp_path, monkeypatch):
+    # a python service inside a JS monorepo that installs varlock as a dependency
+    bin_dir = tmp_path / "node_modules" / ".bin"
+    bin_dir.mkdir(parents=True)
+    binary = _make_executable(bin_dir / "varlock")
+    nested = tmp_path / "services" / "api"
+    nested.mkdir(parents=True)
+    # an intermediate .bin without varlock in it must not stop the search
+    (nested / "node_modules" / ".bin").mkdir(parents=True)
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    assert find_binary(nested) == str(binary)
+
+
+def test_missing_binary_explains_how_to_install(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    with pytest.raises(VarlockBinaryNotFoundError) as err:
+        find_binary(tmp_path)
+    assert "install.sh" in str(err.value)
+    assert err.value.searched

--- a/packages/varlock-python/tests/test_blob.py
+++ b/packages/varlock-python/tests/test_blob.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from varlock._blob import js_env_string, parse_blob, partial_values_from_stdout
+from varlock.errors import VarlockLoadError
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("plain", "plain"),
+        (True, "true"),
+        (False, "false"),
+        (8080, "8080"),
+        (1.5, "1.5"),
+        # JS prints whole floats without a trailing `.0`
+        (2.0, "2"),
+        (None, ""),
+    ],
+)
+def test_env_strings_match_cli_serialization(value, expected):
+    assert js_env_string(value) == expected
+
+
+def test_composite_values_use_the_flat_form_from_the_blob():
+    assert js_env_string(["a", "b"], "a,b") == "a,b"
+
+
+def test_parse_blob_rejects_an_encrypted_blob():
+    with pytest.raises(VarlockLoadError) as err:
+        parse_blob("varlock:v1:whatever")
+    assert "encrypted" in str(err.value)
+
+
+def test_parse_blob_rejects_garbage():
+    with pytest.raises(VarlockLoadError):
+        parse_blob("not json")
+    with pytest.raises(VarlockLoadError):
+        parse_blob("[1, 2, 3]")
+
+
+def test_parse_blob_separates_declared_from_valued_keys():
+    graph = parse_blob(
+        '{"config": {"SET": {"value": 1, "isSensitive": false},'
+        ' "UNSET": {"isSensitive": true}}}'
+    )
+    assert graph.values == {"SET": 1}
+    assert graph.declared_keys == ["SET", "UNSET"]
+    # sensitivity is tracked for every declared key, valued or not
+    assert graph.sensitive_keys == frozenset({"UNSET"})
+
+
+def test_partial_values_from_a_failed_load():
+    stdout = '{"config": {"OK": {"value": "yes"}, "BROKEN": {}}}'
+    assert partial_values_from_stdout(stdout) == {"OK": "yes", "BROKEN": None}
+
+
+def test_partial_values_tolerates_unparseable_output():
+    assert partial_values_from_stdout("💥 not json") == {}
+    assert partial_values_from_stdout("") == {}

--- a/packages/varlock-python/tests/test_cmd_quoting.py
+++ b/packages/varlock-python/tests/test_cmd_quoting.py
@@ -1,0 +1,135 @@
+"""Windows command-line quoting.
+
+These run on every platform: the functions under test build a string, they don't execute it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from varlock._cli import build_cmd_shim_command, quote_for_cmd
+
+CMD_METACHARS = ["&", "|", "<", ">", "^", "(", ")"]
+
+
+@pytest.mark.parametrize("meta", CMD_METACHARS)
+def test_metacharacters_end_up_inside_quotes(meta):
+    # cmd.exe only treats these specially outside quotes, so quoting neutralizes them
+    quoted = quote_for_cmd(f"a{meta}b")
+    assert quoted == f'"a{meta}b"'
+
+
+@pytest.mark.parametrize("meta", CMD_METACHARS)
+def test_a_metacharacter_in_an_argument_cannot_start_a_second_command(meta):
+    command = build_cmd_shim_command(
+        r"C:\shims\varlock.cmd", ["load", "--path", f"a{meta}calc"]
+    )
+    # the payload is quoted, so cmd.exe reads it as one literal argument
+    assert f'"a{meta}calc"' in command
+    # and it never appears bare, which is what would have been parsed as a separator
+    assert f" a{meta}calc" not in command
+
+
+def test_a_metacharacter_in_the_binary_path_is_quoted_too():
+    # an install path like C:\dev&tools\ is enough on its own, with no user arguments
+    command = build_cmd_shim_command(r"C:\dev&tools\varlock.cmd", ["load"])
+    assert r'"C:\dev&tools\varlock.cmd"' in command
+
+
+def test_uses_the_slash_s_form_so_cmd_strips_only_the_outer_quotes():
+    command = build_cmd_shim_command(r"C:\shims\varlock.cmd", ["load"], comspec="cmd.exe")
+    assert command.startswith('"cmd.exe" /d /s /c "')
+    assert command.endswith('"')
+
+
+def test_respects_comspec():
+    command = build_cmd_shim_command("x.cmd", [], comspec=r"C:\Windows\System32\cmd.exe")
+    assert command.startswith(r'"C:\Windows\System32\cmd.exe" /d /s /c ')
+
+
+@pytest.mark.parametrize(
+    "arg",
+    [
+        "plain with space",
+        r"C:\Program Files (x86)\varlock\varlock.cmd",
+        'has "quotes" inside',
+        r"trailing backslash\\",
+        r"back\\slash\"quote",
+        "",
+    ],
+)
+def test_matches_the_stdlib_algorithm_where_the_stdlib_also_quotes(arg):
+    # list2cmdline quotes anything containing whitespace (and the empty string), so for those
+    # the two must agree exactly - that pins our escaping to CPython's implementation
+    expected = subprocess.list2cmdline([arg])
+    if expected.startswith('"'):
+        assert quote_for_cmd(arg) == expected
+
+
+def _parse_msvcrt(command_line: str) -> list:
+    """Split a command line the way CommandLineToArgvW does, so quoting can be checked.
+
+    Rules: 2n backslashes before a quote produce n backslashes and toggle quoting; 2n+1
+    produce n backslashes and a literal quote; backslashes not before a quote are literal.
+    """
+    args, current, backslashes, in_quotes, started = [], [], 0, False, False
+    for char in command_line:
+        if char == "\\":
+            backslashes += 1
+            continue
+        if char == '"':
+            current.append("\\" * (backslashes // 2))
+            if backslashes % 2:
+                current.append('"')
+            else:
+                in_quotes = not in_quotes
+                started = True
+            backslashes = 0
+            continue
+        current.append("\\" * backslashes)
+        backslashes = 0
+        if char.isspace() and not in_quotes:
+            if current or started:
+                args.append("".join(current))
+            current, started = [], False
+            continue
+        current.append(char)
+    current.append("\\" * backslashes)
+    if current or started:
+        args.append("".join(current))
+    return args
+
+
+@pytest.mark.parametrize(
+    "arg",
+    [
+        'a"b',
+        r"c:\path\\",
+        'ends with quote"',
+        r"^&|<>()",
+        r"C:\Program Files (x86)\a & b\varlock.cmd",
+        "--path",
+        "",
+    ],
+)
+def test_quoted_arguments_decode_back_to_the_original(arg):
+    assert _parse_msvcrt(quote_for_cmd(arg)) == [arg]
+
+
+def test_the_decoder_agrees_with_the_stdlib_on_multi_argument_lines():
+    # sanity-checks the decoder itself before trusting it above
+    args = [r"C:\Program Files\x.cmd", "load", 'a"b', r"trail\\"]
+    assert _parse_msvcrt(subprocess.list2cmdline(args)) == args
+
+
+def test_a_full_shim_command_decodes_to_the_intended_argv():
+    binary = r"C:\dev&tools\varlock.cmd"
+    args = ["load", "--path", "a&calc"]
+    command = build_cmd_shim_command(binary, args, comspec="cmd.exe")
+    shell, flag_d, flag_s, flag_c, rest = command.split(" ", 4)
+    assert (flag_d, flag_s, flag_c) == ("/d", "/s", "/c")
+    # cmd /s strips the outer quote pair, leaving the individually quoted tokens
+    assert rest.startswith('"') and rest.endswith('"')
+    assert _parse_msvcrt(rest[1:-1]) == [binary, *args]

--- a/packages/varlock-python/tests/test_env.py
+++ b/packages/varlock-python/tests/test_env.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+import varlock
+from varlock import VarlockMissingKeyError, VarlockNotLoadedError
+
+
+def test_values_are_coerced_not_strings(loaded):
+    assert loaded["APP_ENV"] == "development"
+    assert loaded["PORT"] == 8080
+    assert loaded["DEBUG"] is True
+    assert loaded["TAGS"] == ["a", "b"]
+
+
+def test_attribute_access_matches_item_access(loaded):
+    assert loaded.PORT == loaded["PORT"]
+
+
+def test_mapping_protocol(loaded):
+    assert "APP_ENV" in loaded
+    assert loaded.get("NOPE") is None
+    assert loaded.get("NOPE", "fallback") == "fallback"
+    assert set(loaded.keys()) == {"APP_ENV", "PORT", "DEBUG", "SECRET", "TAGS"}
+    assert dict(loaded)["PORT"] == 8080
+    assert len(loaded) == 5
+
+
+def test_unknown_key_raises(loaded):
+    with pytest.raises(VarlockMissingKeyError) as err:
+        loaded["NOPE"]
+    assert "does not exist" in str(err.value)
+
+
+def test_unknown_key_is_catchable_as_key_and_attribute_error(loaded):
+    with pytest.raises(KeyError):
+        loaded["NOPE"]
+    with pytest.raises(AttributeError):
+        loaded.NOPE
+
+
+def test_declared_but_unset_key_says_so(loaded):
+    with pytest.raises(VarlockMissingKeyError) as err:
+        loaded["OPTIONAL_UNSET"]
+    assert "no value in this environment" in str(err.value)
+    # still absent from the mapping, matching the generated module's NotRequired contract
+    assert "OPTIONAL_UNSET" not in loaded
+    assert loaded.get("OPTIONAL_UNSET") is None
+
+
+def test_access_before_load_raises_actionable_error():
+    with pytest.raises(VarlockNotLoadedError) as err:
+        varlock.ENV.APP_ENV
+    assert "varlock.load()" in str(err.value)
+
+
+def test_dunder_probes_do_not_raise_varlock_errors():
+    # IPython and copy/pickle probe for private attributes before anything is loaded
+    assert not hasattr(varlock.ENV, "_ipython_canary_method_should_not_exist_")
+    assert not hasattr(varlock.ENV, "__wrapped__")
+
+
+def test_uninitialized_instance_does_not_recurse(loaded):
+    # copy/pickle can build an instance without running __init__
+    bare = varlock.Env.__new__(varlock.Env)
+    with pytest.raises(AttributeError):
+        bare._state
+
+
+def test_repr_redacts_sensitive_values(loaded):
+    text = repr(loaded)
+    assert "super-secret-value" not in text
+    assert "su▒▒▒▒▒" in text
+    assert "development" in text
+
+
+def test_html_repr_redacts_sensitive_values(loaded):
+    html = loaded._repr_html_()
+    assert "super-secret-value" not in html
+    assert "OPTIONAL_UNSET" not in html
+    assert "1 declared key(s)" in html
+
+
+def test_to_dict(loaded):
+    assert loaded.to_dict()["SECRET"] == "super-secret-value"
+    assert loaded.to_dict(redact_sensitive=True)["SECRET"] == "su▒▒▒▒▒"
+
+
+def test_dir_includes_keys_for_tab_completion(loaded):
+    assert "APP_ENV" in dir(loaded)
+
+
+def test_sensitive_keys(loaded):
+    assert varlock.get_sensitive_keys() == frozenset({"SECRET"})

--- a/packages/varlock-python/tests/test_env.py
+++ b/packages/varlock-python/tests/test_env.py
@@ -87,7 +87,16 @@ def test_to_dict(loaded):
 
 
 def test_dir_includes_keys_for_tab_completion(loaded):
+    # drives `env.<TAB>`
     assert "APP_ENV" in dir(loaded)
+
+
+def test_key_completions_are_advertised_to_ipython(loaded):
+    # drives `env["<TAB>"]`. IPython only infers keys for real dict instances, so without
+    # this hook subscript completion silently returns nothing.
+    completions = loaded._ipython_key_completions_()
+    assert "APP_ENV" in completions
+    assert "OPTIONAL_UNSET" not in completions
 
 
 def test_sensitive_keys(loaded):

--- a/packages/varlock-python/tests/test_leaks.py
+++ b/packages/varlock-python/tests/test_leaks.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import varlock
+from varlock import VarlockLeakError
+
+SECRET = "super-secret-value"
+
+
+def test_clean_content_passes_through_unchanged(loaded):
+    payload = '{"ok": true}'
+    assert varlock.scan_for_leaks(payload) is payload
+
+
+def test_a_leaked_value_raises_and_names_the_key(loaded):
+    with pytest.raises(VarlockLeakError) as err:
+        varlock.scan_for_leaks(f'{{"token": "{SECRET}"}}')
+    assert err.value.key == "SECRET"
+    assert "SECRET" in str(err.value)
+
+
+def test_scan_reports_where_it_was_scanning(loaded):
+    with pytest.raises(VarlockLeakError) as err:
+        varlock.scan_for_leaks(SECRET, method="response body", file="api/handler.py")
+    assert "response body" in str(err.value)
+    assert "api/handler.py" in str(err.value)
+
+
+def test_scans_bytes(loaded):
+    with pytest.raises(VarlockLeakError):
+        varlock.scan_for_leaks(SECRET.encode())
+
+
+def test_scans_elements_of_a_composite_value(monkeypatch):
+    blob = json.dumps(
+        {
+            "settings": {},
+            "config": {
+                "KEYS": {
+                    "value": ["first-secret", "second-secret"],
+                    "envStr": "first-secret,second-secret",
+                    "isSensitive": True,
+                }
+            },
+        }
+    )
+    monkeypatch.setenv("__VARLOCK_ENV", blob)
+    varlock.load()
+    # leaking one element counts, not just the whole serialized value
+    with pytest.raises(VarlockLeakError):
+        varlock.scan_for_leaks("here is second-secret")
+
+
+def test_items_opted_out_of_leak_detection_are_skipped(monkeypatch):
+    blob = json.dumps(
+        {
+            "settings": {},
+            "config": {
+                # `@sensitive={preventLeaks=false}` - an endpoint legitimately returns this
+                "RETURNED_TOKEN": {
+                    "value": "handed-out-on-purpose",
+                    "isSensitive": True,
+                    "preventLeaks": False,
+                },
+                "SECRET": {"value": SECRET, "isSensitive": True},
+            },
+        }
+    )
+    monkeypatch.setenv("__VARLOCK_ENV", blob)
+    varlock.load()
+
+    assert varlock.scan_for_leaks("handed-out-on-purpose") == "handed-out-on-purpose"
+    # opting out of scanning does not opt out of masking in logs
+    assert varlock.redact("handed-out-on-purpose") == "ha▒▒▒▒▒"
+    with pytest.raises(VarlockLeakError):
+        varlock.scan_for_leaks(SECRET)
+
+
+def test_scan_is_a_noop_before_loading():
+    assert varlock.scan_for_leaks(SECRET) == SECRET
+
+
+def test_non_text_values_pass_through(loaded):
+    sentinel = object()
+    assert varlock.scan_for_leaks(sentinel) is sentinel
+    assert varlock.scan_for_leaks(None) is None

--- a/packages/varlock-python/tests/test_load.py
+++ b/packages/varlock-python/tests/test_load.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+import varlock
+from varlock import VarlockLoadError
+
+from .conftest import SAMPLE_BLOB
+
+
+def test_load_reads_an_already_injected_blob_without_running_the_cli(monkeypatch):
+    monkeypatch.setenv("__VARLOCK_ENV", SAMPLE_BLOB)
+    monkeypatch.setattr(
+        varlock, "run_load", lambda **kwargs: pytest.fail("should not run the CLI")
+    )
+    env = varlock.load()
+    assert env["PORT"] == 8080
+
+
+def test_load_is_idempotent(fake_cli, recorded_argv):
+    argv_path = fake_cli()
+    varlock.load()
+    argv_path.unlink()
+    varlock.load()
+    assert not argv_path.exists(), "second load should not have run the CLI again"
+
+
+def test_load_runs_the_cli_with_expected_flags(fake_cli, recorded_argv):
+    argv_path = fake_cli()
+    varlock.load()
+    assert recorded_argv(argv_path) == ["load", "--format", "json-full", "--compact"]
+
+
+def test_load_passes_path_and_env_flags(fake_cli, recorded_argv):
+    argv_path = fake_cli()
+    varlock.load(path=[".env.prod", "./envs"], env="production")
+    argv = recorded_argv(argv_path)
+    assert argv[-6:] == ["--path", ".env.prod", "--path", "./envs", "--env", "production"]
+
+
+def test_load_injects_values_into_os_environ(fake_cli):
+    fake_cli()
+    varlock.load()
+    assert os.environ["APP_ENV"] == "development"
+    # serialized the way the CLI does it, not the way Python's str() would
+    assert os.environ["PORT"] == "8080"
+    assert os.environ["DEBUG"] == "true"
+    # composite values use the flat form carried in the blob
+    assert os.environ["TAGS"] == "a,b"
+    # unset optional items are not injected at all, matching `varlock run`
+    assert "OPTIONAL_UNSET" not in os.environ
+
+
+def test_load_publishes_the_blob_for_subprocesses(fake_cli):
+    fake_cli()
+    varlock.load()
+    assert json.loads(os.environ["__VARLOCK_ENV"])["config"]["PORT"]["value"] == 8080
+
+
+def test_inject_false_touches_nothing(fake_cli):
+    fake_cli()
+    varlock.load(inject=False)
+    assert "APP_ENV" not in os.environ
+    assert "__VARLOCK_ENV" not in os.environ
+
+
+def test_disable_process_env_injection_setting_is_honored(fake_cli):
+    graph = json.loads(SAMPLE_BLOB)
+    graph["settings"]["disableProcessEnvInjection"] = True
+    fake_cli(stdout=json.dumps(graph))
+    env = varlock.load()
+    assert env["PORT"] == 8080
+    assert "APP_ENV" not in os.environ
+
+
+def test_unload_restores_the_environment(fake_cli):
+    fake_cli()
+    before = dict(os.environ)
+    varlock.load()
+    varlock.unload()
+    assert dict(os.environ) == before
+    assert not varlock.is_loaded()
+
+
+def test_unload_restores_a_preexisting_value(fake_cli, monkeypatch):
+    monkeypatch.setenv("APP_ENV", "set-by-the-user")
+    fake_cli()
+    varlock.load()
+    assert os.environ["APP_ENV"] == "development"
+    varlock.unload()
+    assert os.environ["APP_ENV"] == "set-by-the-user"
+
+
+def test_reload_reruns_the_cli(fake_cli, recorded_argv):
+    argv_path = fake_cli()
+    varlock.load()
+    argv_path.unlink()
+    varlock.reload()
+    assert argv_path.exists()
+
+
+def test_reload_picks_up_new_values(fake_cli, tmp_path, monkeypatch):
+    fake_cli()
+    assert varlock.load()["PORT"] == 8080
+
+    graph = json.loads(SAMPLE_BLOB)
+    graph["config"]["PORT"]["value"] = 9999
+    fake_cli(stdout=json.dumps(graph))
+    assert varlock.reload()["PORT"] == 9999
+    assert os.environ["PORT"] == "9999"
+
+
+def test_reload_drops_keys_that_left_the_schema(fake_cli):
+    fake_cli()
+    varlock.load()
+    assert "TAGS" in os.environ
+
+    graph = json.loads(SAMPLE_BLOB)
+    del graph["config"]["TAGS"]
+    fake_cli(stdout=json.dumps(graph))
+    env = varlock.reload()
+    assert "TAGS" not in env
+    assert "TAGS" not in os.environ
+
+
+def test_failed_load_raises_with_cli_output(fake_cli):
+    partial = json.dumps({"config": {"APP_ENV": {"value": "development"}}})
+    fake_cli(stdout=partial, stderr="💥 SOME_KEY is required", exit_code=1)
+    with pytest.raises(VarlockLoadError) as err:
+        varlock.load()
+    assert err.value.exit_code == 1
+    assert "SOME_KEY is required" in str(err.value)
+    assert err.value.partial_values == {"APP_ENV": "development"}
+    assert not varlock.is_loaded()
+
+
+def test_on_error_exit_writes_stderr_and_exits(fake_cli, capsys):
+    fake_cli(stdout="", stderr="💥 SOME_KEY is required", exit_code=3)
+    with pytest.raises(SystemExit) as err:
+        varlock.load(on_error="exit")
+    assert err.value.code == 3
+    assert "SOME_KEY is required" in capsys.readouterr().err
+
+
+def test_encrypted_blob_reports_clearly(monkeypatch):
+    monkeypatch.setenv("__VARLOCK_ENV", "varlock:v1:abc123")
+    with pytest.raises(VarlockLoadError) as err:
+        varlock.load()
+    assert "encrypted" in str(err.value)
+
+
+def test_is_running_under_varlock_run(monkeypatch):
+    assert not varlock.is_running_under_varlock_run()
+    monkeypatch.setenv("__VARLOCK_RUN", "1")
+    assert varlock.is_running_under_varlock_run()

--- a/packages/varlock-python/tests/test_patching.py
+++ b/packages/varlock-python/tests/test_patching.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+import varlock
+from varlock import _patch
+
+from .conftest import SAMPLE_BLOB
+
+SECRET = "super-secret-value"
+
+
+def test_print_is_redacted(loaded, capsys):
+    print(f"token={SECRET}")
+    out = capsys.readouterr().out
+    assert SECRET not in out
+    assert "token=su▒▒▒▒▒" in out
+
+
+def test_print_redacts_secrets_inside_objects(loaded, capsys):
+    # print stringifies its arguments, so a secret nested in a dict has to be caught too
+    print({"config": {"token": SECRET}})
+    assert SECRET not in capsys.readouterr().out
+
+
+def test_print_preserves_sep_and_end(loaded, capsys):
+    print("a", "b", sep="-", end="!")
+    assert capsys.readouterr().out == "a-b!"
+
+
+def test_stderr_is_redacted(loaded, capsys):
+    import sys
+
+    print(SECRET, file=sys.stderr)
+    assert SECRET not in capsys.readouterr().err
+
+
+def test_logging_is_redacted(loaded, caplog):
+    with caplog.at_level(logging.INFO):
+        logging.getLogger("some.library").info("using %s", SECRET)
+    assert SECRET not in caplog.text
+    assert "su▒▒▒▒▒" in caplog.text
+
+
+def test_logging_redaction_covers_loggers_created_after_loading(loaded, caplog):
+    # the record factory applies everywhere, unlike a filter on one logger or handler
+    with caplog.at_level(logging.INFO):
+        logging.getLogger("created.later").info("value: %s", SECRET)
+    assert SECRET not in caplog.text
+
+
+def test_logging_redacts_dict_style_args(loaded, caplog):
+    with caplog.at_level(logging.INFO):
+        logging.getLogger("pct").info("%(token)s", {"token": SECRET})
+    assert SECRET not in caplog.text
+
+
+def test_uninstall_stops_patching(loaded, capsys):
+    varlock.uninstall_redaction()
+    print(SECRET)
+    assert SECRET in capsys.readouterr().out
+
+
+def test_uninstall_restores_everything_it_patched(loaded):
+    import builtins
+    import io
+
+    stream = io.StringIO()
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr("sys.stdout", stream)
+    varlock.install_redaction()
+    assert getattr(stream.write, "_varlock_patched", False)
+
+    varlock.uninstall_redaction()
+    assert not getattr(stream.write, "_varlock_patched", False)
+    assert not getattr(builtins.print, "_varlock_patched", False)
+    assert not getattr(logging.getLogRecordFactory(), "_varlock_patched", False)
+    monkey.undo()
+
+
+def test_direct_stream_writes_are_redacted(loaded):
+    import io
+
+    stream = io.StringIO()
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr("sys.stdout", stream)
+    varlock.install_redaction()
+    # bypasses print() entirely
+    stream.write(f"raw {SECRET}")
+    varlock.uninstall_redaction()
+    monkey.undo()
+    assert SECRET not in stream.getvalue()
+
+
+def test_a_stream_replaced_after_install_is_repatched(loaded):
+    import io
+
+    replacement = io.StringIO()
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr("sys.stdout", replacement)
+    # the notebook case: something swapped the stream out after we patched the old one
+    varlock.install_redaction()
+    replacement.write(SECRET)
+    varlock.uninstall_redaction()
+    monkey.undo()
+    assert SECRET not in replacement.getvalue()
+
+
+def test_redact_logs_false_skips_patching(fake_cli, capsys):
+    fake_cli()
+    varlock.load(redact_logs=False)
+    print(SECRET)
+    assert SECRET in capsys.readouterr().out
+
+
+def test_schema_setting_disables_patching(fake_cli, capsys):
+    graph = json.loads(SAMPLE_BLOB)
+    graph["settings"]["redactLogs"] = False
+    fake_cli(stdout=json.dumps(graph))
+    varlock.load()
+    print(SECRET)
+    assert SECRET in capsys.readouterr().out
+
+
+def test_patching_is_idempotent(loaded, capsys):
+    varlock.install_redaction()
+    varlock.install_redaction()
+    print(SECRET)
+    out = capsys.readouterr().out
+    # masked once, not masked repeatedly by stacked patches
+    assert out.strip() == "su▒▒▒▒▒"
+    varlock.uninstall_redaction()
+    print(SECRET)
+    assert SECRET in capsys.readouterr().out
+
+
+def test_a_foreign_log_factory_installed_later_is_not_clobbered(loaded):
+    varlock.install_redaction()
+    ours = logging.getLogRecordFactory()
+    theirs = lambda *a, **k: ours(*a, **k)  # noqa: E731
+    logging.setLogRecordFactory(theirs)
+    varlock.uninstall_redaction()
+    assert logging.getLogRecordFactory() is theirs
+    logging.setLogRecordFactory(logging.LogRecord)
+
+
+# -- notebook output ---------------------------------------------------------------------
+
+
+class _FakeFormatter:
+    def format(self, obj, *args, **kwargs):
+        return {"text/plain": repr(obj)}, {}
+
+
+class _FakeIPython:
+    def __init__(self):
+        self.display_formatter = _FakeFormatter()
+
+
+def test_ipython_display_output_is_redacted(loaded, monkeypatch):
+    fake = _FakeIPython()
+    monkeypatch.setattr(_patch, "_get_ipython", lambda: fake)
+    varlock.install_redaction()
+
+    # a cell result goes to the frontend through the formatter, never through stdout
+    data, _ = fake.display_formatter.format({"token": SECRET})
+    assert SECRET not in data["text/plain"]
+
+    varlock.uninstall_redaction()
+    data, _ = fake.display_formatter.format({"token": SECRET})
+    assert SECRET in data["text/plain"]
+
+
+def test_ipython_patch_is_a_noop_outside_a_notebook(loaded, monkeypatch):
+    monkeypatch.setattr(_patch, "_get_ipython", lambda: None)
+    varlock.install_redaction()  # must not raise
+
+
+def test_env_repr_is_redacted_in_a_notebook(loaded, monkeypatch):
+    fake = _FakeIPython()
+    monkeypatch.setattr(_patch, "_get_ipython", lambda: fake)
+    varlock.install_redaction()
+    data, _ = fake.display_formatter.format(varlock.ENV)
+    assert SECRET not in data["text/plain"]

--- a/packages/varlock-python/tests/test_patching.py
+++ b/packages/varlock-python/tests/test_patching.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import json
 import logging
 
@@ -125,6 +126,27 @@ def test_schema_setting_disables_patching(fake_cli, capsys):
     assert SECRET in capsys.readouterr().out
 
 
+def test_reload_with_redaction_disabled_removes_patches(fake_cli):
+    fake_cli()
+    varlock.load()
+    assert _patch.is_patched()
+
+    varlock.reload(redact_logs=False)
+    assert not _patch.is_patched()
+
+
+def test_reload_follows_schema_when_redaction_is_disabled(fake_cli):
+    fake_cli()
+    varlock.load()
+    assert _patch.is_patched()
+
+    graph = json.loads(SAMPLE_BLOB)
+    graph["settings"]["redactLogs"] = False
+    fake_cli(stdout=json.dumps(graph))
+    varlock.reload()
+    assert not _patch.is_patched()
+
+
 def test_patching_is_idempotent(loaded, capsys):
     varlock.install_redaction()
     varlock.install_redaction()
@@ -137,14 +159,58 @@ def test_patching_is_idempotent(loaded, capsys):
     assert SECRET in capsys.readouterr().out
 
 
-def test_a_foreign_log_factory_installed_later_is_not_clobbered(loaded):
+def test_a_foreign_log_factory_installed_later_is_not_clobbered(loaded, caplog):
     varlock.install_redaction()
     ours = logging.getLogRecordFactory()
-    theirs = lambda *a, **k: ours(*a, **k)  # noqa: E731
+    original = _patch._logging_patch[0]
+
+    def theirs(*args, **kwargs):
+        return ours(*args, **kwargs)
+
     logging.setLogRecordFactory(theirs)
+    try:
+        varlock.uninstall_redaction()
+        assert logging.getLogRecordFactory() is theirs
+        with caplog.at_level(logging.INFO):
+            logging.getLogger("foreign.factory").info("still works")
+        assert "still works" in caplog.text
+    finally:
+        logging.setLogRecordFactory(original)
+
+
+def test_a_foreign_print_wrapper_installed_later_is_not_clobbered(loaded, capsys):
+    ours = builtins.print
+    original = _patch._print_patch[0]
+
+    def theirs(*args, **kwargs):
+        return ours(*args, **kwargs)
+
+    builtins.print = theirs
+    try:
+        varlock.uninstall_redaction()
+        assert builtins.print is theirs
+        print("still works")
+        assert "still works" in capsys.readouterr().out
+    finally:
+        builtins.print = original
+
+
+def test_a_foreign_stream_wrapper_installed_later_is_not_clobbered(loaded, monkeypatch):
+    import io
+
+    stream = io.StringIO()
+    monkeypatch.setattr("sys.stdout", stream)
+    varlock.install_redaction()
+    ours = stream.write
+
+    def theirs(text):
+        return ours(text)
+
+    stream.write = theirs
     varlock.uninstall_redaction()
-    assert logging.getLogRecordFactory() is theirs
-    logging.setLogRecordFactory(logging.LogRecord)
+    assert stream.write is theirs
+    stream.write("still works")
+    assert "still works" in stream.getvalue()
 
 
 # -- notebook output ---------------------------------------------------------------------
@@ -172,6 +238,22 @@ def test_ipython_display_output_is_redacted(loaded, monkeypatch):
     varlock.uninstall_redaction()
     data, _ = fake.display_formatter.format({"token": SECRET})
     assert SECRET in data["text/plain"]
+
+
+def test_a_foreign_formatter_wrapper_installed_later_is_not_clobbered(loaded, monkeypatch):
+    fake = _FakeIPython()
+    monkeypatch.setattr(_patch, "_get_ipython", lambda: fake)
+    varlock.install_redaction()
+    ours = fake.display_formatter.format
+
+    def theirs(*args, **kwargs):
+        return ours(*args, **kwargs)
+
+    fake.display_formatter.format = theirs
+    varlock.uninstall_redaction()
+    assert fake.display_formatter.format is theirs
+    data, _ = fake.display_formatter.format("still works")
+    assert "still works" in data["text/plain"]
 
 
 def test_ipython_patch_is_a_noop_outside_a_notebook(loaded, monkeypatch):

--- a/packages/varlock-python/tests/test_redaction.py
+++ b/packages/varlock-python/tests/test_redaction.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import varlock
+
+from .conftest import SAMPLE_BLOB
+
+COMPOSITE_BLOB = json.dumps(
+    {
+        "settings": {},
+        "config": {
+            "APP_ENV": {"value": "development", "isSensitive": False},
+            "SECRET": {"value": "super-secret-value", "isSensitive": True},
+            "KEYS": {
+                "value": ["first-secret", "second-secret"],
+                "envStr": "first-secret,second-secret",
+                "isSensitive": True,
+            },
+            "CREDS": {
+                "value": {"user": "admin", "password": "hunter2000"},
+                "envStr": '{"user":"admin","password":"hunter2000"}',
+                "isSensitive": True,
+            },
+            "PUBLIC_TOKEN": {"value": "not-a-secret", "isSensitive": False},
+        },
+    }
+)
+
+
+@pytest.fixture
+def composite(monkeypatch):
+    monkeypatch.setenv("__VARLOCK_ENV", COMPOSITE_BLOB)
+    return varlock.load()
+
+
+def test_redacts_a_sensitive_value_inside_a_larger_string(loaded):
+    text = "connecting with super-secret-value now"
+    assert varlock.redact(text) == "connecting with su▒▒▒▒▒ now"
+
+
+def test_leaves_non_sensitive_values_alone(composite):
+    assert varlock.redact("not-a-secret is fine") == "not-a-secret is fine"
+
+
+def test_redacts_through_containers(loaded):
+    payload = {
+        "token": "super-secret-value",
+        "nested": [{"deep": "super-secret-value"}],
+        "tuple": ("super-secret-value",),
+    }
+    result = varlock.redact(payload)
+    assert result["token"] == "su▒▒▒▒▒"
+    assert result["nested"][0]["deep"] == "su▒▒▒▒▒"
+    assert result["tuple"] == ("su▒▒▒▒▒",)
+    # the original is not mutated
+    assert payload["token"] == "super-secret-value"
+
+
+def test_redacts_individual_elements_of_a_composite_value(composite):
+    # leaking one element of an array must be caught, not only the whole serialized value
+    assert varlock.redact("first-secret") == "fi▒▒▒▒▒"
+    assert varlock.redact("hunter2000") == "hu▒▒▒▒▒"
+
+
+def test_redacts_the_flat_env_string_form(composite):
+    assert "first-secret" not in varlock.redact("first-secret,second-secret")
+
+
+def test_overlapping_values_match_maximally(monkeypatch):
+    blob = json.dumps(
+        {
+            "settings": {},
+            "config": {
+                "SHORT": {"value": "abc", "isSensitive": True},
+                "LONG": {"value": "abcdef", "isSensitive": True},
+            },
+        }
+    )
+    monkeypatch.setenv("__VARLOCK_ENV", blob)
+    varlock.load()
+    # the longer value wins, rather than being masked as the shorter one plus leftovers
+    assert varlock.redact("abcdef") == "ab▒▒▒▒▒"
+
+
+def test_non_string_values_are_left_alone(loaded):
+    # PORT is 8080; masking every occurrence of "8080" everywhere would be worse than useless
+    assert varlock.redact("listening on 8080") == "listening on 8080"
+
+
+def test_redact_is_a_noop_before_loading():
+    assert varlock.redact("super-secret-value") == "super-secret-value"
+
+
+def test_reveal_keeps_a_deliberately_shown_value_visible(loaded):
+    revealed = varlock.reveal("super-secret-value")
+    assert "super-secret-value" in varlock.redact(revealed)
+
+
+def test_reveal_passes_through_when_redaction_is_inactive():
+    assert varlock.reveal("anything") == "anything"
+
+
+def test_reload_rebuilds_the_map(fake_cli):
+    fake_cli()
+    varlock.load()
+    assert varlock.redact("super-secret-value") == "su▒▒▒▒▒"
+
+    graph = json.loads(SAMPLE_BLOB)
+    graph["config"]["SECRET"]["value"] = "a-brand-new-secret"
+    fake_cli(stdout=json.dumps(graph))
+    varlock.reload()
+
+    # the old value is no longer current, so it is no longer masked
+    assert varlock.redact("super-secret-value") == "super-secret-value"
+    assert varlock.redact("a-brand-new-secret") == "a-▒▒▒▒▒"
+
+
+def test_unload_stops_redacting(loaded):
+    varlock.unload()
+    assert varlock.redact("super-secret-value") == "super-secret-value"

--- a/packages/varlock-python/tests/test_reload_failure.py
+++ b/packages/varlock-python/tests/test_reload_failure.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+import varlock
+from varlock import VarlockLoadError
+
+from .conftest import SAMPLE_BLOB
+
+
+def test_a_failed_reload_keeps_the_previous_values(fake_cli):
+    fake_cli()
+    varlock.load()
+
+    fake_cli(stdout="", stderr="💥 broken schema", exit_code=1)
+    with pytest.raises(VarlockLoadError):
+        varlock.reload()
+
+    # the working env survives a bad edit, which matters most in a notebook
+    assert varlock.is_loaded()
+    assert varlock.ENV["PORT"] == 8080
+    assert os.environ["PORT"] == "8080"
+
+
+def test_reload_hands_the_cli_the_uninjected_environment(fake_cli, tmp_path, monkeypatch):
+    """The CLI must not see values we injected, or it would treat them as overrides."""
+    monkeypatch.setenv("APP_ENV", "set-by-the-user")
+    env_dump = tmp_path / "child-env.json"
+
+    graph = json.loads(SAMPLE_BLOB)
+    fake_cli(stdout=json.dumps(graph))
+    varlock.load()
+    assert os.environ["APP_ENV"] == "development"
+
+    # a fake that records the environment it was handed
+    script = tmp_path / "varlock"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        f"json.dump(dict(os.environ), open({str(env_dump)!r}, 'w'))\n"
+        f"sys.stdout.write({json.dumps(graph)!r})\n"
+    )
+    script.chmod(0o755)
+    monkeypatch.setenv("VARLOCK_BIN", str(script))
+
+    varlock.reload()
+    child_env = json.loads(env_dump.read_text())
+    assert child_env["APP_ENV"] == "set-by-the-user"
+    assert "__VARLOCK_ENV" not in child_env

--- a/packages/varlock-python/uv.lock
+++ b/packages/varlock-python/uv.lock
@@ -1,0 +1,200 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "varlock"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]

--- a/packages/varlock-website/src/content/docs/integrations/jupyter.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/jupyter.mdx
@@ -72,24 +72,50 @@ varlock.load(path=".env.staging")
 varlock.load(env="production")
 ```
 
-## Sharing notebooks
+## Redaction
 
-Values marked [`@sensitive`](/reference/item-decorators/#sensitive) are masked in the notebook's own output. Echoing `env` in a cell, which Jupyter renders through `repr()`, shows masked values rather than writing your secrets into the saved `.ipynb`:
-
-```python
-env
-# <varlock.Env APP_ENV='development', OPENAI_API_KEY='sk▒▒▒▒▒'>
-```
-
-You can build your own redaction from the same list:
+A saved `.ipynb` keeps its cell output, so a secret printed once stays in the file and follows it into git and any share link. `load()` installs redaction to keep that from happening. Values marked [`@sensitive`](/reference/item-decorators/#sensitive) are masked in cell output, in `print()`, and in anything logged through `logging`:
 
 ```python
-varlock.get_sensitive_keys()   # frozenset({'OPENAI_API_KEY'})
+env                                  # <varlock.Env APP_ENV='development', OPENAI_API_KEY='sk▒▒▒▒▒'>
+{"key": env["OPENAI_API_KEY"]}       # {'key': 'sk▒▒▒▒▒'}
+print(env["OPENAI_API_KEY"])         # sk▒▒▒▒▒
+logging.info("using %s", env["OPENAI_API_KEY"])
 ```
 
-:::caution
-This covers displaying the env object itself. It does not stop a cell that prints a secret directly, and the resolved value is a normal string once you read it. Treat a notebook that touched sensitive values the way you would treat any file that might contain them.
+Masking applies wherever the value appears, not only when you display it directly, so a secret buried in a response body or a dict is caught as well. Elements of a composite value are matched individually, so leaking one item out of a list is caught too.
+
+To print a value on purpose, wrap it:
+
+```python
+print(varlock.reveal(env["OPENAI_API_KEY"]))   # 👁 sk-abc123... 👁
+```
+
+The markers make it obvious in the output that the value was deliberately shown.
+
+To check something on its way out of the process, scan it. This raises `VarlockLeakError` naming the key rather than masking, which is what you want before writing a file or calling a third party:
+
+```python
+varlock.scan_for_leaks(payload)
+```
+
+You can also redact anything by hand with `varlock.redact(obj)`, which walks strings, lists, and dicts.
+
+:::caution[What redaction does not cover]
+Redaction is a safety net, not a guarantee. It cannot see a stream a library captured before you called `load()`, writes that go to `sys.stdout.buffer`, or a value rendered by an object's own `__str__` after masking has run. Only values that resolved to **strings** are masked: a sensitive value that resolved to a number is left alone, since masking every occurrence of that number would break unrelated output.
+
+Treat a notebook that touched sensitive values the way you would treat any file that might contain them.
 :::
+
+Redaction follows your schema's [`@redactLogs`](/reference/root-decorators/#redactlogs) setting, which is on unless you turn it off. To control it per call:
+
+```python
+varlock.load(redact_logs=False)   # off for this session
+varlock.install_redaction()       # or turn it back on later
+varlock.uninstall_redaction()
+```
+
+Call `install_redaction()` again if something replaces `sys.stdout` after you loaded, which re-patches the new stream.
 
 ## Plugins that need authentication
 

--- a/packages/varlock-website/src/content/docs/integrations/jupyter.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/jupyter.mdx
@@ -1,0 +1,126 @@
+---
+title: Jupyter notebooks
+description: Load and validate your env schema inside a running Jupyter kernel, without launching it under varlock run
+---
+
+Notebooks are the one Python workflow where [`varlock run`](/reference/cli-commands/#run) is awkward. VS Code's Jupyter extension and JupyterLab spawn the kernel process themselves, so there is no command line for you to wrap. Starting Jupyter from a terminal under `varlock run` and then connecting to it as an existing server works, but it means giving up the normal kernel picker.
+
+The [`varlock` Python package](/integrations/python/#native-package) resolves your schema from inside the kernel instead, so the kernel can be started however you normally start it.
+
+## Setup
+
+Install the CLI, then the Python package into whichever environment your kernel uses:
+
+```bash
+brew install dmno-dev/tap/varlock
+# or: curl -sSfL https://varlock.dev/install.sh | sh -s
+```
+
+```bash
+pip install varlock
+```
+
+The package calls the CLI to resolve values, so both are required. If your kernel runs in a virtualenv or conda env, install into that env, not your system Python.
+
+## Loading values
+
+```python
+import varlock
+
+env = varlock.load()
+```
+
+`load()` resolves and validates your schema, returns the coerced values, and sets them as environment variables in the kernel process. Call it in your first cell:
+
+```python
+env["OPENAI_API_KEY"]   # also env.OPENAI_API_KEY
+env["BATCH_SIZE"]       # 32, an int, not "32"
+```
+
+Because the values also land in `os.environ`, libraries that read the environment on their own pick them up with no extra wiring:
+
+```python
+import openai
+
+varlock.load()
+client = openai.OpenAI()   # finds OPENAI_API_KEY in os.environ
+```
+
+Any subprocess you spawn from the notebook inherits the resolved values too, the same as under `varlock run`.
+
+Reading a key that is not in your schema raises `VarlockMissingKeyError` rather than returning `None`, so a typo fails in the cell that has it instead of somewhere further down.
+
+## Reloading
+
+A kernel outlives many edits. After changing your schema, rotating a secret, or switching environments, re-resolve without restarting:
+
+```python
+varlock.reload()
+```
+
+This re-runs the CLI, replaces the values in `env` and `os.environ`, and drops any keys that left your schema. The `env` object you already have is updated in place, so cells holding a reference to it stay correct.
+
+`load()` on its own is cheap to call repeatedly: once values are loaded it returns them without doing any work, so putting it at the top of a notebook that gets re-run is fine.
+
+## Which schema gets loaded
+
+Schema resolution starts from the process's working directory, which for a notebook is normally the directory the notebook file lives in. To load a schema somewhere else:
+
+```python
+varlock.load(cwd="../services/api")
+varlock.load(path=".env.staging")
+varlock.load(env="production")
+```
+
+## Sharing notebooks
+
+Values marked [`@sensitive`](/reference/item-decorators/#sensitive) are masked in the notebook's own output. Echoing `env` in a cell, which Jupyter renders through `repr()`, shows masked values rather than writing your secrets into the saved `.ipynb`:
+
+```python
+env
+# <varlock.Env APP_ENV='development', OPENAI_API_KEY='sk▒▒▒▒▒'>
+```
+
+You can build your own redaction from the same list:
+
+```python
+varlock.get_sensitive_keys()   # frozenset({'OPENAI_API_KEY'})
+```
+
+:::caution
+This covers displaying the env object itself. It does not stop a cell that prints a secret directly, and the resolved value is a normal string once you read it. Treat a notebook that touched sensitive values the way you would treat any file that might contain them.
+:::
+
+## Plugins that need authentication
+
+If a [plugin](/plugins/overview/) needs you to log in, do that from a terminal before loading:
+
+```bash
+varlock login
+```
+
+The kernel cannot show an interactive prompt, so a load that requires one fails with the CLI's error message rather than hanging. Approval prompts that your OS raises on its own, such as a 1Password biometric check, still work from the notebook, and `load()` waits for them by default.
+
+## Errors
+
+A schema or validation failure raises `VarlockLoadError`, and the CLI's formatted output is included in the message:
+
+```python
+try:
+    varlock.load()
+except varlock.VarlockLoadError as err:
+    print(err)          # the CLI's error output
+    print(err.errors)   # structured per-item errors
+```
+
+The package raises rather than exiting, so a typo in your schema does not kill the kernel.
+
+## Running Jupyter under varlock run
+
+Launching the whole server under [`varlock run`](/reference/cli-commands/#run) still works, and is worth using when you want every kernel to get the env with no in-notebook setup:
+
+```bash
+varlock run -- jupyter lab
+```
+
+Notebooks calling `varlock.load()` work unchanged here. The values are already resolved, so `load()` reads them instead of resolving again.

--- a/packages/varlock-website/src/content/docs/integrations/jupyter.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/jupyter.mdx
@@ -50,6 +50,22 @@ Any subprocess you spawn from the notebook inherits the resolved values too, the
 
 Reading a key that is not in your schema raises `VarlockMissingKeyError` rather than returning `None`, so a typo fails in the cell that has it instead of somewhere further down.
 
+## Types and completion
+
+`env["` and `env.` complete your schema's keys in Jupyter and IPython with no setup, so you can see what is available without leaving the notebook.
+
+Type checking is separate. VS Code checks notebook cells with Pylance, which is static and so cannot know what `load()` returned. To have it check your keys and types, cast to the generated `Env` TypedDict, exactly as you would in a script:
+
+```python
+from typing import cast
+
+from env import Env
+
+env = cast(Env, varlock.load())
+```
+
+See [Types](/integrations/python/#types) for the schema decorator that generates it. This is optional: everything else on this page works without it.
+
 ## Reloading
 
 A kernel outlives many edits. After changing your schema, rotating a secret, or switching environments, re-resolve without restarting:

--- a/packages/varlock-website/src/content/docs/integrations/python.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/python.mdx
@@ -1,11 +1,58 @@
 ---
 title: Python
-description: Use varlock with Python via a generated typed env module, Pydantic Settings, or environs
+description: Use varlock with Python via the varlock package, a generated typed env module, Pydantic Settings, or environs
 ---
 
-To use varlock with Python, [install the standalone binary](/getting-started/installation/#as-a-standalone-binary) and run your app under [`varlock run`](/reference/cli-commands/#run). It loads and validates your env, then injects it into the process.
+There are two ways to use varlock from Python. Both need the [standalone binary](/getting-started/installation/#as-a-standalone-binary) installed.
 
-Add [`@generatePythonEnv`](/reference/root-decorators/#generatepythonenv) to your schema to generate a small, self-contained module: a coerced `Env` [`TypedDict`](https://docs.python.org/3/library/typing.html#typing.TypedDict), a `load_env()` function that parses the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob, and a `SENSITIVE_KEYS` constant.
+1. **The `varlock` package** resolves your schema from inside a running process, so no wrapped launch is needed. Use it in [Jupyter notebooks](/integrations/jupyter/), where there is no command line to wrap, and anywhere else you want one call instead of a launcher.
+2. **[`varlock run`](/reference/cli-commands/#run)** wraps your command, loads and validates your env, then injects it into the process. Pair it with [`@generatePythonEnv`](/reference/root-decorators/#generatepythonenv) for a typed, dependency-free module to read the values back.
+
+## Native package
+
+```bash
+pip install varlock
+```
+
+```python
+import varlock
+
+env = varlock.load()
+
+port = env["DB_PORT"]   # 5432, an int, not "5432"
+debug = env.DEBUG       # attribute access works too
+```
+
+`load()` resolves and validates your schema by calling the CLI, returns the coerced values, and sets them as environment variables so libraries reading `os.environ` and any subprocess you spawn see them. It is cheap to call more than once: after the first call it returns the loaded values without doing any work.
+
+The same call also works under [`varlock run`](/reference/cli-commands/#run). The values are already resolved there, so `load()` reads them instead of resolving again, and one codebase runs both ways.
+
+Reading a key that is not in your schema raises `VarlockMissingKeyError` rather than returning `None`. A key that is declared but has no value in the current environment says so specifically.
+
+| | |
+| --- | --- |
+| `varlock.load(**opts)` | Resolve (or adopt already-resolved values) and return `ENV` |
+| `varlock.reload(**opts)` | Re-resolve, ignoring what is already loaded |
+| `varlock.unload()` | Forget the values and restore every env var varlock set |
+| `varlock.ENV` | The resolved env, a read-only mapping with attribute access |
+| `varlock.get_sensitive_keys()` | Keys whose values are marked `@sensitive` |
+| `varlock.is_running_under_varlock_run()` | Whether the process was started by `varlock run` |
+
+`load()` takes `cwd`, `path`, and `env` to control which schema is loaded, `force` to re-resolve, `inject=False` to leave `os.environ` alone, and `timeout`. Failures raise `VarlockLoadError` with the CLI's own error output attached. To fail fast at startup the way `varlock run` does, import the side-effect module as early as you can instead:
+
+```python
+import varlock.auto_load  # noqa: F401
+
+from varlock import ENV
+```
+
+:::note[Which CLI it calls]
+The package resolves nothing itself: every plugin, cache, and validation behavior comes from the varlock CLI you have installed. It looks for the binary in `VARLOCK_BIN`, then `PATH`, then the standalone install directories, then any `node_modules/.bin` above your working directory.
+:::
+
+## Generated env module
+
+Add [`@generatePythonEnv`](/reference/root-decorators/#generatepythonenv) to your schema to generate a small, self-contained module: a coerced `Env` [`TypedDict`](https://docs.python.org/3/library/typing.html#typing.TypedDict), a `load_env()` function that parses the injected [`__VARLOCK_ENV`](/reference/reserved-variables/#__varlock_env) blob, and a `SENSITIVE_KEYS` constant. Use this when you want types without adding a dependency.
 
 ```env-spec title=".env.schema"
 # @generatePythonEnv(path=env.py)
@@ -13,7 +60,7 @@ Add [`@generatePythonEnv`](/reference/root-decorators/#generatepythonenv) to you
 
 The file is regenerated automatically on [`varlock load`](/reference/cli-commands/#load) and [`varlock run`](/reference/cli-commands/#run), or explicitly with [`varlock codegen`](/reference/cli-commands/#codegen). It has no dependencies, importing it has no side effects, and it imports on any **Python 3.7+** (it uses `from __future__ import annotations`, so `NotRequired`/`Literal` are type-checker-only).
 
-## Reading values
+### Reading values
 
 Call `load_env()` once, then read keys off the dict. Values are coerced (`int`/`bool`/etc.), not raw strings:
 
@@ -34,7 +81,7 @@ varlock run -- python main.py
 
 `load_env()` raises a clear error if `__VARLOCK_ENV` is missing (e.g. you forgot `varlock run`). Optional keys that are unset are absent from the dict (`NotRequired`), not present as `None`.
 
-## Sharing one instance
+### Sharing one instance
 
 Every `load_env()` call re-parses the blob. To avoid reloading, load once in a config module and share it, the idiomatic "settings module" pattern:
 

--- a/packages/varlock-website/src/content/docs/integrations/python.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/python.mdx
@@ -50,6 +50,28 @@ import varlock.auto_load  # noqa: F401
 from varlock import ENV
 ```
 
+### Types
+
+`load()` returns values typed as `Any`. To have a type checker verify them, add [`@generatePythonEnv`](/reference/root-decorators/#generatepythonenv) to your schema and cast the loaded env to the generated `Env` [`TypedDict`](https://docs.python.org/3/library/typing.html#typing.TypedDict):
+
+```env-spec title=".env.schema"
+# @generatePythonEnv(path=env.py)
+```
+
+```python
+from typing import cast
+
+import varlock
+from env import Env
+
+env = cast(Env, varlock.load())
+
+port = env["PORT"]     # int
+env["NOT_A_KEY"]       # error: TypedDict "Env" has no key "NOT_A_KEY"
+```
+
+The cast does nothing at runtime, so this is still the live env object: `reload()`, redaction, and the missing-key errors all behave the same. `TypedDict` types subscript access only, so `env.PORT` stays untyped even with the cast.
+
 ### Redaction
 
 `load()` masks values marked [`@sensitive`](/reference/item-decorators/#sensitive) in `print()` output, in `logging`, and in notebook cell output, following your schema's [`@redactLogs`](/reference/root-decorators/#redactlogs) setting:

--- a/packages/varlock-website/src/content/docs/integrations/python.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/python.mdx
@@ -37,14 +37,30 @@ Reading a key that is not in your schema raises `VarlockMissingKeyError` rather 
 | `varlock.ENV` | The resolved env, a read-only mapping with attribute access |
 | `varlock.get_sensitive_keys()` | Keys whose values are marked `@sensitive` |
 | `varlock.is_running_under_varlock_run()` | Whether the process was started by `varlock run` |
+| `varlock.redact(obj)` | Mask sensitive values found anywhere in `obj` |
+| `varlock.reveal(value)` | Show a sensitive value on purpose |
+| `varlock.scan_for_leaks(value)` | Raise `VarlockLeakError` if `value` contains a sensitive value |
+| `varlock.install_redaction()` / `uninstall_redaction()` | Turn output redaction on or off |
 
-`load()` takes `cwd`, `path`, and `env` to control which schema is loaded, `force` to re-resolve, `inject=False` to leave `os.environ` alone, and `timeout`. Failures raise `VarlockLoadError` with the CLI's own error output attached. To fail fast at startup the way `varlock run` does, import the side-effect module as early as you can instead:
+`load()` takes `cwd`, `path`, and `env` to control which schema is loaded, `force` to re-resolve, `inject=False` to leave `os.environ` alone, `redact_logs` to override the schema's redaction setting, and `timeout`. Failures raise `VarlockLoadError` with the CLI's own error output attached. To fail fast at startup the way `varlock run` does, import the side-effect module as early as you can instead:
 
 ```python
 import varlock.auto_load  # noqa: F401
 
 from varlock import ENV
 ```
+
+### Redaction
+
+`load()` masks values marked [`@sensitive`](/reference/item-decorators/#sensitive) in `print()` output, in `logging`, and in notebook cell output, following your schema's [`@redactLogs`](/reference/root-decorators/#redactlogs) setting:
+
+```python
+print(f"connecting with {env['DB_PASSWORD']}")   # connecting with hu▒▒▒▒▒
+print(varlock.reveal(env["DB_PASSWORD"]))        # 👁 hunter2 👁, shown on purpose
+varlock.scan_for_leaks(response_body)            # raises VarlockLeakError naming the key
+```
+
+Only values that resolved to strings are masked, and a stream captured before `load()` ran can still get through. See the [Jupyter page](/integrations/jupyter/#redaction) for the full list of what is and is not covered.
 
 :::note[Which CLI it calls]
 The package resolves nothing itself: every plugin, cache, and validation behavior comes from the varlock CLI you have installed. It looks for the binary in `VARLOCK_BIN`, then `PATH`, then the standalone install directories, then any `node_modules/.bin` above your working directory.

--- a/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
+++ b/packages/varlock-website/src/content/docs/reference/root-decorators.mdx
@@ -334,7 +334,7 @@ See the [Caching guide](/guides/caching/) for mode selection guidance by environ
 
 Controls whether sensitive config values are automatically redacted from console output. When enabled, any sensitive values will be replaced with `▒▒▒▒▒` in logs.
 
-_Only applies in JavaScript based projects where varlock runtime code is imported._
+_Only applies where varlock runtime code is imported: JavaScript projects, and Python projects using the [`varlock` package](/integrations/python/#native-package)._
 
 - `true` (default): Console logs are automatically redacted
 - `false`: Console logs are not redacted (useful for debugging)

--- a/packages/varlock-website/src/sidebar.ts
+++ b/packages/varlock-website/src/sidebar.ts
@@ -58,6 +58,7 @@ export const sidebar: StarlightUserConfig['sidebar'] = [
       { label: 'mise', slug: 'integrations/mise' },
       { label: 'direnv', slug: 'integrations/direnv' },
       { label: 'Python', slug: 'integrations/python' },
+      { label: 'Jupyter notebooks', slug: 'integrations/jupyter' },
       { label: 'Rust', slug: 'integrations/rust' },
       { label: 'Go', slug: 'integrations/go' },
       { label: 'PHP', slug: 'integrations/php' },

--- a/smoke-tests/smoke-test-python-native/.env.schema
+++ b/smoke-tests/smoke-test-python-native/.env.schema
@@ -1,0 +1,9 @@
+# @defaultSensitive=false
+# ---
+# @type=port
+PORT=8080          # @required @public
+# @type=boolean
+DEBUG=true         # @required @public
+# optional with no value — exercises the declared-but-unset code path
+OPTIONAL_UNSET=    # @optional @public
+SECRET=shhh        # @required @sensitive

--- a/smoke-tests/smoke-test-python-native/main.py
+++ b/smoke-tests/smoke-test-python-native/main.py
@@ -5,6 +5,9 @@ Runs both standalone (the package shells out to the CLI itself) and under `varlo
 which is the point of the integration.
 """
 
+import contextlib
+import io
+import logging
 import os
 
 import varlock
@@ -42,6 +45,22 @@ assert "OPTIONAL_UNSET" not in os.environ
 # sensitive values never appear in the repr (a notebook echoes it into the saved file)
 assert varlock.get_sensitive_keys() == frozenset({"SECRET"})
 assert "shhh" not in repr(env), repr(env)
+
+# redaction is installed by load(), since @redactLogs defaults on
+assert varlock.redact(f"token={env['SECRET']}") == "token=sh▒▒▒▒▒"
+assert "shhh" in varlock.redact(varlock.reveal(env["SECRET"]))
+
+captured = io.StringIO()
+with contextlib.redirect_stdout(captured):
+    print(f"leaking {env['SECRET']}")
+    logging.getLogger("smoke").warning("also %s", env["SECRET"])
+assert "shhh" not in captured.getvalue(), captured.getvalue()
+
+try:
+    varlock.scan_for_leaks(f'{{"token": "{env["SECRET"]}"}}')
+    raise AssertionError("expected VarlockLeakError")
+except varlock.VarlockLeakError as err:
+    assert err.key == "SECRET"
 
 expect_under_run = os.environ.get("EXPECT_VARLOCK_RUN") == "1"
 assert varlock.is_running_under_varlock_run() is expect_under_run

--- a/smoke-tests/smoke-test-python-native/main.py
+++ b/smoke-tests/smoke-test-python-native/main.py
@@ -1,0 +1,49 @@
+"""Smoke test for the native Python package (packages/varlock-python).
+
+Runs both standalone (the package shells out to the CLI itself) and under `varlock run`
+(the package adopts the already-injected blob). The assertions are identical either way,
+which is the point of the integration.
+"""
+
+import os
+
+import varlock
+
+env = varlock.load()
+
+# values are coerced, not raw strings
+assert env["PORT"] == 8080, env["PORT"]
+assert env["DEBUG"] is True, env["DEBUG"]
+# attribute access reads the same value
+assert env.PORT == env["PORT"]
+assert env["SECRET"] == "shhh"
+
+# declared-but-unset optional keys are absent, not present as None
+assert "OPTIONAL_UNSET" not in env, dict(env)
+assert env.get("OPTIONAL_UNSET") is None
+try:
+    env["OPTIONAL_UNSET"]
+    raise AssertionError("expected VarlockMissingKeyError")
+except varlock.VarlockMissingKeyError as err:
+    assert "no value in this environment" in str(err), str(err)
+
+# unknown keys raise rather than returning None
+try:
+    env["NOT_IN_SCHEMA"]
+    raise AssertionError("expected VarlockMissingKeyError")
+except varlock.VarlockMissingKeyError:
+    pass
+
+# resolved values are injected as env vars, serialized the way the CLI does it
+assert os.environ["PORT"] == "8080", os.environ["PORT"]
+assert os.environ["DEBUG"] == "true", os.environ["DEBUG"]
+assert "OPTIONAL_UNSET" not in os.environ
+
+# sensitive values never appear in the repr (a notebook echoes it into the saved file)
+assert varlock.get_sensitive_keys() == frozenset({"SECRET"})
+assert "shhh" not in repr(env), repr(env)
+
+expect_under_run = os.environ.get("EXPECT_VARLOCK_RUN") == "1"
+assert varlock.is_running_under_varlock_run() is expect_under_run
+
+print("OK")

--- a/smoke-tests/tests/python-native.test.ts
+++ b/smoke-tests/tests/python-native.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest';
+import { execSync, spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+import { varlockRun } from '../helpers/run-varlock';
+
+const SMOKE_TESTS_DIR = join(import.meta.dirname, '..');
+const TEST_DIR = join(SMOKE_TESTS_DIR, 'smoke-test-python-native');
+// run the package straight from source - it has no build step and no dependencies
+const PY_SRC_DIR = join(SMOKE_TESTS_DIR, '..', 'packages', 'varlock-python', 'src');
+// pin the CLI the package discovers to the installed one (the packed .tgz in CI), so the test
+// can't silently run against a different varlock that happens to be on the dev machine's PATH
+const VARLOCK_BIN = join(SMOKE_TESTS_DIR, 'node_modules', '.bin', 'varlock');
+
+function hasTool(cmd: string): boolean {
+  try {
+    execSync(`command -v ${cmd}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runPython(env?: Record<string, string>) {
+  const result = spawnSync('python3', ['main.py'], {
+    cwd: TEST_DIR,
+    env: {
+      ...process.env, PYTHONPATH: PY_SRC_DIR, VARLOCK_BIN, ...env,
+    },
+    encoding: 'utf-8',
+  });
+  return {
+    output: (result.stdout ?? '') + (result.stderr ?? ''),
+    exitCode: result.status ?? 1,
+  };
+}
+
+// The native package resolves values by calling the CLI, so these cover both directions:
+// resolving in-process (no wrapped launch, the notebook case) and adopting the blob that
+// `varlock run` already injected. main.py asserts the same things in both.
+describe.skipIf(!hasTool('python3'))('native python package', () => {
+  test('resolves in-process without a wrapped launch', () => {
+    const result = runPython();
+    expect(result.output).toContain('OK');
+    expect(result.exitCode).toBe(0);
+  }, 60_000);
+
+  test('adopts the blob injected by varlock run', () => {
+    const result = varlockRun(['python3', 'main.py'], {
+      cwd: 'smoke-test-python-native',
+      env: { PYTHONPATH: PY_SRC_DIR, EXPECT_VARLOCK_RUN: '1' },
+    });
+    expect(result.output).toContain('OK');
+    expect(result.exitCode).toBe(0);
+  }, 60_000);
+
+  test('reports a schema failure with the CLI output', () => {
+    const result = spawnSync('python3', [
+      '-c', [
+        'import varlock',
+        'try:',
+        '    varlock.load(path="does-not-exist.env")',
+        'except varlock.VarlockLoadError as err:',
+        '    print("CAUGHT", err.exit_code)',
+      ].join('\n'),
+    ], {
+      cwd: TEST_DIR,
+      env: { ...process.env, PYTHONPATH: PY_SRC_DIR, VARLOCK_BIN },
+      encoding: 'utf-8',
+    });
+    expect(result.stdout).toContain('CAUGHT');
+    expect(result.status).toBe(0);
+  }, 60_000);
+});


### PR DESCRIPTION
Adds a `varlock` Python package (`packages/varlock-python`) that resolves the env schema from inside a running process, so no wrapped launch is needed.

```python
import varlock
env = varlock.load()
```

This is a follow-up to the Python codegen support, and the next step toward parity with the deeper JS/TS integrations. It came out of a user request about Jupyter: VS Code and JupyterLab spawn the kernel themselves, so there is no command line for `varlock run` to wrap, which leaves shelling out to `varlock load --format json` and parsing it by hand as the only option today.

## How it works

Same architecture as the deep JS integration, not a reimplementation. It resolves nothing itself: it shells out to `varlock load --format json-full --compact`, parses the graph, injects into `os.environ`, and exposes the values. Every plugin, cache, and validation behavior comes from the installed CLI.

| Module | Mirrors |
| --- | --- |
| `_cli.py` | `execSyncVarlock` |
| `_binary.py` | `findVarlockBin`, plus the standalone installer's directories |
| `_runtime.py` | `initVarlockEnv` state and `process.env` injection |
| `_env.py` | the `ENV` proxy |
| `_redaction.py` | `resetRedactionMap` / `redactSensitiveConfig` / `scanForLeaks` |
| `_patch.py` | `patchGlobalConsole` |
| `auto_load.py` | `varlock/auto-load` |

When the process was started by `varlock run`, the values are already resolved, so `load()` adopts the blob instead of resolving again. The same code works both ways.

`ENV` is a read-only mapping that also allows attribute access. Unknown keys raise rather than returning `None`. Zero runtime dependencies, Python 3.9+.

## Redaction

`load()` masks values marked `@sensitive` in output, following the schema's `@redactLogs` setting. Output escapes a Python process in three separate places, so all three are covered:

- **`logging`**, via the record factory, which every logger and handler goes through no matter when it was created. A filter would only cover the one logger or handler it was attached to.
- **`print()`**, via `builtins.print`, which resolves its stream at call time and so survives a library or kernel replacing `sys.stdout` after redaction was installed. The stream objects are patched too, for direct `write()` calls.
- **Notebook cell output**, via IPython's display formatter. Cell results never go through stdout, and this is the main way a secret ends up saved in an `.ipynb`.

Plus the primitives: `redact()` walks strings, lists, and dicts; `reveal()` marks a value as deliberately shown; `scan_for_leaks()` raises `VarlockLeakError` naming the key and respects `@sensitive={preventLeaks=false}`.

Matching the JS runtime, only values that resolved to strings are registered (masking every occurrence of a sensitive *number* would wreck unrelated output), and elements of composite values register individually so leaking one item of a list is caught.

## Typing

No new codegen mode. The `Env` TypedDict that `@generatePythonEnv` already emits types the native loader as-is:

```python
env = cast(Env, varlock.load())
env["NOT_A_KEY"]   # error: TypedDict "Env" has no key "NOT_A_KEY"
```

Verified with mypy, which catches both unknown keys and wrong-typed assignments. Separately, `ENV.<TAB>` and `ENV["<TAB>"]` complete schema keys at runtime in Jupyter and IPython (the subscript form needs `_ipython_key_completions_`, since IPython only infers keys for real `dict` instances). The cast is a no-op at runtime, so the object is still the live env. This is documented rather than automated: a generated module that imports `varlock` would give up the current one's selling point of having no dependencies, to save a single line.

## Deliberate differences from the JS runtime

- **Raises instead of exiting.** `load()` raises `VarlockLoadError` with the CLI's formatted stderr attached. Killing a kernel is the wrong response to a schema typo. `import varlock.auto_load` opts into fail-fast for scripts and servers.
- **Unset optional keys are absent**, not present as `None`, matching the contract the generated module already documents. `ENV["OPTIONAL"]` reports "exists in your schema, but has no value in this environment", distinct from the unknown-key error.
- **Env var serialization follows the CLI, not Python.** `True` injects as `"true"`, composites use the blob's `envStr`, and unset keys are not injected at all (what `varlock run` does, since Node drops `undefined` env values).
- **A failed `reload()` keeps the previous values.** The uninjected environment is handed to the CLI as a copy rather than applied in place first, so a bad schema edit mid-notebook does not wipe a working env.
- **Merely importing the package never patches global state.** Under `varlock run`, import sets up the redaction map so `redact()` works, but only an explicit `load()` installs the patches.

Binary discovery reads `VARLOCK_BIN`, then `PATH`, then the standalone install directories, then walks up for `node_modules/.bin`.

## Testing

- 128 unit tests, run on 3.9 and 3.13 in a new `python-package` CI job.
- 3 smoke tests against the built CLI: resolving in-process, adopting the `varlock run` blob, and error reporting. The in-process one also asserts redaction of `print`, `logging`, `reveal()`, and `scan_for_leaks`.
- Manually exercised end to end against an installed CLI, including a live `reload()` picking up a schema edit, `unload()` restoring `os.environ`, and the notebook path driven through a real IPython shell (cell output, `print`, and the `ENV` repr all masked).

## Docs

New Jupyter page covering setup, reloading, which schema gets loaded, redaction and its limits, auth prompts, and the `varlock run -- jupyter lab` alternative. The Python page now leads with the two paths and gains a native package section covering the API, typing, and redaction; the codegen content moves under a "Generated env module" heading. `@redactLogs` no longer says it is JavaScript-only.

## Reviewer notes

- **The docs say `pip install varlock`, but nothing is published to PyPI yet.** Both `varlock` and `varlock-cli` are available as names. Either publish an initial version before this merges, or hold the docs pages back. This is the one thing blocking merge as-is.
- **Windows `.cmd` shims no longer go through `shell=True`.** `list2cmdline` only quotes arguments containing whitespace, but `cmd.exe` parses `&`/`|`/`<`/`>`/`^`/parens out of unquoted text before argv splitting, so a metacharacter in a `--path` value or in the install path could start a second command (the Node CVE-2024-27980 class). Now built as an explicit `cmd.exe /d /s /c` line with every token quoted, passed with `shell=False`. The quoting is tested against the stdlib and round-tripped through an MSVCRT parser, but the execution path itself is untested for want of a Windows machine, so a Windows reviewer would help.
- Wrapping `builtins.print` is invasive. It is reversible via `uninstall_redaction()`, and it is the only way to keep `print` redaction working across a stream swap, but worth a second opinion.
- The package is managed with `uv`, not bun. The `package.json` is a private shim so bun workspaces and turbo can see the directory; it is never published to npm.
- Remaining follow-up: platform wheels behind a `varlock[cli]` extra, so `pip install` alone is enough in a fresh notebook environment.