### PR TITLE
fix(dashlane-plugin): don't hang forever on a locked vault (bound dcli calls, add onLocked option)

### DIFF
--- a/.bumpy/dashlane-locked-vault.md
+++ b/.bumpy/dashlane-locked-vault.md
@@ -1,0 +1,5 @@
+---
+"@varlock/dashlane-plugin": minor
+---
+
+dashlane() no longer hangs forever on a locked vault: dcli calls run with stdin closed and a timeout (default 30s). New @initDashlane options: onLocked=error|warn and timeoutMs

--- a/.bumpy/warning-resolution-errors.md
+++ b/.bumpy/warning-resolution-errors.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+warning-severity resolution errors no longer skip required/optional handling: the item resolves empty with the warning surfaced, and required items fail as empty

--- a/packages/plugins/dashlane/README.md
+++ b/packages/plugins/dashlane/README.md
@@ -178,6 +178,8 @@ Initialize a Dashlane plugin instance.
 - `id?: string` - Instance identifier for multiple instances (defaults to `_default`)
 - `autoSync?: boolean` - If `true`, runs `dcli sync` once before the first read (default `false`)
 - `lockOnExit?: boolean` - Lock the vault on process exit. Defaults to `true` in headless mode, `false` in interactive mode.
+- `onLocked?: 'error' | 'warn'` - Behavior when the vault appears locked or a `dcli` call times out. `error` (default) fails the item. With `warn`, the item resolves empty with a warning instead, so optional items do not block the load. Required items still fail as empty.
+- `timeoutMs?: number` - Maximum time in milliseconds to wait for each `dcli` call (default `30000`)
 
 ### Resolver functions
 
@@ -244,6 +246,9 @@ Install the Dashlane CLI following the [installation docs](https://cli.dashlane.
 
 - Run `dcli sync` to sync and unlock your vault
 - If the vault is locked, you may need to enter your master password
+- Set `onLocked=warn` in `@initDashlane` if a locked vault should not block loading optional items
+
+The plugin never waits on a locked vault: `dcli` calls run with stdin closed (so interactive prompts fail immediately) and are killed after `timeoutMs` (default 30 seconds) as a backstop.
 
 ### Stale secrets
 

--- a/packages/plugins/dashlane/src/dashlane-instance.ts
+++ b/packages/plugins/dashlane/src/dashlane-instance.ts
@@ -1,13 +1,22 @@
-import { spawnSync } from 'node:child_process';
-import { spawnAsync, ExecError } from '@env-spec/utils/exec-helpers';
+import { spawn, spawnSync } from 'node:child_process';
+import { ExecError } from '@env-spec/utils/exec-helpers';
 
-type ErrorCtor = new (msg: string, opts?: { tip?: string }) => Error;
+type ErrorCtor = new (msg: string, opts?: { tip?: string; isWarning?: boolean }) => Error;
 
 const FIX_INSTALL_TIP = [
   'The `dcli` command was not found on your system.',
   'Install it following the instructions at:',
   '  https://cli.dashlane.com/installation',
 ].join('\n');
+
+export const DEFAULT_DCLI_TIMEOUT_MS = 30_000;
+
+/** Thrown when a dcli call is killed by our spawn timeout (or an external signal) */
+class DcliTimeoutError extends Error {
+  constructor(readonly signal: NodeJS.Signals) {
+    super(`dcli was killed by ${signal} before completing`);
+  }
+}
 
 export class DashlanePluginInstance {
   private serviceDeviceKeys?: string;
@@ -18,16 +27,25 @@ export class DashlanePluginInstance {
   private syncPromise?: Promise<void>;
   private synced = false;
   private lockAfter = false;
+  private onLocked: 'error' | 'warn' = 'error';
+  private timeoutMs = DEFAULT_DCLI_TIMEOUT_MS;
 
   constructor(
     readonly id: string,
     private ResolutionError: ErrorCtor,
   ) {}
 
-  configure(serviceDeviceKeys?: string, opts?: { autoSync?: boolean; lockOnExit?: boolean }) {
+  configure(serviceDeviceKeys?: string, opts?: {
+    autoSync?: boolean;
+    lockOnExit?: boolean;
+    onLocked?: 'error' | 'warn';
+    timeoutMs?: number;
+  }) {
     this.serviceDeviceKeys = serviceDeviceKeys;
     if (opts?.autoSync !== undefined) this.autoSync = opts.autoSync;
     this.lockAfter = opts?.lockOnExit ?? !!serviceDeviceKeys;
+    if (opts?.onLocked !== undefined) this.onLocked = opts.onLocked;
+    if (opts?.timeoutMs !== undefined) this.timeoutMs = opts.timeoutMs;
   }
 
   /** @internal telemetry: whether this instance auto-syncs the vault before reads */
@@ -44,9 +62,40 @@ export class DashlanePluginInstance {
     };
   }
 
-  private get spawnOpts(): { env: Record<string, string> } | undefined {
-    const env = this.spawnEnv;
-    return env ? { env } : undefined;
+  /**
+   * Run a dcli subcommand with stdin closed and a hard timeout.
+   *
+   * On a locked vault, dcli prompts for the master password and waits on stdin.
+   * With piped stdio and no timeout that call never returns, hanging the whole
+   * load. Ignoring stdin makes the prompt hit EOF and fail immediately; the
+   * timeout is a backstop for any other way dcli can stall.
+   */
+  private execDcli(args: Array<string>): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const child = spawn('dcli', args, {
+        ...this.spawnEnv && { env: this.spawnEnv },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: this.timeoutMs,
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout!.on('data', (data) => {
+        stdout += data.toString();
+      });
+      child.stderr!.on('data', (data) => {
+        stderr += data.toString();
+      });
+      child.on('error', reject);
+      child.on('exit', (exitCode, signal) => {
+        if (exitCode === 0) {
+          resolve(stdout);
+        } else if (signal) {
+          reject(new DcliTimeoutError(signal));
+        } else {
+          reject(new ExecError(exitCode ?? 1, signal, stderr));
+        }
+      });
+    });
   }
 
   async ensureDcliInstalled(): Promise<void> {
@@ -57,7 +106,7 @@ export class DashlanePluginInstance {
 
   private async doDcliCheck(): Promise<void> {
     try {
-      await spawnAsync('dcli', ['--version'], this.spawnOpts);
+      await this.execDcli(['--version']);
       this.dcliChecked = true;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
@@ -81,7 +130,7 @@ export class DashlanePluginInstance {
   private async doSync(): Promise<void> {
     await this.ensureDcliInstalled();
     try {
-      await spawnAsync('dcli', ['sync'], this.spawnOpts);
+      await this.execDcli(['sync']);
     } catch {
       // Sync failure should not block reads - vault may still have recent data
     }
@@ -125,7 +174,7 @@ export class DashlanePluginInstance {
     }
 
     try {
-      const result = await spawnAsync('dcli', ['read', dlUri], this.spawnOpts);
+      const result = await this.execDcli(['read', dlUri]);
       const value = result.replace(/\n$/, '');
       this.cache.set(dlUri, value);
       return value;
@@ -134,7 +183,30 @@ export class DashlanePluginInstance {
     }
   }
 
+  /**
+   * Locked/unsynced vault error. With onLocked=warn this is thrown as a
+   * warning, so the item resolves empty and the load can still pass
+   * (unless the item is required).
+   */
+  private throwLockedVaultError(details?: string): never {
+    throw new this.ResolutionError(
+      `Dashlane vault appears locked or not synced${details ? ` (${details})` : ''}`,
+      {
+        tip: [
+          'Run `dcli sync` to sync and unlock your vault.',
+          'Or set autoSync=true in @initDashlane to sync automatically.',
+          'Set onLocked=warn in @initDashlane to downgrade this to a warning.',
+        ].join('\n'),
+        ...this.onLocked === 'warn' && { isWarning: true },
+      },
+    );
+  }
+
   private handleDcliError(err: unknown, context: string): never {
+    if (err instanceof DcliTimeoutError) {
+      this.throwLockedVaultError(`dcli did not respond within ${this.timeoutMs}ms`);
+    }
+
     if (err instanceof ExecError) {
       const msg = err.data || err.message;
 
@@ -147,21 +219,16 @@ export class DashlanePluginInstance {
         });
       }
 
+      if (msg.match(/locked/i) || msg.match(/sync/i) || msg.match(/master password/i)) {
+        this.throwLockedVaultError();
+      }
+
       if (msg.match(/auth/i) || msg.match(/credential/i) || msg.match(/login/i)) {
         throw new this.ResolutionError('Dashlane authentication failed', {
           tip: [
             'Ensure you are logged in to Dashlane CLI:',
             '  dcli sync',
             'Or provide service device keys for headless auth.',
-          ].join('\n'),
-        });
-      }
-
-      if (msg.match(/locked/i) || msg.match(/sync/i)) {
-        throw new this.ResolutionError('Dashlane vault appears locked or not synced', {
-          tip: [
-            'Run `dcli sync` to sync your vault.',
-            'Or set autoSync=true in @initDashlane to sync automatically.',
           ].join('\n'),
         });
       }

--- a/packages/plugins/dashlane/src/dashlane-manager.ts
+++ b/packages/plugins/dashlane/src/dashlane-manager.ts
@@ -3,7 +3,7 @@ import { DashlanePluginInstance } from './dashlane-instance';
 /** Shared error class stubs -- replaced with plugin.ERRORS at runtime */
 export interface PluginErrors {
   SchemaError: new (msg: string, opts?: { tip?: string }) => Error;
-  ResolutionError: new (msg: string, opts?: { tip?: string }) => Error;
+  ResolutionError: new (msg: string, opts?: { tip?: string; isWarning?: boolean }) => Error;
 }
 
 /** Simulates the shape of a varlock decorator arg value */
@@ -48,12 +48,37 @@ export class DashlaneManager {
       ? (objArgs.lockOnExit.staticValue === true || objArgs.lockOnExit.staticValue === 'true')
       : undefined;
 
+    if (objArgs?.onLocked && !objArgs.onLocked.isStatic) {
+      throw new SchemaError('Expected onLocked to be static');
+    }
+    let onLocked: 'error' | 'warn' | undefined;
+    if (objArgs?.onLocked) {
+      const onLockedVal = objArgs.onLocked.staticValue;
+      if (onLockedVal !== 'error' && onLockedVal !== 'warn') {
+        throw new SchemaError('Expected onLocked to be either "error" or "warn"');
+      }
+      onLocked = onLockedVal;
+    }
+
+    if (objArgs?.timeoutMs && !objArgs.timeoutMs.isStatic) {
+      throw new SchemaError('Expected timeoutMs to be static');
+    }
+    let timeoutMs: number | undefined;
+    if (objArgs?.timeoutMs) {
+      timeoutMs = Number(objArgs.timeoutMs.staticValue);
+      if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+        throw new SchemaError('Expected timeoutMs to be a positive integer (milliseconds)');
+      }
+    }
+
     this.instances[id] = new DashlanePluginInstance(id, this.errors.ResolutionError);
 
     return {
       id,
       autoSync,
       lockOnExit,
+      onLocked,
+      timeoutMs,
       serviceDeviceKeysResolver: objArgs?.serviceDeviceKeys,
     };
   }
@@ -63,11 +88,13 @@ export class DashlaneManager {
    * Called at resolution time.
    */
   async executeInit({
-    id, autoSync, lockOnExit, serviceDeviceKeysResolver,
+    id, autoSync, lockOnExit, onLocked, timeoutMs, serviceDeviceKeysResolver,
   }: {
     id: string;
     autoSync?: boolean;
     lockOnExit?: boolean;
+    onLocked?: 'error' | 'warn';
+    timeoutMs?: number;
     serviceDeviceKeysResolver?: ArgValue;
   }) {
     const serviceDeviceKeys = serviceDeviceKeysResolver
@@ -78,7 +105,9 @@ export class DashlaneManager {
       serviceDeviceKeys && typeof serviceDeviceKeys === 'string'
         ? serviceDeviceKeys
         : undefined,
-      { autoSync, lockOnExit },
+      {
+        autoSync, lockOnExit, onLocked, timeoutMs,
+      },
     );
   }
 

--- a/packages/plugins/dashlane/test/dashlane.test.ts
+++ b/packages/plugins/dashlane/test/dashlane.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import {
-  describe, test, beforeAll, afterAll,
+  describe, test, expect, beforeAll, afterAll,
 } from 'vitest';
 import outdent from 'outdent';
 import { pluginTest } from 'varlock/test-helpers';
@@ -35,6 +35,8 @@ afterAll(() => {
 type DlTestOpts = {
   /** Map of dl:// references to their resolved values */
   dcliResponses?: Record<string, string>;
+  /** Misbehavior mode for the fake dcli `read` subcommand (see fake-dcli.sh) */
+  readBehavior?: 'hang' | 'prompt-stdin' | 'locked';
   /** Schema items section (after ---). Required unless fullSchema is provided. */
   schema?: string;
   /** Extra @initDashlane params (e.g., `autoSync=true`) */
@@ -52,6 +54,7 @@ type DlTestOpts = {
 function dlTest(opts: DlTestOpts) {
   const {
     dcliResponses = {},
+    readBehavior,
     schema,
     initParams = '',
     headless = false,
@@ -61,7 +64,7 @@ function dlTest(opts: DlTestOpts) {
 
   return async () => {
     // Write the dcli config for this test and point the fake script at it
-    fs.writeFileSync(DCLI_CONFIG_PATH, JSON.stringify({ responses: dcliResponses }));
+    fs.writeFileSync(DCLI_CONFIG_PATH, JSON.stringify({ responses: dcliResponses, readBehavior }));
 
     const origPath = process.env.PATH;
     process.env.PATH = `${FAKE_BIN_DIR}:${origPath}`;
@@ -83,7 +86,7 @@ function dlTest(opts: DlTestOpts) {
         ${schema}
       `;
 
-      await pluginTest({
+      return await pluginTest({
         ...rest,
         schema: fullSchema,
         ...(headless ? { injectValues: { DL_SERVICE_KEYS: 'dls_test_key_data_1234', ...rest.injectValues } } : {}),
@@ -238,6 +241,83 @@ describe('dashlane plugin', () => {
         # @initDashlane(id=prod)
         # ---
       `,
+      expectSchemaError: true,
+    }));
+  });
+
+  describe('locked vault handling', () => {
+    // On a locked vault, dcli prompts for the master password and blocks on
+    // stdin. These tests ensure every dcli call is bounded (stdin closed +
+    // timeout) and that onLocked=warn lets a load pass with optional
+    // dashlane items left empty.
+
+    test('master password prompt fails immediately instead of hanging (stdin closed)', dlTest({
+      readBehavior: 'prompt-stdin',
+      schema: 'SECRET=dashlane("dl://abc/password")',
+      expectValues: { SECRET: Error },
+    }), 5000);
+
+    test('hung dcli call fails within the configured timeout', dlTest({
+      readBehavior: 'hang',
+      initParams: 'timeoutMs=500',
+      schema: 'SECRET=dashlane("dl://abc/password")',
+      expectValues: { SECRET: Error },
+    }), 5000);
+
+    test('locked vault fails the item by default', async () => {
+      const g = await dlTest({
+        readBehavior: 'locked',
+        schema: outdent`
+          # @optional
+          SECRET=dashlane("dl://abc/password")
+        `,
+      })();
+      const item = g!.configSchema.SECRET;
+      expect(item.validationState).toBe('error');
+      expect(item.errors[0].message).toContain('locked');
+    });
+
+    test('onLocked=warn: optional item resolves empty with a warning, load stays valid', async () => {
+      const g = await dlTest({
+        readBehavior: 'locked',
+        initParams: 'onLocked=warn',
+        schema: outdent`
+          # @optional
+          SECRET=dashlane("dl://abc/password")
+          OTHER=hello
+        `,
+      })();
+      const secretItem = g!.configSchema.SECRET;
+      expect(secretItem.validationState).toBe('warn');
+      expect(secretItem.resolvedValue).toBeUndefined();
+      // non-dashlane items are unaffected
+      expect(g!.configSchema.OTHER.resolvedValue).toBe('hello');
+      expect(g!.configSchema.OTHER.validationState).toBe('valid');
+    });
+
+    test('onLocked=warn: required item still fails', async () => {
+      const g = await dlTest({
+        readBehavior: 'locked',
+        initParams: 'onLocked=warn',
+        schema: outdent`
+          # @required
+          SECRET=dashlane("dl://abc/password")
+        `,
+      })();
+      const item = g!.configSchema.SECRET;
+      expect(item.validationState).toBe('error');
+      expect(item.errors.some((e) => e.name === 'EmptyRequiredValueError')).toBe(true);
+    });
+
+    test('invalid onLocked value is a schema error', dlTest({
+      initParams: 'onLocked=bogus',
+      schema: 'SECRET=dashlane("dl://abc/password")',
+      expectSchemaError: true,
+    }));
+
+    test('invalid timeoutMs value is a schema error', dlTest({
+      initParams: 'timeoutMs=soon',
+      schema: 'SECRET=dashlane("dl://abc/password")',
       expectSchemaError: true,
     }));
   });

--- a/packages/plugins/dashlane/test/fake-dcli.sh
+++ b/packages/plugins/dashlane/test/fake-dcli.sh
@@ -25,6 +25,36 @@ case "$SUBCMD" in
     ;;
   read)
     REF="$1"
+
+    # Optional misbehavior modes (cfg.readBehavior) used by locked-vault tests
+    BEHAVIOR=$(node -e "
+      const cfg = JSON.parse(require('fs').readFileSync('$CONFIG_FILE', 'utf-8'));
+      process.stdout.write(cfg.readBehavior || 'normal');
+    ")
+    case "$BEHAVIOR" in
+      hang)
+        # simulate dcli stalling forever (must be killed by the plugin's timeout)
+        sleep 30
+        exit 1
+        ;;
+      prompt-stdin)
+        # simulate dcli prompting for the master password on a locked vault:
+        # blocks reading stdin, so it hangs forever unless stdin is closed
+        printf '? Please enter your master password\n' >&2
+        if read -r _MASTER_PW; then
+          echo "unlocked-with-$_MASTER_PW"
+          exit 0
+        else
+          printf 'Vault is locked\n' >&2
+          exit 1
+        fi
+        ;;
+      locked)
+        printf 'Vault is locked, please run dcli sync\n' >&2
+        exit 1
+        ;;
+    esac
+
     # Use node to look up the reference in the JSON config (portable JSON parsing)
     node -e "
       const cfg = JSON.parse(require('fs').readFileSync('$CONFIG_FILE', 'utf-8'));

--- a/packages/varlock-website/src/content/docs/plugins/dashlane.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/dashlane.mdx
@@ -132,6 +132,8 @@ Initialize a Dashlane plugin instance for `dashlane()` resolver.
 - `serviceDeviceKeys` (optional): service device keys for headless authentication
 - `autoSync` (optional): if `true`, runs `dcli sync` once before the first read
 - `lockOnExit` (optional): lock the vault on process exit. Defaults to `true` in headless mode, `false` in interactive mode.
+- `onLocked` (optional): behavior when the vault appears locked or a `dcli` call times out. `error` (default) fails the item. With `warn`, the item resolves empty with a warning instead, so optional items do not block the load. Required items still fail as empty.
+- `timeoutMs` (optional): maximum time in milliseconds to wait for each `dcli` call (default `30000`)
 
 ```env-spec "@initDashlane"
 # Interactive (local dev)
@@ -202,6 +204,7 @@ DB_PASSWORD=dashlane(prod, "dl://abc123/password")
 ### Vault locked or not synced
 - Run `dcli sync` to sync your vault
 - Set `autoSync=true` in `@initDashlane` to sync automatically before reads
+- Set `onLocked=warn` in `@initDashlane` if a locked vault should not block loading optional items
 
 ## Resources
 

--- a/packages/varlock/src/env-graph/lib/config-item.ts
+++ b/packages/varlock/src/env-graph/lib/config-item.ts
@@ -935,8 +935,10 @@ export class ConfigItem {
       this.resolutionError = new ResolutionError('Regex values are meant to be used within function args (e.g., remap()), not as a final resolved value');
     }
 
-    // bail if we have an resolution error
-    if (this.resolutionError) return;
+    // bail if we have a resolution error, unless it is only a warning -
+    // a warning-severity resolution error leaves the value empty and lets normal
+    // required/optional handling take over (required items still fail as empty)
+    if (this.resolutionError && !this.resolutionError.isWarning) return;
 
     this.isResolved = true;
 


### PR DESCRIPTION
## Problem

`dashlane("dl://...")` resolves by spawning `dcli read <uri>` with piped stdio and no timeout. On a locked Dashlane vault, `dcli` prompts for the master password on a pipe that never answers, so the child never exits and any `varlock load` / `varlock run` whose schema contains a `dashlane()` entry hangs forever. This includes `@optional` entries the current command doesn't even need.

Repro:

```
dcli lock
varlock load --skip-cache   # schema with any dashlane() item: hangs forever
```

## Changes

1. **stdin closed on every `dcli` spawn** (`--version`, `sync`, `read`): interactive prompts hit EOF and fail immediately instead of blocking.
2. **Spawn timeout on every `dcli` call** as a backstop: default 30s, configurable via `@initDashlane(timeoutMs=...)`. A timeout maps to the existing "Dashlane vault appears locked or not synced" `ResolutionError` with an actionable tip.
3. **New `@initDashlane(onLocked=error|warn)` option**, default `error` (current behavior). With `warn`, the locked-vault error is thrown with warning severity, so `@optional` `dashlane()` items resolve empty with a surfaced warning and the load still passes; `@required` items still hard fail via `EmptyRequiredValueError`.

Behavior on a locked vault with `onLocked=warn`:

| Item | Before | After |
|---|---|---|
| `@optional` + `dashlane()` | hangs | resolves empty with a warning |
| `@required` + `dashlane()` | hangs | fails fast with a clear error |
| non-dashlane items | hangs | resolve normally |

With the default `onLocked=error`, everything fails fast with the locked-vault error instead of hanging.

## Small core change

`VarlockError` already supports warning severity, but `ConfigItem.resolve()` bailed on any resolution error before the required/optional check, so a warning-severity resolution error would have let `@required` items pass with only a warning. The bail now applies only to error-severity resolution errors: a warning-severity error leaves the value empty and normal required/optional handling takes over. Nothing in core currently throws warning-severity resolution errors, so this only affects plugins that opt in.

## Tests

New `locked vault handling` tests drive the existing fake `dcli` shim with new misbehavior modes: a blocked master-password prompt fails immediately (stdin closed), a hung call fails within `timeoutMs`, the `onLocked=warn` matrix above, and schema validation of the new options. Full dashlane plugin suite and varlock core suite pass, typecheck clean on both packages.

Docs updated in the plugin README and the website plugins page.
