### PR TITLE
Structured, coded errors and warnings in json-full output

### DIFF
--- a/.bumpy/structured-load-error-codes.md
+++ b/.bumpy/structured-load-error-codes.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+`varlock load --format json-full` now reports errors as structured objects with a stable `code` (was free-text strings), so tools can branch on the code instead of matching messages. Warnings are reported too, under a separate `warnings` key, so `errors` still means the load failed. A missing `.env.schema` is still fine, but finding no env files at all, or files that define no items, is now reported as an error in the output and exits non-zero for every format.

--- a/packages/varlock-website/src/content/docs/reference/cli/load-and-run.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli/load-and-run.mdx
@@ -85,6 +85,59 @@ varlock load --filter="#billing"
 
 When emitting machine-readable output, add `--summary-stderr` (or `--summary-file`) to get a human-readable, redacted summary on **stderr** while keeping clean JSON on **stdout**. This is handy for agents and CI.
 
+#### Reading errors from `json-full`
+
+`--format json-full` writes its JSON to stdout **even when loading fails**, and still exits non-zero. So a tool can parse stdout regardless of exit code and read the `errors` key, which is absent entirely when everything resolved:
+
+```jsonc
+{
+  "errors": {
+    // not tied to one item: parse failures, no env files found, etc.
+    "root": [
+      { "code": "no_env_files", "message": "No .env files found in /app", "severity": "error", "tip": "Run `varlock init` ..." }
+    ],
+    // keyed by item; an array, since one item can fail several ways at once
+    "configItems": {
+      "API_KEY": [
+        { "code": "empty_required_value", "message": "Value is required but is currently empty", "severity": "error" }
+      ]
+    }
+  },
+  // same structure, but never a reason the load failed. Absent when there are none.
+  "warnings": {
+    "configItems": {
+      "OTHER_KEY": [
+        { "code": "schema_error", "message": "Unexpected text \"...\" after @public - use another # for trailing comments", "severity": "warning" }
+      ]
+    }
+  }
+}
+```
+
+Branch on `code`, which is stable. Treat `message` as prose that can change between releases.
+
+Warnings live under a separate top-level `warnings` key with the identical structure, so **the presence of `errors` always means the load failed** and `if (data.errors)` stays a valid check. Warnings never block a load. An item that has both (a stray-text warning next to a required-value error, say) appears under both keys, carrying only its relevant entries in each.
+
+Current codes:
+
+| Code | Meaning |
+| --- | --- |
+| `no_env_files` | No `.env*` files found at all |
+| `no_config_items` | Files loaded, but they define no items |
+| `parse_error` | A file could not be parsed |
+| `schema_error` | Invalid decorator, unknown resolver function, and similar schema problems |
+| `loading_failed` | A source could not be read |
+| `resolution_failed` | A resolver threw (plugin error, failed `exec()`, ...) |
+| `decrypt_failed` | A [`varlock("local:...")`](/guides/local-encryption/) value could not be decrypted |
+| `coercion_failed` | Value present but not coercible to the declared `@type` |
+| `validation_failed` | Value failed a validation rule |
+| `empty_required_value` | `@required` item resolved to empty |
+| `config_load_failed` | Unexpected error while loading config |
+
+A `.env.schema` is not required: a project made only of `.env` files loads fine. What does fail is having no env files at all (`no_env_files`) or files that define nothing (`no_config_items`).
+
+Treat this list as open-ended. More specific codes get added over time (a decrypt failure may narrow to a reason reported by the native encryption helper, for example), so match the codes you handle and fall back to generic handling for anything you do not recognize rather than assuming the set is closed.
+
 :::caution
 Setting `@currentEnv` in your `.env.schema` will override the `--env` flag.
 :::

--- a/packages/varlock/src/cli/helpers/error-checks.ts
+++ b/packages/varlock/src/cli/helpers/error-checks.ts
@@ -27,28 +27,22 @@ function showErrorTip(err: VarlockError) {
 }
 
 export function checkForNoEnvFiles(envGraph: EnvGraph, opts?: { noThrow?: boolean }) {
-  if (Object.keys(envGraph.configSchema).length === 0) {
-    // If a source has a parse error, the schema couldn't be read at all so
-    // "no config items defined" is misleading — the parse error (already
-    // reported by checkForSchemaErrors) is the real problem.
-    const hasParseErrors = envGraph.sortedDataSources.some((s) => s.loadingError instanceof ParseError);
-    if (hasParseErrors) {
-      if (opts?.noThrow) return;
-      throw new CliExitError('Parse error', { silent: true });
-    }
+  if (Object.keys(envGraph.configSchema).length > 0) return;
 
-    const displayPath = envGraph.basePath ?? process.cwd();
-    const hasLoadedFiles = envGraph.sortedDataSources.some((s) => s instanceof FileBasedDataSource);
-    if (!hasLoadedFiles) {
-      console.error(`🚨 No .env files found in ${displayPath}\n`);
-      console.error('Run `varlock init` to create a .env.schema file, or use `--path` to specify a file or directory.');
-    } else {
-      console.error(`🚨 No config items defined in ${displayPath}\n`);
-      console.error('Add items to your .env.schema file to get started.');
-    }
+  // The graph owns what counts as unusable (and which of the two reasons it is),
+  // so this stays in step with what `getSerializedGraph` reports in `errors.root`.
+  const emptyGraphError = envGraph.getEmptyGraphError();
+  if (!emptyGraphError) {
+    // some other root error already explains the empty graph — it was reported
+    // by checkForSchemaErrors, so don't pile a misleading message on top
     if (opts?.noThrow) return;
-    throw new CliExitError('No env files', { silent: true });
+    throw new CliExitError('Schema error', { silent: true });
   }
+
+  console.error(`🚨 ${emptyGraphError.message}\n`);
+  if (emptyGraphError.tip) console.error(emptyGraphError.tip);
+  if (opts?.noThrow) return;
+  throw new CliExitError('No env files', { silent: true });
 }
 
 export function checkForSchemaErrors(envGraph: EnvGraph, opts?: { noThrow?: boolean }) {

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -12,7 +12,10 @@ import { computeFilteredKeys, type ParsedItemFilter } from './item-filter';
 import { BaseResolvers, createResolver, type ResolverChildClass } from './resolver';
 import { BaseDataTypes, type EnvGraphDataTypeFactory } from './data-types';
 import { findGraphCycles, getTransitiveDeps, type GraphAdjacencyList } from './graph-utils';
-import { ResolutionError, SchemaError } from './errors';
+import {
+  NoConfigItemsError, NoEnvFilesError, ResolutionError, SchemaError,
+  type ErrorSeverity, type VarlockError,
+} from './errors';
 import {
   builtInCodeGenerators, collectTypeGenItems, resolveFieldTypes,
   type CodeGeneratorDef, type ResolvedFieldType,
@@ -42,12 +45,51 @@ import { parseDuration } from '../../lib/duration';
 const processExists = !!globalThis.process;
 const originalProcessEnv = { ...processExists && process.env };
 
-export type SerializedEnvGraphErrors = {
-  /** Per-item validation errors, keyed by config item key */
-  configItems?: Record<string, string>;
-  /** Root-level errors not tied to a specific config item (loading errors, schema errors, plugin errors, etc.) */
-  root?: Array<string>;
+/**
+ * A single error in serialized output. `code` is a stable machine-readable
+ * identifier (see the `VarlockError` subclasses) - branch on it rather than on
+ * `message`, which is prose and free to change.
+ */
+export type SerializedError = {
+  /** stable machine-readable identifier, e.g. `empty_required_value` */
+  code: string;
+  /** human-readable description - do not parse */
+  message: string;
+  severity: ErrorSeverity;
+  /** actionable next step, when the error carries one */
+  tip?: string;
+  /** source label the error came from, for root-level errors */
+  source?: string;
 };
+
+function serializeError(err: VarlockError, source?: string): SerializedError {
+  return {
+    code: err.code,
+    message: err.message,
+    severity: err.severity,
+    ...err.tip && { tip: err.tip },
+    ...source && { source },
+  };
+}
+
+/**
+ * Diagnostics bucket, used for both `errors` and `warnings` in serialized
+ * output. The two are separate top-level keys rather than one list split by
+ * `severity`, so the presence of `errors` keeps meaning "this load failed".
+ */
+export type SerializedEnvGraphDiagnostics = {
+  /**
+   * Per-item entries keyed by config item key. An item can hit more than one
+   * problem at once (a schema error and a validation error, say), so each key
+   * maps to an array rather than a single entry.
+   */
+  configItems?: Record<string, Array<SerializedError>>;
+  /** Entries not tied to a specific config item (loading, parse, no env files found, etc.) */
+  root?: Array<SerializedError>;
+};
+
+/** @deprecated renamed to {@link SerializedEnvGraphDiagnostics}, which is also used for warnings */
+export type SerializedEnvGraphErrors = SerializedEnvGraphDiagnostics;
 
 /** Entry in the sorted definition sources list — pairs a data source with the node whose
  * import chain filters which keys are visible at that specific position in the precedence chain */
@@ -92,8 +134,14 @@ export type SerializedEnvGraph = {
   }>;
   /** Keys that were genuine process.env overrides at this invocation, so nested varlock invocations re-apply exactly those (and nothing else) as overrides. */
   overrideKeys?: Array<string>;
-  /** Present only when config has errors — consumers can check `if (data.errors)` */
-  errors?: SerializedEnvGraphErrors;
+  /** Present only when config has errors — consumers can check `if (data.errors)` to mean "the load failed" */
+  errors?: SerializedEnvGraphDiagnostics;
+  /**
+   * Present only when there are warnings. Kept separate from `errors` so a
+   * warning never makes a load look failed. Warnings never block a load, so
+   * this is purely informational.
+   */
+  warnings?: SerializedEnvGraphDiagnostics;
 };
 
 /**
@@ -895,6 +943,37 @@ export class EnvGraph {
     return envObject;
   }
 
+  /**
+   * A graph with no config items can't be used, and there are two reasons why:
+   * no env files were found at all, or files loaded but define nothing. Note a
+   * `.env.schema` is NOT required - plain `.env` files are a valid project.
+   *
+   * Returns undefined when the graph has items, or when some other root error
+   * already explains the emptiness (a file that failed to parse defines no
+   * items either, and "no items defined" would be misleading noise on top of
+   * the parse error that actually caused it).
+   *
+   * Shared by `getSerializedGraph` and the CLI's `checkForNoEnvFiles` so the
+   * two can't drift on what counts as an unusable graph.
+   */
+  getEmptyGraphError(opts?: { hasOtherRootErrors?: boolean }): VarlockError | undefined {
+    if (Object.keys(this.configSchema).length > 0) return undefined;
+    const hasOtherRootErrors = opts?.hasOtherRootErrors
+      ?? this.sortedDataSources.some((s) => s.errors.some((e) => !e.isWarning));
+    if (hasOtherRootErrors) return undefined;
+
+    const displayPath = this.basePath ?? process.cwd();
+    const hasLoadedFiles = this.sortedDataSources.some((s) => s instanceof FileBasedDataSource);
+    if (!hasLoadedFiles) {
+      return new NoEnvFilesError(`No .env files found in ${displayPath}`, {
+        tip: 'Run `varlock init` to create a .env.schema file, or use `--path` to specify a file or directory.',
+      });
+    }
+    return new NoConfigItemsError(`No config items defined in ${displayPath}`, {
+      tip: 'Add items to your .env.schema or .env file to get started.',
+    });
+  }
+
   getSerializedGraph(opts?: { includeInternal?: boolean, filterKeys?: Set<string> }): SerializedEnvGraph {
     const serializedGraph: SerializedEnvGraph = {
       basePath: this.basePath,
@@ -963,32 +1042,50 @@ export class EnvGraph {
     // at launch from context. Absent = undefined, and the command defaults it to `auto`.
     if (proxyConfig?.reload) serializedGraph.settings.proxyReload = proxyConfig.reload;
 
-    // collect all errors into a single nested object
-    const errors: SerializedEnvGraphErrors = {};
+    // Errors and warnings are partitioned into two top-level keys rather than
+    // sharing one list distinguished by `severity`. `errors` being present has
+    // to keep meaning "this load failed" — consumers (including our own runtime
+    // and the cloudflare integration) test it for truthiness, and folding
+    // warnings in would silently turn a warning-only load into a failure.
+    const errors: SerializedEnvGraphDiagnostics = {};
+    const warnings: SerializedEnvGraphDiagnostics = {};
 
-    // root-level errors (loading, schema, resolution errors from data sources)
-    const rootErrors: Array<string> = [];
+    // root-level diagnostics (loading, schema, resolution problems from data sources)
+    const rootErrors: Array<SerializedError> = [];
+    const rootWarnings: Array<SerializedError> = [];
     for (const source of this.sortedDataSources) {
-      for (const err of source.errors.filter((e) => !e.isWarning)) {
-        rootErrors.push(`${source.label}: ${err.message}`);
+      for (const err of source.errors) {
+        (err.isWarning ? rootWarnings : rootErrors).push(serializeError(err, source.label));
       }
     }
-    if (rootErrors.length > 0) {
-      errors.root = rootErrors;
-    }
+    // Surfaced as a root error so every consumer of the serialized graph sees it,
+    // not only the CLI paths that happen to call checkForNoEnvFiles.
+    const emptyGraphError = this.getEmptyGraphError({ hasOtherRootErrors: rootErrors.length > 0 });
+    if (emptyGraphError) rootErrors.push(serializeError(emptyGraphError));
 
-    // per-item validation errors keyed by item key
-    const configItemErrors: Record<string, string> = {};
+    if (rootErrors.length > 0) errors.root = rootErrors;
+    if (rootWarnings.length > 0) warnings.root = rootWarnings;
+
+    // per-item diagnostics keyed by item key. An item can land in both buckets:
+    // a stray-text warning alongside a required-value error, say. Warn-state
+    // items (warnings but no real error) appear only under `warnings`, which is
+    // the only way they're visible to a programmatic consumer at all.
+    const configItemErrors: Record<string, Array<SerializedError>> = {};
+    const configItemWarnings: Record<string, Array<SerializedError>> = {};
     for (const itemKey of this.sortedConfigKeys) {
       const item = this.configSchema[itemKey];
-      if (item.validationState === 'error') {
-        configItemErrors[itemKey] = item.errors.map((e) => e.message).join('; ');
-      }
+      if (item.validationState === 'valid') continue;
+      const itemErrors = item.errors.filter((e) => !e.isWarning).map((e) => serializeError(e));
+      const itemWarnings = item.errors.filter((e) => e.isWarning).map((e) => serializeError(e));
+      if (itemErrors.length > 0) configItemErrors[itemKey] = itemErrors;
+      if (itemWarnings.length > 0) configItemWarnings[itemKey] = itemWarnings;
     }
-    if (Object.keys(configItemErrors).length > 0) {
-      errors.configItems = configItemErrors;
-    }
+    if (Object.keys(configItemErrors).length > 0) errors.configItems = configItemErrors;
+    if (Object.keys(configItemWarnings).length > 0) warnings.configItems = configItemWarnings;
 
+    if (warnings.root || warnings.configItems) {
+      serializedGraph.warnings = warnings;
+    }
     // only include errors key if there are any
     if (errors.root || errors.configItems) {
       serializedGraph.errors = errors;

--- a/packages/varlock/src/env-graph/lib/errors.ts
+++ b/packages/varlock/src/env-graph/lib/errors.ts
@@ -54,6 +54,14 @@ export class VarlockError extends Error {
   static defaultIcon = '❌';
   icon: string;
 
+  /**
+   * Stable machine-readable code for this error class, emitted as `code` in
+   * serialized output so tools can branch on it instead of matching message
+   * text. Set explicitly per subclass rather than derived from the class name,
+   * so renaming a class can't silently change a published contract.
+   */
+  static defaultCode = 'unknown_error';
+
   private _severity: ErrorSeverity = 'error';
 
   constructor(errOrMessage: string | Error, readonly more?: {
@@ -97,8 +105,8 @@ export class VarlockError extends Error {
     return this.more?.location;
   }
 
-  get code() {
-    return this.more?.code;
+  get code(): string {
+    return this.more?.code ?? (this.constructor as typeof VarlockError).defaultCode;
   }
   get extraMetadata() {
     return this.more?.extraMetadata;
@@ -120,6 +128,7 @@ export class VarlockError extends Error {
       icon: this.icon,
       type: this.type,
       name: this.name,
+      code: this.code,
       message: this.message,
       severity: this.severity,
       isUnexpected: this.isUnexpected,
@@ -130,6 +139,7 @@ export class VarlockError extends Error {
 }
 
 export class ConfigLoadError extends VarlockError {
+  static defaultCode = 'config_load_failed';
   readonly cleanedStack: Array<string>;
   constructor(err: Error) {
     super(err);
@@ -162,21 +172,27 @@ export class ConfigLoadError extends VarlockError {
 
 export class LoadingError extends VarlockError {
   static defaultIcon = '📂';
+  static defaultCode = 'loading_failed';
 }
 export class ParseError extends VarlockError {
   static defaultIcon = '😵‍💫';
+  static defaultCode = 'parse_error';
 }
 export class SchemaError extends VarlockError {
   static defaultIcon = '🧰';
+  static defaultCode = 'schema_error';
 }
 export class ValidationError extends VarlockError {
   static defaultIcon = '❌';
+  static defaultCode = 'validation_failed';
 }
 export class CoercionError extends VarlockError {
   static defaultIcon = '🛑';
+  static defaultCode = 'coercion_failed';
 }
 export class ResolutionError extends VarlockError {
   static defaultIcon = '⛔';
+  static defaultCode = 'resolution_failed';
   protected _retryable?: boolean = false;
   set retryable(val: boolean) { this._retryable = val; }
   get retryable() {
@@ -188,7 +204,26 @@ export class ResolutionError extends VarlockError {
 
 export class EmptyRequiredValueError extends ValidationError {
   icon = '❓';
+  static defaultCode = 'empty_required_value';
   constructor(_val: undefined | null | '') {
     super('Value is required but is currently empty');
   }
+}
+
+/**
+ * No `.env*` files were found at all. A project does not need a `.env.schema`
+ * (plain `.env` files are enough), but it does need at least one file to load.
+ */
+export class NoEnvFilesError extends VarlockError {
+  static defaultIcon = '🚨';
+  static defaultCode = 'no_env_files';
+}
+
+/**
+ * Env files loaded, but they define no config items. Distinct from
+ * `no_env_files` because the fix is different: add items, not create a file.
+ */
+export class NoConfigItemsError extends VarlockError {
+  static defaultIcon = '🚨';
+  static defaultCode = 'no_config_items';
 }

--- a/packages/varlock/src/env-graph/test/serialized-graph-errors.test.ts
+++ b/packages/varlock/src/env-graph/test/serialized-graph-errors.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import outdent from 'outdent';
+import { EnvGraph } from '../index';
+import { DotEnvFileDataSource } from '../lib/data-source';
+
+async function loadSchema(contents: string, overrideValues?: Record<string, string>) {
+  const g = new EnvGraph();
+  await g.setRootDataSource(new DotEnvFileDataSource('.env.schema', { overrideContents: contents }));
+  await g.finishLoad();
+  if (overrideValues) g.overrideValues = overrideValues;
+  await g.resolveEnvValues();
+  return g;
+}
+
+describe('getSerializedGraph errors', () => {
+  it('omits the errors key entirely when everything resolves', async () => {
+    const g = await loadSchema('FOO=bar # @public');
+    expect(g.getSerializedGraph().errors).toBeUndefined();
+  });
+
+  it('gives each item error a stable code, not just a message', async () => {
+    const g = await loadSchema(outdent`
+      # @required @public
+      NEEDS_VALUE=
+    `);
+    const errors = g.getSerializedGraph().errors;
+    expect(errors?.configItems?.NEEDS_VALUE).toEqual([expect.objectContaining({ code: 'empty_required_value', severity: 'error' })]);
+  });
+
+  it('codes distinguish failure kinds that share a validation state', async () => {
+    const coercion = await loadSchema(outdent`
+      # @required @type=number @public
+      PORT=
+    `, { PORT: 'not-a-number' });
+    const schema = await loadSchema(outdent`
+      # @totallyUnknownDecorator=1 @public
+      FOO=bar
+    `);
+    expect(coercion.getSerializedGraph().errors?.configItems?.PORT?.[0].code).toBe('coercion_failed');
+    expect(schema.getSerializedGraph().errors?.configItems?.FOO?.[0].code).toBe('schema_error');
+  });
+
+  it('keys to an array so an item failing several ways keeps every error', async () => {
+    // stray text after a decorator is a warning; the empty @required is a real
+    // error. They split across the two buckets, and the item appears in both.
+    const g = await loadSchema(outdent`
+      # @required stray words here
+      # @public
+      NEEDS_VALUE=
+    `);
+    const serialized = g.getSerializedGraph();
+    expect(serialized.errors?.configItems?.NEEDS_VALUE).toEqual([expect.objectContaining({ code: 'empty_required_value', severity: 'error' })]);
+    expect(serialized.warnings?.configItems?.NEEDS_VALUE).toEqual([expect.objectContaining({ code: 'schema_error', severity: 'warning' })]);
+  });
+
+  // `errors` being present has to keep meaning "the load failed" - our own
+  // runtime and the cloudflare integration both test it for truthiness, so a
+  // warning must never land in it.
+  it('keeps warning-only items out of errors entirely', async () => {
+    const g = await loadSchema(outdent`
+      # @public stray words here
+      FINE=bar
+    `);
+    const serialized = g.getSerializedGraph();
+    expect(serialized.errors).toBeUndefined();
+    expect(serialized.warnings?.configItems?.FINE).toEqual([expect.objectContaining({ code: 'schema_error', severity: 'warning' })]);
+  });
+
+  it('omits the warnings key when there are none', async () => {
+    const g = await loadSchema('FOO=bar # @public');
+    expect(g.getSerializedGraph().warnings).toBeUndefined();
+  });
+
+  // A project does not need a .env.schema - plain .env files are enough. What it
+  // does need is at least one file, and at least one item defined in it. Both of
+  // those failures used to be invisible in the serialized graph, so a consumer
+  // reading `errors` saw a clean load with an empty config.
+  it('reports no_config_items when files load but define nothing', async () => {
+    const g = await loadSchema('# just a comment, no items\n');
+    const errors = g.getSerializedGraph().errors;
+    expect(errors?.root).toEqual([expect.objectContaining({ code: 'no_config_items', severity: 'error' })]);
+  });
+
+  it('does not report no_config_items when a schema-less file defines items', async () => {
+    const g = await loadSchema('FOO=bar # @public');
+    expect(g.getSerializedGraph().errors).toBeUndefined();
+  });
+
+  it('does not mask a parse error with an empty-config error', async () => {
+    // a file that fails to parse defines no items either, but "no items" would
+    // be a misleading thing to report - the parse error is the real problem
+    const g = await loadSchema('@bogus(((\nBROKEN=\n');
+    const rootCodes = g.getSerializedGraph().errors?.root?.map((e) => e.code);
+    expect(rootCodes).toContain('parse_error');
+    expect(rootCodes).not.toContain('no_config_items');
+  });
+});

--- a/packages/varlock/src/lib/local-encrypt/builtin-resolver.test.ts
+++ b/packages/varlock/src/lib/local-encrypt/builtin-resolver.test.ts
@@ -85,6 +85,19 @@ describe('VarlockResolver with file fallback', () => {
     await expect(resolver.resolve()).rejects.toThrow(/Decryption failed/);
   });
 
+  // Serialized output branches on `code`, so a decrypt failure has to be
+  // distinguishable from any other resolver blowing up (both would otherwise
+  // surface as the generic `resolution_failed`).
+  it('tags decrypt failures with a specific error code', async () => {
+    await localEncrypt.ensureKey();
+
+    const payloadResolver = new StaticValueResolver('local:garbage-data');
+    const resolver = new VarlockResolver([payloadResolver]);
+    resolver.process();
+
+    await expect(resolver.resolve()).rejects.toMatchObject({ code: 'decrypt_failed' });
+  });
+
   it('throws a SchemaError when no arguments are provided', () => {
     const resolver = new VarlockResolver([]);
     resolver.process();

--- a/packages/varlock/src/lib/local-encrypt/builtin-resolver.ts
+++ b/packages/varlock/src/lib/local-encrypt/builtin-resolver.ts
@@ -9,6 +9,7 @@ import { createResolver, Resolver } from '../../env-graph/lib/resolver';
 import { ResolutionError, SchemaError } from '../../env-graph/lib/errors';
 import prompts from '../../cli/helpers/prompts';
 import * as localEncrypt from './index';
+import { DaemonError } from './daemon-client';
 import { writeBackValue } from './write-back';
 
 const LOCAL_PREFIX = 'local:';
@@ -177,9 +178,19 @@ export const VarlockResolver: typeof Resolver = createResolver<VarlockResolverSt
         if (err instanceof ResolutionError) throw err;
 
         const backend = localEncrypt.getBackendInfo();
+        // Carry the native helper's own error code through when it sent one, so
+        // callers can tell *why* a decrypt failed (wrong key vs. no way to
+        // authenticate vs. something else) instead of seeing every failure as a
+        // generic `resolution_failed`. Falls back to `decrypt_failed`, which is
+        // still more specific than the ResolutionError default.
+        const nativeCode = err instanceof DaemonError ? err.code : undefined;
         throw new ResolutionError(
           `Decryption failed: ${err instanceof Error ? err.message : err}`,
           {
+            // native codes are camelCase; serialized varlock codes are snake_case
+            code: nativeCode
+              ? nativeCode.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()
+              : 'decrypt_failed',
             tip: [
               `Backend: ${backend.type} (${backend.hardwareBacked ? 'hardware-backed' : 'file-based'})`,
               'This usually means the value was encrypted with a different key or backend.',


### PR DESCRIPTION
`--format json-full` reported errors as free-text strings, so anything consuming them programmatically had to regex English prose to work out what went wrong. They are now objects with a stable `code`:

```jsonc
"errors": {
  "root": [
    { "code": "no_env_files", "message": "No .env files found in /app", "severity": "error", "tip": "Run `varlock init` ..." }
  ],
  "configItems": {
    "API_KEY": [
      { "code": "empty_required_value", "message": "Value is required but is currently empty", "severity": "error" }
    ]
  }
},
"warnings": { /* same structure */ }
```

Codes are set explicitly per `VarlockError` subclass rather than derived from the class name, so renaming a class can't silently change a published contract. Each key maps to an **array**, since an item can hit several problems at once (`config-item.ts` composes schema, resolver, decorator, resolution, coercion and validation errors) and the old code joined them with `'; '`.

### Warnings

Reported for the first time, under a separate `warnings` key. A warning-only item was previously invisible to any programmatic consumer even though `pretty` printed it.

They are deliberately **not** folded into `errors` with `severity` doing the work. The presence of `errors` has to keep meaning "the load failed" - [runtime/env.ts:390](../blob/main/packages/varlock/src/runtime/env.ts#L390) and [cloudflare/src/index.ts:202](../blob/main/packages/integrations/cloudflare/src/index.ts#L202) both test it for truthiness, and unifying would silently turn a warning-only load into a failure. There's a test pinning that.

### Empty graph is now an error

A `.env.schema` is still optional; a project of plain `.env` files loads fine. What fails is finding no env files at all (`no_env_files`) or files that define no items (`no_config_items`).

`json-full` previously exited **0** for both, emitting `config: {}` and `errors: null`, so a tool pointed at a directory with no varlock project read it as success and silently contributed nothing. Plain `--format json` exited 1 for the same case, so the two formats disagreed. The predicate now lives on the graph (`getEmptyGraphError`) and is shared with the CLI's `checkForNoEnvFiles`, which had been about to drift: the CLI suppressed the "no items" message only for `ParseError`, while any root error should suppress it.

### Decrypt failures

`builtin-resolver.ts` flattened every decrypt failure into a generic `resolution_failed`. It now passes the native encryption helper's own error code through, falling back to `decrypt_failed`. That also means future helper-side codes surface end to end without further plumbing.

### Breaking

The `errors` shape changes from strings to objects. Marked `minor`: no in-repo consumer reads past truthiness and the shape was undocumented until this PR. Bump to major instead if published JSON output should be treated as a stability boundary. `SerializedEnvGraphErrors` is renamed to `SerializedEnvGraphDiagnostics` with the old name kept as a deprecated alias.

Anything that iterates the serialized graph looking for problems will now also see warnings it didn't before. Anything checking `errors` alone is unaffected.

### Testing

11 new tests. Verified end to end against the built CLI:

| Case | `json` | `json-full` | code |
|---|---|---|---|
| valid | 0 | 0 | none |
| no env files | 1 | **1** (was 0) | `no_env_files` |
| files, no vars | 1 | 1 | `no_config_items` |
| `.env` only, has vars | 0 | 0 | none |
| parse error | 1 | 1 | `parse_error` |
| required empty | 1 | 1 | `empty_required_value` |
| bad type | 1 | 1 | `coercion_failed` |
| decrypt failed | 1 | 1 | `decrypt_failed` |
| unknown resolver / decorator | 1 | 1 | `schema_error` |

Exit codes now agree between the two formats, and `pretty` output is unchanged.