### PR TITLE
Add @varlock/cloudflare-gateway: credential proxy adapters for Cloudflare Workers

### DIFF
--- a/.bumpy/proxy-config-command.md
+++ b/.bumpy/proxy-config-command.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+new `varlock proxy config` command: compiles the schema's `@proxy` policy into a static JSON config (rules, placeholders, egress mode, fingerprint - never values) for hosted gateway adapters like Cloudflare Workers

--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,19 @@
         "wrangler",
       ],
     },
+    "packages/integrations/cloudflare-gateway": {
+      "name": "@varlock/cloudflare-gateway",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "catalog:",
+        "tsup": "catalog:",
+        "varlock": "workspace:^1.14.0",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "varlock": "workspace:^1.14.0",
+      },
+    },
     "packages/integrations/expo": {
       "name": "@varlock/expo-integration",
       "version": "1.2.0",
@@ -1476,6 +1489,8 @@
     "@varlock/bumpy": ["@varlock/bumpy@1.18.1", "", { "bin": { "bumpy": "dist/cli.mjs" } }, "sha512-u6PHUr+laAgWWm/c3wdExHBCcvYkkTb+KsiRNR9GCFIbCDrCN9CyOZO/crtRZ5u4KWMKtUTeA7U/s+AA0k7Dcg=="],
 
     "@varlock/ci-env-info": ["@varlock/ci-env-info@workspace:packages/ci-env-info"],
+
+    "@varlock/cloudflare-gateway": ["@varlock/cloudflare-gateway@workspace:packages/integrations/cloudflare-gateway"],
 
     "@varlock/cloudflare-integration": ["@varlock/cloudflare-integration@workspace:packages/integrations/cloudflare"],
 

--- a/packages/integrations/cloudflare-gateway/package.json
+++ b/packages/integrations/cloudflare-gateway/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@varlock/cloudflare-gateway",
+  "description": "Run the varlock credential proxy as a Cloudflare Worker - transparent outbound handler for Cloudflare Sandboxes, explicit HTTPS gateway for any other sandbox",
+  "version": "0.1.0",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dmno-dev/varlock.git",
+    "directory": "packages/integrations/cloudflare-gateway"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "ts-src": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": ["/dist"],
+  "scripts": {
+    "dev": "tsup --watch",
+    "build": "tsup",
+    "test": "vitest",
+    "test:ci": "vitest --run",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "varlock",
+    "cloudflare",
+    "cloudflare-workers",
+    "cloudflare-sandbox",
+    "credential-proxy",
+    "secrets",
+    "egress",
+    "varlock-integration"
+  ],
+  "author": "dmno-dev",
+  "license": "MIT",
+  "peerDependencies": {
+    "varlock": "workspace:^1.14.0"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsup": "catalog:",
+    "varlock": "workspace:^1.14.0",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/integrations/cloudflare-gateway/src/gateway.test.ts
+++ b/packages/integrations/cloudflare-gateway/src/gateway.test.ts
@@ -1,0 +1,317 @@
+import {
+  afterEach, beforeEach, describe, expect, test, vi,
+} from 'vitest';
+import type { ProxyActivity } from 'varlock/proxy-core';
+
+import { createVarlockGateway, GATEWAY_TARGET_HEADER, GATEWAY_TOKEN_HEADER } from './gateway';
+
+const PLACEHOLDER = 'vlk-placeholder-stripe-abc123';
+const REAL_VALUE = 'sk_live_real_secret_value_9876';
+const TOKEN = 'test-data-plane-token';
+
+const ENV = {
+  STRIPE_KEY: REAL_VALUE,
+  _VARLOCK_GATEWAY_TOKEN: TOKEN,
+};
+
+function baseConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    rules: [{ domain: ['api.stripe.com'], itemKeys: ['STRIPE_KEY'] }],
+    placeholders: { STRIPE_KEY: PLACEHOLDER },
+    ...overrides,
+  };
+}
+
+/** Captures upstream fetch calls and returns a canned response. */
+function stubUpstream(response?: () => Response) {
+  const calls: Array<{ url: string; init: RequestInit & { headers: Headers } }> = [];
+  const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: { ...init, headers: new Headers(init?.headers) } });
+    if (response) return response();
+    return new Response('ok', {
+      status: 200,
+      headers: { 'content-type': 'text/plain', 'content-length': '2' },
+    });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return calls;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('asSandboxOutbound (transparent mode)', () => {
+  test('substitutes a placeholder in an auth header and forwards to the original URL', async () => {
+    const calls = stubUpstream();
+    const activities: Array<ProxyActivity> = [];
+    const gateway = createVarlockGateway(baseConfig({ onAudit: (a: ProxyActivity) => activities.push(a) }));
+    const handler = gateway.asSandboxOutbound();
+
+    const res = await handler(new Request('https://api.stripe.com/v1/charges', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${PLACEHOLDER}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ amount: 100 }),
+    }), ENV);
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://api.stripe.com/v1/charges');
+    expect(calls[0].init.headers.get('authorization')).toBe(`Bearer ${REAL_VALUE}`);
+    expect(activities).toMatchObject([{ decision: 'allow', matched: true, injectedKeys: ['STRIPE_KEY'] }]);
+  });
+
+  test('strict egress blocks a host with no rule', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig()).asSandboxOutbound();
+
+    const res = await handler(new Request('https://evil.example.com/exfil'), ENV);
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('not allowed by your egress policy');
+    expect(calls).toHaveLength(0);
+  });
+
+  test('permissive egress forwards unruled hosts untouched', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig({ egressMode: 'permissive' })).asSandboxOutbound();
+
+    const res = await handler(new Request('https://example.com/data?q=1'), ENV);
+
+    expect(res.status).toBe(200);
+    expect(calls[0].url).toBe('https://example.com/data?q=1');
+  });
+
+  test('blocks a placeholder placed in the query (location guard)', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig()).asSandboxOutbound();
+
+    const res = await handler(new Request(`https://api.stripe.com/v1/charges?key=${PLACEHOLDER}`), ENV);
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('appears in the query');
+    expect(calls).toHaveLength(0);
+  });
+
+  test('blocks a duplicated placeholder (occurrence cap)', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig()).asSandboxOutbound();
+
+    const res = await handler(new Request('https://api.stripe.com/v1/charges', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${PLACEHOLDER}`,
+        'x-echo': PLACEHOLDER,
+      },
+    }), ENV);
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('at most 1 is allowed');
+    expect(calls).toHaveLength(0);
+  });
+
+  test('refuses to inject over cleartext http', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig()).asSandboxOutbound();
+
+    const res = await handler(new Request('http://api.stripe.com/v1/charges', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${PLACEHOLDER}` },
+    }), ENV);
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('cleartext');
+    expect(calls).toHaveLength(0);
+  });
+
+  test('fails closed when a carried placeholder has no secret value', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig()).asSandboxOutbound();
+
+    const res = await handler(new Request('https://api.stripe.com/v1/charges', {
+      headers: { authorization: `Bearer ${PLACEHOLDER}` },
+    }), { /* no STRIPE_KEY binding */ });
+
+    expect(res.status).toBe(502);
+    expect(await res.text()).toContain('no value available for STRIPE_KEY');
+    expect(calls).toHaveLength(0);
+  });
+
+  test('forwards a request that does not carry the placeholder even when the secret is unavailable', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig()).asSandboxOutbound();
+
+    const res = await handler(new Request('https://api.stripe.com/v1/status'), {});
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+  });
+
+  test('scrubs a reflected secret out of a buffered response body', async () => {
+    const body = JSON.stringify({ note: `your key is ${REAL_VALUE}` });
+    stubUpstream(() => new Response(body, {
+      status: 200,
+      headers: { 'content-type': 'application/json', 'content-length': String(body.length) },
+    }));
+    const handler = createVarlockGateway(baseConfig()).asSandboxOutbound();
+
+    const res = await handler(new Request('https://api.stripe.com/v1/charges', {
+      headers: { authorization: `Bearer ${PLACEHOLDER}` },
+    }), ENV);
+
+    const text = await res.text();
+    expect(text).toContain(PLACEHOLDER);
+    expect(text).not.toContain(REAL_VALUE);
+  });
+
+  test('scrubs a reflected secret out of a streamed SSE response, across chunk boundaries', async () => {
+    const encoder = new TextEncoder();
+    // split the real value across two chunks to exercise the hold-back logic
+    const part1 = `data: your key is ${REAL_VALUE.slice(0, 10)}`;
+    const part2 = `${REAL_VALUE.slice(10)}\n\n`;
+    stubUpstream(() => new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(part1));
+          controller.enqueue(encoder.encode(part2));
+          controller.close();
+        },
+      }),
+      { status: 200, headers: { 'content-type': 'text/event-stream' } },
+    ));
+    const responses: Array<{ scrubbedKeys: Array<string>; streamed?: boolean }> = [];
+    const handler = createVarlockGateway(baseConfig({
+      onResponse: (info: any) => responses.push(info),
+    })).asSandboxOutbound();
+
+    const res = await handler(new Request('https://api.stripe.com/v1/charges', {
+      headers: { authorization: `Bearer ${PLACEHOLDER}` },
+    }), ENV);
+
+    const text = await res.text();
+    expect(text).toBe(`data: your key is ${PLACEHOLDER}\n\n`);
+    expect(responses).toMatchObject([{ scrubbedKeys: ['STRIPE_KEY'], streamed: true }]);
+  });
+
+  test('creation throws when a rule requires approval (no provider in tier 0)', () => {
+    expect(() => createVarlockGateway(baseConfig({
+      rules: [{ domain: ['api.stripe.com'], itemKeys: ['STRIPE_KEY'], approval: {} }],
+    }))).toThrow(/approval provider/);
+  });
+});
+
+describe('asFetchHandler (explicit gateway mode)', () => {
+  function gatewayRequest(opts: {
+    token?: string | null;
+    target?: string | null;
+    path?: string;
+    headers?: Record<string, string>;
+    method?: string;
+    body?: string;
+  } = {}) {
+    const headers: Record<string, string> = { ...opts.headers };
+    if (opts.token !== null) headers[GATEWAY_TOKEN_HEADER] = opts.token ?? TOKEN;
+    if (opts.target !== null) headers[GATEWAY_TARGET_HEADER] = opts.target ?? 'api.stripe.com';
+    return new Request(`https://gateway.example.workers.dev${opts.path ?? '/v1/charges'}`, {
+      method: opts.method ?? 'GET',
+      headers,
+      ...(opts.body ? { body: opts.body } : {}),
+    });
+  }
+
+  test('refuses everything when no token is configured', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig()).asFetchHandler();
+
+    const res = await handler(gatewayRequest(), { STRIPE_KEY: REAL_VALUE });
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('no data-plane token configured');
+    expect(calls).toHaveLength(0);
+  });
+
+  test('rejects a missing or wrong token', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig()).asFetchHandler();
+
+    expect((await handler(gatewayRequest({ token: null }), ENV)).status).toBe(401);
+    expect((await handler(gatewayRequest({ token: 'wrong' }), ENV)).status).toBe(401);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('accepts the token via Proxy-Authorization basic auth', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig()).asFetchHandler();
+
+    const res = await handler(gatewayRequest({
+      token: null,
+      headers: { 'proxy-authorization': `Basic ${btoa(`varlock:${TOKEN}`)}` },
+    }), ENV);
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+  });
+
+  test('requires and validates the target header', async () => {
+    stubUpstream();
+    const handler = createVarlockGateway(baseConfig()).asFetchHandler();
+
+    expect((await handler(gatewayRequest({ target: null }), ENV)).status).toBe(400);
+    expect((await handler(gatewayRequest({ target: 'not a host!' }), ENV)).status).toBe(400);
+  });
+
+  test('substitutes and forwards to the target host, stripping gateway-internal headers', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig()).asFetchHandler();
+
+    const res = await handler(gatewayRequest({
+      method: 'POST',
+      path: '/v1/charges?expand=balance',
+      headers: { authorization: `Bearer ${PLACEHOLDER}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ amount: 100 }),
+    }), ENV);
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://api.stripe.com/v1/charges?expand=balance');
+    const sent = calls[0].init.headers;
+    expect(sent.get('authorization')).toBe(`Bearer ${REAL_VALUE}`);
+    expect(sent.get(GATEWAY_TARGET_HEADER)).toBeNull();
+    expect(sent.get(GATEWAY_TOKEN_HEADER)).toBeNull();
+    expect(sent.get('proxy-authorization')).toBeNull();
+  });
+
+  test('honors a non-default target port', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig({
+      rules: [{ domain: ['internal.example.com'], itemKeys: [] }],
+    })).asFetchHandler();
+
+    const res = await handler(gatewayRequest({ target: 'internal.example.com:8443', path: '/ping' }), ENV);
+
+    expect(res.status).toBe(200);
+    expect(calls[0].url).toBe('https://internal.example.com:8443/ping');
+  });
+
+  test('blocks an uninjected placeholder with a helpful error', async () => {
+    const calls = stubUpstream();
+    const handler = createVarlockGateway(baseConfig({
+      rules: [
+        { domain: ['api.stripe.com'], itemKeys: ['STRIPE_KEY'] },
+        { domain: ['other.example.com'], itemKeys: [] },
+      ],
+    })).asFetchHandler();
+
+    const res = await handler(gatewayRequest({
+      target: 'other.example.com',
+      headers: { authorization: `Bearer ${PLACEHOLDER}` },
+    }), ENV);
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('no @proxy rule injects it here');
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/packages/integrations/cloudflare-gateway/src/gateway.test.ts
+++ b/packages/integrations/cloudflare-gateway/src/gateway.test.ts
@@ -66,7 +66,7 @@ describe('asSandboxOutbound (transparent mode)', () => {
 
   test('strict egress blocks a host with no rule', async () => {
     const calls = stubUpstream();
-    const handler = createVarlockGateway(baseConfig()).asSandboxOutbound();
+    const handler = createVarlockGateway(baseConfig({ egressMode: 'strict' })).asSandboxOutbound();
 
     const res = await handler(new Request('https://evil.example.com/exfil'), ENV);
 
@@ -75,9 +75,9 @@ describe('asSandboxOutbound (transparent mode)', () => {
     expect(calls).toHaveLength(0);
   });
 
-  test('permissive egress forwards unruled hosts untouched', async () => {
+  test('default (permissive) egress forwards unruled hosts untouched', async () => {
     const calls = stubUpstream();
-    const handler = createVarlockGateway(baseConfig({ egressMode: 'permissive' })).asSandboxOutbound();
+    const handler = createVarlockGateway(baseConfig()).asSandboxOutbound();
 
     const res = await handler(new Request('https://example.com/data?q=1'), ENV);
 

--- a/packages/integrations/cloudflare-gateway/src/gateway.ts
+++ b/packages/integrations/cloudflare-gateway/src/gateway.ts
@@ -1,0 +1,424 @@
+import {
+  detectScrubbedKeys, evaluateProxiedRequestPreBody, evaluateProxiedRequestWithBody,
+  findRealLeak, getHeaderValue, isTextLikeResponse, isUncompressedResponse,
+  parseProxyAuthToken, redactOutgoingHeaders, replaceRealWithPlaceholders,
+  shouldRedactResponseBody, StreamingScrubber, tokenMatches, transformHeaders,
+  type HeadersRecord, type ProxiedRequestFacts,
+  type ProxyManagedItem, type ProxyPolicyState, type RequestScopedManagedItem,
+} from 'varlock/proxy-core';
+
+import type { VarlockGatewayConfig, WaitUntilContext } from './types';
+
+/** Reported after an upstream response is forwarded (mirrors the local runtime's ProxyResponseInfo). */
+export type GatewayResponseInfo = {
+  host: string;
+  method: string;
+  path: string;
+  statusCode: number;
+  scrubbedKeys: Array<string>;
+  streamed?: boolean;
+};
+
+type ResolvedConfig = Required<Pick<VarlockGatewayConfig, 'rules' | 'egressMode' | 'placeholders'>> & {
+  getSecretValue: NonNullable<VarlockGatewayConfig['getSecretValue']>;
+  getToken: NonNullable<VarlockGatewayConfig['getToken']>;
+  onAudit: NonNullable<VarlockGatewayConfig['onAudit']>;
+  onResponse?: (info: GatewayResponseInfo) => void;
+};
+
+/** Header that carries the true destination (`host` or `host:port`) in explicit-gateway mode. */
+export const GATEWAY_TARGET_HEADER = 'x-varlock-target';
+/** Raw-token alternative to `Proxy-Authorization: Basic varlock:<token>` in explicit-gateway mode. */
+export const GATEWAY_TOKEN_HEADER = 'x-varlock-token';
+
+/** Gateway-internal headers: consumed here, never forwarded upstream. */
+const GATEWAY_INTERNAL_HEADERS = [GATEWAY_TARGET_HEADER, GATEWAY_TOKEN_HEADER];
+
+function headersToRecord(headers: Headers): HeadersRecord {
+  const out: HeadersRecord = {};
+  headers.forEach((value, key) => {
+    out[key.toLowerCase()] = value;
+  });
+  return out;
+}
+
+function recordToHeaders(record: Record<string, string | Array<string>>): Headers {
+  const out = new Headers();
+  for (const [key, value] of Object.entries(record)) {
+    if (Array.isArray(value)) {
+      for (const v of value) out.append(key, v);
+    } else {
+      out.set(key, value);
+    }
+  }
+  return out;
+}
+
+function textResponse(status: number, message: string): Response {
+  return new Response(message, { status, headers: { 'content-type': 'text/plain' } });
+}
+
+/**
+ * Scrub real values back to placeholders on an unbounded text stream, chunk by
+ * chunk (the Web-streams sibling of the node runtime's scrubbing Transform).
+ * A streaming TextDecoder keeps multi-byte UTF-8 intact across chunks; the
+ * hold-back of trailing partial real values lives in the shared StreamingScrubber.
+ */
+function createScrubbingTransformStream(
+  managedItems: Array<ProxyManagedItem>,
+  onDone: (matchedKeys: Set<string>) => void,
+  initialMatchedKeys: Iterable<string>,
+): TransformStream<Uint8Array, Uint8Array> {
+  const decoder = new TextDecoder('utf-8');
+  const encoder = new TextEncoder();
+  const matched = new Set(initialMatchedKeys);
+  const scrubber = new StreamingScrubber(managedItems, (key) => matched.add(key));
+  return new TransformStream({
+    transform(chunk, controller) {
+      const text = scrubber.push(decoder.decode(chunk, { stream: true }));
+      if (text) controller.enqueue(encoder.encode(text));
+    },
+    flush(controller) {
+      const text = scrubber.flush(decoder.decode());
+      if (text) controller.enqueue(encoder.encode(text));
+      onDone(matched);
+    },
+  });
+}
+
+/** Everything the shared pipeline needs to know about one gateway request, mode-independent. */
+type GatewayTarget = {
+  host: string;
+  port: number;
+  isHttps: boolean;
+  /** Path + query forwarded upstream. */
+  requestTarget: string;
+  /** Path only (no query), for policy facts. */
+  pathOnly: string;
+};
+
+/**
+ * Parse `host` / `host:port` (the target header). URL-based so bracketed IPv6
+ * literals are handled; mirrors the local runtime's parseHostPort.
+ */
+function parseTargetHost(value: string): { host: string; port: number } | null {
+  try {
+    const url = new URL(`https://${value}`);
+    if (url.pathname !== '/' || url.search || url.hash || url.username) return null;
+    const host = url.hostname.replace(/^\[|\]$/g, '');
+    if (!host) return null;
+    const port = url.port ? Number(url.port) : 443;
+    if (Number.isNaN(port)) return null;
+    return { host, port };
+  } catch {
+    return null;
+  }
+}
+
+/** The Web-streams sibling of the local runtime's forwardUpstreamResponseWithRedaction. */
+async function forwardResponseWithRedaction(
+  upstreamRes: Response,
+  managedItems: Array<ProxyManagedItem>,
+  shouldRedact: boolean,
+  responseCtx: { host: string; method: string; path: string; onResponse?: (info: GatewayResponseInfo) => void },
+): Promise<Response> {
+  const statusCode = upstreamRes.status;
+  const report = (scrubbedKeys: Iterable<string>, streamed: boolean) => {
+    responseCtx.onResponse?.({
+      host: responseCtx.host,
+      method: responseCtx.method,
+      path: responseCtx.path,
+      statusCode,
+      scrubbedKeys: [...new Set(scrubbedKeys)],
+      ...(streamed ? { streamed: true } : {}),
+    });
+  };
+
+  const respHeaderRecord = headersToRecord(upstreamRes.headers);
+  // Detect keys reflected in the (original) response headers, scrubbed regardless of body path.
+  const headerKeys = shouldRedact ? detectScrubbedKeys(JSON.stringify(respHeaderRecord), managedItems) : [];
+  const outgoingHeaders = shouldRedact
+    ? recordToHeaders(redactOutgoingHeaders(respHeaderRecord, managedItems))
+    : new Headers(upstreamRes.headers);
+
+  if (!shouldRedact || !shouldRedactResponseBody(respHeaderRecord)) {
+    // Scrub unbounded uncompressed text streams (e.g. SSE) chunk-by-chunk so a
+    // reflected secret is still replaced. Bounded text bodies take the buffered
+    // path below; compressed/binary bodies pass through unchanged.
+    const hasContentLength = getHeaderValue(respHeaderRecord, 'content-length') !== undefined;
+    const canScrubStream = shouldRedact
+      && managedItems.length > 0
+      && !hasContentLength
+      && isUncompressedResponse(respHeaderRecord)
+      && isTextLikeResponse(respHeaderRecord)
+      && !!upstreamRes.body;
+
+    if (canScrubStream) {
+      const scrubbed = upstreamRes.body!.pipeThrough(createScrubbingTransformStream(
+        managedItems,
+        (matched) => report(matched, true),
+        headerKeys,
+      ));
+      return new Response(scrubbed, { status: statusCode, headers: outgoingHeaders });
+    }
+    report(headerKeys, false);
+    return new Response(upstreamRes.body, { status: statusCode, headers: outgoingHeaders });
+  }
+
+  const originalBody = await upstreamRes.text();
+  const bodyKeys = detectScrubbedKeys(originalBody, managedItems);
+  const redactedBody = replaceRealWithPlaceholders(originalBody, managedItems);
+
+  // Fail-safe (Invariant #6): if a real value somehow survived scrubbing, do
+  // NOT forward it — fail closed rather than leak a secret to the workload.
+  if (findRealLeak(redactedBody, managedItems)) {
+    return textResponse(502, 'Response withheld: a sensitive value could not be redacted');
+  }
+
+  outgoingHeaders.delete('content-length'); // the runtime recomputes it for the redacted body
+  outgoingHeaders.delete('transfer-encoding');
+  outgoingHeaders.delete('etag');
+
+  report([...headerKeys, ...bodyKeys], false);
+  return new Response(redactedBody, { status: statusCode, headers: outgoingHeaders });
+}
+
+/**
+ * The shared request path for both modes: policy → guards → substitution via the
+ * proxy-core two-phase pipeline, then a verified-TLS `fetch()` upstream
+ * (workerd validates upstream certificates before any request bytes are sent,
+ * which is what the local runtime's verifyUpstreamIdentity exists to guarantee),
+ * then response redaction/scrubbing. Every failure path fails closed.
+ */
+async function handleGatewayRequest(
+  request: Request,
+  env: unknown,
+  target: GatewayTarget,
+  config: ResolvedConfig,
+): Promise<Response> {
+  const managedItems: Array<ProxyManagedItem> = Object.entries(config.placeholders)
+    .map(([key, placeholder]) => ({ key, placeholder, realValue: '' }));
+  const policy: ProxyPolicyState = {
+    rules: config.rules,
+    managedItems,
+    egressMode: config.egressMode,
+  };
+  const facts: ProxiedRequestFacts = {
+    host: target.host,
+    isHttps: target.isHttps,
+    method: request.method,
+    pathOnly: target.pathOnly,
+    requestTarget: target.requestTarget,
+  };
+
+  const pre = evaluateProxiedRequestPreBody(facts, policy);
+  if (pre.kind === 'blocked') {
+    config.onAudit(pre.activity);
+    return textResponse(pre.status, pre.message);
+  }
+
+  const bodyBytes = new Uint8Array(await request.arrayBuffer());
+  const bodyText = new TextDecoder().decode(bodyBytes);
+  const headersRecord = headersToRecord(request.headers);
+
+  // Resolve real values lazily, only for the items this request puts in scope.
+  // Fail closed if a carried placeholder's value is unavailable (forwarding it
+  // un-substituted would just fail upstream with a cryptic auth error); items
+  // whose placeholder is NOT in the request are simply dropped from scope.
+  const scanParts = [facts.requestTarget, JSON.stringify(headersRecord), bodyText];
+  const keptItems: Array<RequestScopedManagedItem> = [];
+  for (const item of pre.hostItems) {
+    const value = await config.getSecretValue(item.key, env);
+    if (typeof value === 'string' && value.length > 0) {
+      item.realValue = value;
+      keptItems.push(item);
+    } else if (scanParts.some((part) => part.includes(item.placeholder))) {
+      config.onAudit({
+        host: target.host,
+        method: facts.method,
+        path: facts.pathOnly,
+        url: facts.requestTarget,
+        matched: true,
+        blocked: true,
+        decision: 'blocked-uninjected',
+      });
+      return textResponse(502, `varlock gateway: no value available for ${item.key} - `
+        + 'check the worker secret (or getSecretValue) that should provide it.');
+    }
+  }
+  pre.hostItems = keptItems;
+
+  const outcome = await evaluateProxiedRequestWithBody(
+    pre,
+    facts,
+    policy,
+    { headers: headersRecord, bodyText },
+    {}, // tier 0: no approval provider — require-approval rules fail closed in the pipeline
+  );
+  config.onAudit(outcome.activity);
+  if (outcome.kind === 'blocked') {
+    return textResponse(outcome.status, outcome.message);
+  }
+  const { hostItems, shouldRewrite } = outcome;
+
+  const upstreamHeaderRecord = transformHeaders(headersRecord, outcome.transformHeaderValue);
+  delete upstreamHeaderRecord['proxy-connection'];
+  delete upstreamHeaderRecord.connection;
+  // Hop-by-hop: addressed to this gateway, never the upstream.
+  delete upstreamHeaderRecord['proxy-authorization'];
+  for (const name of GATEWAY_INTERNAL_HEADERS) delete upstreamHeaderRecord[name];
+  // fetch() derives host and content-length itself; a stale value from the
+  // placeholder-form request would conflict with the rewritten body.
+  delete upstreamHeaderRecord.host;
+  delete upstreamHeaderRecord['content-length'];
+
+  const scheme = target.isHttps ? 'https' : 'http';
+  const defaultPort = target.isHttps ? 443 : 80;
+  const portSuffix = target.port && target.port !== defaultPort ? `:${target.port}` : '';
+  const upstreamUrl = `${scheme}://${target.host}${portSuffix}${outcome.rewrittenTarget}`;
+
+  const method = request.method.toUpperCase();
+  let upstreamBody: Uint8Array | undefined;
+  if (method !== 'GET' && method !== 'HEAD') {
+    // Non-rewritten bodies forward the original bytes (binary-safe); rewritten
+    // ones are re-encoded from the substituted text.
+    upstreamBody = shouldRewrite ? new TextEncoder().encode(outcome.rewrittenBodyText) : bodyBytes;
+  }
+
+  let upstreamRes: Response;
+  try {
+    upstreamRes = await fetch(upstreamUrl, {
+      method: request.method,
+      headers: recordToHeaders(upstreamHeaderRecord),
+      ...(upstreamBody !== undefined && upstreamBody.byteLength > 0 ? { body: upstreamBody } : {}),
+      // Proxy semantics: hand redirects back to the workload rather than
+      // following them here (a redirect Location must go through policy too).
+      redirect: 'manual',
+    });
+  } catch {
+    // Fail closed: the connection failed (workerd verifies upstream TLS before
+    // sending), so the secret was never transmitted to an unverified peer.
+    return textResponse(502, 'Upstream request failed');
+  }
+
+  return forwardResponseWithRedaction(upstreamRes, hostItems, shouldRewrite, {
+    host: target.host,
+    method: facts.method,
+    path: facts.pathOnly,
+    onResponse: config.onResponse,
+  });
+}
+
+function resolveConfig(config: VarlockGatewayConfig): ResolvedConfig {
+  // Tier 0 has no approval provider: a require-approval rule would silently deny
+  // every matching request, so surface the misconfiguration loudly at startup.
+  const approvalRule = config.rules.find((rule) => rule.approval);
+  if (approvalRule) {
+    throw new Error('varlock gateway: @proxy approval rules require an approval provider, which this gateway does not support yet. '
+      + 'Remove the approval requirement from the rule, or enforce it with a locally-run proxy instead.');
+  }
+  return {
+    rules: config.rules,
+    egressMode: config.egressMode ?? 'strict',
+    placeholders: config.placeholders,
+    getSecretValue: config.getSecretValue
+      ?? ((itemKey, env) => {
+        const value = (env as Record<string, unknown> | undefined)?.[itemKey];
+        return typeof value === 'string' ? value : undefined;
+      }),
+    getToken: config.getToken
+      ?? ((env) => {
+        const value = (env as Record<string, unknown> | undefined)?._VARLOCK_GATEWAY_TOKEN;
+        return typeof value === 'string' ? value : undefined;
+      }),
+    onAudit: config.onAudit
+      ?? ((activity) => {
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify({ source: 'varlock-gateway', ...activity }));
+      }),
+    ...(config.onResponse ? { onResponse: config.onResponse } : {}),
+  };
+}
+
+/**
+ * A varlock credential gateway for Cloudflare Workers: the same policy →
+ * substitution guards → substitution → response scrubbing pipeline as
+ * `varlock proxy run`, exposed through the two ways traffic can reach a worker.
+ */
+export function createVarlockGateway(configInput: VarlockGatewayConfig) {
+  const config = resolveConfig(configInput);
+
+  return {
+    /**
+     * Outbound handler for the Cloudflare Sandbox SDK / Containers (transparent
+     * mode). Cloudflare terminates the sandbox's TLS and invokes this with the
+     * ORIGINAL request (real URL intact), so nothing inside the sandbox needs a
+     * gateway URL or a varlock binary. Attach it to your Sandbox class:
+     *
+     *   MySandbox.outbound = gateway.asSandboxOutbound();
+     *
+     * and remember to `export { ContainerProxy } from '@cloudflare/sandbox'`.
+     * No token gate: only the platform can route sandbox egress here.
+     */
+    asSandboxOutbound() {
+      return async (request: Request, env?: unknown, _ctx?: unknown): Promise<Response> => {
+        const url = new URL(request.url);
+        const isHttps = url.protocol === 'https:';
+        const defaultPort = isHttps ? 443 : 80;
+        return handleGatewayRequest(request, env, {
+          host: url.hostname.replace(/^\[|\]$/g, ''),
+          port: url.port ? Number(url.port) : defaultPort,
+          isHttps,
+          requestTarget: `${url.pathname}${url.search}`,
+          pathOnly: url.pathname,
+        }, config);
+      };
+    },
+
+    /**
+     * Explicit-gateway fetch handler (for workloads OUTSIDE Cloudflare: E2B,
+     * Fly, CI, ...). Requests arrive as ordinary HTTPS with the true
+     * destination in the `x-varlock-target` header (`host` or `host:port`,
+     * always https) and the data-plane token via
+     * `Proxy-Authorization: Basic varlock:<token>` or `x-varlock-token`.
+     * Auth is checked before anything else; without a configured token every
+     * request is refused (fail closed).
+     *
+     *   export default { fetch: gateway.asFetchHandler() };
+     */
+    asFetchHandler() {
+      return async (request: Request, env?: unknown, _ctx?: WaitUntilContext): Promise<Response> => {
+        const expectedToken = config.getToken(env);
+        if (!expectedToken) {
+          return textResponse(403, 'varlock gateway: no data-plane token configured - set the _VARLOCK_GATEWAY_TOKEN secret.');
+        }
+        const provided = parseProxyAuthToken(request.headers.get('proxy-authorization') ?? undefined)
+          ?? request.headers.get(GATEWAY_TOKEN_HEADER)
+          ?? undefined;
+        if (!tokenMatches(provided, expectedToken)) {
+          return textResponse(401, 'varlock gateway: missing or invalid data-plane token.');
+        }
+
+        const targetRaw = request.headers.get(GATEWAY_TARGET_HEADER);
+        if (!targetRaw) {
+          return textResponse(400, `varlock gateway: missing ${GATEWAY_TARGET_HEADER} header (expected the destination host, e.g. api.stripe.com or host:port).`);
+        }
+        const parsed = parseTargetHost(targetRaw);
+        if (!parsed) {
+          return textResponse(400, `varlock gateway: invalid ${GATEWAY_TARGET_HEADER} header ${JSON.stringify(targetRaw)}.`);
+        }
+
+        const url = new URL(request.url);
+        return handleGatewayRequest(request, env, {
+          host: parsed.host,
+          port: parsed.port,
+          isHttps: true, // explicit-gateway upstreams are always TLS
+          requestTarget: `${url.pathname}${url.search}`,
+          pathOnly: url.pathname,
+        }, config);
+      };
+    },
+  };
+}
+
+export type VarlockGateway = ReturnType<typeof createVarlockGateway>;

--- a/packages/integrations/cloudflare-gateway/src/gateway.ts
+++ b/packages/integrations/cloudflare-gateway/src/gateway.ts
@@ -319,7 +319,7 @@ function resolveConfig(config: VarlockGatewayConfig): ResolvedConfig {
   }
   return {
     rules: config.rules,
-    egressMode: config.egressMode ?? 'strict',
+    egressMode: config.egressMode ?? 'permissive',
     placeholders: config.placeholders,
     getSecretValue: config.getSecretValue
       ?? ((itemKey, env) => {

--- a/packages/integrations/cloudflare-gateway/src/index.ts
+++ b/packages/integrations/cloudflare-gateway/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  createVarlockGateway,
+  GATEWAY_TARGET_HEADER, GATEWAY_TOKEN_HEADER,
+  type GatewayResponseInfo, type VarlockGateway,
+} from './gateway';
+export type { VarlockGatewayConfig, WaitUntilContext } from './types';

--- a/packages/integrations/cloudflare-gateway/src/types.ts
+++ b/packages/integrations/cloudflare-gateway/src/types.ts
@@ -4,6 +4,17 @@ import type { ProxyActivity, ProxyEgressMode, ProxyRule } from 'varlock/proxy-co
 export type WaitUntilContext = { waitUntil?: (promise: Promise<unknown>) => void };
 
 export type VarlockGatewayConfig = {
+  /**
+   * Static-config artifact version, present when this config was emitted by
+   * `varlock proxy config` (the whole JSON file drops in as this config object).
+   */
+  version?: number;
+  /**
+   * Fingerprint of the schema's proxy-relevant definition (from
+   * `varlock proxy config`) - lets deploy tooling detect drift between the
+   * baked config and separately-synced secrets.
+   */
+  schemaFingerprint?: string;
   /** Proxy routing rules (same shape the local proxy enforces, compiled from `@proxy(...)` decorators). */
   rules: Array<ProxyRule>;
   /**

--- a/packages/integrations/cloudflare-gateway/src/types.ts
+++ b/packages/integrations/cloudflare-gateway/src/types.ts
@@ -1,0 +1,51 @@
+import type { ProxyActivity, ProxyEgressMode, ProxyRule } from 'varlock/proxy-core';
+
+/** Structural subset of Cloudflare's ExecutionContext (avoids a workers-types dependency). */
+export type WaitUntilContext = { waitUntil?: (promise: Promise<unknown>) => void };
+
+export type VarlockGatewayConfig = {
+  /** Proxy routing rules (same shape the local proxy enforces, compiled from `@proxy(...)` decorators). */
+  rules: Array<ProxyRule>;
+  /**
+   * `strict` (default): only requests matching a `@proxy` rule are forwarded.
+   * A hosted gateway should not be an open forwarder, even behind its token, so
+   * the default here is stricter than the local proxy's.
+   */
+  egressMode?: ProxyEgressMode;
+  /**
+   * Managed item key → the placeholder the workload holds. Real values are NEVER
+   * part of this config: they are fetched per request via `getSecretValue`, so
+   * the worker bundle stays secret-free.
+   */
+  placeholders: Record<string, string>;
+  /**
+   * Fetch the real value for a managed item, called lazily per request for the
+   * items actually in scope. Defaults to reading the worker env binding named
+   * after the item key (worker secrets). Async so stores like Secrets Store or a
+   * Durable Object can back it without an interface change.
+   */
+  getSecretValue?: (itemKey: string, env: unknown) => string | undefined | Promise<string | undefined>;
+  /**
+   * The data-plane token an external workload must present (explicit-gateway
+   * mode only). Defaults to reading `env._VARLOCK_GATEWAY_TOKEN`. Return
+   * undefined to refuse all external requests (fail closed).
+   */
+  getToken?: (env: unknown) => string | undefined;
+  /**
+   * Audit sink for per-request decisions (never contains secret values).
+   * Defaults to a structured `console.log`, which lands in Workers Logs.
+   */
+  onAudit?: (activity: ProxyActivity) => void;
+  /**
+   * Called after an upstream response is forwarded, with any managed keys whose
+   * real value appeared in it and was scrubbed back to a placeholder.
+   */
+  onResponse?: (info: {
+    host: string;
+    method: string;
+    path: string;
+    statusCode: number;
+    scrubbedKeys: Array<string>;
+    streamed?: boolean;
+  }) => void;
+};

--- a/packages/integrations/cloudflare-gateway/src/types.ts
+++ b/packages/integrations/cloudflare-gateway/src/types.ts
@@ -7,9 +7,13 @@ export type VarlockGatewayConfig = {
   /** Proxy routing rules (same shape the local proxy enforces, compiled from `@proxy(...)` decorators). */
   rules: Array<ProxyRule>;
   /**
-   * `strict` (default): only requests matching a `@proxy` rule are forwarded.
-   * A hosted gateway should not be an open forwarder, even behind its token, so
-   * the default here is stricter than the local proxy's.
+   * `permissive` (default, matching the local proxy): requests to hosts without
+   * a `@proxy` rule are forwarded untouched — no secret is ever involved for
+   * those, and in sandbox-outbound mode ALL of the sandbox's egress (package
+   * installs, git, ...) flows through this handler. `strict` forwards only
+   * rule-matched requests. This is meant to be driven by the schema's egress
+   * setting; for infra-enforced lockdown in sandbox mode prefer the Sandbox
+   * SDK's `allowedHosts` alongside it.
    */
   egressMode?: ProxyEgressMode;
   /**

--- a/packages/integrations/cloudflare-gateway/tsconfig.json
+++ b/packages/integrations/cloudflare-gateway/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@varlock/tsconfig/base.tsconfig.json",
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/integrations/cloudflare-gateway/tsup.config.ts
+++ b/packages/integrations/cloudflare-gateway/tsup.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+
+  // `varlock/proxy-core` stays an import (varlock is a peer dep, and its subpath
+  // ships working types) - the consumer's wrangler build bundles it into the
+  // worker. platform 'neutral' keeps node builtins out of this package too.
+  external: ['varlock/proxy-core'],
+
+  dts: true,
+
+  sourcemap: true,
+  treeshake: true,
+
+  clean: true,
+  outDir: 'dist',
+
+  format: ['esm'],
+  splitting: false,
+  platform: 'neutral',
+});

--- a/packages/integrations/cloudflare-gateway/vitest.config.ts
+++ b/packages/integrations/cloudflare-gateway/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  // resolve `varlock/proxy-core` to monorepo source (same condition tsconfig uses)
+  // so tests don't require varlock's dist to be built first
+  resolve: {
+    conditions: ['ts-src'],
+  },
+  test: {
+    name: '@varlock/cloudflare-gateway',
+  },
+});

--- a/packages/varlock-website/src/content/docs/reference/cli/proxy.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli/proxy.mdx
@@ -23,6 +23,7 @@ Every subcommand operates on a [session](/guides/proxy/running/#sessions). Targe
 - `run -- <command>`: Start a proxy, run `<command>` through it, and tear down on exit. Attaches to a running `proxy start` session for this directory if one exists; otherwise runs self-contained. With `--url` it instead runs through a proxy on **another machine** (a broker started with `--expose`), reached over the built-in WebSocket tunnel, self-wiring the placeholder env and CA certs from the broker. See the [E2B guide](/sandboxes/e2b/).
 - `start`: Start a long-lived proxy session that owns the terminal (a live request log appears here). Stop with `Ctrl+C`.
 - `rules`: Print a static summary of the effective `@proxy` configuration: the rules (host/path/method, block) and each secret's mode (proxied / placeholder / passthrough / omit), without starting a proxy.
+- `config`: Compile the schema's `@proxy` policy into a static config artifact (JSON to stdout, or `--output <file>`): rules, placeholder map, egress mode, and a schema fingerprint. Never values, and no resolver runs, so it is safe anywhere the schema is readable (low-trust CI included). This is the config a hosted gateway adapter bakes into its bundle; real values are delivered separately (for example as worker secrets) and looked up by item key at request time.
 - `env`: Print the proxy + CA environment for a session, to source into another shell (`eval "$(varlock proxy env)"`). Add `--full` to emit the whole child-view env a proxied agent runs with (placeholders for secrets, real values for non-secrets), with `--proxy-url` / `--cert-dir` to repoint it for a remote sandbox.
 - `token`: Print a session's data-plane token, for handing to `proxy run --url`. Its own verb because the token is a credential: it is never included in `status` or `env` output, and the startup banner withholds it unless stdout is a terminal.
 - `status`: List active proxy sessions.
@@ -58,6 +59,9 @@ varlock proxy run -- node agent.js
 # Inspect activity
 varlock proxy status
 varlock proxy audit --format json
+
+# Compile the static gateway config (rules + placeholders, no values)
+varlock proxy config --output varlock-gateway.config.json
 
 # Reach a broker proxy from another machine / a remote sandbox (see the E2B guide)
 varlock proxy start --expose

--- a/packages/varlock/src/cli/commands/proxy.command.ts
+++ b/packages/varlock/src/cli/commands/proxy.command.ts
@@ -84,7 +84,10 @@ import { fetchTunnelBootstrap, startTunnelClientListener } from '../../proxy/tun
 import {
   parseSandboxSpec, isContainerKind, checkSandboxAvailable, type SandboxSpec,
 } from '../../proxy/sandbox';
-import type { ProxyManagedItem, ProxyRule } from '../../proxy/core/types';
+import {
+  PROXY_STATIC_CONFIG_VERSION,
+  type ProxyManagedItem, type ProxyRule, type ProxyStaticConfig,
+} from '../../proxy/core/types';
 import { generateProxyPlaceholderForItem } from '../../proxy/placeholder';
 import { isVarlockReservedKey } from '../../env-graph/lib/reserved-vars';
 import { resetRedactionMap } from '../../runtime/env';
@@ -2326,6 +2329,66 @@ function describeProxyRuleGate(rule: ProxyRule): string {
  * after the fail-closed validation, and for seeing what an agent would and
  * wouldn't be able to reach.
  */
+/**
+ * Compile the schema's proxy policy into the static config artifact (JSON):
+ * rules + placeholders + egress mode + schema fingerprint, never values. This
+ * is what a hosted gateway (e.g. @varlock/cloudflare-gateway) bakes into its
+ * bundle; real values travel separately (worker secrets) and are looked up by
+ * item key at request time.
+ *
+ * Unlike every other proxy verb this never resolves values, so it runs
+ * anywhere the schema is readable - low-trust CI included - and never triggers
+ * a resolver (no keychain/biometric prompt, no cloud call).
+ */
+export async function buildProxyStaticConfig(
+  envGraph: Awaited<ReturnType<typeof loadVarlockEnvGraph>>,
+): Promise<{ staticConfig: ProxyStaticConfig; genericPlaceholderKeys: Array<string> }> {
+  const placeholderMap = await envGraph.getProxyPlaceholderMap();
+  const staticConfig: ProxyStaticConfig = {
+    version: PROXY_STATIC_CONFIG_VERSION,
+    schemaFingerprint: buildProxySchemaFingerprint(envGraph),
+    egressMode: envGraph.proxyEgressMode,
+    rules: await envGraph.getProxyRules(),
+    placeholders: Object.fromEntries(
+      Object.entries(placeholderMap).map(([key, generated]) => [key, generated.placeholder]),
+    ),
+  };
+  return {
+    staticConfig,
+    genericPlaceholderKeys: Object.entries(placeholderMap)
+      .filter(([, generated]) => generated.isGenericFallback)
+      .map(([key]) => key),
+  };
+}
+
+async function configAction(ctx: any) {
+  const envGraph = await loadVarlockEnvGraph({
+    entryFilePaths: ctx.values.path,
+    // This command inspects the schema; don't subject it to the nested guard.
+    skipProxyFingerprintGuard: true,
+  });
+  checkForSchemaErrors(envGraph);
+  checkForNoEnvFiles(envGraph);
+
+  const { staticConfig, genericPlaceholderKeys } = await buildProxyStaticConfig(envGraph);
+  // warnings on stderr so stdout stays valid JSON for piping
+  if (genericPlaceholderKeys.length) {
+    console.error(`⚠️  Proxy items using a generic placeholder: ${genericPlaceholderKeys.join(', ')}`);
+    console.error(
+      '   A generic placeholder may fail an SDK\'s key-format validation (e.g. an `sk-…` prefix check) '
+        + 'at client construction. Add an explicit `@placeholder` or a data type with a known format.',
+    );
+  }
+
+  const json = `${JSON.stringify(staticConfig, null, 2)}\n`;
+  if (ctx.values.output) {
+    await writeFile(ctx.values.output, json, 'utf8');
+    console.error(`Wrote proxy config to ${ctx.values.output}`);
+  } else {
+    process.stdout.write(json);
+  }
+}
+
 async function rulesAction(ctx: any) {
   const envGraph = await loadVarlockEnvGraph({
     entryFilePaths: ctx.values.path,
@@ -2529,6 +2592,20 @@ const rulesCommand = define({
   run: (ctx: any) => rulesAction(ctx),
 });
 
+const configCommand = define({
+  name: 'config',
+  description: 'Compile the schema\'s @proxy policy into a static gateway config (JSON: rules + placeholders, never values)',
+  args: {
+    ...pathArg,
+    output: {
+      type: 'string',
+      short: 'o',
+      description: 'Write to a file instead of stdout (e.g. varlock-gateway.config.json)',
+    },
+  },
+  run: (ctx: any) => configAction(ctx),
+});
+
 const envCommand = define({
   name: 'env',
   description: 'Print a running session\'s proxy env (shell exports or json)',
@@ -2650,6 +2727,7 @@ export const commandSpec = define({
     run: runCommand,
     start: startCommand,
     rules: rulesCommand,
+    config: configCommand,
     env: envCommand,
     token: tokenCommand,
     status: statusCommand,
@@ -2667,6 +2745,7 @@ Proxy command surface:
   varlock proxy run --sandbox=docker --sandbox-image my-agent -- claude   # run the child in a container
   varlock proxy start
   varlock proxy rules                           # summarize the effective @proxy config (no proxy started)
+  varlock proxy config -o varlock-gateway.config.json   # compile static gateway config (rules + placeholders, no values)
   varlock proxy env --session abc12             # this session's wiring env (source locally)
   varlock proxy env --full --proxy-url http://127.0.0.1:8888 --cert-dir /home/user/certs --format json   # full env for a remote sandbox
   varlock proxy start --expose                  # broker: reachable off-loopback, serving the WS tunnel
@@ -2687,7 +2766,7 @@ Proxy command surface:
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   const positionals = ((ctx as any).positionals ?? []).slice((ctx as any).commandPath?.length ?? 0);
   const unknown = positionals[0];
-  const suggestion = 'Use one of: run, start, rules, env, status, audit, reload, stop, prune';
+  const suggestion = 'Use one of: run, start, rules, config, env, status, audit, reload, stop, prune';
   if (unknown) {
     throw new CliExitError(`Unknown proxy action "${unknown}".`, { suggestion });
   }

--- a/packages/varlock/src/cli/commands/test/proxy.command.test.ts
+++ b/packages/varlock/src/cli/commands/test/proxy.command.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from 'vitest';
 import outdent from 'outdent';
 import { DotEnvFileDataSource, EnvGraph } from '../../../env-graph';
 import {
-  buildProxiedChildEnv, computeProxyChildView, isCwdWithin, resolveReloadMode, createReloadKeypressHandler,
+  buildProxiedChildEnv, buildProxyStaticConfig, computeProxyChildView, isCwdWithin, resolveReloadMode,
+  createReloadKeypressHandler,
 } from '../proxy.command.js';
 
 async function loadGraph(envFile: string) {
@@ -367,5 +368,49 @@ describe('buildProxiedChildEnv', () => {
     });
     expect(env.API_KEY).toBe('vlk_placeholder_API_KEY_abc');
     expect(env.__VARLOCK_ENV).toBeUndefined();
+  });
+});
+
+describe('buildProxyStaticConfig (varlock proxy config)', () => {
+  test('emits rules + placeholders + egress + fingerprint from an UNRESOLVED graph', async () => {
+    const graph = new EnvGraph();
+    const source = new DotEnvFileDataSource('.env.schema', {
+      overrideContents: outdent`
+        # @proxyConfig={egress="strict"}
+        # ---
+        BASELINE=1
+
+        # @proxy(domain="api.stripe.com", substituteIn=[header, "body:client_secret"], maxOccurrences=2)
+        # @placeholder=sk_test_placeholder
+        STRIPE_KEY=exec('would-fail-in-ci')
+
+        # @proxy(domain="api.other.com")
+        NO_HINT_KEY=whatever
+      `,
+    });
+    await graph.setRootDataSource(source);
+    await graph.finishLoad();
+    // deliberately NO resolveEnvValues - the compile must not run resolvers
+
+    const { staticConfig, genericPlaceholderKeys } = await buildProxyStaticConfig(graph);
+
+    expect(staticConfig.version).toBe(1);
+    expect(staticConfig.schemaFingerprint).toMatch(/^[0-9a-f]{16,}$/i);
+    expect(staticConfig.egressMode).toBe('strict');
+    expect(staticConfig.rules).toMatchObject([
+      {
+        domain: ['api.stripe.com'],
+        itemKeys: ['STRIPE_KEY'],
+        substituteIn: ['header', 'body:client_secret'],
+        maxOccurrences: 2,
+      },
+      { domain: ['api.other.com'], itemKeys: ['NO_HINT_KEY'] },
+    ]);
+    expect(staticConfig.placeholders.STRIPE_KEY).toBe('sk_test_placeholder');
+    expect(staticConfig.placeholders.NO_HINT_KEY).toMatch(/^vlk_placeholder_NO_HINT_KEY_/);
+    expect(genericPlaceholderKeys).toEqual(['NO_HINT_KEY']);
+
+    // the artifact is pure data - JSON round-trips losslessly
+    expect(JSON.parse(JSON.stringify(staticConfig))).toEqual(staticConfig);
   });
 });

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -31,7 +31,7 @@ import { getCiEnv, type CiEnvInfo } from '@varlock/ci-env-info';
 import { BUILTIN_VARS, isBuiltinVar } from './builtin-vars';
 import { isVarlockReservedKey } from './reserved-vars';
 import { normalizeOverrideKeys } from '../../lib/injected-env-provenance';
-import { generateProxyPlaceholderForItem } from '../../proxy/placeholder';
+import { generateProxyPlaceholderForItem, type GeneratedProxyPlaceholder } from '../../proxy/placeholder';
 import {
   PROXY_APPROVAL_EACH_VALUES,
   parseProxySubstitutionTarget,
@@ -958,7 +958,7 @@ export class EnvGraph {
     serializedGraph.settings.encryptInjectedEnv = this.getRootDec('encryptInjectedEnv')?.resolvedValue ?? false;
     serializedGraph.settings.disableProcessEnvInjection = this.getRootDec('disableProcessEnvInjection')?.resolvedValue ?? false;
     const proxyConfig = this.getRootDec('proxyConfig')?.resolvedValue;
-    serializedGraph.settings.proxyEgress = proxyConfig?.egress === 'strict' ? 'strict' : 'permissive';
+    serializedGraph.settings.proxyEgress = this.proxyEgressMode;
     // Store the raw reload posture (off/manual/auto); the proxy command resolves `auto`
     // at launch from context. Absent = undefined, and the command defaults it to `auto`.
     if (proxyConfig?.reload) serializedGraph.settings.proxyReload = proxyConfig.reload;
@@ -1307,6 +1307,15 @@ export class EnvGraph {
     return out;
   }
 
+  /**
+   * Egress mode from `@proxyConfig={egress=...}`. Root decorators resolve
+   * during finishLoad(), so this needs no value resolution.
+   */
+  get proxyEgressMode(): ProxyEgressMode {
+    const proxyConfig = this.getRootDec('proxyConfig')?.resolvedValue;
+    return proxyConfig?.egress === 'strict' ? 'strict' : 'permissive';
+  }
+
   async getProxyRules(): Promise<Array<ProxyRule>> {
     const rules: Array<ProxyRule> = [];
 
@@ -1337,25 +1346,45 @@ export class EnvGraph {
     return rules;
   }
 
-  async getProxyManagedItems(): Promise<Array<ProxyManagedItem>> {
+  /**
+   * Placeholders for every rule-referenced item, derived from the schema alone
+   * (@placeholder decorators / data types / @type constraints) - value
+   * resolution is NOT required. This is what compiles into a hosted gateway's
+   * static config: there the real values live where the gateway runs (e.g.
+   * worker secrets), so the compiling machine may not hold any values at all.
+   */
+  async getProxyPlaceholderMap(): Promise<Record<string, GeneratedProxyPlaceholder>> {
     const rules = await this.getProxyRules();
     const managedKeys = _.uniq(rules.flatMap((r) => r.itemKeys));
-    const managedItems: Array<ProxyManagedItem> = [];
 
     const usedPlaceholders = new Set<string>();
+    const out: Record<string, GeneratedProxyPlaceholder> = {};
     for (const key of managedKeys) {
       const item = this.configSchema[key];
       if (!item) {
         throw new SchemaError(`@proxy references unknown item "${key}"`);
       }
+      out[key] = await generateProxyPlaceholderForItem(item, usedPlaceholders);
+    }
+    return out;
+  }
+
+  async getProxyManagedItems(): Promise<Array<ProxyManagedItem>> {
+    // Derive from the full schema-only map so a key's placeholder is identical
+    // however it is consumed (local runtime vs compiled gateway config), even in
+    // the uniqueness-suffix edge case - resolution state must not shift them.
+    const placeholderMap = await this.getProxyPlaceholderMap();
+    const managedItems: Array<ProxyManagedItem> = [];
+
+    for (const [key, generated] of Object.entries(placeholderMap)) {
+      const item = this.configSchema[key];
       if (!_.isString(item.resolvedValue) || item.resolvedValue.length === 0) continue;
 
-      const { placeholder, isGenericFallback } = await generateProxyPlaceholderForItem(item, usedPlaceholders);
       managedItems.push({
         key,
-        placeholder,
+        placeholder: generated.placeholder,
         realValue: item.resolvedValue,
-        ...(isGenericFallback ? { placeholderIsGenericFallback: true } : {}),
+        ...(generated.isGenericFallback ? { placeholderIsGenericFallback: true } : {}),
       });
     }
 

--- a/packages/varlock/src/env-graph/test/proxy-mode.test.ts
+++ b/packages/varlock/src/env-graph/test/proxy-mode.test.ts
@@ -373,6 +373,51 @@ describe('proxy decorators', () => {
     expect(byKey.TYPE_KEY?.realValue).toBe('tok_real_secret');
     expect(byKey.NO_HINT_KEY?.realValue).toBe('whatever_real_secret');
   });
+
+  test('placeholder map + egress mode derive from the schema alone, without value resolution', async () => {
+    const schema = outdent`
+      # @proxyConfig={egress="strict"}
+      # ---
+      BASELINE=1
+
+      # @proxy(domain="api.example.com")
+      # @placeholder=sk_test_explicit
+      EXPLICIT_KEY=sk_live_real_explicit
+
+      # @proxy(domain="api.example.com")
+      # @type=string(startsWith=tok_, isLength=12)
+      TYPE_KEY=tok_real_secret
+
+      # a resolver that would fail in a low-trust environment - it must never run here
+      # @proxy(domain="api.stripe.com")
+      # @type=string(startsWith=sk_)
+      UNRESOLVABLE_KEY=exec('definitely-not-a-real-binary-xyz')
+    `;
+
+    // Load WITHOUT resolveEnvValues - the whole point is no resolver ever runs.
+    const graph = new EnvGraph();
+    const source = new DotEnvFileDataSource('.env.schema', { overrideContents: schema });
+    await graph.setRootDataSource(source);
+    await graph.finishLoad();
+
+    expect(graph.proxyEgressMode).toBe('strict');
+
+    const placeholderMap = await graph.getProxyPlaceholderMap();
+    expect(placeholderMap.EXPLICIT_KEY?.placeholder).toBe('sk_test_explicit');
+    expect(placeholderMap.TYPE_KEY?.placeholder).toMatch(/^tok_[0-9a-f]{8}$/);
+    // An item whose value can't resolve locally still gets its placeholder:
+    // for a hosted gateway the value lives remotely (worker secrets), so the
+    // compiling machine may hold no values at all.
+    expect(placeholderMap.UNRESOLVABLE_KEY?.placeholder).toMatch(/^sk_vlk-placeholder-unresolvable-key-/);
+
+    // And the same schema resolved (as the local proxy does it) yields the SAME
+    // placeholders - resolution state must never shift them.
+    const resolvedGraph = await loadGraph(schema.replace("exec('definitely-not-a-real-binary-xyz')", 'sk_resolved'));
+    const managed = await resolvedGraph.getProxyManagedItems();
+    for (const item of managed) {
+      expect(item.placeholder).toBe(placeholderMap[item.key]?.placeholder);
+    }
+  });
 });
 
 describe('proxy resolution view (proxied re-resolution)', () => {

--- a/packages/varlock/src/proxy/core/types.ts
+++ b/packages/varlock/src/proxy/core/types.ts
@@ -164,3 +164,26 @@ export type ProxyManagedItem = {
   /** True when the placeholder is the generic format-agnostic fallback (may fail SDK key-format checks). */
   placeholderIsGenericFallback?: boolean;
 };
+
+export const PROXY_STATIC_CONFIG_VERSION = 1;
+
+/**
+ * The proxy's static policy compiled from a schema, as emitted by
+ * `varlock proxy config`: everything a hosted gateway (e.g. a Cloudflare
+ * Worker) needs EXCEPT real values, which are delivered separately (worker
+ * secrets, a secret store) and looked up by item key at request time. Plain
+ * data - serializes as JSON and diffs cleanly in review.
+ */
+export type ProxyStaticConfig = {
+  version: typeof PROXY_STATIC_CONFIG_VERSION;
+  /**
+   * Fingerprint of the schema's proxy-relevant definition (never values). Lets
+   * a gateway detect drift between its baked config and separately-synced
+   * secrets or a launching orchestrator's schema.
+   */
+  schemaFingerprint: string;
+  egressMode: ProxyEgressMode;
+  rules: Array<ProxyRule>;
+  /** Managed item key → the placeholder the workload holds. */
+  placeholders: Record<string, string>;
+};


### PR DESCRIPTION
> [!NOTE]
> Stacked on #964 (proxy-core extraction). Re-target to `main` once that merges.

## What

New package `@varlock/cloudflare-gateway` (marked `private` for now; flips public when the docs guide ships) that runs the varlock credential proxy pipeline inside a Cloudflare Worker, via the two ways traffic can reach one:

- **`asSandboxOutbound()`** - transparent outbound handler for the Cloudflare Sandbox SDK / Containers. CF terminates the sandbox's TLS per instance and invokes the handler with the original request, so nothing inside the sandbox needs a gateway URL, a CA, or a varlock binary. Attach to the Sandbox class (`MySandbox.outbound = gw.asSandboxOutbound()`) alongside `allowedHosts` for infra-enforced strict egress.
- **`asFetchHandler()`** - explicit HTTPS gateway for workloads outside Cloudflare (E2B, Fly, CI, or the future `varlock proxy run --gateway` guest shim). True destination rides the `x-varlock-target` header (`host` or `host:port`, https only); data-plane auth via `Proxy-Authorization: Basic varlock:<token>` or `x-varlock-token`, constant-time compared, fail closed when no token is configured.

Both modes share one request path built on `varlock/proxy-core`: policy -> substitution guards (placement + occurrence caps) -> placeholder substitution -> upstream `fetch()` (workerd validates upstream TLS before sending, which is what the local runtime's `verifyUpstreamIdentity` exists to guarantee) -> response scrubbing (buffered redaction with the Invariant #6 leak fail-safe, plus chunk-by-chunk `TransformStream` scrubbing for SSE, sharing `StreamingScrubber`'s hold-back logic with the node runtime).

Design decisions:
- **Secret-free bundle**: real values are never in config; they resolve lazily per request through an async `getSecretValue(itemKey, env)` seam (default: worker secret bindings named after the item key). Async from day one so Secrets Store / DO-backed stores slot in without an interface change. A request carrying a placeholder whose value is unavailable fails closed with a pointed error.
- **Permissive egress by default**, matching the local proxy: the schema stays the source of truth for egress mode. In sandbox-outbound mode ALL sandbox egress (package installs, git) flows through the handler, so a strict default would break everything unruled; and without substitution a forwarded request carries no secrets. Infra-level lockdown in sandbox mode is the Sandbox SDK's `allowedHosts`; `strict` remains an explicit opt-in.
- **Approvals**: rules with `approval` throw at gateway creation - no approval provider exists in this tier, and silently denying every matching request would be a confusing failure mode.
- **Audit**: structured `console.log` by default (lands in Workers Logs), overridable via `onAudit`; optional `onResponse` surfaces scrubbed-key info.


## Schema -> config compiler (`varlock proxy config`)

Second commit adds the varlock-side compiler (in varlock core, not the wrangler wrapper): a new `varlock proxy config` subcommand that compiles the schema's `@proxy` policy into the static JSON artifact the gateway bakes into its bundle:

```json
{
  "version": 1,
  "schemaFingerprint": "c81a72…",
  "egressMode": "strict",
  "rules": [{ "domain": ["api.stripe.com"], "itemKeys": ["STRIPE_KEY"] }],
  "placeholders": { "STRIPE_KEY": "sk_test_fake123" }
}
```

- JSON to stdout (or `--output <file>`); warnings go to stderr so stdout stays pipeable.
- **Never values, and no resolver runs**: placeholders now derive from the schema alone via the new `EnvGraph.getProxyPlaceholderMap()`, so the command works in low-trust CI (including Cloudflare Workers Builds) where op/keychain resolvers are unavailable, and never triggers a biometric prompt.
- `getProxyManagedItems()` now builds on the same map, so a key's placeholder is identical however it is consumed (local runtime vs compiled config).
- The gateway config type accepts the artifact directly (optional `version`/`schemaFingerprint` fields), so `import config from './varlock-gateway.config.json'` drops straight into `createVarlockGateway(config)`.
- CLI reference docs updated; `ProxyStaticConfig` type lives in `varlock/proxy-core` so both sides share the shape.

## Tests

Gateway: 18 unit tests run the handlers as plain functions with a stubbed `fetch`: substitution, strict/permissive egress, location + occurrence guards, cleartext refusal, missing-secret fail-closed, buffered + cross-chunk streamed scrubbing, token auth paths, target parsing, internal-header stripping.

Compiler: env-graph tests prove placeholders + egress derive from an unresolved graph and match the resolved path exactly; a command-level test covers the emitted artifact shape; verified end-to-end against a scratch schema whose only value is an unresolvable `exec()`.

Not yet covered (next slices): live workerd verification (miniflare / vitest-pool-workers), the deploy-time secrets sync in `varlock-wrangler` (values to worker secrets + fingerprint drift check), the guest shim, and the docs guide.


