### PR TITLE
Verify and sign release artifacts

### DIFF
--- a/.bumpy/install-sh-checksum-verification.md
+++ b/.bumpy/install-sh-checksum-verification.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+The install script now verifies the sha256 of the downloaded archive against the release's published checksums.txt, and fails without installing on a mismatch.

--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -24,6 +24,7 @@ concurrency: ${{ github.workflow }}-${{ inputs.version }}
 
 jobs:
   release-binaries:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write # keyless cosign signing of checksums.txt
     env:
       RELEASE_VERSION: ${{ inputs.version }}
       RELEASE_TAG: varlock@${{ inputs.version }}
@@ -42,6 +43,11 @@ jobs:
         run: bun install
       - name: Enable turborepo build cache
         uses: rharkor/caching-for-turbo@56219402aacc0d06b650d898c222996dbc1191ec # v2.3.14
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # see the matching step in release.yaml for why cosign is pinned too
+          cosign-release: v3.0.6
 
       # Pull the signed/notarized native binaries from the published npm package
       # instead of rebuilding + re-signing them.
@@ -80,11 +86,16 @@ jobs:
           BUILD_TYPE: release
       - name: Build varlock SEA binaries
         run: bun run packages/varlock/scripts/build-binaries.ts
+      # See the matching step in release.yaml for why only checksums.txt is signed.
+      - name: Sign checksums with cosign
+        working-directory: packages/varlock/dist-sea
+        run: cosign sign-blob --yes --bundle checksums.txt.cosign.bundle checksums.txt
+
       - name: Upload binaries to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         working-directory: packages/varlock/dist-sea
-        run: gh release upload "$RELEASE_TAG" *.{tar.gz,zip} checksums.txt ../SHA256SUMS.txt --clobber
+        run: gh release upload "$RELEASE_TAG" *.{tar.gz,zip} checksums.txt checksums.txt.cosign.bundle ../SHA256SUMS.txt --clobber
 
       - name: Checkout homebrew tap repo
         uses: actions/checkout@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -440,6 +440,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write # keyless cosign signing of checksums.txt
     steps:
       - uses: actions/checkout@v7
       - name: Setup Bun
@@ -452,6 +453,13 @@ jobs:
         run: bun install
       - name: Enable turborepo build cache
         uses: rharkor/caching-for-turbo@56219402aacc0d06b650d898c222996dbc1191ec # v2.3.14
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # pin cosign itself, not just the installer action - the bundle format
+          # the signature is written in is a property of the cosign version, and
+          # the documented `verify-blob` command has to keep matching it
+          cosign-release: v3.0.6
 
       - name: Resolve published varlock version
         id: ver
@@ -489,11 +497,19 @@ jobs:
       - name: Build varlock SEA binaries
         run: bun run packages/varlock/scripts/build-binaries.ts
 
+      # Sign checksums.txt rather than each archive: it already covers every
+      # archive by hash, so one signature transitively covers them all, and
+      # verifiers only need one extra asset. Keyless signing binds the signature
+      # to this workflow's OIDC identity - see guides/verifying-releases.
+      - name: Sign checksums with cosign
+        working-directory: packages/varlock/dist-sea
+        run: cosign sign-blob --yes --bundle checksums.txt.cosign.bundle checksums.txt
+
       - name: Upload binaries to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         working-directory: packages/varlock/dist-sea
-        run: gh release upload "${{ steps.ver.outputs.tag }}" *.{tar.gz,zip} checksums.txt ../SHA256SUMS.txt --clobber
+        run: gh release upload "${{ steps.ver.outputs.tag }}" *.{tar.gz,zip} checksums.txt checksums.txt.cosign.bundle ../SHA256SUMS.txt --clobber
 
       # Update the homebrew tap formula
       - name: Checkout homebrew tap repo

--- a/packages/varlock-website/src/content/docs/getting-started/installation.mdx
+++ b/packages/varlock-website/src/content/docs/getting-started/installation.mdx
@@ -103,7 +103,7 @@ curl -sSfLO "${BASE}/checksums.txt.cosign.bundle"
 cosign verify-blob checksums.txt \
   --bundle checksums.txt.cosign.bundle \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp '^https://github\.com/dmno-dev/varlock/\.github/workflows/(release|binary-release)\.yaml@'
+  --certificate-identity-regexp '^https://github\.com/dmno-dev/varlock/\.github/workflows/(release|binary-release)\.yaml@refs/heads/main$'
 ```
 
 Both workflow identities are accepted because binaries are normally cut by `release.yaml` alongside the npm publish, and re-cut by `binary-release.yaml` when an already-published version needs new archives.
@@ -150,4 +150,3 @@ It provides syntax highlighting, decorator and `@type` IntelliSense, `$KEY` refe
 ### Shell completion
 
 Enable tab completion for varlock commands and flags in bash, zsh, or fish. See the [Shell completion guide](/guides/shell-completion/) for one-time setup. Usually, adding `eval "$(varlock complete)"` to your shell profile is enough.
-

--- a/packages/varlock-website/src/content/docs/getting-started/installation.mdx
+++ b/packages/varlock-website/src/content/docs/getting-started/installation.mdx
@@ -76,6 +76,42 @@ Options:
   --skip-win-exe    on WSL, skip installing the Windows encryption helper (varlock-local-encrypt.exe) (default: false)
 ```
 
+### Verifying a release
+
+Both install paths already check integrity for you: the homebrew formula pins a sha256 per archive, and `install.sh` verifies the downloaded archive against the release's `checksums.txt` before installing.
+
+If you are pinning varlock yourself (a container image, a provisioning script, or a tool that installs varlock on a user's behalf), download the archive from the release tag and verify it the same way:
+
+```bash
+VERSION=1.14.0
+BASE="https://github.com/dmno-dev/varlock/releases/download/varlock@${VERSION}"
+ARCHIVE="varlock-linux-x64.tar.gz"
+
+curl -sSfLO "${BASE}/${ARCHIVE}"
+curl -sSfLO "${BASE}/checksums.txt"
+
+grep " ${ARCHIVE}\$" checksums.txt | sha256sum -c -
+# on macOS, which has no sha256sum:
+grep " ${ARCHIVE}\$" checksums.txt | shasum -a 256 -c -
+```
+
+`checksums.txt` is signed with [cosign](https://docs.sigstore.dev/) keyless signing, so you can also confirm it came from varlock's release workflow rather than from someone with write access to the repo's releases. The signature covers `checksums.txt`, which in turn covers every archive by hash:
+
+```bash
+curl -sSfLO "${BASE}/checksums.txt.cosign.bundle"
+
+cosign verify-blob checksums.txt \
+  --bundle checksums.txt.cosign.bundle \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github\.com/dmno-dev/varlock/\.github/workflows/(release|binary-release)\.yaml@'
+```
+
+Both workflow identities are accepted because binaries are normally cut by `release.yaml` alongside the npm publish, and re-cut by `binary-release.yaml` when an already-published version needs new archives.
+
+:::note
+Signing was added after varlock 1.14.0, so older releases have `checksums.txt` but no bundle. If a release has no `checksums.txt.cosign.bundle` asset, it predates signing and only the checksum step applies.
+:::
+
 ## Varlock skill
 
 Then install the Varlock agent skill:

--- a/packages/varlock/install.sh
+++ b/packages/varlock/install.sh
@@ -300,7 +300,8 @@ sha256_of_file() {
 # generated alongside the archives in scripts/build-binaries.ts. We fetch it over
 # the same TLS connection as the archive, so this is an integrity check against a
 # corrupt or truncated download and a tampered release asset - not a defense
-# against a compromised github account. Releases are not signed yet.
+# against a compromised github account. Releases are signed, but this script does
+# not verify the cosign bundle.
 verify_checksum() {
   _vc_archive_path="$1"
   _vc_archive_name="$2"

--- a/packages/varlock/install.sh
+++ b/packages/varlock/install.sh
@@ -127,7 +127,8 @@ main() {
   require_cmd mktemp
   require_cmd grep
   require_cmd rm
-  
+  require_cmd awk
+
 
   # check installation directory is writable
   mkdir -p "${INSTALL_DIR}"
@@ -152,12 +153,14 @@ main() {
     echo "Version ${VERSION} will be installed"
   fi
   _url="${GITHUB_RELEASES_URL}/download/varlock@${VERSION}/${_archive_name}"
+  _checksums_url="${GITHUB_RELEASES_URL}/download/varlock@${VERSION}/checksums.txt"
 
   # Installation
   _temp_dir=$(mktemp -d)
   _archive_path="${_temp_dir}/${_archive_name}"
 
   download "${_url}" "${_archive_path}" || return 1
+  verify_checksum "${_archive_path}" "${_archive_name}" "${_checksums_url}" || return 1
 
   case $_archive_path in
     *.zip)
@@ -276,6 +279,54 @@ is_wsl() {
   esac
 }
 
+# $1 - path to a file. Prints its sha256 as lowercase hex.
+# Returns 1 if no hashing tool is available.
+sha256_of_file() {
+  if cmd_exists sha256sum; then
+    sha256sum "$1" | cut -d ' ' -f 1
+  elif cmd_exists shasum; then
+    shasum -a 256 "$1" | cut -d ' ' -f 1
+  elif cmd_exists openssl; then
+    openssl dgst -sha256 "$1" | sed 's/.*= *//'
+  else
+    return 1
+  fi
+}
+
+# $1 - downloaded archive path. $2 - archive name as it appears in checksums.txt.
+# $3 - url of the release's checksums.txt
+#
+# The release publishes `checksums.txt` in `sha256sum` format ("<hash>  <name>"),
+# generated alongside the archives in scripts/build-binaries.ts. We fetch it over
+# the same TLS connection as the archive, so this is an integrity check against a
+# corrupt or truncated download and a tampered release asset - not a defense
+# against a compromised github account. Releases are not signed yet.
+verify_checksum() {
+  _vc_archive_path="$1"
+  _vc_archive_name="$2"
+  _vc_url="$3"
+  _vc_checksums_path="${_temp_dir}/checksums.txt"
+
+  _vc_actual=$(sha256_of_file "${_vc_archive_path}") || err "Unable to verify download: none of \`sha256sum\`, \`shasum\` or \`openssl\` was found.\n> install one of them, or install varlock via homebrew or npm instead"
+
+  download "${_vc_url}" "${_vc_checksums_path}" || err "Failed to download checksums.txt for varlock@${VERSION}"
+
+  # match the name field exactly rather than substring-matching the whole line,
+  # so `varlock-linux-x64.tar.gz` cannot be satisfied by another entry
+  _vc_expected=$(awk -v name="${_vc_archive_name}" '$2 == name { print $1 }' "${_vc_checksums_path}" | head -n 1)
+
+  if [ -z "${_vc_expected}" ]; then
+    err "No checksum published for ${_vc_archive_name} in varlock@${VERSION}"
+  fi
+
+  if [ "${_vc_actual}" != "${_vc_expected}" ]; then
+    rm -f "${_vc_archive_path}"
+    err "Checksum mismatch for ${_vc_archive_name}\n>   expected: ${_vc_expected}\n>   actual:   ${_vc_actual}\n> the download was discarded. Please retry, and report this if it persists @ ${GITHUB_URL}/issues"
+  fi
+
+  echo "  Verified checksum for ${_vc_archive_name}"
+}
+
 # $1 - url for download. $2 - path to download
 # Wrapper function for curl/wget
 download() {
@@ -317,7 +368,8 @@ cmd_exists() {
 }
 
 err() {
-  printf "🚨 VARLOCK INSTALLATION ERROR - %s\n" "$1"
+  # %b (not %s) so callers can use \n to add detail lines
+  printf "🚨 VARLOCK INSTALLATION ERROR - %b\n" "$1"
   exit 1
 }
 


### PR DESCRIPTION
`install.sh` downloaded a release archive and untarred it with no integrity check at all. It now fetches the release's `checksums.txt`, matches the archive by exact name, verifies the sha256 with whichever of `sha256sum`/`shasum`/`openssl` is present, and deletes the download and aborts on a mismatch.

The release workflows now sign `checksums.txt` with cosign keyless signing and publish `checksums.txt.cosign.bundle` alongside it. That lets anyone pinning varlock (a container image, a provisioning script, or another tool that installs varlock on a user's behalf) confirm the artifacts came from the release workflow rather than from someone with write access to releases. Signing the one file that already covers every archive by hash keeps it to a single extra asset.

Two details worth a look in review:

- `cosign-release` is pinned explicitly, not just the installer action. cosign-installer v4.1.2 installs cosign v3.0.6, and the bundle format is a property of the cosign version, so the documented `verify-blob` command has to keep matching it.
- Both jobs needed `id-token: write` for keyless signing.

Docs get a "Verifying a release" section covering both the checksum and the signature.

### Testing

The checksum path was exercised against the real 1.14.0 release: happy path installs, and corrupt archive / name absent from checksums / substring-collision name / no hashing tool available all abort with exit 1.

The signing steps have not run: keyless signing needs a GitHub Actions OIDC token and can't be executed locally. Flags were checked against the cosign v3.0.6 command docs, including that `--new-bundle-format` defaults to true on both `sign-blob` and `verify-blob` so the two agree. The first release cutting a bundle is the real proof, and the docs note says releases before this one have no bundle.

Also fixed in passing: `err()` used `printf %s`, so the `\n>` detail lines in existing error messages printed literally instead of wrapping.