### PR TITLE
Add push-sparingly guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ This is a monorepo managed with bun workspaces and Turborepo:
 ## Branches & pull requests
 
 - Branch names must be meaningful — a short kebab-case description of the change (e.g. `fix-cf-fifo-secret-concat`, `vite-plugin-hmr`). Never push an auto-generated session/worktree branch name (e.g. `claude/dreamy-jones-a79c22`); rename it first with `git branch -m <meaningful-name>`
+- **Do not push after every commit.** Pushes to open PRs trigger automated reviews that cost money. Commit locally as you go, and only push when the work is complete (or the user asks for feedback on work in progress). When in doubt, ask before pushing
 - Do **not** add AI attribution to PRs or commits — no "Authored by Claude" / "Generated with Claude Code" lines in PR descriptions, and no `Co-Authored-By: Claude` commit trailers
 - Keep PR descriptions concise: what changed and why. Don't mention linting passing or bump files being added — those are enforced by hooks and expected, not news
 - When pushing new commits to an open PR, update the PR description if the changes alter what it says


### PR DESCRIPTION
Now that pullfrog reviews run on PR pushes (and cost money), agents should stop pushing every commit. Adds a bullet to the branches/PRs conventions: commit locally as you go, push only when the work is complete or the user asks, and ask when in doubt.