### PR TITLE
1password: pass op inject template as a file instead of stdin

### DIFF
--- a/.bumpy/1password-inject-stdin-fix.md
+++ b/.bumpy/1password-inject-stdin-fix.md
@@ -1,0 +1,5 @@
+---
+"@varlock/1password-plugin": patch
+---
+
+Fix 1Password CLI batch reads failing with "expected data on stdin but none found". The op inject template is now passed as a file rather than on stdin, which op only accepts from a true pipe.

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -3,6 +3,9 @@ import {
 } from 'varlock/plugin-lib';
 
 import { createHash, randomUUID } from 'node:crypto';
+import { writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createDeferredPromise, type DeferredPromise } from '@env-spec/utils/defer';
 import { spawnAsync } from '@env-spec/utils/exec-helpers';
 import { Client, createClient } from '@1password/sdk';
@@ -42,6 +45,30 @@ function buildInjectTemplate(opReferences: Array<string>) {
     return `${key}={{ ${ref} }}${separator}`;
   }).join('');
   return { template, separator, keyToRef };
+}
+
+/*
+  The template is handed to `op inject` as a file (`-i`) rather than on stdin.
+
+  `op inject` requires its stdin to be a real pipe (it checks for `os.ModeNamedPipe`), and
+  node/bun both hand spawned children a socketpair instead, so writing the template to the
+  child's stdin always fails with "expected data on stdin but none found" on every platform.
+  A regular file redirected onto stdin fails that check too, so `-i` is the portable option.
+
+  The template holds only `op://` references, never resolved secret values, so it is safe to
+  write to disk. Resolved values still come back over stdout and never touch the filesystem.
+*/
+async function runOpInject(extraArgs: Array<string>, template: string, env: NodeJS.ProcessEnv) {
+  const templatePath = join(tmpdir(), `varlock-1p-inject-${randomUUID()}.tpl`);
+  // `wx` = O_CREAT|O_EXCL, so this refuses to follow a pre-existing file or symlink
+  // planted at the path on a shared tmpdir, and 0600 keeps it owner-only while it exists.
+  await writeFile(templatePath, template, { mode: 0o600, flag: 'wx' });
+  try {
+    return await spawnAsync('op', ['inject', '-i', templatePath, ...extraArgs], { env });
+  } finally {
+    // a cleanup failure should never mask the batch result
+    await rm(templatePath, { force: true }).catch(() => undefined);
+  }
 }
 
 /** Parse `op inject` output back into op-ref → value (dangling segments, e.g. a trailing newline, are ignored). */
@@ -97,16 +124,13 @@ async function executeAppCliBatch(batchToExecute: NonNullable<typeof appAuthBatc
   const startAt = new Date();
 
   const authCompletedFn = await checkAppCliAuth();
-  await spawnAsync('op', ['inject', ...lockCliToOpAccount ? ['--account', lockCliToOpAccount] : []], {
-    env: {
-      PATH: process.env.PATH!,
-      ...process.env.USER && { USER: process.env.USER },
-      ...process.env.HOME && { HOME: process.env.HOME },
-      ...process.env.XDG_CONFIG_HOME && { XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
-      ...pickProxyEnv(),
-      OP_BIOMETRIC_UNLOCK_ENABLED: 'true',
-    },
-    input: template,
+  await runOpInject(lockCliToOpAccount ? ['--account', lockCliToOpAccount] : [], template, {
+    PATH: process.env.PATH!,
+    ...process.env.USER && { USER: process.env.USER },
+    ...process.env.HOME && { HOME: process.env.HOME },
+    ...process.env.XDG_CONFIG_HOME && { XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
+    ...pickProxyEnv(),
+    OP_BIOMETRIC_UNLOCK_ENABLED: 'true',
   })
     .then((result) => {
       authCompletedFn?.(true);
@@ -397,22 +421,19 @@ class OpPluginInstance {
     const startAt = new Date();
 
     const authCompletedFn = await this.checkCliAuth();
-    await spawnAsync('op', ['inject', ...this.account ? ['--account', this.account] : []], {
-      env: {
-        // have to pass a few things through at least path so it can find `op` and related config files
-        PATH: process.env.PATH!,
-        ...process.env.USER && { USER: process.env.USER },
-        ...process.env.HOME && { HOME: process.env.HOME },
-        ...process.env.XDG_CONFIG_HOME && { XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
-        // proxy env vars so `op` can connect through HTTP/SOCKS proxies
-        ...pickProxyEnv(),
-        // forward service account token when the instance opted into CLI-based service account auth
-        ...this.useCliWithServiceAccount && this.token && { OP_SERVICE_ACCOUNT_TOKEN: this.token },
-        // this setting actually just enables the CLI + Desktop App integration
-        // which in some cases op has a hard time detecting via app setting
-        OP_BIOMETRIC_UNLOCK_ENABLED: 'true',
-      },
-      input: template,
+    await runOpInject(this.account ? ['--account', this.account] : [], template, {
+      // have to pass a few things through at least path so it can find `op` and related config files
+      PATH: process.env.PATH!,
+      ...process.env.USER && { USER: process.env.USER },
+      ...process.env.HOME && { HOME: process.env.HOME },
+      ...process.env.XDG_CONFIG_HOME && { XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
+      // proxy env vars so `op` can connect through HTTP/SOCKS proxies
+      ...pickProxyEnv(),
+      // forward service account token when the instance opted into CLI-based service account auth
+      ...this.useCliWithServiceAccount && this.token && { OP_SERVICE_ACCOUNT_TOKEN: this.token },
+      // this setting actually just enables the CLI + Desktop App integration
+      // which in some cases op has a hard time detecting via app setting
+      OP_BIOMETRIC_UNLOCK_ENABLED: 'true',
     })
       .then(async (result) => {
         authCompletedFn?.(true);

--- a/packages/plugins/1password/test/fake-op.sh
+++ b/packages/plugins/1password/test/fake-op.sh
@@ -15,17 +15,33 @@ case "$1" in
     echo "Test User <test@example.com>"
     ;;
   inject)
-    # op inject [--account X]
-    # Reads a template from stdin, resolves {{ op://... }} references from
-    # config, and prints the substituted template. Mimics real op inject
-    # behavior: fails the whole batch on the first bad reference, strips
-    # control characters (except newline/tab) from output, and appends a
+    # op inject -i <template-file> [--account X]
+    # Resolves {{ op://... }} references from config and prints the substituted
+    # template. Mimics real op inject behavior: requires the template to come
+    # from a file, fails the whole batch on the first bad reference, strips
+    # control characters (except \t \n \v \f \r) from output, and appends a
     # trailing newline.
+    #
+    # Real `op inject` only accepts stdin when it is a true pipe (it checks for
+    # os.ModeNamedPipe), and node/bun hand spawned children a socketpair, so a
+    # template written to the child's stdin is never seen. Reject that here so
+    # tests fail the same way real op does instead of silently passing.
+    TEMPLATE_FILE=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -i) TEMPLATE_FILE="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [ -z "$TEMPLATE_FILE" ]; then
+      echo "[ERROR] 2024/01/01 00:00:00 expected data on stdin but none found" >&2
+      exit 1
+    fi
     node -e "
       const cfg = JSON.parse(require('fs').readFileSync('$CONFIG_FILE', 'utf-8'));
       const responses = cfg.responses || {};
       const errors = cfg.errors || {};
-      const template = require('fs').readFileSync(0, 'utf-8');
+      const template = require('fs').readFileSync('$TEMPLATE_FILE', 'utf-8');
 
       const refs = [...template.matchAll(/\{\{\s*(op:\/\/[^}]+?)\s*\}\}/g)].map((m) => m[1]);
 
@@ -40,7 +56,7 @@ case "$1" in
       const output = template.replace(/\{\{\s*(op:\/\/[^}]+?)\s*\}\}/g, (match, ref) => {
         return ref in responses ? responses[ref] : match;
       });
-      process.stdout.write(output.replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '') + '\n');
+      process.stdout.write(output.replace(/[\x00-\x08\x0e-\x1f\x7f]/g, '') + '\n');
     "
     ;;
   environment)


### PR DESCRIPTION
Fixes a total regression in `@varlock/1password-plugin` 2.0.1: every CLI batch read fails with `expected data on stdin but none found`.

## Root cause

#938 swapped `op run -- env -0` for `op inject` to fix Windows, feeding the template to op over the spawned child's stdin. But `op inject` only accepts a template on stdin when stdin is a **true pipe** (it checks Go's `os.ModeNamedPipe`), and Node and Bun both hand spawned children a **socketpair** rather than `pipe(2)`:

```
in the child: fstatSync(0).isSocket() === true, isFIFO() === false
```

So op never saw the template. This affects **both** CLI paths (app auth and service account), every platform, and both the npm package and the compiled binary. Reproduced deterministically at 1 through 800 refs. The SDK path is unaffected.

Verified against real `op` 2.34:

| stdin shape | result |
| --- | --- |
| shell pipe `cat f \| op inject` | works |
| regular file redirect `op inject < f` | fails, same error |
| node/bun `spawn` + `stdin.write()` | fails, same error |
| `op inject -i <file>` | works |

## Fix

Keep `op inject` (so the Windows fix stands) and pass the template with `-i <file>`. A regular file redirected onto stdin fails the same check, so `-i` is the only portable option.

The template holds only `op://` references, never resolved secret values, so it is safe on disk. Results still come back over stdout. It is written `0600` with `O_EXCL` (so it will not follow a file or symlink pre-planted in a shared tmpdir) under a random UUID name, and removed in a `finally`.

## Why CI was green

`test/fake-op.sh` read stdin with a blocking `readFileSync(0)`, so it accepted what the real binary rejects: the double modeled op's output but not its input-shape precondition. It now requires `-i` and emits op's exact error otherwise. Reverting the source fix with that guard in place produces **11 failing tests**. Its control-character stripping was also wrong and now matches real op (strips `00-08`, `0e-1f`, `7f`, preserves `\t \n \v \f \r`).

## Verification

- Real `op` against a real vault: the old path fails with the production error; the new path resolves 5/5 refs, every value **byte-identical to `op read`**, including a multiline note.
- 29/29 unit tests, typecheck and lint clean.

One tradeoff worth noting: an environment with an unwritable `tmpdir` would now fail where stdin needed no disk. The child never needs `TMPDIR` since it receives an absolute path.

## Follow-up (not in this PR)

- `packages/plugins/keepass/src/cli-helper.ts:76` uses the same `input:`-over-stdin mechanism with a different CLI. It presumably works since it shipped earlier, but is worth confirming against the real binary.
- `spawnAsync`'s `input` option writes to `childProcess.stdin` without an `error` handler on that stream, so an EPIPE from a child that exits early becomes an uncaught exception. Left alone here to keep the hotfix contained.
