### PR TITLE
Add generateOtp() for TOTP 2FA codes

### DIFF
--- a/.bumpy/generate-otp.md
+++ b/.bumpy/generate-otp.md
@@ -2,4 +2,4 @@
 varlock: minor
 ---
 
-Add generateOtp() for generating TOTP 2FA codes, e.g. for npm publish
+Add generateOtp() for generating TOTP 2FA codes

--- a/.bumpy/generate-otp.md
+++ b/.bumpy/generate-otp.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+Add generateOtp() for generating TOTP 2FA codes, e.g. for npm publish

--- a/.bumpy/op-otp-references.md
+++ b/.bumpy/op-otp-references.md
@@ -1,0 +1,5 @@
+---
+"@varlock/1password-plugin": patch
+---
+
+Never cache one-time password codes, and give a clear error when Connect is asked for one

--- a/.bumpy/vscode-generate-otp.md
+++ b/.bumpy/vscode-generate-otp.md
@@ -1,0 +1,5 @@
+---
+env-spec-language: patch
+---
+
+Add generateOtp() to autocomplete

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -281,7 +281,7 @@ interface ConnectVault {
  * `op://vault/item/one-time password?attribute=otp`
  */
 function isOtpReference(ref: string) {
-  return /[?&]attribute=(otp|totp)(&|$)/i.test(ref);
+  return /[?&](?:attribute|attr)=(otp|totp)(&|$)/i.test(ref);
 }
 
 /** Parse an `op://vault/item/[section/]field` reference into its parts */

--- a/packages/plugins/1password/src/plugin.ts
+++ b/packages/plugins/1password/src/plugin.ts
@@ -276,6 +276,14 @@ interface ConnectVault {
   name?: string;
 }
 
+/**
+ * Detects references that generate a one-time password code, e.g.
+ * `op://vault/item/one-time password?attribute=otp`
+ */
+function isOtpReference(ref: string) {
+  return /[?&]attribute=(otp|totp)(&|$)/i.test(ref);
+}
+
 /** Parse an `op://vault/item/[section/]field` reference into its parts */
 function parseOpReference(ref: string): {
   vault: string; item: string; section?: string; field: string;
@@ -656,6 +664,14 @@ class OpPluginInstance {
   }
 
   private async readItemViaConnect(opReference: string): Promise<string> {
+    if (isOtpReference(opReference)) {
+      throw new ResolutionError('1Password Connect cannot generate one-time password codes', {
+        tip: [
+          '`?attribute=otp` is only supported by the `op` CLI and the 1Password SDKs.',
+          'Instead, store the TOTP seed in a normal field and generate the code with `generateOtp()`.',
+        ].join('\n'),
+      });
+    }
     const parsed = parseOpReference(opReference);
     const vaultId = await this.connectResolveVaultId(parsed.vault);
     const itemId = await this.connectResolveItemId(vaultId, parsed.item);
@@ -989,7 +1005,8 @@ plugin.registerResolverFunction({
     const shouldAllowMissing = allowMissing ?? selectedInstance.allowMissing;
 
     // check cache if cacheTtl is configured and cache is available
-    if (selectedInstance.cacheTtl !== undefined && pluginCache) {
+    // (one-time password codes are skipped - a cached code is expired by definition)
+    if (selectedInstance.cacheTtl !== undefined && pluginCache && !isOtpReference(opReference)) {
       const cacheKey = `op:${instanceId}:${selectedInstance.cacheKeyIdentity}:${opReference}`;
       return await pluginCache.getOrSet(cacheKey, selectedInstance.cacheTtl, async () => {
         try {

--- a/packages/plugins/1password/test/1password.test.ts
+++ b/packages/plugins/1password/test/1password.test.ts
@@ -3,10 +3,11 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import {
-  describe, test, beforeAll, afterAll,
+  describe, test, beforeAll, afterAll, expect, vi,
 } from 'vitest';
 import outdent from 'outdent';
 import { pluginTest } from 'varlock/test-helpers';
+import { InMemoryCacheStore } from '../../../varlock/src/lib/cache/in-memory-cache-store';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLUGIN_PATH = path.join(__dirname, '..');
@@ -259,6 +260,31 @@ describe('1password plugin', () => {
       `,
       expectValues: { NPM_OTP: '123456' },
     }));
+
+    test('does not cache an OTP reference using the attr alias', async () => {
+      const cacheSpy = vi.spyOn(InMemoryCacheStore.prototype, 'getOrSet');
+      try {
+        await opTest({
+          opConfig: {
+            responses: { 'op://vault/npm/one-time password?attr=otp': '123456' },
+          },
+          fullSchema: outdent`
+            # @plugin(${PLUGIN_PATH})
+            # @cache=memory
+            # @initOp(token=$OP_SA_TOKEN, useCliWithServiceAccount=true, cacheTtl="1h")
+            # ---
+            # @type=string @sensitive
+            OP_SA_TOKEN=
+            NPM_OTP=op("op://vault/npm/one-time password?attr=otp")
+          `,
+          injectValues: { OP_SA_TOKEN: 'ops_fake_test_token' },
+          expectValues: { NPM_OTP: '123456' },
+        })();
+        expect(cacheSpy).not.toHaveBeenCalled();
+      } finally {
+        cacheSpy.mockRestore();
+      }
+    });
 
     test('bad vault reference rejects that item and retries the rest', opTest({
       opConfig: {

--- a/packages/plugins/1password/test/1password.test.ts
+++ b/packages/plugins/1password/test/1password.test.ts
@@ -249,6 +249,17 @@ describe('1password plugin', () => {
       },
     }));
 
+    test('resolves a one-time password reference', opTest({
+      opConfig: {
+        responses: { 'op://vault/npm/one-time password?attribute=otp': '123456' },
+      },
+      schema: outdent`
+        # @internal
+        NPM_OTP=op("op://vault/npm/one-time password?attribute=otp")
+      `,
+      expectValues: { NPM_OTP: '123456' },
+    }));
+
     test('bad vault reference rejects that item and retries the rest', opTest({
       opConfig: {
         responses: { 'op://good-vault/item/field': 'good-value' },

--- a/packages/varlock-website/src/content/docs/plugins/1password.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/1password.mdx
@@ -170,11 +170,11 @@ PROD_ITEM=op(prod, op://vault-name/item-name/field-name)
 
 ### One-time passwords
 
-1Password items can hold a one-time password (TOTP) field, and a secret reference with `?attribute=otp` resolves to the current code rather than the stored seed. This is handy for CLIs that want a 2FA code, e.g. `npm publish`, which reads `NPM_CONFIG_OTP` as if you had passed `--otp=<code>`:
+1Password items can hold a one-time password (TOTP) field, and a secret reference with `?attribute=otp` resolves to the current code rather than the stored seed. This is handy for CLIs that want a 2FA code on every invocation:
 
 ```env-spec title=".env.schema"
 # @sensitive
-NPM_CONFIG_OTP=op("op://Private/npm/one-time password?attribute=otp")
+MFA_CODE=op("op://Private/aws/one-time password?attribute=otp")
 ```
 
 The field name is whatever the field is called in the item (`one-time password` is the default for the built-in field). Use `Copy Secret Reference` on the field to get the exact reference, then append `?attribute=otp` yourself, since the copied reference does not include it.
@@ -183,10 +183,10 @@ Alternatively, store the raw TOTP seed in a normal field and generate the code w
 
 ```env-spec title=".env.schema"
 # @internal @sensitive
-NPM_TOTP_SECRET=op("op://Private/npm/totp seed")
+MFA_SECRET=op("op://Private/aws/totp seed")
 
 # @sensitive
-NPM_CONFIG_OTP=generateOtp($NPM_TOTP_SECRET)
+MFA_CODE=generateOtp($MFA_SECRET)
 ```
 
 Which to pick:

--- a/packages/varlock-website/src/content/docs/plugins/1password.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/1password.mdx
@@ -168,6 +168,49 @@ PROD_ITEM=op(prod, op://vault-name/item-name/field-name)
 
 
 
+### One-time passwords
+
+1Password items can hold a one-time password (TOTP) field, and a secret reference with `?attribute=otp` resolves to the current code rather than the stored seed. This is handy for CLIs that want a 2FA code, e.g. `npm publish`, which reads `NPM_CONFIG_OTP` as if you had passed `--otp=<code>`:
+
+```env-spec title=".env.schema"
+# @sensitive
+NPM_CONFIG_OTP=op("op://Private/npm/one-time password?attribute=otp")
+```
+
+The field name is whatever the field is called in the item (`one-time password` is the default for the built-in field). Use `Copy Secret Reference` on the field to get the exact reference, then append `?attribute=otp` yourself, since the copied reference does not include it.
+
+Alternatively, store the raw TOTP seed in a normal field and generate the code with [`generateOtp()`](/reference/functions/#generateotp):
+
+```env-spec title=".env.schema"
+# @internal @sensitive
+NPM_TOTP_SECRET=op("op://Private/npm/totp seed")
+
+# @sensitive
+NPM_CONFIG_OTP=generateOtp(ref(NPM_TOTP_SECRET))
+```
+
+Which to pick:
+
+- **`?attribute=otp`** keeps the seed inside 1Password. The seed never reaches your machine, only the code does. Prefer this when it works for your auth mode.
+- **`generateOtp()`** works with any source (an encrypted local value, any other plugin, a plain field) and with all 1Password auth modes. The tradeoff is that the seed itself gets resolved locally, so keep it `@internal` and `@sensitive`.
+
+Support by auth mode:
+
+| Auth mode | `?attribute=otp` |
+| --- | --- |
+| Desktop app auth (`allowAppAuth`) | ✅ |
+| Service account via CLI (`useCliWithServiceAccount`) | ✅ |
+| Service account via SDK | ✅ |
+| 1Password Connect | ❌ (Connect has no OTP attribute) |
+
+With Connect, use the `generateOtp()` approach instead. Varlock raises an error explaining this rather than reporting a missing field.
+
+:::note[OTP references bypass `cacheTtl`]
+If your instance sets [`cacheTtl`](#initop), references using `?attribute=otp` are excluded from that cache, since a cached code is expired by definition. Everything else on the instance still caches normally.
+:::
+
+See [`generateOtp()`](/reference/functions/#generateotp) for the rest of the caveats, including code reuse and what putting a seed next to a token costs you.
+
 ### Loading 1Password Environments
 
 Use `opLoadEnvironment()` with `@setValuesBulk` to load all variables from a [1Password environment](https://www.1password.dev/environments/) at once, instead of wiring up each secret individually:
@@ -254,11 +297,16 @@ Fetches an individual field using a 1Password secret reference
 - `secretReference`: secret reference to fetch value from, in the format `op://vault-name/item-name/field-name`
 
 
+Secret references may include [query parameters](https://www.1password.dev/cli/secret-reference-syntax/), most usefully `?attribute=otp` to get a one-time password code instead of the stored seed. See [one-time passwords](#one-time-passwords).
+
 ```env-spec /op\\(.*\\)/
 ITEM=op(op://vault-name/item-name/field-name)
 
 # example using a plugin instance id
 ITEM_WITH_INSTANCE_ID=op(prod, op://vault-name/item-name/field-name)
+
+# current 2FA code rather than the stored seed
+OTP_CODE=op("op://vault-name/item-name/one-time password?attribute=otp")
 ```
 </div>
 

--- a/packages/varlock-website/src/content/docs/plugins/1password.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/1password.mdx
@@ -186,7 +186,7 @@ Alternatively, store the raw TOTP seed in a normal field and generate the code w
 NPM_TOTP_SECRET=op("op://Private/npm/totp seed")
 
 # @sensitive
-NPM_CONFIG_OTP=generateOtp(ref(NPM_TOTP_SECRET))
+NPM_CONFIG_OTP=generateOtp($NPM_TOTP_SECRET)
 ```
 
 Which to pick:

--- a/packages/varlock-website/src/content/docs/reference/functions.mdx
+++ b/packages/varlock-website/src/content/docs/reference/functions.mdx
@@ -383,16 +383,11 @@ NPM_TOTP_SECRET=varlock(local:abc123...)
 
 # npm reads NPM_CONFIG_OTP as if you passed --otp=<code>
 # @sensitive
-NPM_CONFIG_OTP=generateOtp(ref(NPM_TOTP_SECRET))
-
-# seed from a password manager, as a full otpauth:// URI
-# (digits/period/algorithm come from the URI)
-# @sensitive
-OTHER_OTP=generateOtp(op("op://vault/some-service/otpauth uri"))
+NPM_CONFIG_OTP=generateOtp($NPM_TOTP_SECRET)
 
 # non-default params
 # @sensitive
-LEGACY_OTP=generateOtp(ref(LEGACY_SEED), digits=8, period=60, algorithm=SHA256)
+LEGACY_OTP=generateOtp($LEGACY_SEED, digits=8, period=60, algorithm=SHA256)
 ```
 
 Then `varlock run -- npm publish` picks up the code. For tools with no env var for it, expand the value in the child shell instead: `varlock run -- sh -c 'some-cli --otp=$OTP_CODE'` (single quotes matter, so the expansion happens after injection).

--- a/packages/varlock-website/src/content/docs/reference/functions.mdx
+++ b/packages/varlock-website/src/content/docs/reference/functions.mdx
@@ -390,7 +390,20 @@ NPM_CONFIG_OTP=generateOtp($NPM_TOTP_SECRET)
 LEGACY_OTP=generateOtp($LEGACY_SEED, digits=8, period=60, algorithm=SHA256)
 ```
 
-Then `varlock run -- npm publish` picks up the code. For tools with no env var for it, expand the value in the child shell instead: `varlock run -- sh -c 'some-cli --otp=$OTP_CODE'` (single quotes matter, so the expansion happens after injection).
+Then run the command through varlock. Tools that shell out to `npm` inherit the same env var, so they pick up the code too:
+
+```bash
+varlock run -- npm publish
+
+# fledgling claims npm package names and syncs trusted publishing settings
+varlock run -- bunx fledgling add --new supercool-tool
+```
+
+For tools with no env var for it, expand the value in the child shell instead: `varlock run -- sh -c 'some-cli --otp=$OTP_CODE'` (single quotes matter, so the expansion happens after injection).
+
+:::note[One code per command]
+A code covers one authenticated call. If a command makes several npm calls in a run, prefer handing it the seed and letting it mint a code per call. [fledgling](https://github.com/dmno-dev/fledgling), for example, takes `FLEDGLING_OTP_SECRET`.
+:::
 
 To get the seed in the first place, you generally have to re-enroll the second factor: on the "scan this QR code" screen, take the manual-entry / setup-key option and save that string. Most authenticator apps will not show you a seed after the fact.
 

--- a/packages/varlock-website/src/content/docs/reference/functions.mdx
+++ b/packages/varlock-website/src/content/docs/reference/functions.mdx
@@ -403,10 +403,6 @@ To get the seed in the first place, you generally have to enroll (or re-enroll) 
 A code covers one authenticated call, and providers generally reject a reused one. If a command makes several authenticated calls in a run, prefer handing it the seed and letting it mint a code per call. [fledgling](https://github.com/dmno-dev/fledgling), for example, takes `FLEDGLING_OTP_SECRET`.
 :::
 
-:::caution[Not for npm]
-npm no longer issues new authenticator-app secrets, and only offers passkeys and security keys for new 2FA setups. Existing secrets still work for now, so `NPM_CONFIG_OTP=generateOtp($NPM_TOTP_SECRET)` covers `npm publish` if you have a grandfathered one, but do not build new automation on it. Use [trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) instead, and see the [OIDC guide](/guides/oidc/) for how varlock handles workload identity.
-:::
-
 :::caution[Codes cannot be cached]
 Wrapping this in [`cache()`](#cache) is an error, since a cached code is expired by definition. Cache the *secret* instead: `generateOtp(cache(op("op://vault/aws/mfa seed")))`.
 :::

--- a/packages/varlock-website/src/content/docs/reference/functions.mdx
+++ b/packages/varlock-website/src/content/docs/reference/functions.mdx
@@ -364,7 +364,7 @@ TEMP_LABEL=randomString(10)
 <div>
 ### `generateOtp()`
 
-Generates a time-based one-time password (TOTP) code from a shared secret, the same codes an authenticator app shows. Useful for CLIs that require a 2FA code on every invocation, e.g. `npm publish --otp=123456`.
+Generates a time-based one-time password (TOTP) code from a shared secret, the same codes an authenticator app shows. Useful for CLIs that require a 2FA code on every invocation, e.g. `aws sts get-session-token --token-code 123456`.
 
 - First arg: the shared secret. Either the base32 seed from your 2FA setup, or a full `otpauth://totp/...` URI. Spaces, hyphens, lowercase, and padding in a base32 seed are all fine.
 - `digits=N` option: code length, 6 to 10 (default: 6)
@@ -377,46 +377,45 @@ When the secret is an `otpauth://` URI, any `digits`, `period`, and `algorithm` 
 The seed is a long-lived credential, so keep it [`@internal`](/reference/item-decorators/#internal) (resolved by varlock, never injected into your app or child processes) and [`@sensitive`](/reference/item-decorators/#sensitive). Only the generated code gets injected.
 
 ```env-spec "generateOtp"
-# TOTP seed from npm's 2FA setup screen, encrypted at rest
+# TOTP seed from your provider's 2FA setup, encrypted at rest
 # @internal @sensitive
-NPM_TOTP_SECRET=varlock(local:abc123...)
+MFA_SECRET=varlock(local:abc123...)
 
-# npm reads NPM_CONFIG_OTP as if you passed --otp=<code>
 # @sensitive
-NPM_CONFIG_OTP=generateOtp($NPM_TOTP_SECRET)
+MFA_CODE=generateOtp($MFA_SECRET)
 
 # non-default params
 # @sensitive
-LEGACY_OTP=generateOtp($LEGACY_SEED, digits=8, period=60, algorithm=SHA256)
+LEGACY_CODE=generateOtp($LEGACY_SEED, digits=8, period=60, algorithm=SHA256)
 ```
 
-Then run the command through varlock. Tools that shell out to `npm` inherit the same env var, so they pick up the code too:
+Then hand the code to whatever needs it. Tools that take a flag need the expansion to happen in the child shell, so use single quotes:
 
 ```bash
-varlock run -- npm publish
-
-# fledgling claims npm package names and syncs trusted publishing settings
-varlock run -- bunx fledgling add --new supercool-tool
+varlock run -- sh -c 'aws sts get-session-token --serial-number $AWS_MFA_ARN --token-code $MFA_CODE'
 ```
 
-For tools with no env var for it, expand the value in the child shell instead: `varlock run -- sh -c 'some-cli --otp=$OTP_CODE'` (single quotes matter, so the expansion happens after injection).
+Tools that read a code from the environment need no extra wrapping, since varlock injects it directly.
+
+To get the seed in the first place, you generally have to enroll (or re-enroll) the second factor: on the "scan this QR code" screen, take the manual-entry / setup-key option and save that string. Most authenticator apps will not show you a seed after the fact.
 
 :::note[One code per command]
-A code covers one authenticated call. If a command makes several npm calls in a run, prefer handing it the seed and letting it mint a code per call. [fledgling](https://github.com/dmno-dev/fledgling), for example, takes `FLEDGLING_OTP_SECRET`.
+A code covers one authenticated call, and providers generally reject a reused one. If a command makes several authenticated calls in a run, prefer handing it the seed and letting it mint a code per call. [fledgling](https://github.com/dmno-dev/fledgling), for example, takes `FLEDGLING_OTP_SECRET`.
 :::
 
-To get the seed in the first place, you generally have to re-enroll the second factor: on the "scan this QR code" screen, take the manual-entry / setup-key option and save that string. Most authenticator apps will not show you a seed after the fact.
+:::caution[Not for npm]
+npm no longer issues new authenticator-app secrets, and only offers passkeys and security keys for new 2FA setups. Existing secrets still work for now, so `NPM_CONFIG_OTP=generateOtp($NPM_TOTP_SECRET)` covers `npm publish` if you have a grandfathered one, but do not build new automation on it. Use [trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) instead, and see the [OIDC guide](/guides/oidc/) for how varlock handles workload identity.
+:::
 
 :::caution[Codes cannot be cached]
-Wrapping this in [`cache()`](#cache) is an error, since a cached code is expired by definition. Cache the *secret* instead: `generateOtp(cache(op("op://vault/npm/totp seed")))`.
+Wrapping this in [`cache()`](#cache) is an error, since a cached code is expired by definition. Cache the *secret* instead: `generateOtp(cache(op("op://vault/aws/mfa seed")))`.
 :::
 
 A few other things to know:
 
 - **Codes expire.** They rotate every `period` seconds, so generate at the moment of use. A long command that only needs the code at the very end can outlive it.
-- **A code may only work once.** Registries generally treat a code as single-use, so reusing one inside its window can be rejected even though it has not expired. If you publish several packages back to back and the second fails, that is the likely cause.
 - **Your clock has to be right.** Codes are derived from the current time. Check clock sync before assuming the seed is wrong.
-- **This weakens your second factor.** A seed sitting next to the token it protects, on the same machine, is no longer an independent factor. That can be a reasonable trade for a local publish flow where the seed is encrypted at rest and never injected into your app. It is a bad trade in CI, where [OIDC workload identity](/guides/oidc/) or a token that does not require 2FA is the better answer.
+- **This weakens your second factor.** A seed sitting next to the token it protects, on the same machine, is no longer an independent factor. That can be a reasonable trade for a local workflow where the seed is encrypted at rest and never injected into your app. It is a bad trade in CI, where [OIDC workload identity](/guides/oidc/) or credentials that do not require 2FA are the better answer.
 </div>
 </div>
 

--- a/packages/varlock-website/src/content/docs/reference/functions.mdx
+++ b/packages/varlock-website/src/content/docs/reference/functions.mdx
@@ -22,7 +22,7 @@ CONFIG=exec(`./scripts/load-config.sh ${APP_ENV}`)
 ```
 
 
-There are built-in utility functions, [random value generators](#random-value-generators), a [`cache()`](#cache) function for reusing values according to your global cache mode, encryption functions for device-local secrets, and plugin-provided resolver functions that can fetch data from external providers. See the [Plugins guide](/guides/plugins/) for more information on plugin-provided functions.
+There are built-in utility functions, [random value generators](#random-value-generators), [`generateOtp()`](#generateotp) for 2FA codes, a [`cache()`](#cache) function for reusing values according to your global cache mode, encryption functions for device-local secrets, and plugin-provided resolver functions that can fetch data from external providers. See the [Plugins guide](/guides/plugins/) for more information on plugin-provided functions.
 
 ## Core
 <div class="reference-docs">
@@ -355,6 +355,60 @@ PIN_CODE=cache(randomString(8, charset="0123456789"))
 # One-off random string
 TEMP_LABEL=randomString(10)
 ```
+</div>
+</div>
+
+## One-time passwords
+
+<div class="reference-docs">
+<div>
+### `generateOtp()`
+
+Generates a time-based one-time password (TOTP) code from a shared secret, the same codes an authenticator app shows. Useful for CLIs that require a 2FA code on every invocation, e.g. `npm publish --otp=123456`.
+
+- First arg: the shared secret. Either the base32 seed from your 2FA setup, or a full `otpauth://totp/...` URI. Spaces, hyphens, lowercase, and padding in a base32 seed are all fine.
+- `digits=N` option: code length, 6 to 10 (default: 6)
+- `period=N` option: how long each code is valid, **in seconds** (default: 30). A duration string like `"60s"` also works.
+- `algorithm=S` option: `SHA1` (default), `SHA256`, or `SHA512`
+- `encoding=S` option: how the secret itself is encoded, `base32` (default), `hex`, or `ascii`
+
+When the secret is an `otpauth://` URI, any `digits`, `period`, and `algorithm` params in the URI are used, and explicitly passed options override them.
+
+The seed is a long-lived credential, so keep it [`@internal`](/reference/item-decorators/#internal) (resolved by varlock, never injected into your app or child processes) and [`@sensitive`](/reference/item-decorators/#sensitive). Only the generated code gets injected.
+
+```env-spec "generateOtp"
+# TOTP seed from npm's 2FA setup screen, encrypted at rest
+# @internal @sensitive
+NPM_TOTP_SECRET=varlock(local:abc123...)
+
+# npm reads NPM_CONFIG_OTP as if you passed --otp=<code>
+# @sensitive
+NPM_CONFIG_OTP=generateOtp(ref(NPM_TOTP_SECRET))
+
+# seed from a password manager, as a full otpauth:// URI
+# (digits/period/algorithm come from the URI)
+# @sensitive
+OTHER_OTP=generateOtp(op("op://vault/some-service/otpauth uri"))
+
+# non-default params
+# @sensitive
+LEGACY_OTP=generateOtp(ref(LEGACY_SEED), digits=8, period=60, algorithm=SHA256)
+```
+
+Then `varlock run -- npm publish` picks up the code. For tools with no env var for it, expand the value in the child shell instead: `varlock run -- sh -c 'some-cli --otp=$OTP_CODE'` (single quotes matter, so the expansion happens after injection).
+
+To get the seed in the first place, you generally have to re-enroll the second factor: on the "scan this QR code" screen, take the manual-entry / setup-key option and save that string. Most authenticator apps will not show you a seed after the fact.
+
+:::caution[Codes cannot be cached]
+Wrapping this in [`cache()`](#cache) is an error, since a cached code is expired by definition. Cache the *secret* instead: `generateOtp(cache(op("op://vault/npm/totp seed")))`.
+:::
+
+A few other things to know:
+
+- **Codes expire.** They rotate every `period` seconds, so generate at the moment of use. A long command that only needs the code at the very end can outlive it.
+- **A code may only work once.** Registries generally treat a code as single-use, so reusing one inside its window can be rejected even though it has not expired. If you publish several packages back to back and the second fails, that is the likely cause.
+- **Your clock has to be right.** Codes are derived from the current time. Check clock sync before assuming the seed is wrong.
+- **This weakens your second factor.** A seed sitting next to the token it protects, on the same machine, is no longer an independent factor. That can be a reasonable trade for a local publish flow where the seed is encrypted at rest and never injected into your app. It is a bad trade in CI, where [OIDC workload identity](/guides/oidc/) or a token that does not require 2FA is the better answer.
 </div>
 </div>
 

--- a/packages/varlock/src/env-graph/lib/resolver.ts
+++ b/packages/varlock/src/env-graph/lib/resolver.ts
@@ -14,6 +14,11 @@ import { ConfigItem } from './config-item';
 import { SimpleQueue } from './simple-queue';
 import { ResolutionError, SchemaError, VarlockError } from './errors';
 import { parseTtl, TTL_FOREVER } from '../../lib/cache/ttl-parser';
+import { parseDuration } from '../../lib/duration';
+import {
+  generateTotp, normalizeOtpAlgorithm, OTP_ALGORITHMS, OTP_SECRET_ENCODINGS,
+  type GeneratedTotp, type OtpAlgorithm, type OtpSecretEncoding,
+} from '../../lib/otp';
 import { assertValidCacheKey, hasInvalidCacheKeyChars, MAX_CACHE_KEY_LENGTH } from '../../lib/cache/cache-store';
 import type { EnvGraphDataSource } from './data-source';
 import { DecoratorInstance } from './decorators';
@@ -898,6 +903,116 @@ export const RandomStringResolver: typeof Resolver = createResolver({
   },
 });
 
+// ── One-time passwords ─────────────────────────────────────────────────
+
+export const GenerateOtpResolver: typeof Resolver = createResolver({
+  name: 'generateOtp',
+  description: 'Generate a time-based one-time password (TOTP) code from a shared secret',
+  icon: 'mdi:timer-lock-outline',
+  inferredType: 'string',
+  argsSchema: {
+    type: 'mixed',
+    arrayExactLength: 1,
+  },
+  process() {
+    // note that the secret itself is usually not static (a ref, encrypted value,
+    // or plugin fn call) so it only gets validated at resolution time
+    const secretResolver = this.arrArgs![0];
+
+    let digits: number | undefined;
+    const digitsResolver = this.objArgs?.digits;
+    if (digitsResolver) {
+      if (!digitsResolver.isStatic || typeof digitsResolver.staticValue !== 'number') {
+        throw new SchemaError('digits must be a static number');
+      }
+      digits = digitsResolver.staticValue as number;
+      if (!Number.isInteger(digits) || digits < 6 || digits > 10) {
+        throw new SchemaError('digits must be an integer in [6, 10]');
+      }
+    }
+
+    let period: number | undefined;
+    const periodResolver = this.objArgs?.period;
+    if (periodResolver) {
+      if (!periodResolver.isStatic) {
+        throw new SchemaError('period must be a static value');
+      }
+      const periodVal = periodResolver.staticValue;
+      if (typeof periodVal === 'number') {
+        // bare numbers are seconds here (not ms like `cache()` ttl) since that is
+        // how every TOTP setup screen expresses it
+        period = periodVal;
+      } else if (typeof periodVal === 'string') {
+        try {
+          period = parseDuration(periodVal) / 1000;
+        } catch (err) {
+          throw new SchemaError(err instanceof Error ? err.message : String(err));
+        }
+      } else {
+        throw new SchemaError('period must be a number of seconds or a duration string like "60s"');
+      }
+      // sub-second windows are never a real TOTP config, and catch `period="60"`,
+      // which the duration parser reads as 60ms
+      if (!Number.isFinite(period) || period < 1) {
+        throw new SchemaError('period must be at least 1 second');
+      }
+    }
+
+    let algorithm: OtpAlgorithm | undefined;
+    const algorithmResolver = this.objArgs?.algorithm;
+    if (algorithmResolver) {
+      if (!algorithmResolver.isStatic || typeof algorithmResolver.staticValue !== 'string') {
+        throw new SchemaError('algorithm must be a static string');
+      }
+      algorithm = normalizeOtpAlgorithm(algorithmResolver.staticValue as string);
+      if (!algorithm) {
+        throw new SchemaError(`algorithm must be one of: ${OTP_ALGORITHMS.join(', ')}`);
+      }
+    }
+
+    let encoding: OtpSecretEncoding | undefined;
+    const encodingResolver = this.objArgs?.encoding;
+    if (encodingResolver) {
+      if (!encodingResolver.isStatic || typeof encodingResolver.staticValue !== 'string') {
+        throw new SchemaError('encoding must be a static string');
+      }
+      const encodingVal = String(encodingResolver.staticValue).toLowerCase();
+      if (!(OTP_SECRET_ENCODINGS as ReadonlyArray<string>).includes(encodingVal)) {
+        throw new SchemaError(`encoding must be one of: ${OTP_SECRET_ENCODINGS.join(', ')}`);
+      }
+      encoding = encodingVal as OtpSecretEncoding;
+    }
+
+    return {
+      secretResolver, digits, period, algorithm, encoding,
+    };
+  },
+  async resolve({
+    secretResolver, digits, period, algorithm, encoding,
+  }) {
+    const secret = await secretResolver.resolve();
+    if (typeof secret !== 'string' || !secret) {
+      throw new ResolutionError('expects a non-empty string secret', {
+        tip: 'The secret should be the base32 seed (or `otpauth://totp/...` URI) from your 2FA setup',
+      });
+    }
+
+    let generated: GeneratedTotp;
+    try {
+      generated = generateTotp({
+        secret, digits, period, algorithm, encoding,
+      });
+    } catch (err) {
+      // error messages from otp.ts never contain the secret itself
+      throw new ResolutionError(`failed to generate code: ${err instanceof Error ? err.message : String(err)}`, {
+        tip: 'The secret should be the base32 seed (or `otpauth://totp/...` URI) from your 2FA setup',
+      });
+    }
+
+    return generated.code;
+  },
+});
+
 // ── Cache resolver ─────────────────────────────────────────────────────
 
 export const CacheResolver: typeof Resolver = createResolver({
@@ -922,6 +1037,14 @@ export const CacheResolver: typeof Resolver = createResolver({
         'wraps a static value which never changes — caching has no effect',
         { isWarning: true },
       ));
+    }
+
+    // a one-time password is only valid within its current time window, so a
+    // cached one is always either stale or about to be
+    if (childResolver?.fnName === 'generateOtp') {
+      throw new SchemaError('cannot cache generateOtp(), since codes expire', {
+        tip: 'Cache the secret instead, e.g. `generateOtp(cache(op("op://vault/item/totp seed")))`',
+      });
     }
 
     // optional explicit cache key
@@ -1039,6 +1162,7 @@ export const BaseResolvers: Array<ResolverChildClass> = [
   RandomUuidResolver,
   RandomHexResolver,
   RandomStringResolver,
+  GenerateOtpResolver,
   CacheResolver,
   RemapResolver,
   IfsResolver,

--- a/packages/varlock/src/env-graph/test/generate-otp-resolver.test.ts
+++ b/packages/varlock/src/env-graph/test/generate-otp-resolver.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the generateOtp() resolver function.
+ * The code generation itself is covered by src/lib/test/otp.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { outdent } from 'outdent';
+import { DotEnvFileDataSource, EnvGraph } from '../index';
+import { ResolutionError, SchemaError } from '../lib/errors';
+
+// base32 of '12345678901234567890'
+const TEST_SECRET = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+
+async function loadAndResolve(envContent: string) {
+  const g = new EnvGraph();
+  const source = new DotEnvFileDataSource('.env.schema', {
+    overrideContents: outdent`
+      # @defaultRequired=false
+      # ---
+      ${envContent}
+    `,
+  });
+  await g.setRootDataSource(source);
+  await g.finishLoad();
+  await g.resolveEnvValues();
+  return g;
+}
+
+describe('generateOtp()', () => {
+  it('generates a 6 digit code by default', async () => {
+    const g = await loadAndResolve(`A=generateOtp("${TEST_SECRET}")`);
+    expect(g.configSchema.A.errors).toEqual([]);
+    expect(g.configSchema.A.resolvedValue).toMatch(/^\d{6}$/);
+  });
+
+  it('resolves as a string, so leading zeros survive', async () => {
+    const g = await loadAndResolve(`A=generateOtp("${TEST_SECRET}")`);
+    expect(typeof g.configSchema.A.resolvedValue).toEqual('string');
+  });
+
+  it('works with a secret from another item', async () => {
+    const g = await loadAndResolve(outdent`
+      # @internal @sensitive
+      TOTP_SECRET=${TEST_SECRET}
+      OTP=generateOtp(ref(TOTP_SECRET))
+    `);
+    expect(g.configSchema.OTP.errors).toEqual([]);
+    expect(g.configSchema.OTP.resolvedValue).toMatch(/^\d{6}$/);
+  });
+
+  it('works with an expanded secret reference', async () => {
+    const g = await loadAndResolve(outdent`
+      # @internal
+      TOTP_SECRET=${TEST_SECRET}
+      OTP=generateOtp("\${TOTP_SECRET}")
+    `);
+    expect(g.configSchema.OTP.errors).toEqual([]);
+    expect(g.configSchema.OTP.resolvedValue).toMatch(/^\d{6}$/);
+  });
+
+  it('accepts an otpauth:// URI', async () => {
+    const g = await loadAndResolve(`A=generateOtp("otpauth://totp/npm:theo?secret=${TEST_SECRET}&issuer=npm&digits=8")`);
+    expect(g.configSchema.A.errors).toEqual([]);
+    expect(g.configSchema.A.resolvedValue).toMatch(/^\d{8}$/);
+  });
+
+  it('honors digits, period, and algorithm options', async () => {
+    const g = await loadAndResolve(
+      `A=generateOtp("${TEST_SECRET}", digits=8, period=60, algorithm=SHA256)`,
+    );
+    expect(g.configSchema.A.errors).toEqual([]);
+    expect(g.configSchema.A.resolvedValue).toMatch(/^\d{8}$/);
+  });
+
+  it('accepts a duration string for period', async () => {
+    const g = await loadAndResolve(`A=generateOtp("${TEST_SECRET}", period="60s")`);
+    expect(g.configSchema.A.errors).toEqual([]);
+    expect(g.configSchema.A.resolvedValue).toMatch(/^\d{6}$/);
+  });
+
+  it('accepts hex encoded secrets', async () => {
+    const g = await loadAndResolve('A=generateOtp("3132333435363738393031323334353637383930", encoding=hex)');
+    expect(g.configSchema.A.errors).toEqual([]);
+    expect(g.configSchema.A.resolvedValue).toMatch(/^\d{6}$/);
+  });
+
+  it('requires exactly one positional arg', async () => {
+    const noArgs = await loadAndResolve('A=generateOtp()');
+    expect(noArgs.configSchema.A.errors.length).toBeGreaterThan(0);
+    const twoArgs = await loadAndResolve(`A=generateOtp("${TEST_SECRET}", 6)`);
+    expect(twoArgs.configSchema.A.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects out of range digits', async () => {
+    const g = await loadAndResolve(`A=generateOtp("${TEST_SECRET}", digits=4)`);
+    expect(g.configSchema.A.errors[0]).toBeInstanceOf(SchemaError);
+    expect(g.configSchema.A.errors[0].message).toContain('digits');
+  });
+
+  it('rejects an unsupported algorithm', async () => {
+    const g = await loadAndResolve(`A=generateOtp("${TEST_SECRET}", algorithm=MD5)`);
+    expect(g.configSchema.A.errors[0]).toBeInstanceOf(SchemaError);
+    expect(g.configSchema.A.errors[0].message).toContain('algorithm');
+  });
+
+  it('rejects an unsupported encoding', async () => {
+    const g = await loadAndResolve(`A=generateOtp("${TEST_SECRET}", encoding=base64)`);
+    expect(g.configSchema.A.errors[0]).toBeInstanceOf(SchemaError);
+    expect(g.configSchema.A.errors[0].message).toContain('encoding');
+  });
+
+  it('rejects a sub-second period', async () => {
+    const zero = await loadAndResolve(`A=generateOtp("${TEST_SECRET}", period=0)`);
+    expect(zero.configSchema.A.errors[0]).toBeInstanceOf(SchemaError);
+    // the duration parser reads a bare numeric string as ms, so this is 60ms
+    const bareString = await loadAndResolve(`A=generateOtp("${TEST_SECRET}", period="60")`);
+    expect(bareString.configSchema.A.errors[0]).toBeInstanceOf(SchemaError);
+    expect(bareString.configSchema.A.errors[0].message).toContain('at least 1 second');
+  });
+
+  it('fails resolution on an invalid secret, without leaking it', async () => {
+    const g = await loadAndResolve('A=generateOtp("not-a-valid-secret!")');
+    expect(g.configSchema.A.resolutionError).toBeInstanceOf(ResolutionError);
+    expect(g.configSchema.A.resolutionError!.message).toContain('generateOtp()');
+    expect(g.configSchema.A.resolutionError!.message).not.toContain('not-a-valid-secret');
+  });
+
+  it('fails resolution when the secret is empty', async () => {
+    const g = await loadAndResolve(outdent`
+      # @internal
+      TOTP_SECRET=
+      OTP=generateOtp(ref(TOTP_SECRET))
+    `);
+    expect(g.configSchema.OTP.resolutionError).toBeInstanceOf(ResolutionError);
+  });
+
+  it('cannot be wrapped in cache()', async () => {
+    const g = await loadAndResolve(`A=cache(generateOtp("${TEST_SECRET}"))`);
+    const errors = g.configSchema.A.errors.filter((e) => !e.isWarning);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toContain('cannot cache generateOtp()');
+  });
+
+  it('can wrap a cached secret', async () => {
+    const g = await loadAndResolve(`A=generateOtp(cache("${TEST_SECRET}"))`);
+    expect(g.configSchema.A.errors.filter((e) => !e.isWarning)).toEqual([]);
+    expect(g.configSchema.A.resolvedValue).toMatch(/^\d{6}$/);
+  });
+});

--- a/packages/varlock/src/env-graph/test/generate-otp-resolver.test.ts
+++ b/packages/varlock/src/env-graph/test/generate-otp-resolver.test.ts
@@ -52,10 +52,12 @@ describe('generateOtp()', () => {
     const g = await loadAndResolve(outdent`
       # @internal
       TOTP_SECRET=${TEST_SECRET}
-      OTP=generateOtp("\${TOTP_SECRET}")
+      BARE=generateOtp($TOTP_SECRET)
+      BRACED=generateOtp("\${TOTP_SECRET}")
     `);
-    expect(g.configSchema.OTP.errors).toEqual([]);
-    expect(g.configSchema.OTP.resolvedValue).toMatch(/^\d{6}$/);
+    expect(g.configSchema.BARE.errors).toEqual([]);
+    expect(g.configSchema.BARE.resolvedValue).toMatch(/^\d{6}$/);
+    expect(g.configSchema.BRACED.resolvedValue).toEqual(g.configSchema.BARE.resolvedValue);
   });
 
   it('accepts an otpauth:// URI', async () => {

--- a/packages/varlock/src/env-graph/test/generate-otp-resolver.test.ts
+++ b/packages/varlock/src/env-graph/test/generate-otp-resolver.test.ts
@@ -125,6 +125,15 @@ describe('generateOtp()', () => {
     expect(g.configSchema.A.resolutionError!.message).not.toContain('not-a-valid-secret');
   });
 
+  it.each([
+    `otpauth://totp/x?secret=${TEST_SECRET}&algorithm=SENSITIVE_MARKER`,
+    `otpauth://SENSITIVE_MARKER/x?secret=${TEST_SECRET}`,
+  ])('does not leak malformed URI values in resolution errors', async (secret) => {
+    const g = await loadAndResolve(`A=generateOtp("${secret}")`);
+    expect(g.configSchema.A.resolutionError).toBeInstanceOf(ResolutionError);
+    expect(g.configSchema.A.resolutionError!.message).not.toContain('SENSITIVE_MARKER');
+  });
+
   it('fails resolution when the secret is empty', async () => {
     const g = await loadAndResolve(outdent`
       # @internal

--- a/packages/varlock/src/lib/otp.ts
+++ b/packages/varlock/src/lib/otp.ts
@@ -121,7 +121,7 @@ export function parseOtpAuthUri(uri: string): ParsedOtpAuthUri {
     throw new Error('counter-based (HOTP) otpauth:// URIs are not supported, only time-based (TOTP)');
   }
   if (otpType !== 'totp') {
-    throw new Error(`unsupported otpauth:// URI type "${otpType}", expected "totp"`);
+    throw new Error('unsupported otpauth:// URI type, expected "totp"');
   }
 
   const secret = parsed.searchParams.get('secret');
@@ -132,7 +132,9 @@ export function parseOtpAuthUri(uri: string): ParsedOtpAuthUri {
   const digits = parsed.searchParams.get('digits');
   if (digits) {
     const digitsNum = Number(digits);
-    if (!Number.isInteger(digitsNum)) throw new Error('otpauth:// URI has an invalid `digits` param');
+    if (!Number.isInteger(digitsNum) || digitsNum < 6 || digitsNum > 10) {
+      throw new Error('otpauth:// URI has an invalid `digits` param (must be between 6 and 10)');
+    }
     result.digits = digitsNum;
   }
 
@@ -148,7 +150,7 @@ export function parseOtpAuthUri(uri: string): ParsedOtpAuthUri {
   const algorithm = parsed.searchParams.get('algorithm');
   if (algorithm) {
     const normalized = normalizeOtpAlgorithm(algorithm);
-    if (!normalized) throw new Error(`otpauth:// URI has an unsupported \`algorithm\` param "${algorithm}"`);
+    if (!normalized) throw new Error('otpauth:// URI has an unsupported `algorithm` param');
     result.algorithm = normalized;
   }
 

--- a/packages/varlock/src/lib/otp.ts
+++ b/packages/varlock/src/lib/otp.ts
@@ -1,0 +1,215 @@
+/**
+ * TOTP / HOTP code generation (RFC 4226 + RFC 6238).
+ *
+ * Powers the `generateOtp()` resolver function, so a TOTP seed held in your env
+ * schema (usually `@internal` and encrypted) can be turned into the 6-digit code
+ * a CLI like `npm publish --otp=...` asks for.
+ *
+ * Error messages here must never echo any part of the secret, since resolver
+ * errors are printed unredacted.
+ */
+
+/* eslint-disable no-bitwise */
+
+import { createHmac } from 'node:crypto';
+
+export const OTP_ALGORITHMS = ['SHA1', 'SHA256', 'SHA512'] as const;
+export type OtpAlgorithm = typeof OTP_ALGORITHMS[number];
+
+export const OTP_SECRET_ENCODINGS = ['base32', 'hex', 'ascii'] as const;
+export type OtpSecretEncoding = typeof OTP_SECRET_ENCODINGS[number];
+
+export const OTP_DEFAULTS = {
+  digits: 6,
+  period: 30,
+  algorithm: 'SHA1' as OtpAlgorithm,
+  encoding: 'base32' as OtpSecretEncoding,
+};
+
+/** Accepts `SHA1`, `sha-256`, etc. Returns undefined if not a supported algorithm. */
+export function normalizeOtpAlgorithm(input: string): OtpAlgorithm | undefined {
+  const normalized = input.replace(/[\s_-]/g, '').toUpperCase();
+  return (OTP_ALGORITHMS as ReadonlyArray<string>).includes(normalized)
+    ? normalized as OtpAlgorithm
+    : undefined;
+}
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+/**
+ * Decodes an RFC 4648 base32 secret. Seeds get displayed in all sorts of ways
+ * (lowercase, space or hyphen separated groups of 4, with or without padding)
+ * so we normalize rather than being strict about it.
+ */
+export function decodeBase32Secret(input: string): Buffer {
+  const normalized = input.replace(/[\s-]/g, '').replace(/=+$/, '').toUpperCase();
+  let bits = 0;
+  let value = 0;
+  const bytes: Array<number> = [];
+  for (const char of normalized) {
+    const charIndex = BASE32_ALPHABET.indexOf(char);
+    if (charIndex === -1) throw new Error('secret is not valid base32');
+    // 12 bits is the most we ever hold (7 leftover + 5 new) before flushing a byte
+    value = ((value << 5) | charIndex) & 0xfff;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((value >> bits) & 0xff);
+    }
+  }
+  if (!bytes.length) throw new Error('secret is too short');
+  return Buffer.from(bytes);
+}
+
+export function decodeOtpSecret(secret: string, encoding: OtpSecretEncoding): Buffer {
+  if (encoding === 'base32') return decodeBase32Secret(secret);
+  if (encoding === 'hex') {
+    const normalized = secret.replace(/[\s-]/g, '');
+    if (!/^[0-9a-fA-F]+$/.test(normalized) || normalized.length % 2 !== 0) {
+      throw new Error('secret is not valid hex');
+    }
+    return Buffer.from(normalized, 'hex');
+  }
+  const buf = Buffer.from(secret, 'utf8');
+  if (!buf.length) throw new Error('secret is empty');
+  return buf;
+}
+
+/** Generates an HOTP code for a specific counter value (RFC 4226) */
+export function generateHotpCode(opts: {
+  secret: Buffer;
+  counter: number | bigint;
+  digits: number;
+  algorithm: OtpAlgorithm;
+}): string {
+  const counterBuf = Buffer.alloc(8);
+  counterBuf.writeBigUInt64BE(BigInt(opts.counter));
+
+  const hmac = createHmac(opts.algorithm.toLowerCase(), opts.secret).update(counterBuf).digest();
+
+  // dynamic truncation - low 4 bits of the last byte pick a 4-byte window
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const binary = ((hmac[offset] & 0x7f) << 24)
+    | ((hmac[offset + 1] & 0xff) << 16)
+    | ((hmac[offset + 2] & 0xff) << 8)
+    | (hmac[offset + 3] & 0xff);
+
+  return String(binary % (10 ** opts.digits)).padStart(opts.digits, '0');
+}
+
+export type ParsedOtpAuthUri = {
+  secret: string;
+  digits?: number;
+  period?: number;
+  algorithm?: OtpAlgorithm;
+};
+
+/**
+ * Parses an `otpauth://totp/...` URI - the format behind 2FA setup QR codes, and
+ * what password managers hand back for a one-time password field.
+ */
+export function parseOtpAuthUri(uri: string): ParsedOtpAuthUri {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    throw new Error('secret looks like an otpauth:// URI but could not be parsed');
+  }
+
+  const otpType = parsed.host.toLowerCase();
+  if (otpType === 'hotp') {
+    throw new Error('counter-based (HOTP) otpauth:// URIs are not supported, only time-based (TOTP)');
+  }
+  if (otpType !== 'totp') {
+    throw new Error(`unsupported otpauth:// URI type "${otpType}", expected "totp"`);
+  }
+
+  const secret = parsed.searchParams.get('secret');
+  if (!secret) throw new Error('otpauth:// URI is missing a `secret` param');
+
+  const result: ParsedOtpAuthUri = { secret };
+
+  const digits = parsed.searchParams.get('digits');
+  if (digits) {
+    const digitsNum = Number(digits);
+    if (!Number.isInteger(digitsNum)) throw new Error('otpauth:// URI has an invalid `digits` param');
+    result.digits = digitsNum;
+  }
+
+  const period = parsed.searchParams.get('period');
+  if (period) {
+    const periodNum = Number(period);
+    if (!Number.isInteger(periodNum) || periodNum <= 0) {
+      throw new Error('otpauth:// URI has an invalid `period` param');
+    }
+    result.period = periodNum;
+  }
+
+  const algorithm = parsed.searchParams.get('algorithm');
+  if (algorithm) {
+    const normalized = normalizeOtpAlgorithm(algorithm);
+    if (!normalized) throw new Error(`otpauth:// URI has an unsupported \`algorithm\` param "${algorithm}"`);
+    result.algorithm = normalized;
+  }
+
+  return result;
+}
+
+export type GenerateTotpOptions = {
+  /** base32 secret (default), an encoding matching `encoding`, or a full `otpauth://totp/...` URI */
+  secret: string;
+  digits?: number;
+  /** length of each code's validity window, in seconds */
+  period?: number;
+  algorithm?: OtpAlgorithm;
+  encoding?: OtpSecretEncoding;
+  /** unix time in ms - defaults to now */
+  now?: number;
+};
+
+export type GeneratedTotp = {
+  code: string;
+  /** how long the returned code stays valid, in ms */
+  expiresInMs: number;
+  digits: number;
+  period: number;
+  algorithm: OtpAlgorithm;
+};
+
+/**
+ * Generates a time-based one-time password. Params encoded in an `otpauth://` URI
+ * are used as defaults, and explicitly passed options win over them.
+ */
+export function generateTotp(opts: GenerateTotpOptions): GeneratedTotp {
+  const rawSecret = opts.secret.trim();
+  if (!rawSecret) throw new Error('secret is empty');
+
+  let secretStr = rawSecret;
+  let uriParams: ParsedOtpAuthUri | undefined;
+  if (/^otpauth:\/\//i.test(rawSecret)) {
+    uriParams = parseOtpAuthUri(rawSecret);
+    secretStr = uriParams.secret;
+  }
+
+  const digits = opts.digits ?? uriParams?.digits ?? OTP_DEFAULTS.digits;
+  const period = opts.period ?? uriParams?.period ?? OTP_DEFAULTS.period;
+  const algorithm = opts.algorithm ?? uriParams?.algorithm ?? OTP_DEFAULTS.algorithm;
+  // an otpauth:// URI always carries a base32 secret, regardless of the `encoding` option
+  const encoding = uriParams ? 'base32' : (opts.encoding ?? OTP_DEFAULTS.encoding);
+
+  const secret = decodeOtpSecret(secretStr, encoding);
+
+  const now = opts.now ?? Date.now();
+  const periodMs = period * 1000;
+  const counter = Math.floor(now / periodMs);
+
+  return {
+    code: generateHotpCode({
+      secret, counter, digits, algorithm,
+    }),
+    expiresInMs: periodMs - (now % periodMs),
+    digits,
+    period,
+    algorithm,
+  };
+}

--- a/packages/varlock/src/lib/otp.ts
+++ b/packages/varlock/src/lib/otp.ts
@@ -3,7 +3,7 @@
  *
  * Powers the `generateOtp()` resolver function, so a TOTP seed held in your env
  * schema (usually `@internal` and encrypted) can be turned into the 6-digit code
- * a CLI like `npm publish --otp=...` asks for.
+ * a CLI like `aws sts get-session-token --token-code ...` asks for.
  *
  * Error messages here must never echo any part of the secret, since resolver
  * errors are printed unredacted.

--- a/packages/varlock/src/lib/test/otp.test.ts
+++ b/packages/varlock/src/lib/test/otp.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decodeBase32Secret, decodeOtpSecret, generateHotpCode, generateTotp,
+  normalizeOtpAlgorithm, parseOtpAuthUri,
+} from '../otp';
+
+// the shared secrets used by the RFC 4226 / RFC 6238 test vectors
+const RFC_SECRET_SHA1 = '12345678901234567890';
+const RFC_SECRET_SHA256 = '12345678901234567890123456789012';
+const RFC_SECRET_SHA512 = '1234567890123456789012345678901234567890123456789012345678901234';
+
+describe('decodeBase32Secret()', () => {
+  it('decodes a base32 secret', () => {
+    expect(decodeBase32Secret('GEZDGNBVGY3TQOJQ').toString('utf8')).toEqual('1234567890');
+  });
+
+  it('ignores spacing, hyphens, case, and padding', () => {
+    const expected = decodeBase32Secret('GEZDGNBVGY3TQOJQ');
+    expect(decodeBase32Secret('gezd gnbv gy3t qojq')).toEqual(expected);
+    expect(decodeBase32Secret('GEZD-GNBV-GY3T-QOJQ')).toEqual(expected);
+    expect(decodeBase32Secret('GEZDGNBVGY3TQOJQ====')).toEqual(expected);
+  });
+
+  it('rejects invalid base32 without echoing the secret', () => {
+    expect(() => decodeBase32Secret('ABC!8888DEF')).toThrowError(/not valid base32/);
+    try {
+      decodeBase32Secret('ABC!8888DEF');
+    } catch (err) {
+      expect((err as Error).message).not.toContain('8888');
+    }
+  });
+
+  it('rejects an empty secret', () => {
+    expect(() => decodeBase32Secret('')).toThrowError(/too short/);
+    expect(() => decodeBase32Secret('   ')).toThrowError(/too short/);
+  });
+});
+
+describe('decodeOtpSecret()', () => {
+  it('decodes hex secrets', () => {
+    expect(decodeOtpSecret('3132 3334', 'hex').toString('utf8')).toEqual('1234');
+  });
+
+  it('rejects invalid hex', () => {
+    expect(() => decodeOtpSecret('zzz', 'hex')).toThrowError(/not valid hex/);
+    expect(() => decodeOtpSecret('abc', 'hex')).toThrowError(/not valid hex/);
+  });
+
+  it('passes ascii secrets through', () => {
+    expect(decodeOtpSecret(RFC_SECRET_SHA1, 'ascii').toString('utf8')).toEqual(RFC_SECRET_SHA1);
+  });
+});
+
+describe('generateHotpCode(): RFC 4226 test vectors', () => {
+  const expectedCodes = [
+    '755224',
+    '287082',
+    '359152',
+    '969429',
+    '338314',
+    '254676',
+    '287922',
+    '162583',
+    '399871',
+    '520489',
+  ];
+  it.each(expectedCodes.map((code, counter) => ({ counter, code })))(
+    'counter $counter → $code',
+    ({ counter, code }) => {
+      expect(generateHotpCode({
+        secret: Buffer.from(RFC_SECRET_SHA1, 'utf8'),
+        counter,
+        digits: 6,
+        algorithm: 'SHA1',
+      })).toEqual(code);
+    },
+  );
+});
+
+describe('generateTotp(): RFC 6238 test vectors', () => {
+  const vectors = [
+    {
+      time: 59, sha1: '94287082', sha256: '46119246', sha512: '90693936',
+    },
+    {
+      time: 1111111109, sha1: '07081804', sha256: '68084774', sha512: '25091201',
+    },
+    {
+      time: 1111111111, sha1: '14050471', sha256: '67062674', sha512: '99943326',
+    },
+    {
+      time: 1234567890, sha1: '89005924', sha256: '91819424', sha512: '93441116',
+    },
+    {
+      time: 2000000000, sha1: '69279037', sha256: '90698825', sha512: '38618901',
+    },
+    {
+      time: 20000000000, sha1: '65353130', sha256: '77737706', sha512: '47863826',
+    },
+  ];
+
+  it.each(vectors)('T=$time', ({
+    time, sha1, sha256, sha512,
+  }) => {
+    const base = { digits: 8, encoding: 'ascii' as const, now: time * 1000 };
+    expect(generateTotp({ ...base, secret: RFC_SECRET_SHA1, algorithm: 'SHA1' }).code).toEqual(sha1);
+    expect(generateTotp({ ...base, secret: RFC_SECRET_SHA256, algorithm: 'SHA256' }).code).toEqual(sha256);
+    expect(generateTotp({ ...base, secret: RFC_SECRET_SHA512, algorithm: 'SHA512' }).code).toEqual(sha512);
+  });
+});
+
+describe('generateTotp()', () => {
+  const secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ'; // base32 of RFC_SECRET_SHA1
+
+  it('defaults to 6 digits / 30s / SHA1', () => {
+    const result = generateTotp({ secret, now: 59_000 });
+    expect(result).toMatchObject({ digits: 6, period: 30, algorithm: 'SHA1' });
+    // same vector as RFC T=59, truncated to 6 digits
+    expect(result.code).toEqual('287082');
+  });
+
+  it('keeps leading zeros', () => {
+    expect(generateTotp({ secret, digits: 8, now: 1111111109_000 }).code).toEqual('07081804');
+  });
+
+  it('returns the same code within a window and a new one after it', () => {
+    // 1_200_000_000_000 lands exactly on a 30s window boundary
+    const first = generateTotp({ secret, now: 1_200_000_000_000 });
+    const sameWindow = generateTotp({ secret, now: 1_200_000_029_999 });
+    const nextWindow = generateTotp({ secret, now: 1_200_000_030_000 });
+    expect(sameWindow.code).toEqual(first.code);
+    expect(nextWindow.code).not.toEqual(first.code);
+  });
+
+  it('reports how long the code stays valid', () => {
+    expect(generateTotp({ secret, now: 1_200_000_000_000 }).expiresInMs).toEqual(30_000);
+    expect(generateTotp({ secret, now: 1_200_000_025_000 }).expiresInMs).toEqual(5_000);
+  });
+
+  it('honors a custom period', () => {
+    const period60 = generateTotp({ secret, period: 60, now: 59_000 });
+    expect(period60.period).toEqual(60);
+    // T=59 with a 60s window is counter 0, matching the HOTP counter-0 vector
+    expect(period60.code).toEqual('755224');
+  });
+
+  it('accepts a secret with the display formatting left in', () => {
+    expect(generateTotp({ secret: 'gezd gnbv gy3t qojq gezd gnbv gy3t qojq', now: 59_000 }).code)
+      .toEqual(generateTotp({ secret, now: 59_000 }).code);
+  });
+
+  it('rejects an empty secret', () => {
+    expect(() => generateTotp({ secret: '  ' })).toThrowError(/empty/);
+  });
+});
+
+describe('generateTotp() with otpauth:// URIs', () => {
+  const secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+
+  it('pulls params out of the URI', () => {
+    const result = generateTotp({
+      secret: `otpauth://totp/npm:theo?secret=${secret}&issuer=npm&algorithm=SHA256&digits=8&period=60`,
+      now: 59_000,
+    });
+    expect(result).toMatchObject({ digits: 8, period: 60, algorithm: 'SHA256' });
+  });
+
+  it('lets explicit options override URI params', () => {
+    const result = generateTotp({
+      secret: `otpauth://totp/npm:theo?secret=${secret}&digits=8&period=60`,
+      digits: 6,
+      period: 30,
+      now: 59_000,
+    });
+    expect(result).toMatchObject({ digits: 6, period: 30 });
+    expect(result.code).toEqual(generateTotp({ secret, now: 59_000 }).code);
+  });
+
+  it('ignores the encoding option, since URI secrets are always base32', () => {
+    const result = generateTotp({
+      secret: `otpauth://totp/npm:theo?secret=${secret}`,
+      encoding: 'hex',
+      now: 59_000,
+    });
+    expect(result.code).toEqual(generateTotp({ secret, now: 59_000 }).code);
+  });
+
+  it('rejects HOTP URIs', () => {
+    expect(() => generateTotp({ secret: `otpauth://hotp/x?secret=${secret}&counter=1` }))
+      .toThrowError(/HOTP/);
+  });
+
+  it('rejects a URI with no secret param', () => {
+    expect(() => generateTotp({ secret: 'otpauth://totp/npm:theo?issuer=npm' }))
+      .toThrowError(/missing a `secret` param/);
+  });
+
+  it('rejects unsupported algorithms', () => {
+    expect(() => parseOtpAuthUri(`otpauth://totp/x?secret=${secret}&algorithm=MD5`))
+      .toThrowError(/unsupported `algorithm` param/);
+  });
+});
+
+describe('normalizeOtpAlgorithm()', () => {
+  it('accepts common spellings', () => {
+    expect(normalizeOtpAlgorithm('sha1')).toEqual('SHA1');
+    expect(normalizeOtpAlgorithm('SHA-256')).toEqual('SHA256');
+    expect(normalizeOtpAlgorithm('sha_512')).toEqual('SHA512');
+  });
+
+  it('returns undefined for unsupported algorithms', () => {
+    expect(normalizeOtpAlgorithm('md5')).toBeUndefined();
+  });
+});

--- a/packages/varlock/src/lib/test/otp.test.ts
+++ b/packages/varlock/src/lib/test/otp.test.ts
@@ -199,6 +199,11 @@ describe('generateTotp() with otpauth:// URIs', () => {
     expect(() => parseOtpAuthUri(`otpauth://totp/x?secret=${secret}&algorithm=MD5`))
       .toThrowError(/unsupported `algorithm` param/);
   });
+
+  it.each([5, 11])('rejects digits=%i', (digits) => {
+    expect(() => parseOtpAuthUri(`otpauth://totp/x?secret=${secret}&digits=${digits}`))
+      .toThrowError(/invalid `digits` param/);
+  });
 });
 
 describe('normalizeOtpAlgorithm()', () => {

--- a/packages/vscode-plugin/src/intellisense-catalog.ts
+++ b/packages/vscode-plugin/src/intellisense-catalog.ts
@@ -488,6 +488,12 @@ export const RESOLVERS: Array<ResolverInfo> = [
     insertText: 'isEmpty(${1:$$OPTIONAL_KEY})',
   },
   {
+    name: 'generateOtp',
+    summary: 'Generates a time-based one-time password (TOTP) code.',
+    documentation: 'Takes the base32 seed or an `otpauth://totp/...` URI. Options: `digits`, `period` (seconds), `algorithm`, `encoding`.',
+    insertText: 'generateOtp(${1:$$TOTP_SECRET})',
+  },
+  {
     name: 'inferFromPrefix',
     summary: 'Special helper for `@defaultSensitive`.',
     documentation: 'Used as `@defaultSensitive=inferFromPrefix(PUBLIC_)`.',


### PR DESCRIPTION
Adds a `generateOtp()` resolver function that turns a TOTP seed into the current code, so CLIs that require a 2FA code on every invocation can get it from the environment:

```env-spec
# TOTP seed from your provider's 2FA setup, encrypted at rest
# @internal @sensitive
MFA_SECRET=varlock(local:abc123...)

# @sensitive
MFA_CODE=generateOtp($MFA_SECRET)
```

```bash
varlock run -- sh -c 'aws sts get-session-token --serial-number $AWS_MFA_ARN --token-code $MFA_CODE'
```

The seed stays `@internal`, so only the generated code is injected.

Accepts a base32 seed (tolerant of the spacing/case/padding people paste) or a full `otpauth://totp/...` URI, whose params become defaults. Options: `digits` (6-10), `period` (seconds, or a duration string), `algorithm` (SHA1/256/512), `encoding` (base32/hex/ascii). Returns a string so leading zeros survive. TOTP/HOTP math is in `packages/varlock/src/lib/otp.ts` using `node:crypto`, no new dependencies.

Two guardrails:
- `cache(generateOtp(...))` is a schema error with a tip to cache the secret instead. A cached code is expired by definition.
- Resolver errors print unredacted, so error messages never echo any part of the secret or of a malformed `otpauth://` URI.

## Not aimed at npm

This started from `npm publish --otp=...`, but npm no longer issues new authenticator-app secrets and only offers passkeys and security keys for new 2FA setups. Existing secrets are grandfathered, so `NPM_CONFIG_OTP=generateOtp(...)` still works if you have one, but the docs no longer lead with it and explicitly steer new automation to trusted publishing (OIDC). Examples use AWS STS MFA instead, which is a durable TOTP case.

## 1Password

`?attribute=otp` was undocumented and had two problems:

- With `cacheTtl` set on an instance, OTP codes were being cached. Now bypassed, including the `attr` short alias.
- The Connect path would have reported a confusing "field not found", since Connect has no OTP attribute. Now a clear error pointing at `generateOtp()`.

Docs cover both routes (let 1Password generate the code vs. store the seed and use `generateOtp()`) with a support table per auth mode.

## Tests

Full RFC 4226 and RFC 6238 test vectors across all three algorithms, plus resolver-level coverage and a 1Password test for an `?attribute=otp` reference. Verified end to end: the injected code matched an independent TOTP calculation, with the seed absent from the child env.