### PR TITLE
Spike: credential broker with Docker sandboxes and Docker Sandboxes (sbx)

### DIFF
--- a/DOCKER_SANDBOX_BROKER_SPIKE.md
+++ b/DOCKER_SANDBOX_BROKER_SPIKE.md
@@ -1,0 +1,114 @@
+# Docker sandboxes + credential broker: spike findings
+
+Question: can a Docker-sandboxed agent use the broker topology (`proxy start --expose` on
+the host, `proxy run --url` in the guest), given that a locked-down container can't reach
+the host network?
+
+Verified empirically on Docker Desktop 29.1.3 (macOS, VirtioFS), including two live
+end-to-end runs through the real broker + tunnel (agent image = node:22 + npm-installed
+`pack:local` tarball; fixture schema with `@proxy(domain="postman-echo.com")`).
+
+## Verified facts
+
+| # | Test | Result |
+|---|------|--------|
+| 1 | default bridge -> `host.docker.internal:port` | reachable |
+| 2 | `--internal` net -> host (even with `--add-host host-gateway`) | fails: network unreachable |
+| 3 | host service bound to `127.0.0.1` only, via `host.docker.internal` | reachable on Docker Desktop (routes to host loopback); native Linux host-gateway does NOT |
+| 4 | host-created unix socket bind-mounted into container | fails: `connect(): Not supported` (VirtioFS won't carry a UDS across the macOS/VM boundary; works on native Linux) |
+| 5 | container-created UDS in bind-mounted host dir, host connects | fails too (same boundary, both directions) |
+| 6 | UDS in a named volume shared between two containers, agent on `--network=none` | works |
+
+End-to-end runs (broker: `proxy start --expose --port 18080` on the host):
+
+- **Variant A** (shipped `--sandbox=docker` shape carrying the tunnel): agent on an
+  `--internal` net, socat sidecar (`varlock-proxy:8888` -> `host.docker.internal:18080`),
+  agent runs `varlock proxy run --url ws://varlock-proxy:8888 --token ... -- curl ...`.
+  PASS: broker log shows `inject: MY_API_KEY` / `scrubbed: MY_API_KEY`, agent saw
+  `Bearer sk▒▒▒▒▒`.
+- **Variant B** (file-socket shape): agent on `--network=none`, socat sidecar bridging
+  `UNIX-LISTEN:/vsock/tunnel.sock` (named volume) -> `TCP:host.docker.internal:18080`,
+  plus an in-agent socat shim `127.0.0.1:8888 -> UNIX-CONNECT:/vsock/tunnel.sock` (only
+  because `proxy run --url` can't dial a UDS yet). PASS, same inject/scrub evidence.
+
+So the premise holds for the case that matters: a sandbox-grade network (`--internal` or
+`none`) cannot reach the host broker over TCP, and the naive
+`--url ws://host.docker.internal` fails. But the tunnel rides fine over any byte pipe;
+only the transport reach is the problem, and two workable paths are proven.
+
+## Design gap found in passing
+
+`proxy start --expose=127.0.0.1` boots but silently serves no tunnel and mints no token
+(`bindIsLoopback` in proxy.command.ts gates `dataPlaneToken`, and runtime-proxy only
+attaches the tunnel when a token exists). Today the only way to get the tunnel is a
+0.0.0.0 (LAN-visible) bind. Docker Desktop can reach loopback-bound host services
+(fact 3), so a "tunnel on loopback" mode is exactly what local docker wants. It is also a
+UX trap: `--expose=127.0.0.1` looks like it worked.
+
+## Options
+
+1. **Docs-only recipe (works today, zero code).** Variant A: `--expose` + socat sidecar +
+   `proxy run --url ws://varlock-proxy:8888`. Cost: none. Downsides: broker listens on the
+   LAN (token-gated, but a real surface), manual multi-step docker setup, agent keeps a
+   network stack + embedded DNS + sidecar reachability.
+
+2. **Loopback expose mode (small).** Serve the tunnel + mint the token on a loopback bind
+   (`--expose=127.0.0.1` gains meaning, or a dedicated flag). The Docker Desktop sidecar
+   then reaches a broker that never leaves 127.0.0.1. Native Linux caveat: host-gateway
+   cannot reach loopback-bound services, so Linux needs option 3 (or a bridge-IP bind).
+
+3. **UDS transport for the tunnel (recommended).**
+   - Broker: `--expose-socket[=path]` serves the same tunnel protocol on a unix socket
+     (can coexist with TCP expose). Keep token auth: a mounted socket is not a trusted
+     caller.
+   - Guest: `proxy run --socket /path/tunnel.sock` (or `--url unix://...`). The native
+     WebSocket client can't dial a UDS, but the only UDS client is our own CLI; the
+     RFC 6455 codec in tunnel.ts is ours, so either add a small masked-frame client codec
+     and keep one framing for both transports (keeps `handleTunnelConnection` unchanged),
+     or run the protocol with minimal framing over the socket.
+   - Per-platform topology:
+     - **Native Linux: no sidecar at all.** Bind-mount the broker's socket into the agent
+       (`-v /run/varlock/xyz.sock:/varlock.sock`), agent on `--network=none` or
+       `--internal`. No TCP anywhere, no LAN exposure, no forwarder container.
+     - **macOS Docker Desktop: sidecar still required** (fact 4 kills the direct UDS
+       bind-mount). Named-volume UDS + socat sidecar -> host TCP (loopback, with
+       option 2). The agent still gets `--network=none` (proven in variant B), which is
+       strictly stronger than `--internal`: no interfaces, no DNS, no
+       container-to-container reach; the mounted socket is the only channel out.
+   - The in-agent socat shim from variant B disappears once `proxy run` dials the UDS
+     itself.
+
+4. **Extend the shipped `--sandbox=docker` instead: no.** The two integration shapes are
+   different products:
+   - *varlock spawns the container*: already shipped (`proxy run --sandbox=docker`,
+     CONNECT proxy + forwarder, env injected via `docker -e`, no varlock needed in-image).
+   - *container attaches to a broker* (this spike): for containers varlock did NOT start:
+     compose stacks, devcontainers, CI jobs, third-party runners, N agents sharing one
+     broker. This is the gap the tunnel/UDS work fills; it should not be folded into
+     `--sandbox`.
+
+Rejected transports: `docker exec` stdio tunnel (inverted initiation, needs muxing,
+docker-only); vsock (not portably exposed by docker); agent-listens/broker-dials (inverts
+the trust model); `--network=host` (no sandbox).
+
+## Recommendation
+
+Do 3 + 2 together, with the docs recipe (1) in the interim:
+
+- tunnel.ts: transport-agnostic client/server framing; UDS listener on the broker; UDS
+  dial in `proxy run`.
+- proxy.command.ts: `--expose-socket[=path]`; make a loopback `--expose=<addr>` serve the
+  tunnel + token (or error loudly instead of silently degrading).
+- Guide: Linux (pure bind-mount, `--network=none`) and macOS (named volume + socat
+  sidecar) recipes.
+
+## Repro crumbs
+
+- Agent image: `node:22-bookworm-slim` + curl + socat + `npm i -g varlock-<v>.tgz`
+  (from `bun run --filter varlock pack:local`).
+- Broker fixture: the E2B guide's schema/local pair, `VARLOCK_PROXY_TOKEN` pinned, run via
+  `node packages/varlock/bin/cli.js proxy start --expose --port 18080`.
+- Sidecar: `alpine/socat:1.8.0.0`, `UNIX-LISTEN:/vsock/tunnel.sock,fork,unlink-early
+  TCP:host.docker.internal:18080`, with `--add-host host.docker.internal:host-gateway`.
+- To re-verify when Linux work starts: podman-machine (applehv) and Apple `container`
+  presumably share the VM/UDS limitation; untested.

--- a/DOCKER_SANDBOX_BROKER_SPIKE.md
+++ b/DOCKER_SANDBOX_BROKER_SPIKE.md
@@ -78,7 +78,20 @@ UX trap: `--expose=127.0.0.1` looks like it worked.
    - The in-agent socat shim from variant B disappears once `proxy run` dials the UDS
      itself.
 
-4. **Extend the shipped `--sandbox=docker` instead: no.** The two integration shapes are
+4. **Broker inside a container (the Fly Sprites shape).** Run `varlock proxy start
+   --expose` in its own dual-homed container (internal net + egress net); agents on the
+   internal net reach it directly by container DNS. No socat and no tunnel at all: the WS
+   tunnel exists only for HTTP-only ingress, and plain `HTTPS_PROXY=http://broker:port`
+   CONNECT works container-to-container (variant A proved the reachability; the forwarder
+   was a stand-in for a broker peer). The trade is resolution context: an in-container
+   broker has no secure-enclave local-encrypt, no `op` biometric session (service-account
+   token instead), and no TTY approvals. Right default for CI / teams / service-account
+   secrets; wrong one for local hardware-custody work. Works today with the Linux binary;
+   needs only a compose recipe/guide. (A hybrid where the host resolves and a container
+   broker adopts the session env buys complexity but puts real values in container memory
+   anyway, weaker than a host broker.)
+
+5. **Extend the shipped `--sandbox=docker` instead: no.** The two integration shapes are
    different products:
    - *varlock spawns the container*: already shipped (`proxy run --sandbox=docker`,
      CONNECT proxy + forwarder, env injected via `docker -e`, no varlock needed in-image).
@@ -87,9 +100,42 @@ UX trap: `--expose=127.0.0.1` looks like it worked.
      broker. This is the gap the tunnel/UDS work fills; it should not be folded into
      `--sandbox`.
 
+Which shape fits is mostly "where do secrets resolve":
+
+| Scenario | Best shape |
+|---|---|
+| Local dev, enclave/1P-biometric custody | broker on host + this PR's transport work |
+| Local custody, remote agents | broker on host + existing WS tunnel (unchanged) |
+| CI / teams / service-account secrets | broker-in-container (option 4), no new code |
+| Docker Sandboxes (sbx) | separate track, see below |
+
 Rejected transports: `docker exec` stdio tunnel (inverted initiation, needs muxing,
 docker-only); vsock (not portably exposed by docker); agent-listens/broker-dials (inverts
 the trust model); `--network=host` (no sandbox).
+
+## Docker Sandboxes (sbx) is a different animal
+
+Everything above is about plain `docker run` containers (compose, devcontainers, CI,
+third-party runners). Docker's newer Sandboxes product (`sbx run claude`,
+docs.docker.com/ai/sandboxes/) is a microVM per sandbox with its own Docker daemon, and
+it already ships a miniature of our idea: all egress forced through a host-side HTTP(S)
+proxy with a deny-by-default domain allowlist, plus a keychain-backed secrets manager
+whose credentials are injected into outbound requests by that host proxy ("raw credential
+values never enter the VM"). Loopback and private IPs are blocked, non-HTTP protocols are
+blocked, and sandboxes cannot network with each other.
+
+Consequences:
+
+- Inside sbx, neither a host broker nor a broker-in-a-neighbor-sandbox is reachable, by
+  design. The seams are: (a) a broker at a public allowlisted domain (the Fly/Vercel/CF
+  gateway direction), or (b) `DOCKER_SANDBOXES_PROXY`, which chains sbx's host proxy
+  through an upstream proxy (http/socks5). Pointing that at a varlock proxy on the same
+  host is an unverified spike; TLS/CA handling across the two proxies is the open
+  question.
+- It is also partially a competitor for the local story (same "credentials never enter
+  the sandbox" pitch). Their injection looks like simple domain-to-header rules; no
+  schema, approvals, response scrubbing, or custody options visible in the docs. Deserves
+  a survey pass alongside microsandbox.
 
 ## Recommendation
 
@@ -101,6 +147,8 @@ Do 3 + 2 together, with the docs recipe (1) in the interim:
   tunnel + token (or error loudly instead of silently degrading).
 - Guide: Linux (pure bind-mount, `--network=none`) and macOS (named volume + socat
   sidecar) recipes.
+- In parallel and independent of any code: a broker-in-container compose guide
+  (option 4) for the service-account/CI audience, mirroring the Fly Sprites guide.
 
 ## Repro crumbs
 

--- a/DOCKER_SBX_SPIKE.md
+++ b/DOCKER_SBX_SPIKE.md
@@ -1,0 +1,132 @@
+# Docker Sandboxes (sbx) + varlock credential broker: spike findings
+
+Tested live on sbx v0.37.1 (macOS, Apple silicon, standalone `sbx` CLI, balanced
+policy), 2026-07-30. Includes a passing end-to-end of the varlock broker with an agent
+inside an sbx microVM, plus notes to pass to the Docker team.
+
+## How sbx networking actually works (observed)
+
+- Sandboxes are microVMs. Egress is wired three ways at once:
+  - explicit env proxy: `HTTP(S)_PROXY=http://gateway.docker.internal:3128`, plus
+    `NODE_USE_ENV_PROXY=1`, `JAVA_TOOL_OPTIONS`, and CA env vars
+    (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`) pointed at a trust
+    store that includes a "Docker Sandboxes Proxy CA" (also exported as
+    `PROXY_CA_CERT_B64`)
+  - a transparent path: direct TCP to allowed hosts on 443 works without the proxy env
+    and shows the origin's real certificate (SNI-gated, `sbx policy log` labels it
+    `transparent` vs `forward` / `forward-bypass`)
+  - DNS filtering: non-allowed domains do not resolve
+- TLS MITM is selective and dynamic: with no secret stored, even `api.anthropic.com` is
+  tunneled with its real certificate. Storing a secret for a host flips that host to
+  MITM (issuer becomes the sbx CA) so headers can be injected.
+- Credential model is the placeholder pattern: built-in service secrets surface env vars
+  like `ANTHROPIC_API_KEY=proxy-managed`; `sbx secret set-custom` generates a
+  placeholder (`sbx-cs-<rand>`), sets it as an env var, and the gateway substitutes the
+  real value in request headers for matching hosts. Architecturally this is a
+  fixed-function version of the varlock proxy.
+
+## End-to-end: varlock broker + sbx sandbox (PASS)
+
+Topology: `varlock proxy start --expose --port 18080` on the host;
+`varlock proxy run --url ... --token ...` inside the sandbox (installed via
+workspace-mounted `pack:local` tarball; the shell template ships Node 22).
+
+1. `sbx policy allow network localhost:18080` is the rule that opens the path. The
+   gateway rewrites `host.docker.internal` to `localhost` before policy evaluation, so
+   allowing `host.docker.internal:18080` does NOT work (see notes below), but once
+   `localhost:18080` is allowed, `http://host.docker.internal:18080` from the sandbox
+   reaches the host broker through the gateway.
+2. The tunnel WS must be dialed through the gateway (`CONNECT` via
+   `gateway.docker.internal:3128`). varlock's tunnel client uses the runtime's native
+   WebSocket, which ignores proxy env vars, so today it needs a shim; with one in place
+   the full flow passes:
+
+   ```
+   socat TCP-LISTEN:18081,bind=127.0.0.1,fork PROXY:gateway.docker.internal:host.docker.internal:18080,proxyport=3128 &
+   varlock proxy run --url ws://127.0.0.1:18081 --token <token> -- <command>
+   ```
+
+   Result: broker log shows `inject: MY_API_KEY` / `scrubbed: MY_API_KEY`; the agent saw
+   only the placeholder. Host custody (enclave, 1Password, approvals) composes with
+   sbx's microVM isolation.
+3. varlock work item to make this first-class: teach the tunnel client to honor
+   `HTTP(S)_PROXY` for its WebSocket dial (CONNECT through an egress proxy). This also
+   helps any provider or corporate network that fronts sandboxes with an explicit proxy.
+   With that, the recipe is two commands: one policy rule + `proxy run --url`.
+4. WSS to an allowed public domain also works from inside (native WebSocket, proven via
+   an echo server), so the remote-broker path (Fly/Vercel/E2B-style public URL) works
+   with zero changes once the broker domain is allowlisted.
+
+## Chaining (`DOCKER_SANDBOXES_PROXY`): wrong seam
+
+Pointing the daemon at varlock as its upstream proxy mechanically works: the gateway
+forwards per-destination `CONNECT`s (varlock logged and policy-blocked
+`registry.npmjs.org`). But TLS layering kills it as an integration point:
+
+- for sbx-MITMed hosts, the gateway is the TLS client and does not trust varlock's CA
+- for tunneled hosts, the client in the VM trusts only the sbx CA, so varlock's MITM
+  fails there too
+
+Two MITM proxies cannot stack unless the outer one can be told to trust the inner's CA.
+Also `sbx daemon start` runs in the foreground (fine), and routing the daemon's own
+control-plane traffic through a strict upstream will break it.
+
+## Notes for the Docker team
+
+Bugs / mismatches:
+
+1. `host.docker.internal` is rewritten to `localhost` before policy evaluation, so an
+   allow rule for `host.docker.internal:PORT` never matches (the deny message says
+   `domain localhost:PORT`), while `sbx policy check network host.docker.internal:PORT`
+   evaluates the literal name and answers "Allowed". The working rule
+   (`localhost:PORT`) is undiscoverable from either surface.
+2. Those denials never show up in `sbx policy log`, which makes 1 harder to debug.
+3. Custom secrets cannot be removed: every form of `sbx secret rm` reports
+   `No secret found for service ... in scope "(global)"`, while `set-custom` says the
+   secret exists in scope `"_"`. (v0.37.1, `set-custom` is experimental.)
+4. Docs say loopback/private/host access is blocked; in practice explicit policy rules
+   for `localhost:PORT` and LAN IPs do route (useful! but the docs and the hard-block
+   claim should agree, and it deserves a documented recipe if intentional).
+
+Security gap worth fixing:
+
+5. Injected secrets come back unscrubbed in response bodies. With a custom secret for
+   `postman-echo.com`, `curl https://postman-echo.com/get -H "authorization: Bearer
+   <placeholder>"` returns the REAL secret in the echoed body, inside the sandbox. Any
+   allowlisted endpoint that reflects request data (echo endpoints, error messages
+   quoting headers, request-logging dashboards) hands the agent the real credential,
+   defeating "the secret never enters the sandbox". Mitigation: scan/scrub response
+   bodies for injected values (varlock does this), and consider capping substitution
+   occurrences per request.
+
+Feature requests that would make third-party credential brokers first-class:
+
+6. A way for the gateway to trust an extra CA for upstream connections
+   (`DOCKER_SANDBOXES_PROXY` + corporate or broker MITM CAs cannot compose today).
+7. A documented, supported policy recipe for reaching a host-local service (today:
+   `sbx policy allow network localhost:PORT`), or a first-class "expose host port into
+   sandbox policy" flag.
+8. Pluggable secret backends for the gateway's injection (today: OS keychain values
+   only). A broker like varlock could then own custody (biometric gating, approvals,
+   audit) while sbx keeps the data plane.
+
+## Comparison snapshot (sbx gateway vs varlock proxy)
+
+Both: explicit proxy + CA in guest, placeholder env vars, host-side header injection,
+domain allowlists. sbx adds microVM isolation + DNS filtering + transparent SNI gating
+(deeper enforcement than varlock's same-host proxy). varlock adds schema-driven config,
+response scrubbing/leak scanning, substitution-surface guards, approvals (TTY today,
+phone/passkey planned), audit log, non-custodial custody (enclave/1Password), and works
+across providers. The composition that uses each for what it is best at: sbx for
+isolation + egress enforcement, varlock broker for custody + injection + scrubbing.
+
+## Repro crumbs
+
+- Install: `brew trust docker/tap && brew install docker/tap/sbx && sbx login`, then
+  `sbx policy init balanced`.
+- Probe sandbox: `sbx create --name vlspike shell <dir>`, `sbx exec vlspike -- sh -c ...`
+  (`shell` template has node 22, curl, socat, git).
+- Policy log labels: `transparent`, `forward`, `forward-bypass`; MITM state visible via
+  `openssl s_client -proxy gateway.docker.internal:3128 -connect <host>:443`.
+- Broker fixture: same as DOCKER_SANDBOX_BROKER_SPIKE.md (postman-echo schema,
+  `VARLOCK_PROXY_TOKEN` pinned).


### PR DESCRIPTION
Findings and options writeups for using the broker topology (`proxy start --expose` + `proxy run --url`) with locally run Docker sandboxes. No code changes; the deliverables are `DOCKER_SANDBOX_BROKER_SPIKE.md` (plain docker containers) and `DOCKER_SBX_SPIKE.md` (the Docker Sandboxes / `sbx` microVM product, including notes to pass to the Docker team).

**Plain docker containers** (Docker Desktop 29.1.3, two live end-to-ends through the real broker + tunnel):

- A sandbox-grade network (`--internal` or `--network=none`) cannot reach the host broker over TCP, so `--url ws://host.docker.internal` fails there (default bridge works fine).
- A host-created unix socket bind-mounted into a container does not work on Docker Desktop (VirtioFS refuses UDS across the VM boundary); it works only on native Linux.
- A unix socket in a shared **named volume** works container-to-container, letting the agent run with `--network=none`. Proven end-to-end: agent with no network stack at all, secret injected and response scrubbed by the broker.
- Gap found in passing: `--expose=127.0.0.1` boots but silently serves no tunnel and mints no token.
- Recommended build: a UDS transport for the tunnel (broker `--expose-socket`, guest `proxy run --socket`, token auth kept) plus making a loopback `--expose` serve the tunnel + token. Linux then needs no sidecar at all; macOS keeps one socat sidecar via a named volume.
- Also covered: broker-in-container (the Fly Sprites shape, right default for CI/service-account secrets) and a "where do secrets resolve" decision matrix.

**Docker Sandboxes (`sbx` v0.37.1)** — live end-to-end PASS of the varlock broker with an agent inside an sbx microVM:

- sbx's gateway is architecturally a fixed-function varlock proxy: explicit env proxy + CA in guest, placeholder env vars (`sbx secret set-custom`), host-side header injection, selective per-host MITM that turns on when a secret is stored.
- The working route to a host broker is `sbx policy allow network localhost:PORT` (the gateway rewrites `host.docker.internal` to `localhost` before policy evaluation), then dialing the tunnel WS through `gateway.docker.internal:3128` via CONNECT. varlock work item: teach the tunnel client to honor `HTTP(S)_PROXY` for its WebSocket dial (a socat shim stands in today).
- `DOCKER_SANDBOXES_PROXY` chaining is the wrong seam: two MITM proxies cannot stack (no way to add an upstream CA trust).
- Notes for the Docker team include a policy check/enforcement mismatch on `host.docker.internal`, unremovable custom secrets, and a real security gap: injected secrets come back **unscrubbed in response bodies**, so any allowlisted endpoint that echoes request data hands the agent the real credential.