### PR TITLE
auto-load: reuse injected env blob instead of re-resolving

### DIFF
--- a/.bumpy/auto-load-reuse-injected-env.md
+++ b/.bumpy/auto-load-reuse-injected-env.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+varlock/auto-load now reuses the env blob injected by a parent varlock run instead of re-resolving via the CLI, when it was resolved in the same directory. Set _VARLOCK_USE_INJECTED_ENV=1 to always trust an injected blob (e.g. handing env into a sandbox with no .env files), or 0 to always re-resolve.

--- a/.bumpy/auto-load-reuse-injected-env.md
+++ b/.bumpy/auto-load-reuse-injected-env.md
@@ -2,4 +2,4 @@
 varlock: minor
 ---
 
-varlock/auto-load now reuses the env blob injected by a parent varlock run instead of re-resolving via the CLI, when it was resolved in the same directory. Set _VARLOCK_USE_INJECTED_ENV=1 to always trust an injected blob (e.g. handing env into a sandbox with no .env files), or 0 to always re-resolve.
+varlock/auto-load and varlock run now reuse an injected __VARLOCK_ENV blob instead of re-resolving, when it was resolved in the same directory. Set _VARLOCK_USE_INJECTED_ENV=1 to always trust an injected blob (e.g. handing env into a sandbox with no .env files), or 0 to always re-resolve.

--- a/packages/varlock-website/src/content/docs/integrations/javascript.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/javascript.mdx
@@ -76,19 +76,7 @@ Reuse only happens when it is safe to assume a fresh resolution would produce th
 - the blob resolved without errors
 - no env var override recorded in the blob has changed since (e.g. `varlock run -- sh -c 'FOO=x node app.js'` re-resolves so the new `FOO` is honored)
 
-If any check fails, auto-load falls back to resolving via the CLI exactly as before. You can also control this explicitly with the [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) env var: `0` always re-resolves, and `1` always trusts the blob.
-
-Setting `_VARLOCK_USE_INJECTED_ENV=1` is how you hand an env into an environment that has no `.env` files at all, for example a remote sandbox:
-
-```bash
-# on the host: capture the resolved env as a blob
-BLOB=$(varlock load --format json-full --compact)
-
-# in the sandbox: provide only the blob - no .env files or varlock CLI needed
-__VARLOCK_ENV="$BLOB" _VARLOCK_USE_INJECTED_ENV=1 node app.js
-```
-
-Everything auto-load normally provides (the `ENV` object, `process.env` injection, redaction, leak detection) is hydrated from the blob. Combine with [`@encryptInjectedEnv`](/reference/root-decorators/#encryptinjectedenv) and `_VARLOCK_ENV_KEY` to pass the blob as ciphertext and deliver the key separately.
+If any check fails, auto-load falls back to resolving via the CLI exactly as before. You can also control this explicitly with the [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) env var: `0` always re-resolves, and `1` always trusts the blob, skipping the directory check. The trust mode is how you hand an env into an environment with no `.env` files at all, for example a remote sandbox; see the [E2B](/sandboxes/e2b/#passing-the-env-as-a-blob) and [Fly.io](/sandboxes/flyio/#passing-the-env-as-a-blob) guides for that recipe.
 
 
 ## Boot via `varlock run`

--- a/packages/varlock-website/src/content/docs/integrations/javascript.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/javascript.mdx
@@ -76,7 +76,7 @@ Reuse only happens when it is safe to assume a fresh resolution would produce th
 - the blob resolved without errors
 - no env var override recorded in the blob has changed since (e.g. `varlock run -- sh -c 'FOO=x node app.js'` re-resolves so the new `FOO` is honored)
 
-If any check fails, auto-load falls back to resolving via the CLI exactly as before. You can also control this explicitly with the [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) env var: `0` always re-resolves, and `1` always trusts the blob, skipping the directory check. The trust mode is how you hand an env into an environment with no `.env` files at all, for example a remote sandbox; see the [E2B](/sandboxes/e2b/#passing-the-env-as-a-blob) and [Fly.io](/sandboxes/flyio/#passing-the-env-as-a-blob) guides for that recipe.
+If any check fails, auto-load falls back to resolving via the CLI exactly as before. You can also control this explicitly with the [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) env var: `0` always re-resolves, and `1` always trusts the blob, skipping the directory check. The trust mode is how you hand an env into an environment with no `.env` files at all, for example a remote sandbox; see the [E2B](/sandboxes/e2b/#passing-resolved-values) and [Fly.io](/sandboxes/flyio/#passing-resolved-values) guides for that recipe.
 
 
 ## Boot via `varlock run`

--- a/packages/varlock-website/src/content/docs/integrations/javascript.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/javascript.mdx
@@ -76,7 +76,7 @@ Reuse only happens when it is safe to assume a fresh resolution would produce th
 - the blob resolved without errors
 - no env var override recorded in the blob has changed since (e.g. `varlock run -- sh -c 'FOO=x node app.js'` re-resolves so the new `FOO` is honored)
 
-If any check fails, auto-load falls back to resolving via the CLI exactly as before. You can also control this explicitly with the [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) env var: `0` always re-resolves, and `1` always trusts the blob, skipping the directory check. The trust mode is how you hand an env into an environment with no `.env` files at all, for example a remote sandbox; see the [E2B](/sandboxes/e2b/#passing-resolved-values) and [Fly.io](/sandboxes/flyio/#passing-resolved-values) guides for that recipe.
+If any check fails, auto-load falls back to resolving via the CLI exactly as before. You can also control this explicitly with the [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) env var: `0` always re-resolves, and `1` always trusts the blob, skipping the directory check. (`varlock run` applies the same reuse rules when it finds a blob in its environment, which covers non-Node workloads.) The trust mode is how you hand an env into an environment with no `.env` files at all, for example a remote sandbox; see the [E2B](/sandboxes/e2b/#passing-resolved-values) and [Fly.io](/sandboxes/flyio/#passing-resolved-values) guides for that recipe.
 
 
 ## Boot via `varlock run`

--- a/packages/varlock-website/src/content/docs/integrations/javascript.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/javascript.mdx
@@ -68,15 +68,15 @@ Only resolved values are available to the hook, so this does not help with `.env
 
 ### Reusing an injected env blob
 
-If the process was launched by [`varlock run`](/reference/cli/load-and-run/#run), a serialized copy of the resolved env is already present in the environment (the `__VARLOCK_ENV` blob). In that case `varlock/auto-load` reuses the blob directly instead of calling out to the CLI again, so wrapping an auto-load app in `varlock run` does not pay for a second resolution.
+When the process was launched by [`varlock run`](/reference/cli/load-and-run/#run), the resolved env is already present as the `__VARLOCK_ENV` blob. auto-load reuses it instead of calling the CLI again, so wrapping an auto-load app in `varlock run` does not cost a second resolution.
 
-Reuse only happens when it is safe to assume a fresh resolution would produce the same result:
+Reuse only happens when a fresh resolution would produce the same result:
 
-- the blob was resolved in the same directory the app would resolve in anyway (so in a monorepo, a root-level `varlock run` does not stop per-package resolution)
-- the blob resolved without errors
-- no env var override recorded in the blob has changed since (e.g. `varlock run -- sh -c 'FOO=x node app.js'` re-resolves so the new `FOO` is honored)
+- the blob was resolved in the same directory the app would resolve in (a root-level `varlock run` in a monorepo does not stop per-package resolution)
+- it resolved without errors
+- no env override recorded in the blob has changed since (`varlock run -- sh -c 'FOO=x node app.js'` re-resolves, so the new `FOO` wins)
 
-If any check fails, auto-load falls back to resolving via the CLI exactly as before. You can also control this explicitly with the [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) env var: `0` always re-resolves, and `1` always trusts the blob, skipping the directory check. (`varlock run` applies the same reuse rules when it finds a blob in its environment, which covers non-Node workloads.) The trust mode is how you hand an env into an environment with no `.env` files at all, for example a remote sandbox; see the [E2B](/sandboxes/e2b/#passing-resolved-values) and [Fly.io](/sandboxes/flyio/#passing-resolved-values) guides for that recipe.
+If any check fails, auto-load falls back to the CLI. Control it explicitly with [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env): `0` always re-resolves, `1` always trusts the blob, skipping the directory check. `varlock run` applies the same rules when it finds a blob, which covers non-Node workloads. Trust mode is how you hand an env into an environment with no `.env` files at all, like a remote sandbox; see the [E2B](/sandboxes/e2b/#passing-resolved-values) and [Fly.io](/sandboxes/flyio/#passing-resolved-values) guides.
 
 
 ## Boot via `varlock run`

--- a/packages/varlock-website/src/content/docs/integrations/javascript.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/javascript.mdx
@@ -13,7 +13,7 @@ Some tools/frameworks may require an additional package, or have more specific i
 
 ## Node.js - `varlock/auto-load`
 
-The best way to integrate varlock into a plain Node.js application (⚠️ version 22 or higher) is to import the `varlock/auto-load` module. This uses `execSync` to call out to the varlock CLI, sets resolved env vars into `process.env`, and initializes varlock's runtime code, including:
+The best way to integrate varlock into a plain Node.js application (⚠️ version 22 or higher) is to import the `varlock/auto-load` module. This uses `execSync` to call out to the varlock CLI (or [reuses env injected by a parent `varlock run`](#reusing-an-injected-env-blob)), sets resolved env vars into `process.env`, and initializes varlock's runtime code, including:
 
 - varlock's `ENV` object
 - log redaction (if enabled)
@@ -65,6 +65,30 @@ Two things to keep in mind:
 - Reporting is best-effort. auto-load does not `await` your hook (that would change how env is injected), so it gives async work a short window and then forces the process to exit. Return a promise from the hook and auto-load will exit as soon as it settles.
 
 Only resolved values are available to the hook, so this does not help with `.env` **parse or schema errors**, where resolution is skipped entirely. To report those, the DSN must come from a real environment variable and be picked up by an already-initialized reporter.
+
+### Reusing an injected env blob
+
+If the process was launched by [`varlock run`](/reference/cli/load-and-run/#run), a serialized copy of the resolved env is already present in the environment (the `__VARLOCK_ENV` blob). In that case `varlock/auto-load` reuses the blob directly instead of calling out to the CLI again, so wrapping an auto-load app in `varlock run` does not pay for a second resolution.
+
+Reuse only happens when it is safe to assume a fresh resolution would produce the same result:
+
+- the blob was resolved in the same directory the app would resolve in anyway (so in a monorepo, a root-level `varlock run` does not stop per-package resolution)
+- the blob resolved without errors
+- no env var override recorded in the blob has changed since (e.g. `varlock run -- sh -c 'FOO=x node app.js'` re-resolves so the new `FOO` is honored)
+
+If any check fails, auto-load falls back to resolving via the CLI exactly as before. You can also control this explicitly with the [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) env var: `0` always re-resolves, and `1` always trusts the blob.
+
+Setting `_VARLOCK_USE_INJECTED_ENV=1` is how you hand an env into an environment that has no `.env` files at all, for example a remote sandbox:
+
+```bash
+# on the host: capture the resolved env as a blob
+BLOB=$(varlock load --format json-full --compact)
+
+# in the sandbox: provide only the blob - no .env files or varlock CLI needed
+__VARLOCK_ENV="$BLOB" _VARLOCK_USE_INJECTED_ENV=1 node app.js
+```
+
+Everything auto-load normally provides (the `ENV` object, `process.env` injection, redaction, leak detection) is hydrated from the blob. Combine with [`@encryptInjectedEnv`](/reference/root-decorators/#encryptinjectedenv) and `_VARLOCK_ENV_KEY` to pass the blob as ciphertext and deliver the key separately.
 
 
 ## Boot via `varlock run`

--- a/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
+++ b/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
@@ -52,6 +52,16 @@ Set to `warn` to downgrade the build/prerender-time guard on [public+dynamic](/g
 
 When set (`1` / `true`), [`varlock/auto-load`](/integrations/javascript/#reporting-load-failures) throws the error on a load failure instead of exiting, so an already-initialized error tracker (e.g. Sentry) can capture it via its `uncaughtException` handler. Setting a `globalThis._varlockOnLoadError` hook enables the same throw behavior. See [Reporting load failures](/integrations/javascript/#reporting-load-failures).
 
+### `_VARLOCK_USE_INJECTED_ENV`
+
+Controls whether [`varlock/auto-load`](/integrations/javascript/#reusing-an-injected-env-blob) reuses an already-injected [`__VARLOCK_ENV`](#__varlock_env) blob (e.g. from a parent `varlock run`) instead of re-resolving via the CLI:
+
+- unset (default): reuse the blob only when it was resolved in the same directory the app would resolve in anyway, and nothing relevant has changed since
+- `1` / `true`: always trust the blob, skipping the directory check. Use this to hand a blob into an environment with no `.env` files at all (e.g. a sandbox). Missing or unusable blobs become hard errors.
+- `0` / `false`: always re-resolve via the CLI
+
+See [Reusing an injected env blob](/integrations/javascript/#reusing-an-injected-env-blob).
+
 {/*
   Intentionally NOT documented for end users; internal/testing only.
   Kept here (and in VARLOCK_CONFIG_ENV_VARS with internal:true) for maintainer reference.

--- a/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
+++ b/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
@@ -54,13 +54,13 @@ When set (`1` / `true`), [`varlock/auto-load`](/integrations/javascript/#reporti
 
 ### `_VARLOCK_USE_INJECTED_ENV`
 
-Controls whether [`varlock/auto-load`](/integrations/javascript/#reusing-an-injected-env-blob) reuses an already-injected [`__VARLOCK_ENV`](#__varlock_env) blob (e.g. from a parent `varlock run`) instead of re-resolving via the CLI:
+Controls whether [`varlock/auto-load`](/integrations/javascript/#reusing-an-injected-env-blob) and [`varlock run`](/reference/cli/load-and-run/#run) reuse an already-injected [`__VARLOCK_ENV`](#__varlock_env) blob (e.g. from a parent `varlock run`) instead of re-resolving:
 
-- unset (default): reuse the blob only when it was resolved in the same directory the app would resolve in anyway, and nothing relevant has changed since
-- `1` / `true`: always trust the blob, skipping the directory check. Use this to hand a blob into an environment with no `.env` files at all (e.g. a sandbox). Missing or unusable blobs become hard errors.
-- `0` / `false`: always re-resolve via the CLI
+- unset (default): reuse the blob only when it was resolved in the same directory the consumer would resolve in anyway, and nothing relevant has changed since
+- `1` / `true`: always trust the blob, skipping the directory check. Use this to hand a blob into an environment with no `.env` files at all (e.g. a sandbox): auto-load hydrates a Node app from it, and `varlock run` injects its values into any child command. Missing or unusable blobs become hard errors.
+- `0` / `false`: always re-resolve
 
-Values are matched case-insensitively; any other value is ignored (same as unset).
+Values are matched case-insensitively; any other value is ignored (same as unset). `varlock run` flags that change what a resolution produces (`--path`, `--filter`, `--clear-cache`, `--skip-cache`, `--include-internal`) disable reuse, and are rejected when combined with `1`.
 
 See [Reusing an injected env blob](/integrations/javascript/#reusing-an-injected-env-blob).
 

--- a/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
+++ b/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
@@ -56,8 +56,8 @@ When set (`1` / `true`), [`varlock/auto-load`](/integrations/javascript/#reporti
 
 Controls whether [`varlock/auto-load`](/integrations/javascript/#reusing-an-injected-env-blob) and [`varlock run`](/reference/cli/load-and-run/#run) reuse an already-injected [`__VARLOCK_ENV`](#__varlock_env) blob (e.g. from a parent `varlock run`) instead of re-resolving:
 
-- unset (default): reuse the blob only when it was resolved in the same directory the consumer would resolve in anyway, and nothing relevant has changed since
-- `1` / `true`: always trust the blob, skipping the directory check. Use this to hand a blob into an environment with no `.env` files at all (e.g. a sandbox): auto-load hydrates a Node app from it, and `varlock run` injects its values into any child command. Missing or unusable blobs become hard errors.
+- unset (default): reuse the blob only when it was resolved in the same directory the consumer would resolve in, and nothing relevant has changed since
+- `1` / `true`: always trust the blob, skipping the directory check. Use this to hand a blob into an environment with no `.env` files (e.g. a sandbox): auto-load hydrates a Node app from it, and `varlock run` injects its values into any child command. Missing or unusable blobs are hard errors.
 - `0` / `false`: always re-resolve
 
 Values are matched case-insensitively; any other value is ignored (same as unset). `varlock run` flags that change what a resolution produces (`--path`, `--filter`, `--clear-cache`, `--skip-cache`, `--include-internal`) disable reuse, and are rejected when combined with `1`.

--- a/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
+++ b/packages/varlock-website/src/content/docs/reference/reserved-variables.mdx
@@ -60,6 +60,8 @@ Controls whether [`varlock/auto-load`](/integrations/javascript/#reusing-an-inje
 - `1` / `true`: always trust the blob, skipping the directory check. Use this to hand a blob into an environment with no `.env` files at all (e.g. a sandbox). Missing or unusable blobs become hard errors.
 - `0` / `false`: always re-resolve via the CLI
 
+Values are matched case-insensitively; any other value is ignored (same as unset).
+
 See [Reusing an injected env blob](/integrations/javascript/#reusing-an-injected-env-blob).
 
 {/*

--- a/packages/varlock-website/src/content/docs/sandboxes/e2b.mdx
+++ b/packages/varlock-website/src/content/docs/sandboxes/e2b.mdx
@@ -27,6 +27,29 @@ const sandbox = await Sandbox.create({
 
 This is the standard E2B posture: sandboxes hold real values, and the values transit E2B's API. If the sandboxed project is itself a varlock project (it has a `.env.schema`), you can instead install varlock in the sandbox and use `varlock run` there, the same way you would in a [Docker container](/integrations/docker/): values come in via `envs` (the schema validates them at load), or the sandbox resolves its own secrets with a [plugin](/guides/plugins/) and a service-account token as the only bootstrap credential.
 
+### Passing the env as a blob
+
+When the code in the sandbox is a Node app that imports [`varlock/auto-load`](/integrations/javascript/), you can skip enumerating values entirely: capture varlock's serialized env as a single blob, scoped with [`--filter`](/reference/cli-commands/#filtering-items) to just the items that workload should see, and set [`_VARLOCK_USE_INJECTED_ENV=1`](/reference/reserved-variables/#_varlock_use_injected_env) so auto-load in the sandbox hydrates from the blob instead of looking for `.env` files:
+
+```ts title="orchestrate.ts"
+import { execSync } from 'node:child_process';
+import { Sandbox } from 'e2b';
+
+const envBlob = execSync(
+  'varlock load --format json-full --compact --filter "STRIPE_*,SENTRY_DSN"',
+  { encoding: 'utf8' },
+).trim();
+
+const sandbox = await Sandbox.create({
+  envs: {
+    __VARLOCK_ENV: envBlob,
+    _VARLOCK_USE_INJECTED_ENV: '1',
+  },
+});
+```
+
+The sandboxed project needs the `varlock` npm package (and Node 22+, see the install note below), but no `.env` files and no varlock CLI: importing `varlock/auto-load` hydrates `process.env`, the `ENV` object, log redaction, and leak detection straight from the blob, since sensitivity metadata travels with the values. Compared to enumerating `envs`, the filter is the single place that decides what the sandbox sees, and the schema's validation and redaction behavior come along for free.
+
 ## Credential proxy: the broker sandbox
 
 One long-lived sandbox (the broker) runs `varlock proxy start --expose`, which serves the built-in WebSocket tunnel on its proxy port (E2B's public sandbox URLs carry it). Agent sandboxes reach it with `varlock proxy run --url`, which self-wires their placeholder env and CA certs from the broker over the tunnel. The proxy injects real values into requests at the wire, on verified TLS connections to hosts your schema allows, with every request checked against your [`@proxy` rules](/guides/proxy/rules/#routing-rules) and recorded in the [audit log](/guides/proxy/running/#auditing). A compromised or prompt-injected agent can exfiltrate nothing but placeholders.

--- a/packages/varlock-website/src/content/docs/sandboxes/e2b.mdx
+++ b/packages/varlock-website/src/content/docs/sandboxes/e2b.mdx
@@ -5,11 +5,11 @@ description: Using varlock with E2B cloud sandboxes, from resolving and validati
 
 [E2B](https://e2b.dev) runs code in cloud microVM sandboxes, commonly as the execution layer for AI agents. Sandboxes get their env vars from the code that creates them (`envs` at sandbox creation or per command), which makes that orchestrator code the natural place for varlock to do its job.
 
-For workloads you trust with the credentials they use, [pass resolved values](#passing-resolved-values). For agentic workloads, the recommended shape is the [broker sandbox](#credential-proxy-the-broker-sandbox): one sandbox runs the [credential proxy](/guides/proxy/) and holds the real secrets, and agent sandboxes route through it holding only [placeholders](/guides/proxy/rules/#placeholders). The other [topologies](/sandboxes/overview/#topologies) get a brief mention at the end.
+For workloads you trust with the credentials they use, [pass resolved values](#passing-resolved-values). For agentic workloads, the recommended shape is the [broker sandbox](#credential-proxy-the-broker-sandbox): one sandbox runs the [credential proxy](/guides/proxy/) and holds the real secrets, and agent sandboxes route through it holding only [placeholders](/guides/proxy/rules/#placeholders).
 
 ## Passing resolved values
 
-Import [`varlock/auto-load`](/integrations/javascript/) at the top of the orchestrator: varlock resolves your values (from plugins, `.env.local`, etc.), validates them against your schema, and redacts them in the orchestrator's logs. Then hand the sandbox its env in one shot:
+Import [`varlock/auto-load`](/integrations/javascript/) at the top of the orchestrator: varlock resolves your values (plugins, `.env.local`, etc.), validates them against your schema, and redacts them in the orchestrator's logs.
 
 ```ts title="orchestrate.ts"
 import 'varlock/auto-load';
@@ -17,8 +17,8 @@ import { ENV } from 'varlock/env';
 import { execSync } from 'node:child_process';
 import { Sandbox } from 'e2b';
 
-// capture the resolved env as one blob, --filter scoping it to
-// just the items this sandbox should see
+// one blob with the resolved env, scoped by --filter to what
+// this sandbox should see
 const envBlob = execSync(
   'varlock load --format json-full --compact --filter "STRIPE_*,SENTRY_DSN"',
   { encoding: 'utf8' },
@@ -36,7 +36,7 @@ const sandbox = await Sandbox.create({
 });
 ```
 
-This is the standard E2B posture: sandboxes hold real values, and the values transit E2B's API. In the sandbox, the blob works with either the `varlock` npm package (Node 22+, imported by the app as above) or the varlock CLI (`varlock run -- <command>` injects plain env vars from the blob, for any workload); see [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details. From a shell instead of Node, `varlock run --inject blob --filter ... -- sh -c '...'` exposes the same blob as `$__VARLOCK_ENV` for forwarding.
+This is the standard E2B posture: sandboxes hold real values, and the values transit E2B's API. Consuming the blob needs either the `varlock` npm package (Node 22+) or the varlock CLI (`varlock run -- <command>` injects plain env vars from the blob, for any workload). See [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env). From a shell, `varlock run --inject blob --filter ... -- sh -c '...'` exposes the blob as `$__VARLOCK_ENV` for forwarding.
 
 ## Credential proxy: the broker sandbox
 

--- a/packages/varlock-website/src/content/docs/sandboxes/e2b.mdx
+++ b/packages/varlock-website/src/content/docs/sandboxes/e2b.mdx
@@ -36,7 +36,7 @@ const sandbox = await Sandbox.create({
 });
 ```
 
-This is the standard E2B posture: sandboxes hold real values, and the values transit E2B's API. The blob route needs the `varlock` npm package (Node 22+) in the sandboxed project; see [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details. From a shell instead of Node, `varlock run --inject blob --filter ... -- sh -c '...'` exposes the same blob as `$__VARLOCK_ENV` for forwarding.
+This is the standard E2B posture: sandboxes hold real values, and the values transit E2B's API. In the sandbox, the blob works with either the `varlock` npm package (Node 22+, imported by the app as above) or the varlock CLI (`varlock run -- <command>` injects plain env vars from the blob, for any workload); see [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details. From a shell instead of Node, `varlock run --inject blob --filter ... -- sh -c '...'` exposes the same blob as `$__VARLOCK_ENV` for forwarding.
 
 ## Credential proxy: the broker sandbox
 

--- a/packages/varlock-website/src/content/docs/sandboxes/e2b.mdx
+++ b/packages/varlock-website/src/content/docs/sandboxes/e2b.mdx
@@ -9,32 +9,16 @@ For workloads you trust with the credentials they use, [pass resolved values](#p
 
 ## Passing resolved values
 
-Import [`varlock/auto-load`](/integrations/javascript/) at the top of the orchestrator. Varlock resolves your values (from plugins, `.env.local`, etc.), validates them against your schema, and sets up log redaction, with no wrapper command; E2B delivery stays plain `envs`:
+Import [`varlock/auto-load`](/integrations/javascript/) at the top of the orchestrator: varlock resolves your values (from plugins, `.env.local`, etc.), validates them against your schema, and redacts them in the orchestrator's logs. Then hand the sandbox its env in one shot:
 
 ```ts title="orchestrate.ts"
 import 'varlock/auto-load';
 import { ENV } from 'varlock/env';
-import { Sandbox } from 'e2b';
-
-const sandbox = await Sandbox.create({
-  envs: {
-    STRIPE_SECRET_KEY: ENV.STRIPE_SECRET_KEY,
-  },
-});
-```
-
-(Running the orchestrator under `varlock run -- node orchestrate.ts` works too, and is the option when the orchestrator is not a Node program. From a shell, keep any `$VAR` expansion inside a `sh -c '...'` wrapper so varlock resolves it first.)
-
-This is the standard E2B posture: sandboxes hold real values, and the values transit E2B's API. If the sandboxed project is itself a varlock project (it has a `.env.schema`), you can instead install varlock in the sandbox and use `varlock run` there, the same way you would in a [Docker container](/integrations/docker/): values come in via `envs` (the schema validates them at load), or the sandbox resolves its own secrets with a [plugin](/guides/plugins/) and a service-account token as the only bootstrap credential.
-
-### Passing the env as a blob
-
-When the code in the sandbox is a Node app that imports [`varlock/auto-load`](/integrations/javascript/), you can skip enumerating values entirely: capture varlock's serialized env as a single blob, scoped with [`--filter`](/reference/cli-commands/#filtering-items) to just the items that workload should see, and set [`_VARLOCK_USE_INJECTED_ENV=1`](/reference/reserved-variables/#_varlock_use_injected_env) so auto-load in the sandbox hydrates from the blob instead of looking for `.env` files:
-
-```ts title="orchestrate.ts"
 import { execSync } from 'node:child_process';
 import { Sandbox } from 'e2b';
 
+// capture the resolved env as one blob, --filter scoping it to
+// just the items this sandbox should see
 const envBlob = execSync(
   'varlock load --format json-full --compact --filter "STRIPE_*,SENTRY_DSN"',
   { encoding: 'utf8' },
@@ -42,13 +26,17 @@ const envBlob = execSync(
 
 const sandbox = await Sandbox.create({
   envs: {
+    // a Node app that imports varlock hydrates process.env, the ENV object,
+    // and log redaction from the blob - no .env files or CLI in the sandbox
     __VARLOCK_ENV: envBlob,
     _VARLOCK_USE_INJECTED_ENV: '1',
+    // for workloads that don't import varlock, enumerate plain vars instead:
+    // STRIPE_SECRET_KEY: ENV.STRIPE_SECRET_KEY,
   },
 });
 ```
 
-The sandboxed project needs the `varlock` npm package (and Node 22+, see the install note below), but no `.env` files and no varlock CLI: importing `varlock/auto-load` hydrates `process.env`, the `ENV` object, log redaction, and leak detection straight from the blob, since sensitivity metadata travels with the values. Compared to enumerating `envs`, the filter is the single place that decides what the sandbox sees, and the schema's validation and redaction behavior come along for free.
+This is the standard E2B posture: sandboxes hold real values, and the values transit E2B's API. The blob route needs the `varlock` npm package (Node 22+) in the sandboxed project; see [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details. From a shell instead of Node, `varlock run --inject blob --filter ... -- sh -c '...'` exposes the same blob as `$__VARLOCK_ENV` for forwarding.
 
 ## Credential proxy: the broker sandbox
 

--- a/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
+++ b/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
@@ -33,20 +33,18 @@ await sprite.exec('node agent.js', {
     // and log redaction from the blob - no .env files or CLI in the sprite
     __VARLOCK_ENV: envBlob,
     _VARLOCK_USE_INJECTED_ENV: '1',
-    // for workloads that don't import varlock, enumerate plain vars instead:
-    // STRIPE_SECRET_KEY: ENV.STRIPE_SECRET_KEY,
+    // or enumerate plain vars: STRIPE_SECRET_KEY: ENV.STRIPE_SECRET_KEY,
   },
 });
+
+// non-Node workload? install varlock in the sprite (npm i -g varlock) and
+// wrap the command instead - varlock run injects plain env vars from the blob:
+// await sprite.exec('varlock run -- ./my-agent', {
+//   env: { __VARLOCK_ENV: envBlob, _VARLOCK_USE_INJECTED_ENV: '1' },
+// });
 ```
 
-From a shell, wrap the command so the blob is expanded **inside** varlock's env rather than by your own shell first:
-
-```bash
-varlock run --inject blob --filter "STRIPE_*,SENTRY_DSN" -- sh -c \
-  'sprite exec -s my-sprite --env __VARLOCK_ENV="$__VARLOCK_ENV" --env _VARLOCK_USE_INJECTED_ENV=1 -- node agent.js'
-```
-
-This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. In the sprite, the blob works with either the `varlock` npm package (imported by the app as above; sprites ship Node 24+) or the varlock CLI (`varlock run -- <command>` injects plain env vars from the blob, for any workload); see [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details.
+This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. See [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details. One sprite CLI caveat: `sprite exec --env` treats its value as comma-delimited `KEY=v,KEY2=v2` pairs, so it cannot carry the JSON blob from a shell; use the SDK/API env map as above, or upload the blob with `--file` and read it in the command (`sh -c '__VARLOCK_ENV="$(cat /tmp/blob)" _VARLOCK_USE_INJECTED_ENV=1 varlock run -- ./my-agent'`).
 
 ## Credential proxy: the broker sprite
 

--- a/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
+++ b/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
@@ -9,31 +9,7 @@ For workloads you trust with the credentials they use, [pass resolved values](#p
 
 ## Passing resolved values
 
-Sprite env is per exec, so credentials exist only for the duration of one command. Import [`varlock/auto-load`](/integrations/javascript/) in the orchestrator and pass the values that sprite needs; varlock resolves them (from plugins, `.env.local`, etc.), validates them against your schema, and redacts them in the orchestrator's logs:
-
-```ts title="orchestrate.ts"
-import 'varlock/auto-load';
-import { ENV } from 'varlock/env';
-import { SpritesClient } from '@fly/sprites';
-
-const sprite = new SpritesClient(ENV.SPRITES_TOKEN).sprite('my-sprite');
-
-await sprite.exec('node agent.js', { env: { STRIPE_SECRET_KEY: ENV.STRIPE_SECRET_KEY } });
-```
-
-Your Sprites token is a varlock-managed secret like any other, hence `ENV.SPRITES_TOKEN`. (`sprite.spawn(cmd, args, { env })` takes the same options and streams output instead of resolving.)
-
-From a shell, wrap the command so the value is expanded **inside** varlock's env rather than by your own shell first:
-
-```bash
-varlock run -- sh -c 'sprite exec -s my-sprite --env STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY" -- node agent.js'
-```
-
-This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. If the code in the sprite is itself a varlock project (it has a `.env.schema`), install varlock there instead and use `varlock run` in the sprite, the way you would in a [Docker container](/integrations/docker/): sprites ship Node 24+, so `npm i -g varlock` works, and a [checkpoint](https://docs.sprites.dev/) makes the install stick (sprites have no custom images; the persistent filesystem is the customization story).
-
-### Passing the env as a blob
-
-When the code in the sprite is a Node app that imports [`varlock/auto-load`](/integrations/javascript/), you can skip enumerating values entirely: capture varlock's serialized env as a single blob, scoped with [`--filter`](/reference/cli-commands/#filtering-items) to just the items that workload should see, and set [`_VARLOCK_USE_INJECTED_ENV=1`](/reference/reserved-variables/#_varlock_use_injected_env) so auto-load in the sprite hydrates from the blob instead of looking for `.env` files:
+Sprite env is per exec, so credentials exist only for the duration of one command. Import [`varlock/auto-load`](/integrations/javascript/) in the orchestrator: varlock resolves your values (from plugins, `.env.local`, etc.), validates them against your schema, and redacts them in the orchestrator's logs. Then hand the sprite its env in one shot:
 
 ```ts title="orchestrate.ts"
 import 'varlock/auto-load';
@@ -41,28 +17,36 @@ import { ENV } from 'varlock/env';
 import { execSync } from 'node:child_process';
 import { SpritesClient } from '@fly/sprites';
 
+// capture the resolved env as one blob, --filter scoping it to
+// just the items this sprite should see
 const envBlob = execSync(
   'varlock load --format json-full --compact --filter "STRIPE_*,SENTRY_DSN"',
   { encoding: 'utf8' },
 ).trim();
 
+// your Sprites token is a varlock-managed secret like any other
 const sprite = new SpritesClient(ENV.SPRITES_TOKEN).sprite('my-sprite');
+
 await sprite.exec('node agent.js', {
-  env: { __VARLOCK_ENV: envBlob, _VARLOCK_USE_INJECTED_ENV: '1' },
+  env: {
+    // a Node app that imports varlock hydrates process.env, the ENV object,
+    // and log redaction from the blob - no .env files or CLI in the sprite
+    __VARLOCK_ENV: envBlob,
+    _VARLOCK_USE_INJECTED_ENV: '1',
+    // for workloads that don't import varlock, enumerate plain vars instead:
+    // STRIPE_SECRET_KEY: ENV.STRIPE_SECRET_KEY,
+  },
 });
 ```
 
-From a shell, `varlock run --inject blob` produces the same filtered blob as an env var you can forward. If your schema sets [`@encryptInjectedEnv`](/reference/root-decorators/#encryptinjectedenv), the blob it injects is already ciphertext; forward `_VARLOCK_ENV_KEY` alongside it to decrypt in the sprite:
+From a shell, wrap the command so the blob is expanded **inside** varlock's env rather than by your own shell first:
 
 ```bash
 varlock run --inject blob --filter "STRIPE_*,SENTRY_DSN" -- sh -c \
-  'sprite exec -s my-sprite \
-     --env __VARLOCK_ENV="$__VARLOCK_ENV" \
-     --env _VARLOCK_USE_INJECTED_ENV=1 \
-     -- node agent.js'
+  'sprite exec -s my-sprite --env __VARLOCK_ENV="$__VARLOCK_ENV" --env _VARLOCK_USE_INJECTED_ENV=1 -- node agent.js'
 ```
 
-The project in the sprite needs the `varlock` npm package, but no `.env` files and no varlock CLI: importing `varlock/auto-load` hydrates `process.env`, the `ENV` object, log redaction, and leak detection straight from the blob, since sensitivity metadata travels with the values. Compared to enumerating `--env` flags, the filter is the single place that decides what the sprite sees, and the schema's validation and redaction behavior come along for free.
+This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. The blob route needs the `varlock` npm package in the sprite's project (sprites ship Node 24+); see [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details.
 
 ## Credential proxy: the broker sprite
 

--- a/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
+++ b/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
@@ -46,7 +46,7 @@ varlock run --inject blob --filter "STRIPE_*,SENTRY_DSN" -- sh -c \
   'sprite exec -s my-sprite --env __VARLOCK_ENV="$__VARLOCK_ENV" --env _VARLOCK_USE_INJECTED_ENV=1 -- node agent.js'
 ```
 
-This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. The blob route needs the `varlock` npm package in the sprite's project (sprites ship Node 24+); see [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details.
+This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. In the sprite, the blob works with either the `varlock` npm package (imported by the app as above; sprites ship Node 24+) or the varlock CLI (`varlock run -- <command>` injects plain env vars from the blob, for any workload); see [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details.
 
 ## Credential proxy: the broker sprite
 

--- a/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
+++ b/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
@@ -44,7 +44,7 @@ await sprite.exec('node agent.js', {
 // });
 ```
 
-This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. See [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details. One sprite CLI caveat: `sprite exec --env` treats its value as comma-delimited `KEY=v,KEY2=v2` pairs, so it cannot carry the JSON blob from a shell; use the SDK/API env map as above, or upload the blob with `--file` and read it in the command (`sh -c '__VARLOCK_ENV="$(cat /tmp/blob)" _VARLOCK_USE_INJECTED_ENV=1 varlock run -- ./my-agent'`).
+This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. See [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details. One sprite CLI caveat: `sprite exec --env` treats its value as comma-delimited `KEY=v,KEY2=v2` pairs, so a JSON blob passed through it gets silently truncated at the first comma; use the SDK/API env map as above, or upload the blob with `--file` and read it in the command (`sh -c '__VARLOCK_ENV="$(cat /tmp/blob)" _VARLOCK_USE_INJECTED_ENV=1 varlock run -- ./my-agent'`).
 
 ## Credential proxy: the broker sprite
 

--- a/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
+++ b/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
@@ -5,11 +5,11 @@ description: Using varlock with Fly.io Sprites, from resolving and validating sa
 
 [Sprites](https://fly.io/sprites/) are Fly.io's agent sandboxes: persistent, hardware-isolated Linux microVMs with their own CLI and SDKs. Sprites get env vars from the code that creates and execs into them, which makes that orchestrator code the natural place for varlock to do its job.
 
-For workloads you trust with the credentials they use, [pass resolved values](#passing-resolved-values). For agentic workloads, the recommended shape is the [broker sprite](#credential-proxy-the-broker-sprite): one sprite runs the [credential proxy](/guides/proxy/) and holds the real secrets, and agent sprites route through it holding only [placeholders](/guides/proxy/rules/#placeholders). The other [topologies](/sandboxes/overview/#topologies) get a brief mention at the end, along with notes for raw [Fly Machines](#raw-fly-machines).
+For workloads you trust with the credentials they use, [pass resolved values](#passing-resolved-values). For agentic workloads, the recommended shape is the [broker sprite](#credential-proxy-the-broker-sprite): one sprite runs the [credential proxy](/guides/proxy/) and holds the real secrets, and agent sprites route through it holding only [placeholders](/guides/proxy/rules/#placeholders).
 
 ## Passing resolved values
 
-Sprite env is per exec, so credentials exist only for the duration of one command. Import [`varlock/auto-load`](/integrations/javascript/) in the orchestrator: varlock resolves your values (from plugins, `.env.local`, etc.), validates them against your schema, and redacts them in the orchestrator's logs.
+Sprite env is per exec, so credentials exist only for the duration of one command. Import [`varlock/auto-load`](/integrations/javascript/) in the orchestrator: varlock resolves your values (plugins, `.env.local`, etc.), validates them against your schema, and redacts them in the orchestrator's logs.
 
 ```ts title="orchestrate.ts"
 import 'varlock/auto-load';
@@ -25,10 +25,9 @@ await sprite.exec('node agent.js', {
   env: { STRIPE_SECRET_KEY: ENV.STRIPE_SECRET_KEY },
 });
 
-// or hand over the whole env as one blob, --filter scoping it to just the
-// items this sprite should see. A Node app that imports varlock hydrates
-// process.env, the ENV object, and log redaction from the blob - no .env
-// files or CLI in the sprite
+// or pass the whole env as one blob, scoped by --filter. A Node app that
+// imports varlock hydrates process.env, the ENV object, and log redaction
+// from it - no .env files or CLI in the sprite
 const envBlob = execSync(
   'varlock load --format json-full --compact --filter "STRIPE_*,SENTRY_DSN"',
   { encoding: 'utf8' },
@@ -44,9 +43,9 @@ await sprite.exec('varlock run -- ./my-agent', {
 });
 ```
 
-This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. See [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details.
+This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. See [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env).
 
-From the sprite CLI, `--env` cannot carry the blob: it parses its value as comma-delimited `KEY=v,KEY2=v2` pairs and silently truncates at the first comma. Upload the blob with `--file` instead:
+The sprite CLI's `--env` cannot carry the blob: it parses comma-delimited `KEY=v,KEY2=v2` pairs and silently truncates at the first comma. Upload the blob with `--file` instead:
 
 ```bash
 varlock load --format json-full --compact --filter "STRIPE_*,SENTRY_DSN" > env-blob

--- a/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
+++ b/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
@@ -31,6 +31,39 @@ varlock run -- sh -c 'sprite exec -s my-sprite --env STRIPE_SECRET_KEY="$STRIPE_
 
 This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. If the code in the sprite is itself a varlock project (it has a `.env.schema`), install varlock there instead and use `varlock run` in the sprite, the way you would in a [Docker container](/integrations/docker/): sprites ship Node 24+, so `npm i -g varlock` works, and a [checkpoint](https://docs.sprites.dev/) makes the install stick (sprites have no custom images; the persistent filesystem is the customization story).
 
+### Passing the env as a blob
+
+When the code in the sprite is a Node app that imports [`varlock/auto-load`](/integrations/javascript/), you can skip enumerating values entirely: capture varlock's serialized env as a single blob, scoped with [`--filter`](/reference/cli-commands/#filtering-items) to just the items that workload should see, and set [`_VARLOCK_USE_INJECTED_ENV=1`](/reference/reserved-variables/#_varlock_use_injected_env) so auto-load in the sprite hydrates from the blob instead of looking for `.env` files:
+
+```ts title="orchestrate.ts"
+import 'varlock/auto-load';
+import { ENV } from 'varlock/env';
+import { execSync } from 'node:child_process';
+import { SpritesClient } from '@fly/sprites';
+
+const envBlob = execSync(
+  'varlock load --format json-full --compact --filter "STRIPE_*,SENTRY_DSN"',
+  { encoding: 'utf8' },
+).trim();
+
+const sprite = new SpritesClient(ENV.SPRITES_TOKEN).sprite('my-sprite');
+await sprite.exec('node agent.js', {
+  env: { __VARLOCK_ENV: envBlob, _VARLOCK_USE_INJECTED_ENV: '1' },
+});
+```
+
+From a shell, `varlock run --inject blob` produces the same filtered blob as an env var you can forward. If your schema sets [`@encryptInjectedEnv`](/reference/root-decorators/#encryptinjectedenv), the blob it injects is already ciphertext; forward `_VARLOCK_ENV_KEY` alongside it to decrypt in the sprite:
+
+```bash
+varlock run --inject blob --filter "STRIPE_*,SENTRY_DSN" -- sh -c \
+  'sprite exec -s my-sprite \
+     --env __VARLOCK_ENV="$__VARLOCK_ENV" \
+     --env _VARLOCK_USE_INJECTED_ENV=1 \
+     -- node agent.js'
+```
+
+The project in the sprite needs the `varlock` npm package, but no `.env` files and no varlock CLI: importing `varlock/auto-load` hydrates `process.env`, the `ENV` object, log redaction, and leak detection straight from the blob, since sensitivity metadata travels with the values. Compared to enumerating `--env` flags, the filter is the single place that decides what the sprite sees, and the schema's validation and redaction behavior come along for free.
+
 ## Credential proxy: the broker sprite
 
 One sprite (the broker) runs `varlock proxy start --expose` as a sprite *service*, serving the built-in WebSocket tunnel on the sprite's public URL. Agent sprites reach it with `varlock proxy run --url`, which self-wires their placeholder env and CA certs from the broker over the tunnel. The proxy injects real values into requests at the wire, on verified TLS connections to hosts your schema allows, with every request checked against your [`@proxy` rules](/guides/proxy/rules/#routing-rules) and recorded in the [audit log](/guides/proxy/running/#auditing). A compromised or prompt-injected agent can exfiltrate nothing but placeholders.

--- a/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
+++ b/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
@@ -9,7 +9,7 @@ For workloads you trust with the credentials they use, [pass resolved values](#p
 
 ## Passing resolved values
 
-Sprite env is per exec, so credentials exist only for the duration of one command. Import [`varlock/auto-load`](/integrations/javascript/) in the orchestrator: varlock resolves your values (from plugins, `.env.local`, etc.), validates them against your schema, and redacts them in the orchestrator's logs. Then hand the sprite its env in one shot:
+Sprite env is per exec, so credentials exist only for the duration of one command. Import [`varlock/auto-load`](/integrations/javascript/) in the orchestrator: varlock resolves your values (from plugins, `.env.local`, etc.), validates them against your schema, and redacts them in the orchestrator's logs.
 
 ```ts title="orchestrate.ts"
 import 'varlock/auto-load';
@@ -17,31 +17,31 @@ import { ENV } from 'varlock/env';
 import { execSync } from 'node:child_process';
 import { SpritesClient } from '@fly/sprites';
 
-// capture the resolved env as one blob, --filter scoping it to
-// just the items this sprite should see
+// your Sprites token is a varlock-managed secret like any other
+const sprite = new SpritesClient(ENV.SPRITES_TOKEN).sprite('my-sprite');
+
+// simplest: pass individual resolved values
+await sprite.exec('node agent.js', {
+  env: { STRIPE_SECRET_KEY: ENV.STRIPE_SECRET_KEY },
+});
+
+// or hand over the whole env as one blob, --filter scoping it to just the
+// items this sprite should see. A Node app that imports varlock hydrates
+// process.env, the ENV object, and log redaction from the blob - no .env
+// files or CLI in the sprite
 const envBlob = execSync(
   'varlock load --format json-full --compact --filter "STRIPE_*,SENTRY_DSN"',
   { encoding: 'utf8' },
 ).trim();
-
-// your Sprites token is a varlock-managed secret like any other
-const sprite = new SpritesClient(ENV.SPRITES_TOKEN).sprite('my-sprite');
-
 await sprite.exec('node agent.js', {
-  env: {
-    // a Node app that imports varlock hydrates process.env, the ENV object,
-    // and log redaction from the blob - no .env files or CLI in the sprite
-    __VARLOCK_ENV: envBlob,
-    _VARLOCK_USE_INJECTED_ENV: '1',
-    // or enumerate plain vars: STRIPE_SECRET_KEY: ENV.STRIPE_SECRET_KEY,
-  },
+  env: { __VARLOCK_ENV: envBlob, _VARLOCK_USE_INJECTED_ENV: '1' },
 });
 
-// non-Node workload? install varlock in the sprite (npm i -g varlock) and
-// wrap the command instead - varlock run injects plain env vars from the blob:
-// await sprite.exec('varlock run -- ./my-agent', {
-//   env: { __VARLOCK_ENV: envBlob, _VARLOCK_USE_INJECTED_ENV: '1' },
-// });
+// non-Node workloads: install varlock in the sprite (npm i -g varlock) and
+// wrap the command - varlock run injects plain env vars from the same blob
+await sprite.exec('varlock run -- ./my-agent', {
+  env: { __VARLOCK_ENV: envBlob, _VARLOCK_USE_INJECTED_ENV: '1' },
+});
 ```
 
 This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. See [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details. One sprite CLI caveat: `sprite exec --env` treats its value as comma-delimited `KEY=v,KEY2=v2` pairs, so a JSON blob passed through it gets silently truncated at the first comma; use the SDK/API env map as above, or upload the blob with `--file` and read it in the command (`sh -c '__VARLOCK_ENV="$(cat /tmp/blob)" _VARLOCK_USE_INJECTED_ENV=1 varlock run -- ./my-agent'`).

--- a/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
+++ b/packages/varlock-website/src/content/docs/sandboxes/flyio.mdx
@@ -44,7 +44,17 @@ await sprite.exec('varlock run -- ./my-agent', {
 });
 ```
 
-This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. See [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details. One sprite CLI caveat: `sprite exec --env` treats its value as comma-delimited `KEY=v,KEY2=v2` pairs, so a JSON blob passed through it gets silently truncated at the first comma; use the SDK/API env map as above, or upload the blob with `--file` and read it in the command (`sh -c '__VARLOCK_ENV="$(cat /tmp/blob)" _VARLOCK_USE_INJECTED_ENV=1 varlock run -- ./my-agent'`).
+This is the standard Sprites posture, and what Fly recommends: the workload holds real values transiently. See [`_VARLOCK_USE_INJECTED_ENV`](/reference/reserved-variables/#_varlock_use_injected_env) for details.
+
+From the sprite CLI, `--env` cannot carry the blob: it parses its value as comma-delimited `KEY=v,KEY2=v2` pairs and silently truncates at the first comma. Upload the blob with `--file` instead:
+
+```bash
+varlock load --format json-full --compact --filter "STRIPE_*,SENTRY_DSN" > env-blob
+# read-and-delete inside the command, so the blob does not linger on disk
+sprite exec -s my-sprite --file env-blob:/tmp/env-blob -- sh -c \
+  '__VARLOCK_ENV="$(cat /tmp/env-blob; rm /tmp/env-blob)" _VARLOCK_USE_INJECTED_ENV=1 varlock run -- ./my-agent'
+rm env-blob
+```
 
 ## Credential proxy: the broker sprite
 

--- a/packages/varlock/src/auto-load.ts
+++ b/packages/varlock/src/auto-load.ts
@@ -35,6 +35,10 @@ function getPartialResolvedEnv(err: unknown): Record<string, unknown> {
   }
 }
 
+// `@internal` keys stripped from a reused blob - their ambient env values are scrubbed
+// after init (see the bottom of this module)
+let strippedInternalKeys: Array<string> = [];
+
 try {
   // An already-injected __VARLOCK_ENV blob (e.g. from a parent `varlock run`, or handed
   // into a sandbox) can be reused directly instead of re-resolving via the CLI - see
@@ -53,6 +57,7 @@ try {
     debug('reusing injected env blob - skipping resolution');
     parsed = reuseDecision.parsedEnv;
     parsedJsonStr = reuseDecision.blobJson;
+    strippedInternalKeys = reuseDecision.strippedInternalKeys;
   } else {
     debug('resolving env via CLI (%s)', reuseDecision.reason);
     const { stdout } = execSyncVarlock('load --format json-full --compact', {
@@ -170,6 +175,16 @@ try {
 
 // initialize varlock and patch globals as necessary
 initVarlockEnv();
+// An ambient value for an @internal key stripped from a reused blob must not stay readable
+// via process.env (matching `varlock run`'s ambient-carry stripping). This has to happen
+// AFTER initVarlockEnv, whose reload cleanup restores the pre-injection snapshot - and the
+// snapshot itself is scrubbed too, so a later re-init cannot bring the value back. Safe to
+// drop from the snapshot: its only legitimate consumer is a fresh resolution needing the
+// bootstrap secret, which by definition is not happening when a blob was reused.
+for (const internalKey of strippedInternalKeys) {
+  delete process.env[internalKey];
+  delete getPreInjectionProcessEnv()[internalKey];
+}
 // these will be no-ops if these are disabled by settings
 patchGlobalConsole();
 patchGlobalServerResponse();

--- a/packages/varlock/src/auto-load.ts
+++ b/packages/varlock/src/auto-load.ts
@@ -1,10 +1,14 @@
 import { execSyncVarlock, VarlockExecError } from './lib/exec-sync-varlock';
-import { encryptEnvBlobSync, generateEncryptionKeyHex } from './runtime/crypto';
+import { encryptEnvBlobSync, generateEncryptionKeyHex, isEncryptedBlob } from './runtime/crypto';
+import { evaluateInjectedEnvReuse } from './lib/injected-env-reuse';
+import { createDebug } from './lib/debug';
 
-import { initVarlockEnv } from './runtime/env';
+import { initVarlockEnv, getPreInjectionProcessEnv } from './runtime/env';
 import { patchGlobalConsole } from './runtime/patch-console';
 import { patchGlobalServerResponse } from './runtime/patch-server-response';
 import { patchGlobalResponse } from './runtime/patch-response';
+
+const debug = createDebug('varlock:auto-load');
 
 // The varlock loading process uses async calls, but we need this to run synchronously.
 // because even with top level await, we run into hoisting issues where things happen out of order
@@ -32,29 +36,64 @@ function getPartialResolvedEnv(err: unknown): Record<string, unknown> {
 }
 
 try {
-  const { stdout } = execSyncVarlock('load --format json-full --compact', {
-    fullResult: true,
-    // Pass the directory of this module so that in monorepos the binary search
-    // starts from inside the varlock package (e.g. apps/web/node_modules/varlock)
-    // rather than from process.cwd(), which may be an unrelated workspace root.
-    callerDir: import.meta.dirname ?? new URL('.', import.meta.url).pathname,
+  // An already-injected __VARLOCK_ENV blob (e.g. from a parent `varlock run`, or handed
+  // into a sandbox) can be reused directly instead of re-resolving via the CLI - see
+  // evaluateInjectedEnvReuse for the conditions. Throws in explicit-trust mode
+  // (_VARLOCK_USE_INJECTED_ENV=1) when the blob is missing/unusable, which flows into
+  // the same load-failure handling below.
+  const reuseDecision = evaluateInjectedEnvReuse({
+    env: process.env,
+    preInjectionEnv: getPreInjectionProcessEnv(),
+    cwd: process.cwd(),
   });
 
-  const parsed = JSON.parse(stdout);
+  let parsed: any;
+  let parsedJsonStr: string;
+  if (reuseDecision.reuse) {
+    debug('reusing injected env blob - skipping resolution');
+    parsed = reuseDecision.parsedEnv;
+    parsedJsonStr = reuseDecision.blobJson;
+  } else {
+    debug('resolving env via CLI (%s)', reuseDecision.reason);
+    const { stdout } = execSyncVarlock('load --format json-full --compact', {
+      fullResult: true,
+      // Pass the directory of this module so that in monorepos the binary search
+      // starts from inside the varlock package (e.g. apps/web/node_modules/varlock)
+      // rather than from process.cwd(), which may be an unrelated workspace root.
+      callerDir: import.meta.dirname ?? new URL('.', import.meta.url).pathname,
+      // Spawn the CLI with the env as it was BEFORE the runtime auto-init re-injected the
+      // parent blob's values into process.env (that injection happens during our own import
+      // chain, when a plaintext blob is present). Otherwise a command-local override under a
+      // parent `varlock run` (e.g. `varlock run -- sh -c 'FOO=x node app.js'`) reaches the
+      // CLI already clobbered back to the parent's value, and the nested override handling
+      // in load-graph can never see the user's real value.
+      env: getPreInjectionProcessEnv() as NodeJS.ProcessEnv,
+    });
+    parsed = JSON.parse(stdout);
+    parsedJsonStr = stdout;
+  }
+
   // set parsed object on globalThis so initVarlockEnv() picks it up directly
   (globalThis as any).__varlockLoadedEnv = parsed;
 
   // encrypt the blob in process.env so sensitive values aren't sitting
   // in plaintext in process.env.__VARLOCK_ENV
-  let encryptionKey = process.env._VARLOCK_ENV_KEY;
-  if (parsed.settings?.encryptInjectedEnv && !encryptionKey) {
-    encryptionKey = generateEncryptionKeyHex();
-    process.env._VARLOCK_ENV_KEY = encryptionKey;
-  }
-  if (encryptionKey) {
-    process.env.__VARLOCK_ENV = encryptEnvBlobSync(stdout, encryptionKey);
-  } else {
-    process.env.__VARLOCK_ENV = stdout;
+  // (a REUSED blob that arrived already encrypted stays exactly as-is - never write the
+  // decrypted form back into process.env. after a fresh resolution the env blob is always
+  // replaced, even if a stale encrypted parent blob was sitting there)
+  const reusedEncryptedBlob = reuseDecision.reuse
+    && !!process.env.__VARLOCK_ENV && isEncryptedBlob(process.env.__VARLOCK_ENV);
+  if (!reusedEncryptedBlob) {
+    let encryptionKey = process.env._VARLOCK_ENV_KEY;
+    if (parsed.settings?.encryptInjectedEnv && !encryptionKey) {
+      encryptionKey = generateEncryptionKeyHex();
+      process.env._VARLOCK_ENV_KEY = encryptionKey;
+    }
+    if (encryptionKey) {
+      process.env.__VARLOCK_ENV = encryptEnvBlobSync(parsedJsonStr, encryptionKey);
+    } else {
+      process.env.__VARLOCK_ENV = parsedJsonStr;
+    }
   }
 } catch (err) {
   if (err instanceof VarlockExecError && err.stderr) {

--- a/packages/varlock/src/auto-load.ts
+++ b/packages/varlock/src/auto-load.ts
@@ -80,8 +80,11 @@ try {
   // in plaintext in process.env.__VARLOCK_ENV
   // (a REUSED blob that arrived already encrypted stays exactly as-is - never write the
   // decrypted form back into process.env. after a fresh resolution the env blob is always
-  // replaced, even if a stale encrypted parent blob was sitting there)
+  // replaced, even if a stale encrypted parent blob was sitting there. a reused blob that
+  // had @internal items stripped must also be re-written, so children never inherit them -
+  // the ambient key is guaranteed present in that case, since decryption succeeded)
   const reusedEncryptedBlob = reuseDecision.reuse
+    && reuseDecision.strippedInternalKeys.length === 0
     && !!process.env.__VARLOCK_ENV && isEncryptedBlob(process.env.__VARLOCK_ENV);
   if (!reusedEncryptedBlob) {
     let encryptionKey = process.env._VARLOCK_ENV_KEY;

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -14,6 +14,7 @@ import { resolveInjectMode } from '../helpers/inject-mode';
 import { CliExitError } from '../helpers/exit-error';
 import { evaluateInjectedEnvReuse, getUseInjectedEnvMode, USE_INJECTED_ENV_VAR } from '../../lib/injected-env-reuse';
 import { injectedEnvStringForm } from '../../lib/injected-env-provenance';
+import { isEncryptedBlob, encryptEnvBlobSync } from '../../runtime/crypto';
 import { getPreInjectionProcessEnv } from '../../runtime/env';
 import { createDebug } from '../../lib/debug';
 import type { EnvGraph, SerializedEnvGraph } from '../../env-graph';
@@ -293,8 +294,18 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
       ambientEnvKey: process.env._VARLOCK_ENV_KEY,
     });
   } else if (injectBlob) {
+    // normally the ambient blob is forwarded byte-for-byte; if @internal items were
+    // stripped from it on consumption, forward the sanitized form instead (re-encrypted
+    // with the ambient key when the original was encrypted - the key must have been
+    // present for decryption to have succeeded)
+    let childBlob = process.env.__VARLOCK_ENV!;
+    if (reuseDecision.strippedInternalKeys.length) {
+      childBlob = isEncryptedBlob(childBlob)
+        ? encryptEnvBlobSync(reuseDecision.blobJson, process.env._VARLOCK_ENV_KEY!)
+        : reuseDecision.blobJson;
+    }
     injectedBlobEnv = {
-      __VARLOCK_ENV: process.env.__VARLOCK_ENV,
+      __VARLOCK_ENV: childBlob,
       ...(process.env._VARLOCK_ENV_KEY ? { _VARLOCK_ENV_KEY: process.env._VARLOCK_ENV_KEY } : {}),
     };
   }
@@ -309,11 +320,14 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   // @internal items must not reach the application. The spread of process.env above can carry
   // an ambiently-set value (e.g. `OP_TOKEN=xxx varlock run ...`), so strip those keys here —
   // unless --include-internal was passed, in which case they were intentionally injected above.
-  // (reuse path: the blob never carries internal items, and --include-internal disables reuse)
+  // (reuse path: internal items were already stripped from the blob itself on consumption,
+  // and --include-internal disables reuse - but the same ambient-carry hole applies)
   if (envGraph && !includeInternal) {
     for (const itemKey of envGraph.sortedConfigKeys) {
       if (envGraph.configSchema[itemKey].isInternal) delete fullInjectedEnv[itemKey];
     }
+  } else if (reuseDecision.reuse) {
+    for (const itemKey of reuseDecision.strippedInternalKeys) delete fullInjectedEnv[itemKey];
   }
 
   // Same ambient-carry problem for --filter: an excluded schema key set in the calling env

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -11,6 +11,14 @@ import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { REDACT_STDOUT_ARG, resolveStdoutRedaction, pipeRedactedStreams } from '../helpers/stdout-redaction';
 import { buildInjectedBlobEnv } from '../helpers/injected-env-blob';
 import { resolveInjectMode } from '../helpers/inject-mode';
+import { CliExitError } from '../helpers/exit-error';
+import { evaluateInjectedEnvReuse, getUseInjectedEnvMode, USE_INJECTED_ENV_VAR } from '../../lib/injected-env-reuse';
+import { injectedEnvStringForm } from '../../lib/injected-env-provenance';
+import { getPreInjectionProcessEnv } from '../../runtime/env';
+import { createDebug } from '../../lib/debug';
+import type { EnvGraph, SerializedEnvGraph } from '../../env-graph';
+
+const debug = createDebug('varlock:run');
 
 export const commandSpec = define({
   name: 'run',
@@ -175,36 +183,93 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   // console.log('running command', pathAwareCommand || rawCommand, commandArgsOnly);
 
 
-  const envGraph = await loadVarlockEnvGraph({
-    entryFilePaths: ctx.values.path,
-    clearCache: ctx.values['clear-cache'],
-    skipCache: ctx.values['skip-cache'],
-  });
-  checkForSchemaErrors(envGraph);
-  checkForNoEnvFiles(envGraph);
+  // An already-injected __VARLOCK_ENV blob (from a parent `varlock run`, or handed into a
+  // sandbox with no .env files alongside _VARLOCK_USE_INJECTED_ENV=1) can be consumed
+  // directly instead of re-resolving - same conditions and escape hatches as
+  // varlock/auto-load. Flags that change what a fresh resolution would produce disable
+  // reuse (and are rejected when reuse was explicitly forced, rather than being silently
+  // ignored).
+  const resolutionFlags = [
+    ctx.values.path?.length ? '--path' : undefined,
+    ctx.values.filter ? '--filter' : undefined,
+    ctx.values['clear-cache'] ? '--clear-cache' : undefined,
+    ctx.values['skip-cache'] ? '--skip-cache' : undefined,
+    ctx.values['include-internal'] ? '--include-internal' : undefined,
+  ].filter(Boolean) as Array<string>;
 
-  // Generate types before resolving values — uses only non-env-specific schema info
-  await envGraph.runCodeGeneratorsIfNeeded();
-
-  // A --filter scopes resolution (and validation) to what it selects plus dependencies — an
-  // unrelated broken item outside the filter won't block this run, and excluded items'
-  // value resolvers never run. Decorator selectors resolve item metadata first, then match
-  // exactly (see EnvGraph.resolveEnvValuesForFilter).
-  const itemFilter = getCliItemFilter(ctx.values.filter);
-  if (itemFilter) await itemFilter.resolveScoped(envGraph);
-  else await envGraph.resolveEnvValues();
-  checkForConfigErrors(envGraph);
-
-  // will fail above if there are any errors
+  let reuseDecision: ReturnType<typeof evaluateInjectedEnvReuse>;
+  if (resolutionFlags.length) {
+    if (getUseInjectedEnvMode(process.env) === 'force') {
+      throw new CliExitError(`${USE_INJECTED_ENV_VAR} cannot be combined with ${resolutionFlags.join(', ')}`, {
+        suggestion: 'These flags change what a fresh resolution produces, so there is nothing to reuse. Drop them, or unset the env var to resolve normally.',
+      });
+    }
+    reuseDecision = { reuse: false, reason: `resolution flags passed (${resolutionFlags.join(', ')})` };
+  } else {
+    try {
+      reuseDecision = evaluateInjectedEnvReuse({
+        env: process.env,
+        preInjectionEnv: getPreInjectionProcessEnv(),
+        cwd: process.cwd(),
+      });
+    } catch (err) {
+      // explicit trust mode with a missing/unusable blob
+      throw new CliExitError((err as Error).message.replace(/^\[varlock\] /, ''), {
+        suggestion: 'Provide a valid __VARLOCK_ENV blob (e.g. captured via `varlock load --format json-full --compact`), '
+          + `or unset ${USE_INJECTED_ENV_VAR} to resolve from .env files.`,
+      });
+    }
+  }
 
   // by default @internal items are never handed to the child; --include-internal opts out
   // (e.g. a nested `varlock run` whose own resolution needs a secret-zero token)
   const includeInternal = !!ctx.values['include-internal'];
-  const filterKeys = itemFilter?.getFilterKeys(Object.values(envGraph.configSchema));
-  // string-serialized values (composites become separator-joined/JSON strings) since
-  // these are injected directly into the child's process.env
-  const resolvedEnv = envGraph.getResolvedEnvStringObject({ includeInternal, filterKeys });
-  const serializedGraph = envGraph.getSerializedGraph({ filterKeys });
+
+  let envGraph: EnvGraph | undefined;
+  let filterKeys: Set<string> | undefined;
+  let resolvedEnv: Record<string, string | undefined>;
+  let serializedGraph: SerializedEnvGraph;
+
+  if (reuseDecision.reuse) {
+    debug('reusing injected env blob - skipping resolution');
+    serializedGraph = reuseDecision.parsedEnv;
+    // same shape as getResolvedEnvStringObject: unset items stay undefined, so they still
+    // mask any inherited value when the child env is built. The blob never carries
+    // @internal items, so there is nothing extra to strip.
+    resolvedEnv = {};
+    for (const [itemKey, item] of Object.entries(serializedGraph.config)) {
+      resolvedEnv[itemKey] = item.value === undefined ? undefined : injectedEnvStringForm(item);
+    }
+  } else {
+    debug('resolving env (%s)', reuseDecision.reason);
+    envGraph = await loadVarlockEnvGraph({
+      entryFilePaths: ctx.values.path,
+      clearCache: ctx.values['clear-cache'],
+      skipCache: ctx.values['skip-cache'],
+    });
+    checkForSchemaErrors(envGraph);
+    checkForNoEnvFiles(envGraph);
+
+    // Generate types before resolving values — uses only non-env-specific schema info
+    await envGraph.runCodeGeneratorsIfNeeded();
+
+    // A --filter scopes resolution (and validation) to what it selects plus dependencies — an
+    // unrelated broken item outside the filter won't block this run, and excluded items'
+    // value resolvers never run. Decorator selectors resolve item metadata first, then match
+    // exactly (see EnvGraph.resolveEnvValuesForFilter).
+    const itemFilter = getCliItemFilter(ctx.values.filter);
+    if (itemFilter) await itemFilter.resolveScoped(envGraph);
+    else await envGraph.resolveEnvValues();
+    checkForConfigErrors(envGraph);
+
+    // will fail above if there are any errors
+
+    filterKeys = itemFilter?.getFilterKeys(Object.values(envGraph.configSchema));
+    // string-serialized values (composites become separator-joined/JSON strings) since
+    // these are injected directly into the child's process.env
+    resolvedEnv = envGraph.getResolvedEnvStringObject({ includeInternal, filterKeys });
+    serializedGraph = envGraph.getSerializedGraph({ filterKeys });
+  }
   const { resetRedactionMap } = await import('../../runtime/env');
   // console.log(resolvedEnv);
 
@@ -216,23 +281,36 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   }
   const { injectVars, injectBlob } = resolveInjectMode(ctx.values.inject, injectDefault as 'all' | 'vars');
 
-  const fullInjectedEnv: NodeJS.ProcessEnv = {
-    ...process.env,
-    ...(injectVars ? resolvedEnv : {}),
-    __VARLOCK_RUN: '1', // flag for a child process to detect it is running via `varlock run`
-    // honors @encryptInjectedEnv in blob-only mode; reuses/forwards an ambient key
-    ...buildInjectedBlobEnv({
+  // when reusing, the ambient blob passes through untouched (it may be encrypted - the
+  // ambient key rides along with it); a fresh resolution builds a new blob, honoring
+  // @encryptInjectedEnv in blob-only mode and reusing/forwarding an ambient key
+  let injectedBlobEnv: { __VARLOCK_ENV?: string, _VARLOCK_ENV_KEY?: string } = {};
+  if (!reuseDecision.reuse) {
+    injectedBlobEnv = buildInjectedBlobEnv({
       serializedGraph,
       injectVars,
       injectBlob,
       ambientEnvKey: process.env._VARLOCK_ENV_KEY,
-    }),
+    });
+  } else if (injectBlob) {
+    injectedBlobEnv = {
+      __VARLOCK_ENV: process.env.__VARLOCK_ENV,
+      ...(process.env._VARLOCK_ENV_KEY ? { _VARLOCK_ENV_KEY: process.env._VARLOCK_ENV_KEY } : {}),
+    };
+  }
+
+  const fullInjectedEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...(injectVars ? resolvedEnv : {}),
+    __VARLOCK_RUN: '1', // flag for a child process to detect it is running via `varlock run`
+    ...injectedBlobEnv,
   };
 
   // @internal items must not reach the application. The spread of process.env above can carry
   // an ambiently-set value (e.g. `OP_TOKEN=xxx varlock run ...`), so strip those keys here —
   // unless --include-internal was passed, in which case they were intentionally injected above.
-  if (!includeInternal) {
+  // (reuse path: the blob never carries internal items, and --include-internal disables reuse)
+  if (envGraph && !includeInternal) {
     for (const itemKey of envGraph.sortedConfigKeys) {
       if (envGraph.configSchema[itemKey].isInternal) delete fullInjectedEnv[itemKey];
     }
@@ -243,7 +321,7 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   // straight through the process.env spread — and since excluded items are also left out of the
   // redaction map, it would even print unredacted. Reserved _VARLOCK_* keys configure varlock's
   // own behavior (incl. in nested runs) and are never subject to --filter.
-  if (filterKeys) {
+  if (envGraph && filterKeys) {
     for (const itemKey of envGraph.sortedConfigKeys) {
       if (isVarlockReservedKey(itemKey)) continue;
       if (!filterKeys.has(itemKey)) delete fullInjectedEnv[itemKey];

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -87,6 +87,15 @@ export type SerializedEnvGraph = {
     preventLeaks?: boolean;
     /** true = used only by varlock, not injected into the app. Only present in inspection output (never in the blob). */
     isInternal?: boolean;
+    /**
+     * The raw pre-coercion string of the process.env override that produced this value,
+     * present only when it differs from the injected string form (e.g. `FLAG=YES` coerced
+     * to boolean `true` injects as "true"). Lets consumers comparing ambient env values
+     * against the blob (nested invocations, auto-load reuse) recognize the raw form as
+     * this same value rather than a new override. Omitted for sensitive items so the blob
+     * never carries a value variant the redaction map doesn't know about.
+     */
+    overrideStr?: string;
     /** whether the value must stay runtime-resolved (never inlined at build time). Omitted when it matches `isSensitive` (the default linkage), so consumers should read `isDynamic ?? isSensitive`. */
     isDynamic?: boolean;
   }>;
@@ -923,12 +932,21 @@ export class EnvGraph {
       if (item.isInternal && !opts?.includeInternal) continue;
       // when set (e.g. via the CLI `--filter` flag), only include selected keys
       if (opts?.filterKeys && !opts.filterKeys.has(itemKey)) continue;
+      // raw pre-coercion form of a process.env override, when it differs from the
+      // injected string form (see the SerializedEnvGraph type for why this travels)
+      let overrideStr: string | undefined;
+      if (!item.isSensitive && itemKey in this.overrideValues) {
+        const rawOverride = this.overrideValues[itemKey];
+        const injectedForm = item.resolvedEnvStringValue ?? (item.resolvedValue === undefined ? '' : String(item.resolvedValue));
+        if (rawOverride !== undefined && rawOverride !== injectedForm) overrideStr = rawOverride;
+      }
       serializedGraph.config[itemKey] = {
         value: item.resolvedValue,
         // composite values carry their flat string form, since re-deriving it requires
         // the item's type settings (separator vs JSON) which don't travel in the blob
         ...(typeof item.resolvedValue === 'object' && item.resolvedValue !== null)
           ? { envStr: item.resolvedEnvStringValue } : {},
+        ...(overrideStr !== undefined) ? { overrideStr } : {},
         isSensitive: item.isSensitive,
         ...item.isInternal ? { isInternal: true } : {},
         // only emit when opted out — keeps the common-case blob smaller

--- a/packages/varlock/src/env-graph/lib/reserved-vars.ts
+++ b/packages/varlock/src/env-graph/lib/reserved-vars.ts
@@ -50,6 +50,10 @@ export const VARLOCK_CONFIG_ENV_VARS: Array<ReservedVarInfo> = [
     description: 'Set to `warn` to downgrade the build/prerender-time public+dynamic access guard from an error to a one-time warning per key (e.g. while migrating an existing app).',
   },
   {
+    name: '_VARLOCK_USE_INJECTED_ENV',
+    description: 'Controls whether `varlock/auto-load` reuses an already-injected `__VARLOCK_ENV` blob instead of re-resolving via the CLI. `1`/`true` always trusts the blob (e.g. handing a blob into a sandbox with no .env files); `0`/`false` always re-resolves. Unset, auto-load reuses the blob only when it was resolved in the same directory.',
+  },
+  {
     name: '_VARLOCK_FORCE_FILE_ENCRYPTION_FALLBACK',
     description: 'Forces the file-based local encryption fallback instead of the native binary. Intended for testing/debugging.',
     internal: true,

--- a/packages/varlock/src/env-graph/test/override-str-serialization.test.ts
+++ b/packages/varlock/src/env-graph/test/override-str-serialization.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import outdent from 'outdent';
+import { EnvGraph } from '../index';
+import { DotEnvFileDataSource } from '../lib/data-source';
+
+async function loadSchema(contents: string, overrideValues?: Record<string, string>) {
+  const g = new EnvGraph();
+  await g.setRootDataSource(new DotEnvFileDataSource('.env.schema', { overrideContents: contents }));
+  await g.finishLoad();
+  if (overrideValues) g.overrideValues = overrideValues;
+  await g.resolveEnvValues();
+  return g;
+}
+
+describe('getSerializedGraph overrideStr', () => {
+  it('records the raw override string when coercion changed its injected form', async () => {
+    const g = await loadSchema(outdent`
+      # @type=boolean @public
+      FLAG=false
+    `, { FLAG: 'YES' });
+    const blob = g.getSerializedGraph();
+    expect(blob.config.FLAG.value).toBe(true);
+    expect(blob.config.FLAG.overrideStr).toBe('YES');
+  });
+
+  it('omits overrideStr when the raw override already matches the injected form', async () => {
+    const g = await loadSchema(outdent`
+      PLAIN=abc  # @public
+    `, { PLAIN: 'from-env' });
+    const blob = g.getSerializedGraph();
+    expect(blob.config.PLAIN.value).toBe('from-env');
+    expect(blob.config.PLAIN.overrideStr).toBeUndefined();
+  });
+
+  it('omits overrideStr for items that were not overridden', async () => {
+    const g = await loadSchema(outdent`
+      # @type=boolean @public
+      FLAG=yes
+    `);
+    const blob = g.getSerializedGraph();
+    expect(blob.config.FLAG.value).toBe(true);
+    expect(blob.config.FLAG.overrideStr).toBeUndefined();
+  });
+
+  it('omits overrideStr for sensitive items even when coercion changed the form', async () => {
+    const g = await loadSchema(outdent`
+      # @type=boolean @sensitive
+      SECRET_FLAG=false
+    `, { SECRET_FLAG: 'YES' });
+    const blob = g.getSerializedGraph();
+    expect(blob.config.SECRET_FLAG.value).toBe(true);
+    expect(blob.config.SECRET_FLAG.overrideStr).toBeUndefined();
+  });
+});

--- a/packages/varlock/src/lib/injected-env-provenance.ts
+++ b/packages/varlock/src/lib/injected-env-provenance.ts
@@ -50,3 +50,50 @@ export function selectOverrideValuesFromEnv(
   }
   return selected;
 }
+
+/**
+ * The string form a blob config item takes when injected into process.env
+ * (same formula as initVarlockEnv / `varlock run`'s individual-var injection).
+ */
+export function injectedEnvStringForm(item: { envStr?: string, value?: any }): string {
+  return item.envStr ?? (item.value === undefined ? '' : String(item.value));
+}
+
+/**
+ * Select the env values that should act as overrides for a fresh resolution running
+ * under an injected `__VARLOCK_ENV` blob:
+ *
+ *  - keys the blob RECORDS as genuine overrides at the parent invocation (their current
+ *    env value is re-read, so a changed value is honored)
+ *  - any other blob config key whose current env value DIFFERS from what the parent
+ *    injected. A parent echo is by definition equal to the blob's injected value, so a
+ *    differing value must have been introduced deliberately after the parent resolved
+ *    (e.g. `varlock run -- sh -c 'FOO=x node app.js'` where FOO was not overridden at
+ *    the parent) and is a genuine override, even though the parent didn't record it.
+ *
+ * Unchanged parent-injected values match the blob and are excluded, preserving the core
+ * rule that parent-injected values must not shadow fresh resolution.
+ *
+ * Returns undefined when the blob is missing/unparseable or carries no override
+ * provenance at all (older producers), so callers can fall back to default behavior.
+ */
+export function selectOverridesFromInjectedEnv(
+  blob: string | undefined,
+  env: Record<string, string | undefined>,
+): Record<string, string | undefined> | undefined {
+  const overrideKeys = parseBlobOverrideKeys(blob);
+  if (!overrideKeys) return undefined;
+
+  const selected = selectOverrideValuesFromEnv(env, overrideKeys);
+
+  // blob is known-parseable here (parseBlobOverrideKeys succeeded)
+  const config = (JSON.parse(blob!) as { config?: unknown }).config;
+  if (config && typeof config === 'object' && !Array.isArray(config)) {
+    for (const [key, item] of Object.entries(config as Record<string, { envStr?: string, value?: any }>)) {
+      if (key in selected) continue;
+      if (!(key in env)) continue; // absent (e.g. `--inject blob` mode) is not a divergence
+      if (env[key] !== injectedEnvStringForm(item)) selected[key] = env[key];
+    }
+  }
+  return selected;
+}

--- a/packages/varlock/src/lib/injected-env-provenance.ts
+++ b/packages/varlock/src/lib/injected-env-provenance.ts
@@ -60,6 +60,22 @@ export function injectedEnvStringForm(item: { envStr?: string, value?: any }): s
 }
 
 /**
+ * Whether an ambient env value is just this blob item's own value echoing back - either
+ * the injected string form, or the raw pre-coercion override string the parent recorded
+ * (e.g. `FLAG=YES` coerced to boolean `true`: the raw "YES" survives in the child env
+ * under `--inject blob`, where no individual vars are injected over it).
+ */
+type BlobConfigItem = { envStr?: string, value?: any, overrideStr?: string };
+
+export function envValueMatchesBlobItem(
+  envValue: string | undefined,
+  item: BlobConfigItem,
+): boolean {
+  if (envValue === injectedEnvStringForm(item)) return true;
+  return item.overrideStr !== undefined && envValue === item.overrideStr;
+}
+
+/**
  * Select the env values that should act as overrides for a fresh resolution running
  * under an injected `__VARLOCK_ENV` blob:
  *
@@ -89,10 +105,10 @@ export function selectOverridesFromInjectedEnv(
   // blob is known-parseable here (parseBlobOverrideKeys succeeded)
   const config = (JSON.parse(blob!) as { config?: unknown }).config;
   if (config && typeof config === 'object' && !Array.isArray(config)) {
-    for (const [key, item] of Object.entries(config as Record<string, { envStr?: string, value?: any }>)) {
+    for (const [key, item] of Object.entries(config as Record<string, BlobConfigItem>)) {
       if (key in selected) continue;
       if (!(key in env)) continue; // absent (e.g. `--inject blob` mode) is not a divergence
-      if (env[key] !== injectedEnvStringForm(item)) selected[key] = env[key];
+      if (!envValueMatchesBlobItem(env[key], item)) selected[key] = env[key];
     }
   }
   return selected;

--- a/packages/varlock/src/lib/injected-env-reuse.ts
+++ b/packages/varlock/src/lib/injected-env-reuse.ts
@@ -1,0 +1,179 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { SerializedEnvGraph } from '../env-graph';
+import { isEncryptedBlob, decryptEnvBlobSync } from '../runtime/crypto';
+import { readVarlockPackageJsonConfig } from './package-json-config';
+
+/**
+ * Decides whether `varlock/auto-load` can reuse an already-injected `__VARLOCK_ENV` blob
+ * (e.g. set by a parent `varlock run`) instead of spawning the CLI to re-resolve.
+ *
+ * Two goals drive this:
+ *  1. A command "unnecessarily" wrapped in `varlock run` (same directory the app would
+ *     resolve in anyway) should not pay for a second resolution.
+ *  2. A blob can be handed into an environment with no .env files at all (e.g. a sandbox)
+ *     and auto-load hydrates everything from it.
+ *
+ * Goal 1 is the automatic path, gated on conservative checks; any failed check falls back
+ * to spawning the CLI, which is exactly today's behavior (including the nested-invocation
+ * override-provenance handling in load-graph). Goal 2 is explicit, via
+ * `_VARLOCK_USE_INJECTED_ENV=1`, since a blob from another machine can never pass the
+ * directory check and there is nothing to fall back to.
+ */
+
+/** user-controllable behavior flag (leading single underscore per convention) */
+export const USE_INJECTED_ENV_VAR = '_VARLOCK_USE_INJECTED_ENV';
+
+export type InjectedEnvReuseDecision = | {
+  reuse: true,
+  parsedEnv: SerializedEnvGraph,
+  /** plaintext JSON of the blob (post-decryption) - used if it needs re-encryption into process.env */
+  blobJson: string,
+}
+  | { reuse: false, reason: string };
+
+type EnvRecord = Record<string, string | undefined>;
+
+function parseMode(rawValue: string | undefined): 'auto' | 'force' | 'never' {
+  if (rawValue === undefined || rawValue === '') return 'auto';
+  const normalized = rawValue.toLowerCase();
+  if (normalized === '0' || normalized === 'false') return 'never';
+  return 'force';
+}
+
+/**
+ * Replicates how load-graph/loader would pick the resolution base dir for a default
+ * (flag-less) load: package.json `varlock.loadPath` if configured, otherwise cwd.
+ * Returns undefined when it can't be determined (e.g. loadPath points at a missing
+ * path) - the CLI should run and surface its own error in that case.
+ */
+function getExpectedResolutionBasePath(cwd: string): string | undefined {
+  const pkgLoadPath = readVarlockPackageJsonConfig({ cwd })?.loadPath;
+  if (!pkgLoadPath) return cwd;
+
+  const rawPaths = Array.isArray(pkgLoadPath) ? pkgLoadPath : [pkgLoadPath];
+  // multiple entry paths -> loader keeps basePath = cwd
+  if (rawPaths.length !== 1) return cwd;
+
+  const resolved = path.resolve(cwd, rawPaths[0]);
+  try {
+    return fs.statSync(resolved).isDirectory() ? resolved : path.dirname(resolved);
+  } catch {
+    return undefined;
+  }
+}
+
+/** compare two paths after realpath normalization (symlinks, /private/tmp, worktrees) */
+function isSamePath(a: string, b: string): boolean {
+  const normalize = (p: string) => {
+    try {
+      return fs.realpathSync(p);
+    } catch {
+      return path.resolve(p);
+    }
+  };
+  return normalize(a) === normalize(b);
+}
+
+/** the string form a value takes when injected into process.env (see initVarlockEnv) */
+function injectedEnvString(item: SerializedEnvGraph['config'][string]): string {
+  return item.envStr ?? (item.value === undefined ? '' : String(item.value));
+}
+
+export function evaluateInjectedEnvReuse(opts: {
+  /** env holding the blob/key/flags - normally the live process.env */
+  env: EnvRecord,
+  /**
+   * Snapshot of process.env from before varlock injected anything. Needed because the
+   * runtime's module-level auto-init may have already re-injected the parent blob's
+   * values into the live process.env by the time auto-load's body runs, which would
+   * mask a command-local override (`FOO=bar node app.js` under a parent `varlock run`).
+   */
+  preInjectionEnv?: EnvRecord,
+  cwd?: string,
+}): InjectedEnvReuseDecision {
+  const { env } = opts;
+  const preInjectionEnv = opts.preInjectionEnv ?? env;
+  const cwd = opts.cwd ?? process.cwd();
+
+  const mode = parseMode(env[USE_INJECTED_ENV_VAR]);
+  if (mode === 'never') return { reuse: false, reason: `${USE_INJECTED_ENV_VAR} disabled reuse` };
+
+  const rawBlob = env.__VARLOCK_ENV;
+  if (!rawBlob) {
+    if (mode === 'force') {
+      throw new Error(`[varlock] ${USE_INJECTED_ENV_VAR} is enabled but no __VARLOCK_ENV blob is present in the environment`);
+    }
+    return { reuse: false, reason: 'no injected env blob present' };
+  }
+
+  let blobJson = rawBlob;
+  if (isEncryptedBlob(rawBlob)) {
+    const key = env._VARLOCK_ENV_KEY;
+    if (!key) {
+      if (mode === 'force') {
+        throw new Error(`[varlock] ${USE_INJECTED_ENV_VAR} is enabled but __VARLOCK_ENV is encrypted and _VARLOCK_ENV_KEY is not set`);
+      }
+      return { reuse: false, reason: 'blob is encrypted and no _VARLOCK_ENV_KEY is set' };
+    }
+    try {
+      blobJson = decryptEnvBlobSync(rawBlob, key);
+    } catch (err) {
+      if (mode === 'force') {
+        throw new Error(`[varlock] failed to decrypt __VARLOCK_ENV blob: ${(err as Error).message}`);
+      }
+      return { reuse: false, reason: 'failed to decrypt blob' };
+    }
+  }
+
+  let parsedEnv: SerializedEnvGraph;
+  try {
+    parsedEnv = JSON.parse(blobJson);
+    if (!parsedEnv || typeof parsedEnv !== 'object' || !parsedEnv.config || typeof parsedEnv.config !== 'object') {
+      throw new Error('not a serialized env graph');
+    }
+  } catch {
+    if (mode === 'force') {
+      throw new Error(`[varlock] ${USE_INJECTED_ENV_VAR} is enabled but the __VARLOCK_ENV blob is not a valid serialized env graph`);
+    }
+    return { reuse: false, reason: 'blob is not a valid serialized env graph' };
+  }
+
+  // explicit trust - the sandbox path. The blob is authoritative regardless of where it
+  // was resolved; directory/drift checks make no sense for a blob from another machine.
+  if (mode === 'force') return { reuse: true, parsedEnv, blobJson };
+
+  // -- automatic path: reuse only when a fresh resolution would clearly produce the same result
+
+  // a blob carrying errors means the producer's load failed - let the CLI re-run and
+  // surface a proper failure rather than booting the app on known-bad values
+  if (parsedEnv.errors) return { reuse: false, reason: 'blob contains resolution errors' };
+
+  // older producers may not have recorded basePath - we can't verify locality, so re-resolve
+  if (!parsedEnv.basePath) return { reuse: false, reason: 'blob has no basePath recorded' };
+
+  const expectedBasePath = getExpectedResolutionBasePath(cwd);
+  if (!expectedBasePath || !isSamePath(parsedEnv.basePath, expectedBasePath)) {
+    return {
+      reuse: false,
+      reason: `blob was resolved in a different directory (${parsedEnv.basePath})`,
+    };
+  }
+
+  // Override drift: the blob records which keys were genuine user overrides at the parent
+  // invocation. If one of those has since been changed in the ambient env (e.g.
+  // `varlock run -- sh -c 'FOO=x node app.js'`), reusing the blob would clobber FOO back
+  // to the stale value - re-resolving picks the new value up via the normal
+  // nested-invocation override handling. A key *absent* from the env is not drift
+  // (`--inject blob` mode injects no individual vars at all).
+  for (const overrideKey of parsedEnv.overrideKeys ?? []) {
+    const item = parsedEnv.config[overrideKey];
+    if (!item) continue;
+    if (!(overrideKey in preInjectionEnv)) continue;
+    if (preInjectionEnv[overrideKey] !== injectedEnvString(item)) {
+      return { reuse: false, reason: `env override for ${overrideKey} changed since the blob was created` };
+    }
+  }
+
+  return { reuse: true, parsedEnv, blobJson };
+}

--- a/packages/varlock/src/lib/injected-env-reuse.ts
+++ b/packages/varlock/src/lib/injected-env-reuse.ts
@@ -29,8 +29,17 @@ export const USE_INJECTED_ENV_VAR = '_VARLOCK_USE_INJECTED_ENV';
 export type InjectedEnvReuseDecision = | {
   reuse: true,
   parsedEnv: SerializedEnvGraph,
-  /** plaintext JSON of the blob (post-decryption) - used if it needs re-encryption into process.env */
+  /** plaintext JSON of the (sanitized) blob - used when it needs re-serialization/re-encryption */
   blobJson: string,
+  /**
+   * `@internal` item keys that were stripped from the blob on consumption. Fresh-resolution
+   * blobs never carry internal items, but the inspection command (`load --format json-full
+   * --include-internal`) is a supported producer, and a secret-zero value must never reach
+   * the app or a child process through reuse. Non-empty means parsedEnv/blobJson were
+   * rewritten without those entries; consumers must also drop any ambient env values for
+   * these keys before handing env to a child.
+   */
+  strippedInternalKeys: Array<string>,
 }
   | { reuse: false, reason: string };
 
@@ -103,6 +112,16 @@ export function evaluateInjectedEnvReuse(opts: {
   const mode = getUseInjectedEnvMode(env);
   if (mode === 'never') return { reuse: false, reason: `${USE_INJECTED_ENV_VAR} disabled reuse` };
 
+  // _VARLOCK_FILTER is the env-var form of --filter, honored by any fresh resolution
+  // (see getCliItemFilter) - reusing an unscoped blob would bypass it and hand over
+  // values the caller expected to exclude
+  if (env._VARLOCK_FILTER) {
+    if (mode === 'force') {
+      throw new Error(`[varlock] ${USE_INJECTED_ENV_VAR} cannot be combined with _VARLOCK_FILTER - capture the blob with --filter instead`);
+    }
+    return { reuse: false, reason: '_VARLOCK_FILTER is set' };
+  }
+
   const rawBlob = env.__VARLOCK_ENV;
   if (!rawBlob) {
     if (mode === 'force') {
@@ -143,9 +162,26 @@ export function evaluateInjectedEnvReuse(opts: {
     return { reuse: false, reason: 'blob is not a valid serialized env graph' };
   }
 
+  // @internal items are never handed to the app/child by any fresh resolution path, but a
+  // blob produced by the inspection command (`load --format json-full --include-internal`)
+  // can carry them - strip on consumption, in every mode, and re-serialize so a forwarded
+  // blob is clean too
+  const strippedInternalKeys: Array<string> = [];
+  for (const itemKey of Object.keys(parsedEnv.config)) {
+    if (parsedEnv.config[itemKey].isInternal) {
+      strippedInternalKeys.push(itemKey);
+      delete parsedEnv.config[itemKey];
+    }
+  }
+  if (strippedInternalKeys.length) blobJson = JSON.stringify(parsedEnv);
+
   // explicit trust - the sandbox path. The blob is authoritative regardless of where it
   // was resolved; directory/drift checks make no sense for a blob from another machine.
-  if (mode === 'force') return { reuse: true, parsedEnv, blobJson };
+  if (mode === 'force') {
+    return {
+      reuse: true, parsedEnv, blobJson, strippedInternalKeys,
+    };
+  }
 
   // -- automatic path: reuse only when a fresh resolution would clearly produce the same result
 
@@ -179,5 +215,7 @@ export function evaluateInjectedEnvReuse(opts: {
     }
   }
 
-  return { reuse: true, parsedEnv, blobJson };
+  return {
+    reuse: true, parsedEnv, blobJson, strippedInternalKeys,
+  };
 }

--- a/packages/varlock/src/lib/injected-env-reuse.ts
+++ b/packages/varlock/src/lib/injected-env-reuse.ts
@@ -34,11 +34,17 @@ export type InjectedEnvReuseDecision = | {
 
 type EnvRecord = Record<string, string | undefined>;
 
+/**
+ * Same accepted values as `parseEnvToggle` (see `_VARLOCK_REDACT_STDOUT`): only `1`/`true`
+ * and `0`/`false`, case-insensitive. Anything else falls back to auto rather than being
+ * treated as an opt-in - `=f`/`=no`/`=off` must never silently grant blob trust.
+ */
 function parseMode(rawValue: string | undefined): 'auto' | 'force' | 'never' {
-  if (rawValue === undefined || rawValue === '') return 'auto';
-  const normalized = rawValue.toLowerCase();
+  if (rawValue === undefined) return 'auto';
+  const normalized = rawValue.trim().toLowerCase();
+  if (normalized === '1' || normalized === 'true') return 'force';
   if (normalized === '0' || normalized === 'false') return 'never';
-  return 'force';
+  return 'auto';
 }
 
 /**

--- a/packages/varlock/src/lib/injected-env-reuse.ts
+++ b/packages/varlock/src/lib/injected-env-reuse.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { SerializedEnvGraph } from '../env-graph';
 import { isEncryptedBlob, decryptEnvBlobSync } from '../runtime/crypto';
 import { readVarlockPackageJsonConfig } from './package-json-config';
+import { injectedEnvStringForm } from './injected-env-provenance';
 
 /**
  * Decides whether `varlock/auto-load` can reuse an already-injected `__VARLOCK_ENV` blob
@@ -79,11 +80,6 @@ function isSamePath(a: string, b: string): boolean {
     }
   };
   return normalize(a) === normalize(b);
-}
-
-/** the string form a value takes when injected into process.env (see initVarlockEnv) */
-function injectedEnvString(item: SerializedEnvGraph['config'][string]): string {
-  return item.envStr ?? (item.value === undefined ? '' : String(item.value));
 }
 
 export function evaluateInjectedEnvReuse(opts: {
@@ -166,18 +162,17 @@ export function evaluateInjectedEnvReuse(opts: {
     };
   }
 
-  // Override drift: the blob records which keys were genuine user overrides at the parent
-  // invocation. If one of those has since been changed in the ambient env (e.g.
-  // `varlock run -- sh -c 'FOO=x node app.js'`), reusing the blob would clobber FOO back
-  // to the stale value - re-resolving picks the new value up via the normal
-  // nested-invocation override handling. A key *absent* from the env is not drift
-  // (`--inject blob` mode injects no individual vars at all).
-  for (const overrideKey of parsedEnv.overrideKeys ?? []) {
-    const item = parsedEnv.config[overrideKey];
-    if (!item) continue;
-    if (!(overrideKey in preInjectionEnv)) continue;
-    if (preInjectionEnv[overrideKey] !== injectedEnvString(item)) {
-      return { reuse: false, reason: `env override for ${overrideKey} changed since the blob was created` };
+  // Env drift: if ANY blob config key's ambient value differs from what the parent
+  // injected (e.g. `varlock run -- sh -c 'FOO=x node app.js'`, whether or not FOO was
+  // already an override at the parent), reusing the blob would clobber FOO back to the
+  // stale value - re-resolving honors the new value via the nested-invocation override
+  // handling in load-graph. An unchanged value is just the parent's own injection echoing
+  // back, and a key *absent* from the env is not drift (`--inject blob` mode injects no
+  // individual vars at all).
+  for (const itemKey of Object.keys(parsedEnv.config)) {
+    if (!(itemKey in preInjectionEnv)) continue;
+    if (preInjectionEnv[itemKey] !== injectedEnvStringForm(parsedEnv.config[itemKey])) {
+      return { reuse: false, reason: `env value for ${itemKey} changed since the blob was created` };
     }
   }
 

--- a/packages/varlock/src/lib/injected-env-reuse.ts
+++ b/packages/varlock/src/lib/injected-env-reuse.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { SerializedEnvGraph } from '../env-graph';
 import { isEncryptedBlob, decryptEnvBlobSync } from '../runtime/crypto';
 import { readVarlockPackageJsonConfig } from './package-json-config';
-import { injectedEnvStringForm } from './injected-env-provenance';
+import { envValueMatchesBlobItem } from './injected-env-provenance';
 
 /**
  * Decides whether `varlock/auto-load` can reuse an already-injected `__VARLOCK_ENV` blob
@@ -166,12 +166,13 @@ export function evaluateInjectedEnvReuse(opts: {
   // injected (e.g. `varlock run -- sh -c 'FOO=x node app.js'`, whether or not FOO was
   // already an override at the parent), reusing the blob would clobber FOO back to the
   // stale value - re-resolving honors the new value via the nested-invocation override
-  // handling in load-graph. An unchanged value is just the parent's own injection echoing
-  // back, and a key *absent* from the env is not drift (`--inject blob` mode injects no
-  // individual vars at all).
+  // handling in load-graph. An unchanged value is just this blob's own value echoing back
+  // (injected form, or the raw pre-coercion override string the parent recorded), and a
+  // key *absent* from the env is not drift (`--inject blob` mode injects no individual
+  // vars at all).
   for (const itemKey of Object.keys(parsedEnv.config)) {
     if (!(itemKey in preInjectionEnv)) continue;
-    if (preInjectionEnv[itemKey] !== injectedEnvStringForm(parsedEnv.config[itemKey])) {
+    if (!envValueMatchesBlobItem(preInjectionEnv[itemKey], parsedEnv.config[itemKey])) {
       return { reuse: false, reason: `env value for ${itemKey} changed since the blob was created` };
     }
   }

--- a/packages/varlock/src/lib/injected-env-reuse.ts
+++ b/packages/varlock/src/lib/injected-env-reuse.ts
@@ -6,8 +6,9 @@ import { readVarlockPackageJsonConfig } from './package-json-config';
 import { envValueMatchesBlobItem } from './injected-env-provenance';
 
 /**
- * Decides whether `varlock/auto-load` can reuse an already-injected `__VARLOCK_ENV` blob
- * (e.g. set by a parent `varlock run`) instead of spawning the CLI to re-resolve.
+ * Decides whether a consumer (`varlock/auto-load`, or a `varlock run` that finds a blob
+ * in its environment) can reuse an already-injected `__VARLOCK_ENV` blob instead of
+ * re-resolving from .env files.
  *
  * Two goals drive this:
  *  1. A command "unnecessarily" wrapped in `varlock run` (same directory the app would
@@ -40,7 +41,8 @@ type EnvRecord = Record<string, string | undefined>;
  * and `0`/`false`, case-insensitive. Anything else falls back to auto rather than being
  * treated as an opt-in - `=f`/`=no`/`=off` must never silently grant blob trust.
  */
-function parseMode(rawValue: string | undefined): 'auto' | 'force' | 'never' {
+export function getUseInjectedEnvMode(env: EnvRecord): 'auto' | 'force' | 'never' {
+  const rawValue = env[USE_INJECTED_ENV_VAR];
   if (rawValue === undefined) return 'auto';
   const normalized = rawValue.trim().toLowerCase();
   if (normalized === '1' || normalized === 'true') return 'force';
@@ -98,7 +100,7 @@ export function evaluateInjectedEnvReuse(opts: {
   const preInjectionEnv = opts.preInjectionEnv ?? env;
   const cwd = opts.cwd ?? process.cwd();
 
-  const mode = parseMode(env[USE_INJECTED_ENV_VAR]);
+  const mode = getUseInjectedEnvMode(env);
   if (mode === 'never') return { reuse: false, reason: `${USE_INJECTED_ENV_VAR} disabled reuse` };
 
   const rawBlob = env.__VARLOCK_ENV;

--- a/packages/varlock/src/lib/load-graph.ts
+++ b/packages/varlock/src/lib/load-graph.ts
@@ -8,7 +8,7 @@ import { captureUsageContextFromEnvGraph, captureTelemetryGraphLoadFailure } fro
 import { runWithWorkspaceInfo } from './workspace-utils';
 import { readVarlockPackageJsonConfig } from './package-json-config';
 import { createDebug } from './debug';
-import { parseBlobOverrideKeys, selectOverrideValuesFromEnv } from './injected-env-provenance';
+import { selectOverridesFromInjectedEnv } from './injected-env-provenance';
 import { getPreInjectionProcessEnv } from '../runtime/env';
 import { getActiveProxySession, getProxyResolutionViewForEnv } from '../proxy/session-registry';
 import { PROXY_CHILD_ENV_VAR } from '../proxy/env-vars';
@@ -17,14 +17,14 @@ import { enforceProxySchemaFingerprint } from '../cli/helpers/proxy-schema-finge
 const debug = createDebug('varlock:load');
 
 function getGraphEnvOverridesFromRuntimeEnv() {
-  const overrideKeys = parseBlobOverrideKeys(process.env.__VARLOCK_ENV);
-  if (!overrideKeys) return undefined;
   // Select from the pre-injection process.env snapshot, not the live one: the
   // runtime auto-init re-injects the parent blob's resolved values into
   // process.env, which would otherwise clobber a command-local override
   // (`FOO=bar varlock ...`) back to the parent's value when a nested `varlock`
-  // runs under a parent `varlock run`.
-  return selectOverrideValuesFromEnv(getPreInjectionProcessEnv(), overrideKeys);
+  // runs under a parent `varlock run`. Overrides are the blob's recorded override
+  // keys plus any env value that diverged from what the parent injected (an
+  // override introduced after the parent resolved).
+  return selectOverridesFromInjectedEnv(process.env.__VARLOCK_ENV, getPreInjectionProcessEnv());
 }
 
 function normalizePkgLoadPath(pkgLoadPath: string | Array<string>): Array<string> {

--- a/packages/varlock/src/lib/test/injected-env-provenance.test.ts
+++ b/packages/varlock/src/lib/test/injected-env-provenance.test.ts
@@ -115,4 +115,38 @@ describe('selectOverridesFromInjectedEnv', () => {
     // with any non-empty value means it was set after the parent resolved
     expect(selectOverridesFromInjectedEnv(blob, { UNSET: 'now-set' })).toEqual({ UNSET: 'now-set' });
   });
+
+  test('the raw pre-coercion override string is recognized as an echo, not a new override', () => {
+    // FLAG=YES was coerced to boolean true at the parent (injected form "true"); the
+    // raw "YES" can survive in the ambient env under --inject blob
+    const coercedBlob = JSON.stringify({
+      overrideKeys: ['FLAG'],
+      config: {
+        FLAG: {
+          value: true, overrideStr: 'YES', isSensitive: false,
+        },
+      },
+      settings: {},
+      sources: [],
+    });
+    // recorded override keys are always re-read, so the raw form is selected - and
+    // re-coerces to the same value during resolution
+    expect(selectOverridesFromInjectedEnv(coercedBlob, { FLAG: 'YES' })).toEqual({ FLAG: 'YES' });
+
+    // for a NON-recorded item (hypothetical old/new producer mix), the raw form must
+    // not be misread as a newly introduced override
+    const nonRecordedBlob = JSON.stringify({
+      overrideKeys: [],
+      config: {
+        FLAG: {
+          value: true, overrideStr: 'YES', isSensitive: false,
+        },
+      },
+      settings: {},
+      sources: [],
+    });
+    expect(selectOverridesFromInjectedEnv(nonRecordedBlob, { FLAG: 'YES' })).toEqual({});
+    expect(selectOverridesFromInjectedEnv(nonRecordedBlob, { FLAG: 'true' })).toEqual({});
+    expect(selectOverridesFromInjectedEnv(nonRecordedBlob, { FLAG: 'no' })).toEqual({ FLAG: 'no' });
+  });
 });

--- a/packages/varlock/src/lib/test/injected-env-provenance.test.ts
+++ b/packages/varlock/src/lib/test/injected-env-provenance.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeOverrideKeys,
   parseBlobOverrideKeys,
   selectOverrideValuesFromEnv,
+  selectOverridesFromInjectedEnv,
 } from '../injected-env-provenance';
 
 describe('injected env override keys', () => {
@@ -57,5 +58,61 @@ describe('injected env override keys', () => {
     expect(selected).toEqual({
       B: '2',
     });
+  });
+});
+
+describe('selectOverridesFromInjectedEnv', () => {
+  const blob = JSON.stringify({
+    overrideKeys: ['RECORDED'],
+    config: {
+      RECORDED: { value: 'recorded-override', isSensitive: false },
+      INJECTED: { value: 'injected-val', isSensitive: false },
+      LIST: { value: ['a', 'b'], envStr: 'a,b', isSensitive: false },
+      UNSET: { value: undefined, isSensitive: false },
+    },
+    settings: {},
+    sources: [],
+  });
+
+  test('returns undefined without a blob or without override provenance', () => {
+    expect(selectOverridesFromInjectedEnv(undefined, { A: '1' })).toBeUndefined();
+    expect(selectOverridesFromInjectedEnv(JSON.stringify({ config: {} }), { A: '1' })).toBeUndefined();
+  });
+
+  test('recorded override keys are re-read from the env (changed values honored)', () => {
+    expect(selectOverridesFromInjectedEnv(blob, {
+      RECORDED: 'changed-later',
+      INJECTED: 'injected-val',
+    })).toEqual({ RECORDED: 'changed-later' });
+  });
+
+  test('unchanged parent-injected values are NOT treated as overrides', () => {
+    expect(selectOverridesFromInjectedEnv(blob, {
+      INJECTED: 'injected-val',
+      LIST: 'a,b',
+    })).toEqual({});
+  });
+
+  test('a value introduced after the parent resolved IS treated as an override', () => {
+    // INJECTED was not overridden at the parent, but its ambient value no longer
+    // matches what the parent injected - someone set it deliberately in between
+    expect(selectOverridesFromInjectedEnv(blob, {
+      INJECTED: 'introduced-later',
+    })).toEqual({ INJECTED: 'introduced-later' });
+  });
+
+  test('composite values compare via their envStr form', () => {
+    expect(selectOverridesFromInjectedEnv(blob, { LIST: 'a,b' })).toEqual({});
+    expect(selectOverridesFromInjectedEnv(blob, { LIST: 'a,b,c' })).toEqual({ LIST: 'a,b,c' });
+  });
+
+  test('keys absent from the env are not overrides (--inject blob mode)', () => {
+    expect(selectOverridesFromInjectedEnv(blob, {})).toEqual({});
+  });
+
+  test('an undefined-valued blob item set to a real value counts as introduced', () => {
+    // `varlock run` drops undefined-valued keys from the child env, so presence
+    // with any non-empty value means it was set after the parent resolved
+    expect(selectOverridesFromInjectedEnv(blob, { UNSET: 'now-set' })).toEqual({ UNSET: 'now-set' });
   });
 });

--- a/packages/varlock/src/lib/test/injected-env-reuse.test.ts
+++ b/packages/varlock/src/lib/test/injected-env-reuse.test.ts
@@ -1,0 +1,296 @@
+import {
+  describe, test, expect, beforeEach, afterEach,
+} from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { evaluateInjectedEnvReuse, USE_INJECTED_ENV_VAR } from '../injected-env-reuse';
+import { encryptEnvBlobSync, generateEncryptionKeyHex } from '../../runtime/crypto';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'varlock-injected-env-reuse-'));
+  // realpath so assertions aren't confused by symlinked tmp dirs (e.g. /tmp on macOS)
+  tempDir = fs.realpathSync(tempDir);
+});
+
+afterEach(() => {
+  if (tempDir && fs.existsSync(tempDir)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+function makeBlob(overrides?: Record<string, any>) {
+  return JSON.stringify({
+    basePath: tempDir,
+    sources: [],
+    settings: {},
+    config: {
+      FOO: { value: 'foo-val', isSensitive: false },
+      SECRET: { value: 'secret-val', isSensitive: true },
+    },
+    overrideKeys: [],
+    ...overrides,
+  });
+}
+
+describe('evaluateInjectedEnvReuse', () => {
+  describe('automatic mode', () => {
+    test('reuses a matching blob', () => {
+      const decision = evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: makeBlob() },
+        cwd: tempDir,
+      });
+      expect(decision.reuse).toBe(true);
+      if (decision.reuse) {
+        expect(decision.parsedEnv.config.FOO.value).toBe('foo-val');
+      }
+    });
+
+    test('does not reuse when no blob is present', () => {
+      const decision = evaluateInjectedEnvReuse({ env: {}, cwd: tempDir });
+      expect(decision).toMatchObject({ reuse: false, reason: expect.stringContaining('no injected env blob') });
+    });
+
+    test('does not reuse when the blob was resolved in a different directory', () => {
+      const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), 'varlock-other-'));
+      try {
+        const decision = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: makeBlob() },
+          cwd: otherDir,
+        });
+        expect(decision).toMatchObject({ reuse: false, reason: expect.stringContaining('different directory') });
+      } finally {
+        fs.rmSync(otherDir, { recursive: true, force: true });
+      }
+    });
+
+    test('directory comparison uses realpath (symlinks match)', () => {
+      const linkPath = path.join(os.tmpdir(), `varlock-link-${path.basename(tempDir)}`);
+      fs.symlinkSync(tempDir, linkPath);
+      try {
+        const decision = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: makeBlob() },
+          cwd: linkPath,
+        });
+        expect(decision.reuse).toBe(true);
+      } finally {
+        fs.unlinkSync(linkPath);
+      }
+    });
+
+    test('does not reuse a blob that contains errors', () => {
+      const decision = evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: makeBlob({ errors: { root: ['something failed'] } }) },
+        cwd: tempDir,
+      });
+      expect(decision).toMatchObject({ reuse: false, reason: expect.stringContaining('errors') });
+    });
+
+    test('does not reuse a blob with no basePath', () => {
+      const decision = evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: makeBlob({ basePath: undefined }) },
+        cwd: tempDir,
+      });
+      expect(decision).toMatchObject({ reuse: false, reason: expect.stringContaining('basePath') });
+    });
+
+    test('does not reuse an unparseable blob', () => {
+      const decision = evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: 'not-json' },
+        cwd: tempDir,
+      });
+      expect(decision).toMatchObject({ reuse: false, reason: expect.stringContaining('not a valid') });
+    });
+
+    describe('package.json loadPath handling', () => {
+      test('reuses when loadPath dir matches the blob basePath', () => {
+        const envDir = path.join(tempDir, 'envs');
+        fs.mkdirSync(envDir);
+        fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({
+          name: 'x', varlock: { loadPath: './envs' },
+        }));
+        const decision = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: makeBlob({ basePath: envDir }) },
+          cwd: tempDir,
+        });
+        expect(decision.reuse).toBe(true);
+      });
+
+      test('does not reuse when loadPath points elsewhere than the blob basePath', () => {
+        const envDir = path.join(tempDir, 'envs');
+        fs.mkdirSync(envDir);
+        fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({
+          name: 'x', varlock: { loadPath: './envs' },
+        }));
+        const decision = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: makeBlob() }, // basePath = tempDir, not tempDir/envs
+          cwd: tempDir,
+        });
+        expect(decision.reuse).toBe(false);
+      });
+
+      test('loadPath pointing at a file compares against its directory', () => {
+        const envDir = path.join(tempDir, 'config');
+        fs.mkdirSync(envDir);
+        fs.writeFileSync(path.join(envDir, '.env.schema'), '');
+        fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({
+          name: 'x', varlock: { loadPath: './config/.env.schema' },
+        }));
+        const decision = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: makeBlob({ basePath: envDir }) },
+          cwd: tempDir,
+        });
+        expect(decision.reuse).toBe(true);
+      });
+
+      test('does not reuse when loadPath points at a missing path (CLI should surface its error)', () => {
+        fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({
+          name: 'x', varlock: { loadPath: './does-not-exist' },
+        }));
+        const decision = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: makeBlob() },
+          cwd: tempDir,
+        });
+        expect(decision.reuse).toBe(false);
+      });
+    });
+
+    describe('override drift', () => {
+      test('reuses when override values still match', () => {
+        const decision = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: makeBlob({ overrideKeys: ['FOO'] }) },
+          preInjectionEnv: { FOO: 'foo-val' },
+          cwd: tempDir,
+        });
+        expect(decision.reuse).toBe(true);
+      });
+
+      test('does not reuse when an override value changed since the blob was created', () => {
+        const decision = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: makeBlob({ overrideKeys: ['FOO'] }) },
+          preInjectionEnv: { FOO: 'changed!' },
+          cwd: tempDir,
+        });
+        expect(decision).toMatchObject({ reuse: false, reason: expect.stringContaining('FOO') });
+      });
+
+      test('an override key absent from the env is not drift (--inject blob mode)', () => {
+        const decision = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: makeBlob({ overrideKeys: ['FOO'] }) },
+          preInjectionEnv: {},
+          cwd: tempDir,
+        });
+        expect(decision.reuse).toBe(true);
+      });
+
+      test('composite values compare via their envStr form', () => {
+        const blob = makeBlob({
+          config: {
+            LIST: { value: ['a', 'b'], envStr: 'a,b', isSensitive: false },
+          },
+          overrideKeys: ['LIST'],
+        });
+        const matching = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: blob },
+          preInjectionEnv: { LIST: 'a,b' },
+          cwd: tempDir,
+        });
+        expect(matching.reuse).toBe(true);
+        const drifted = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: blob },
+          preInjectionEnv: { LIST: 'a,b,c' },
+          cwd: tempDir,
+        });
+        expect(drifted.reuse).toBe(false);
+      });
+    });
+
+    describe('encrypted blobs', () => {
+      test('decrypts and reuses when the key is present', () => {
+        const key = generateEncryptionKeyHex();
+        const decision = evaluateInjectedEnvReuse({
+          env: {
+            __VARLOCK_ENV: encryptEnvBlobSync(makeBlob(), key),
+            _VARLOCK_ENV_KEY: key,
+          },
+          cwd: tempDir,
+        });
+        expect(decision.reuse).toBe(true);
+        if (decision.reuse) {
+          expect(decision.parsedEnv.config.SECRET.value).toBe('secret-val');
+          // blobJson is the decrypted plaintext form
+          expect(decision.blobJson).toContain('secret-val');
+        }
+      });
+
+      test('does not reuse an encrypted blob without a key', () => {
+        const key = generateEncryptionKeyHex();
+        const decision = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: encryptEnvBlobSync(makeBlob(), key) },
+          cwd: tempDir,
+        });
+        expect(decision).toMatchObject({ reuse: false, reason: expect.stringContaining('encrypted') });
+      });
+
+      test('does not reuse when decryption fails (wrong key)', () => {
+        const decision = evaluateInjectedEnvReuse({
+          env: {
+            __VARLOCK_ENV: encryptEnvBlobSync(makeBlob(), generateEncryptionKeyHex()),
+            _VARLOCK_ENV_KEY: generateEncryptionKeyHex(),
+          },
+          cwd: tempDir,
+        });
+        expect(decision).toMatchObject({ reuse: false, reason: expect.stringContaining('decrypt') });
+      });
+    });
+  });
+
+  describe(`explicit modes (${USE_INJECTED_ENV_VAR})`, () => {
+    test('=0 disables reuse even for a matching blob', () => {
+      const decision = evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: makeBlob(), [USE_INJECTED_ENV_VAR]: '0' },
+        cwd: tempDir,
+      });
+      expect(decision.reuse).toBe(false);
+    });
+
+    test('=1 reuses regardless of directory mismatch', () => {
+      const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), 'varlock-other-'));
+      try {
+        const decision = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: makeBlob(), [USE_INJECTED_ENV_VAR]: '1' },
+          cwd: otherDir,
+        });
+        expect(decision.reuse).toBe(true);
+      } finally {
+        fs.rmSync(otherDir, { recursive: true, force: true });
+      }
+    });
+
+    test('=1 throws when no blob is present', () => {
+      expect(() => evaluateInjectedEnvReuse({
+        env: { [USE_INJECTED_ENV_VAR]: '1' },
+        cwd: tempDir,
+      })).toThrow(/no __VARLOCK_ENV blob/);
+    });
+
+    test('=1 throws when blob is encrypted and no key is set', () => {
+      expect(() => evaluateInjectedEnvReuse({
+        env: {
+          __VARLOCK_ENV: encryptEnvBlobSync(makeBlob(), generateEncryptionKeyHex()),
+          [USE_INJECTED_ENV_VAR]: '1',
+        },
+        cwd: tempDir,
+      })).toThrow(/_VARLOCK_ENV_KEY/);
+    });
+
+    test('=1 throws on an unparseable blob', () => {
+      expect(() => evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: 'not-json', [USE_INJECTED_ENV_VAR]: '1' },
+        cwd: tempDir,
+      })).toThrow(/not a valid serialized env graph/);
+    });
+  });
+});

--- a/packages/varlock/src/lib/test/injected-env-reuse.test.ts
+++ b/packages/varlock/src/lib/test/injected-env-reuse.test.ts
@@ -292,5 +292,46 @@ describe('evaluateInjectedEnvReuse', () => {
         cwd: tempDir,
       })).toThrow(/not a valid serialized env graph/);
     });
+
+    test('accepts true/false (case-insensitive) as aliases for 1/0', () => {
+      const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), 'varlock-other-'));
+      try {
+        const forced = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: makeBlob(), [USE_INJECTED_ENV_VAR]: 'TRUE' },
+          cwd: otherDir, // would fail the dir check in auto mode
+        });
+        expect(forced.reuse).toBe(true);
+      } finally {
+        fs.rmSync(otherDir, { recursive: true, force: true });
+      }
+      const disabled = evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: makeBlob(), [USE_INJECTED_ENV_VAR]: 'False' },
+        cwd: tempDir, // would reuse in auto mode
+      });
+      expect(disabled.reuse).toBe(false);
+    });
+
+    test('unrecognized values fall back to auto mode, never force-trust', () => {
+      // `f`, `no`, `off`, etc. must not be treated as either opt-in or opt-out
+      const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), 'varlock-other-'));
+      try {
+        for (const rawValue of ['f', 'no', 'off', 'yes', 'anything']) {
+          // dir mismatch: auto mode declines, so force-trust would be visible here
+          const decision = evaluateInjectedEnvReuse({
+            env: { __VARLOCK_ENV: makeBlob(), [USE_INJECTED_ENV_VAR]: rawValue },
+            cwd: otherDir,
+          });
+          expect(decision.reuse).toBe(false);
+        }
+      } finally {
+        fs.rmSync(otherDir, { recursive: true, force: true });
+      }
+      // and in a matching dir, auto mode still reuses (value didn't disable it either)
+      const decision = evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: makeBlob(), [USE_INJECTED_ENV_VAR]: 'yes' },
+        cwd: tempDir,
+      });
+      expect(decision.reuse).toBe(true);
+    });
   });
 });

--- a/packages/varlock/src/lib/test/injected-env-reuse.test.ts
+++ b/packages/varlock/src/lib/test/injected-env-reuse.test.ts
@@ -196,6 +196,38 @@ describe('evaluateInjectedEnvReuse', () => {
         expect(decision.reuse).toBe(true);
       });
 
+      test('a coerced override\'s raw string form is an echo, not drift', () => {
+        // parent ran with FLAG=YES (coerced to boolean true); under --inject blob the
+        // raw "YES" survives in the child env and must not block reuse
+        const blob = makeBlob({
+          config: {
+            FLAG: {
+              value: true, overrideStr: 'YES', isSensitive: false,
+            },
+          },
+          overrideKeys: ['FLAG'],
+        });
+        const rawForm = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: blob },
+          preInjectionEnv: { FLAG: 'YES' },
+          cwd: tempDir,
+        });
+        expect(rawForm.reuse).toBe(true);
+        const coercedForm = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: blob },
+          preInjectionEnv: { FLAG: 'true' },
+          cwd: tempDir,
+        });
+        expect(coercedForm.reuse).toBe(true);
+        // a value matching NEITHER form is a genuine change
+        const changed = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: blob },
+          preInjectionEnv: { FLAG: 'no' },
+          cwd: tempDir,
+        });
+        expect(changed.reuse).toBe(false);
+      });
+
       test('composite values compare via their envStr form', () => {
         const blob = makeBlob({
           config: {

--- a/packages/varlock/src/lib/test/injected-env-reuse.test.ts
+++ b/packages/varlock/src/lib/test/injected-env-reuse.test.ts
@@ -176,6 +176,17 @@ describe('evaluateInjectedEnvReuse', () => {
         expect(decision).toMatchObject({ reuse: false, reason: expect.stringContaining('FOO') });
       });
 
+      test('drift on a key that was NOT an override at the parent still blocks reuse', () => {
+        // FOO was resolved (not overridden) at the parent; setting it between the parent
+        // run and the app boot is a newly introduced override that reuse would clobber
+        const decision = evaluateInjectedEnvReuse({
+          env: { __VARLOCK_ENV: makeBlob() }, // overrideKeys: []
+          preInjectionEnv: { FOO: 'introduced-later' },
+          cwd: tempDir,
+        });
+        expect(decision).toMatchObject({ reuse: false, reason: expect.stringContaining('FOO') });
+      });
+
       test('an override key absent from the env is not drift (--inject blob mode)', () => {
         const decision = evaluateInjectedEnvReuse({
           env: { __VARLOCK_ENV: makeBlob({ overrideKeys: ['FOO'] }) },

--- a/packages/varlock/src/lib/test/injected-env-reuse.test.ts
+++ b/packages/varlock/src/lib/test/injected-env-reuse.test.ts
@@ -290,6 +290,68 @@ describe('evaluateInjectedEnvReuse', () => {
     });
   });
 
+  describe('_VARLOCK_FILTER interaction', () => {
+    test('a set _VARLOCK_FILTER disables reuse (fresh resolution honors the filter)', () => {
+      const decision = evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: makeBlob(), _VARLOCK_FILTER: 'FOO' },
+        cwd: tempDir,
+      });
+      expect(decision).toMatchObject({ reuse: false, reason: expect.stringContaining('_VARLOCK_FILTER') });
+    });
+
+    test('forced mode rejects _VARLOCK_FILTER instead of silently ignoring it', () => {
+      expect(() => evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: makeBlob(), _VARLOCK_FILTER: 'FOO', [USE_INJECTED_ENV_VAR]: '1' },
+        cwd: tempDir,
+      })).toThrow(/_VARLOCK_FILTER/);
+    });
+  });
+
+  describe('@internal items in the blob', () => {
+    const blobWithInternal = () => makeBlob({
+      config: {
+        FOO: { value: 'foo-val', isSensitive: false },
+        SECRET_ZERO: { value: 'internal-val', isSensitive: false, isInternal: true },
+      },
+    });
+
+    test('internal items are stripped on reuse and reported', () => {
+      const decision = evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: blobWithInternal() },
+        cwd: tempDir,
+      });
+      expect(decision.reuse).toBe(true);
+      if (decision.reuse) {
+        expect(decision.strippedInternalKeys).toEqual(['SECRET_ZERO']);
+        expect(decision.parsedEnv.config).not.toHaveProperty('SECRET_ZERO');
+        expect(decision.parsedEnv.config.FOO.value).toBe('foo-val');
+        // the re-serialized blob is clean too, so forwarding it cannot leak the value
+        expect(decision.blobJson).not.toContain('internal-val');
+      }
+    });
+
+    test('internal items are stripped in forced mode too', () => {
+      const decision = evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: blobWithInternal(), [USE_INJECTED_ENV_VAR]: '1' },
+        cwd: tempDir,
+      });
+      expect(decision.reuse).toBe(true);
+      if (decision.reuse) {
+        expect(decision.strippedInternalKeys).toEqual(['SECRET_ZERO']);
+        expect(decision.blobJson).not.toContain('SECRET_ZERO');
+      }
+    });
+
+    test('blobs without internal items report an empty stripped list', () => {
+      const decision = evaluateInjectedEnvReuse({
+        env: { __VARLOCK_ENV: makeBlob() },
+        cwd: tempDir,
+      });
+      expect(decision.reuse).toBe(true);
+      if (decision.reuse) expect(decision.strippedInternalKeys).toEqual([]);
+    });
+  });
+
   describe(`explicit modes (${USE_INJECTED_ENV_VAR})`, () => {
     test('=0 disables reuse even for a matching blob', () => {
       const decision = evaluateInjectedEnvReuse({

--- a/smoke-tests/smoke-test-injected-env/.env.schema
+++ b/smoke-tests/smoke-test-injected-env/.env.schema
@@ -7,3 +7,6 @@ PUBLIC_VAR=public-value
 SECRET_TOKEN=secret-token-val
 
 OVERRIDE_ME=default-value
+
+# @type=boolean
+COERCED_FLAG=false

--- a/smoke-tests/smoke-test-injected-env/.env.schema
+++ b/smoke-tests/smoke-test-injected-env/.env.schema
@@ -1,0 +1,9 @@
+# @defaultSensitive=false
+# ---
+
+PUBLIC_VAR=public-value
+
+# @sensitive
+SECRET_TOKEN=secret-token-val
+
+OVERRIDE_ME=default-value

--- a/smoke-tests/smoke-test-injected-env/app.mjs
+++ b/smoke-tests/smoke-test-injected-env/app.mjs
@@ -5,3 +5,4 @@ import { ENV } from 'varlock/env';
 console.log(`PUBLIC_VAR=${ENV.PUBLIC_VAR}`);
 console.log(`SECRET_OK=${ENV.SECRET_TOKEN === 'secret-token-val' && process.env.SECRET_TOKEN === 'secret-token-val'}`);
 console.log(`OVERRIDE_ME=${ENV.OVERRIDE_ME}`);
+console.log(`COERCED_FLAG=${ENV.COERCED_FLAG}`);

--- a/smoke-tests/smoke-test-injected-env/app.mjs
+++ b/smoke-tests/smoke-test-injected-env/app.mjs
@@ -1,0 +1,7 @@
+import 'varlock/auto-load';
+import { ENV } from 'varlock/env';
+
+// print comparison results rather than raw values, so redaction can't hide what we assert on
+console.log(`PUBLIC_VAR=${ENV.PUBLIC_VAR}`);
+console.log(`SECRET_OK=${ENV.SECRET_TOKEN === 'secret-token-val' && process.env.SECRET_TOKEN === 'secret-token-val'}`);
+console.log(`OVERRIDE_ME=${ENV.OVERRIDE_ME}`);

--- a/smoke-tests/smoke-test-injected-env/sandbox/README.md
+++ b/smoke-tests/smoke-test-injected-env/sandbox/README.md
@@ -1,0 +1,5 @@
+# sandbox fixture
+
+Deliberately contains NO `.env` files: simulates an environment (e.g. a remote sandbox)
+where only the `__VARLOCK_ENV` blob is provided and `varlock/auto-load` must hydrate
+everything from it via `_VARLOCK_USE_INJECTED_ENV=1`.

--- a/smoke-tests/smoke-test-injected-env/sandbox/app.mjs
+++ b/smoke-tests/smoke-test-injected-env/sandbox/app.mjs
@@ -5,3 +5,4 @@ import { ENV } from 'varlock/env';
 console.log(`PUBLIC_VAR=${ENV.PUBLIC_VAR}`);
 console.log(`SECRET_OK=${ENV.SECRET_TOKEN === 'secret-token-val' && process.env.SECRET_TOKEN === 'secret-token-val'}`);
 console.log(`OVERRIDE_ME=${ENV.OVERRIDE_ME}`);
+console.log(`COERCED_FLAG=${ENV.COERCED_FLAG}`);

--- a/smoke-tests/smoke-test-injected-env/sandbox/app.mjs
+++ b/smoke-tests/smoke-test-injected-env/sandbox/app.mjs
@@ -1,0 +1,7 @@
+import 'varlock/auto-load';
+import { ENV } from 'varlock/env';
+
+// print comparison results rather than raw values, so redaction can't hide what we assert on
+console.log(`PUBLIC_VAR=${ENV.PUBLIC_VAR}`);
+console.log(`SECRET_OK=${ENV.SECRET_TOKEN === 'secret-token-val' && process.env.SECRET_TOKEN === 'secret-token-val'}`);
+console.log(`OVERRIDE_ME=${ENV.OVERRIDE_ME}`);

--- a/smoke-tests/tests/injected-env-reuse.test.ts
+++ b/smoke-tests/tests/injected-env-reuse.test.ts
@@ -83,6 +83,19 @@ describe('auto-load reuse of injected env blob', () => {
     expect(result.output).toContain('OVERRIDE_ME=changed-later');
   });
 
+  test.skipIf(process.platform === 'win32')('an override INTRODUCED between run and app (not overridden at the parent) is honored', () => {
+    // OVERRIDE_ME resolves from the .env file at the parent (no ambient override), so the
+    // blob does not record it as an override; setting it mid-chain must still win
+    const result = varlockRun(['sh', '-c', 'OVERRIDE_ME=introduced-later node app.mjs'], {
+      cwd: SCENARIO,
+      env: { DEBUG: 'varlock:auto-load' },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain(RESOLVED_MSG);
+    expect(result.output).not.toContain(REUSED_MSG);
+    expect(result.output).toContain('OVERRIDE_ME=introduced-later');
+  });
+
   test('without a wrapping varlock run, auto-load resolves via the CLI as before', () => {
     const result = runNodeApp();
     expect(result.exitCode).toBe(0);

--- a/smoke-tests/tests/injected-env-reuse.test.ts
+++ b/smoke-tests/tests/injected-env-reuse.test.ts
@@ -194,14 +194,49 @@ describe('auto-load reuse of injected env blob', () => {
         ['run', '--', 'sh', '-c', 'echo "NORMAL=$NORMAL_VAR BLOB=$__VARLOCK_ENV"; if [ -z "$SECRET_ZERO" ]; then echo INTERNAL_UNSET; fi'],
         {
           cwd: `${SCENARIO}/sandbox`,
-          env: { __VARLOCK_ENV: blob, _VARLOCK_USE_INJECTED_ENV: '1' },
+          // the ambient value must be stripped from the child env too, not just the blob
+          env: { __VARLOCK_ENV: blob, _VARLOCK_USE_INJECTED_ENV: '1', SECRET_ZERO: 'ambient-secret' },
         },
       );
       expect(result.exitCode).toBe(0);
       expect(result.output).toContain('NORMAL=normal-val');
       expect(result.output).toContain('INTERNAL_UNSET');
       expect(result.output).not.toContain('internal-val');
+      expect(result.output).not.toContain('ambient-secret');
       expect(result.output).not.toContain('SECRET_ZERO');
+    });
+
+    test('@internal items in a reused blob are scrubbed from process.env by auto-load too', () => {
+      // pass the internal key BOTH in the blob and as an ambient env value; after
+      // auto-load initializes, neither form may remain readable via process.env
+      const blob = JSON.stringify({
+        basePath: '/nonexistent',
+        sources: [],
+        settings: {},
+        overrideKeys: [],
+        config: {
+          NORMAL_VAR: { value: 'normal-val', isSensitive: false },
+          SECRET_ZERO: { value: 'internal-val', isSensitive: false, isInternal: true },
+        },
+      });
+      const script = 'import "varlock/auto-load";'
+        + 'console.log("NORMAL=" + process.env.NORMAL_VAR);'
+        + 'console.log("SZ=" + ("SECRET_ZERO" in process.env ? process.env.SECRET_ZERO : "ABSENT"));';
+      const result = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+        cwd: join(SCENARIO_DIR, 'sandbox'),
+        env: {
+          ...process.env,
+          __VARLOCK_ENV: blob,
+          _VARLOCK_USE_INJECTED_ENV: '1',
+          SECRET_ZERO: 'ambient-secret',
+        },
+        encoding: 'utf-8',
+      });
+      const output = (result.stdout ?? '') + (result.stderr ?? '');
+      expect(result.status).toBe(0);
+      expect(output).toContain('NORMAL=normal-val');
+      expect(output).toContain('SZ=ABSENT');
+      expect(output).not.toContain('ambient-secret');
     });
 
     test('forced mode with no blob is a clear error', () => {

--- a/smoke-tests/tests/injected-env-reuse.test.ts
+++ b/smoke-tests/tests/injected-env-reuse.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
-import { varlockRun, runVarlock } from '../helpers/run-varlock.js';
+import { varlockRun, runVarlock, VARLOCK_CLI } from '../helpers/run-varlock.js';
 
 // End-to-end tests for `varlock/auto-load` reusing an already-injected __VARLOCK_ENV blob
 // instead of spawning the CLI to re-resolve:
@@ -125,6 +125,65 @@ describe('auto-load reuse of injected env blob', () => {
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain(RESOLVED_MSG);
     expect(result.output).not.toContain(REUSED_MSG);
+  });
+
+  describe('varlock run consuming a blob (non-Node workloads)', () => {
+    test.skipIf(process.platform === 'win32')('a nested varlock run reuses the outer blob instead of re-resolving', () => {
+      const result = runVarlock(
+        ['run', '--', 'node', VARLOCK_CLI, 'run', '--', 'sh', '-c', 'echo INNER_PUBLIC_VAR=$PUBLIC_VAR'],
+        { cwd: SCENARIO, env: { DEBUG: 'varlock:run' } },
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain(REUSED_MSG);
+      expect(result.output).toContain('INNER_PUBLIC_VAR=public-value');
+    });
+
+    test.skipIf(process.platform === 'win32')('sandbox: varlock run hydrates any workload from the blob with no env files', () => {
+      // capture with a coerced ambient override, so the sandbox side must serialize the
+      // coerced boolean back into the child env
+      const captured = runVarlock(['load', '--format', 'json-full', '--compact'], {
+        cwd: SCENARIO,
+        env: { COERCED_FLAG: 'YES' },
+      });
+      expect(captured.exitCode).toBe(0);
+      const result = runVarlock(
+        ['run', '--', 'sh', '-c', 'echo PUBLIC_VAR=$PUBLIC_VAR COERCED_FLAG=$COERCED_FLAG'],
+        {
+          cwd: `${SCENARIO}/sandbox`,
+          env: {
+            __VARLOCK_ENV: captured.stdout.trim(),
+            _VARLOCK_USE_INJECTED_ENV: '1',
+            DEBUG: 'varlock:run',
+          },
+        },
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain(REUSED_MSG);
+      expect(result.output).toContain('PUBLIC_VAR=public-value');
+      expect(result.output).toContain('COERCED_FLAG=true');
+    });
+
+    test('forced mode with no blob is a clear error', () => {
+      const result = runVarlock(['run', '--', 'node', '--version'], {
+        cwd: `${SCENARIO}/sandbox`,
+        env: { _VARLOCK_USE_INJECTED_ENV: '1' },
+      });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.output).toContain('no __VARLOCK_ENV blob');
+    });
+
+    test('forced mode rejects flags that would change what a resolution produces', () => {
+      const captured = runVarlock(['load', '--format', 'json-full', '--compact'], { cwd: SCENARIO });
+      const result = runVarlock(['run', '--filter', 'PUBLIC_VAR', '--', 'node', '--version'], {
+        cwd: `${SCENARIO}/sandbox`,
+        env: {
+          __VARLOCK_ENV: captured.stdout.trim(),
+          _VARLOCK_USE_INJECTED_ENV: '1',
+        },
+      });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.output).toContain('cannot be combined with --filter');
+    });
   });
 
   describe('sandbox mode (blob only, no env files)', () => {

--- a/smoke-tests/tests/injected-env-reuse.test.ts
+++ b/smoke-tests/tests/injected-env-reuse.test.ts
@@ -163,6 +163,47 @@ describe('auto-load reuse of injected env blob', () => {
       expect(result.output).toContain('COERCED_FLAG=true');
     });
 
+    test('_VARLOCK_FILTER disables reuse so the filter is honored', () => {
+      // the outer run filters the blob and child env to the selected keys; the child
+      // auto-load must NOT reuse blindly but re-resolve, honoring the inherited filter
+      const result = varlockRun(['node', 'app.mjs'], {
+        cwd: SCENARIO,
+        env: { DEBUG: 'varlock:auto-load', _VARLOCK_FILTER: 'PUBLIC_VAR,OVERRIDE_ME,COERCED_FLAG' },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain(RESOLVED_MSG);
+      expect(result.output).not.toContain(REUSED_MSG);
+      expect(result.output).toContain('PUBLIC_VAR=public-value');
+      expect(result.output).toContain('SECRET_OK=false'); // filtered out
+    });
+
+    test.skipIf(process.platform === 'win32')('@internal items in a blob are stripped on reuse and not forwarded', () => {
+      // an inspection blob (load --include-internal) can carry internal items; a reused
+      // run must not inject them, and the forwarded blob must be sanitized
+      const blob = JSON.stringify({
+        basePath: '/nonexistent',
+        sources: [],
+        settings: {},
+        overrideKeys: [],
+        config: {
+          NORMAL_VAR: { value: 'normal-val', isSensitive: false },
+          SECRET_ZERO: { value: 'internal-val', isSensitive: false, isInternal: true },
+        },
+      });
+      const result = runVarlock(
+        ['run', '--', 'sh', '-c', 'echo "NORMAL=$NORMAL_VAR BLOB=$__VARLOCK_ENV"; if [ -z "$SECRET_ZERO" ]; then echo INTERNAL_UNSET; fi'],
+        {
+          cwd: `${SCENARIO}/sandbox`,
+          env: { __VARLOCK_ENV: blob, _VARLOCK_USE_INJECTED_ENV: '1' },
+        },
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain('NORMAL=normal-val');
+      expect(result.output).toContain('INTERNAL_UNSET');
+      expect(result.output).not.toContain('internal-val');
+      expect(result.output).not.toContain('SECRET_ZERO');
+    });
+
     test('forced mode with no blob is a clear error', () => {
       const result = runVarlock(['run', '--', 'node', '--version'], {
         cwd: `${SCENARIO}/sandbox`,

--- a/smoke-tests/tests/injected-env-reuse.test.ts
+++ b/smoke-tests/tests/injected-env-reuse.test.ts
@@ -24,7 +24,7 @@ function runNodeApp(opts: { cwd?: string; env?: Record<string, string | undefine
   };
   // an inherited value (e.g. if the test runner itself runs under varlock) must not
   // accidentally satisfy or flip the scenario under test
-  for (const key of ['__VARLOCK_ENV', '_VARLOCK_ENV_KEY', '_VARLOCK_USE_INJECTED_ENV', 'OVERRIDE_ME']) {
+  for (const key of ['__VARLOCK_ENV', '_VARLOCK_ENV_KEY', '_VARLOCK_USE_INJECTED_ENV', 'OVERRIDE_ME', 'COERCED_FLAG']) {
     if (!(opts.env && key in opts.env)) delete env[key];
   }
   const result = spawnSync(process.execPath, ['app.mjs'], {
@@ -60,6 +60,19 @@ describe('auto-load reuse of injected env blob', () => {
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain(REUSED_MSG);
     expect(result.output).toContain('SECRET_OK=true');
+  });
+
+  test('a COERCED ambient override does not block reuse under --inject blob', () => {
+    // COERCED_FLAG=YES coerces to boolean true (injected form "true"); in blob-only mode
+    // no individual vars are injected, so the raw "YES" survives in the child env. The
+    // blob's recorded raw override string must be recognized as an echo, not drift.
+    const result = runVarlock(['run', '--inject', 'blob', '--', 'node', 'app.mjs'], {
+      cwd: SCENARIO,
+      env: { DEBUG: 'varlock:auto-load', COERCED_FLAG: 'YES' },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain(REUSED_MSG);
+    expect(result.output).toContain('COERCED_FLAG=true');
   });
 
   test('an ambient override at the parent invocation still reuses (value already in the blob)', () => {

--- a/smoke-tests/tests/injected-env-reuse.test.ts
+++ b/smoke-tests/tests/injected-env-reuse.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { varlockRun, runVarlock } from '../helpers/run-varlock.js';
+
+// End-to-end tests for `varlock/auto-load` reusing an already-injected __VARLOCK_ENV blob
+// instead of spawning the CLI to re-resolve:
+//  - automatic reuse when running under `varlock run` in the same directory
+//  - fallback to CLI resolution on override drift (and the drifted value being honored)
+//  - explicit trust via _VARLOCK_USE_INJECTED_ENV=1 in a dir with no .env files (sandbox)
+// The DEBUG=varlock:auto-load output tells us which path was taken.
+
+const SCENARIO = 'smoke-test-injected-env';
+const SCENARIO_DIR = join(import.meta.dirname, '..', SCENARIO);
+
+const REUSED_MSG = 'reusing injected env blob';
+const RESOLVED_MSG = 'resolving env via CLI';
+
+function runNodeApp(opts: { cwd?: string; env?: Record<string, string | undefined> } = {}) {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    DEBUG: 'varlock:auto-load',
+    ...opts.env,
+  };
+  // an inherited value (e.g. if the test runner itself runs under varlock) must not
+  // accidentally satisfy or flip the scenario under test
+  for (const key of ['__VARLOCK_ENV', '_VARLOCK_ENV_KEY', '_VARLOCK_USE_INJECTED_ENV', 'OVERRIDE_ME']) {
+    if (!(opts.env && key in opts.env)) delete env[key];
+  }
+  const result = spawnSync(process.execPath, ['app.mjs'], {
+    cwd: opts.cwd ?? SCENARIO_DIR,
+    env: env as NodeJS.ProcessEnv,
+    encoding: 'utf-8',
+  });
+  return {
+    exitCode: result.status ?? 1,
+    output: (result.stdout ?? '') + (result.stderr ?? ''),
+  };
+}
+
+describe('auto-load reuse of injected env blob', () => {
+  test('under varlock run, the blob is reused and no re-resolution happens', () => {
+    const result = varlockRun(['node', 'app.mjs'], {
+      cwd: SCENARIO,
+      env: { DEBUG: 'varlock:auto-load' },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain(REUSED_MSG);
+    expect(result.output).not.toContain(RESOLVED_MSG);
+    expect(result.output).toContain('PUBLIC_VAR=public-value');
+    expect(result.output).toContain('SECRET_OK=true');
+    expect(result.output).toContain('OVERRIDE_ME=default-value');
+  });
+
+  test('under varlock run --inject blob (no individual vars), the blob is still reused and hydrates process.env', () => {
+    const result = runVarlock(['run', '--inject', 'blob', '--', 'node', 'app.mjs'], {
+      cwd: SCENARIO,
+      env: { DEBUG: 'varlock:auto-load' },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain(REUSED_MSG);
+    expect(result.output).toContain('SECRET_OK=true');
+  });
+
+  test('an ambient override at the parent invocation still reuses (value already in the blob)', () => {
+    const result = varlockRun(['node', 'app.mjs'], {
+      cwd: SCENARIO,
+      env: { DEBUG: 'varlock:auto-load', OVERRIDE_ME: 'parent-override' },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain(REUSED_MSG);
+    expect(result.output).toContain('OVERRIDE_ME=parent-override');
+  });
+
+  test.skipIf(process.platform === 'win32')('override drift between run and app falls back to re-resolution and honors the new value', () => {
+    const result = varlockRun(['sh', '-c', 'OVERRIDE_ME=changed-later node app.mjs'], {
+      cwd: SCENARIO,
+      env: { DEBUG: 'varlock:auto-load', OVERRIDE_ME: 'parent-override' },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain(RESOLVED_MSG);
+    expect(result.output).not.toContain(REUSED_MSG);
+    expect(result.output).toContain('OVERRIDE_ME=changed-later');
+  });
+
+  test('without a wrapping varlock run, auto-load resolves via the CLI as before', () => {
+    const result = runNodeApp();
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain(RESOLVED_MSG);
+    expect(result.output).toContain('PUBLIC_VAR=public-value');
+    expect(result.output).toContain('SECRET_OK=true');
+  });
+
+  test('_VARLOCK_USE_INJECTED_ENV=0 forces re-resolution even under varlock run', () => {
+    const result = varlockRun(['node', 'app.mjs'], {
+      cwd: SCENARIO,
+      env: { DEBUG: 'varlock:auto-load', _VARLOCK_USE_INJECTED_ENV: '0' },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain(RESOLVED_MSG);
+    expect(result.output).not.toContain(REUSED_MSG);
+  });
+
+  describe('sandbox mode (blob only, no env files)', () => {
+    // capture a blob the way a host machine would before handing it into a sandbox
+    function captureBlob() {
+      const result = runVarlock(['load', '--format', 'json-full', '--compact'], { cwd: SCENARIO });
+      expect(result.exitCode).toBe(0);
+      return result.stdout.trim();
+    }
+
+    test('_VARLOCK_USE_INJECTED_ENV=1 hydrates everything from the blob with no env files present', () => {
+      const blob = captureBlob();
+      const result = runNodeApp({
+        cwd: join(SCENARIO_DIR, 'sandbox'),
+        env: {
+          __VARLOCK_ENV: blob,
+          _VARLOCK_USE_INJECTED_ENV: '1',
+        },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain(REUSED_MSG);
+      expect(result.output).toContain('PUBLIC_VAR=public-value');
+      expect(result.output).toContain('SECRET_OK=true');
+      expect(result.output).toContain('OVERRIDE_ME=default-value');
+    });
+
+    test('without the explicit flag, a foreign-directory blob is not silently reused', () => {
+      const blob = captureBlob();
+      const result = runNodeApp({
+        cwd: join(SCENARIO_DIR, 'sandbox'),
+        env: { __VARLOCK_ENV: blob },
+      });
+      // auto-load falls back to CLI resolution; with no env files here that yields an
+      // empty env - the point is the foreign blob's values were NOT hydrated
+      expect(result.output).toContain(RESOLVED_MSG);
+      expect(result.output).not.toContain(REUSED_MSG);
+      expect(result.output).toContain('PUBLIC_VAR=undefined');
+      expect(result.output).toContain('SECRET_OK=false');
+    });
+
+    test('_VARLOCK_USE_INJECTED_ENV=1 with no blob at all is a hard error', () => {
+      const result = runNodeApp({
+        cwd: join(SCENARIO_DIR, 'sandbox'),
+        env: { _VARLOCK_USE_INJECTED_ENV: '1' },
+      });
+      expect(result.exitCode).not.toBe(0);
+      expect(result.output).toContain('no __VARLOCK_ENV blob');
+    });
+  });
+});

--- a/smoke-tests/tests/injected-env-reuse.test.ts
+++ b/smoke-tests/tests/injected-env-reuse.test.ts
@@ -125,6 +125,27 @@ describe('auto-load reuse of injected env blob', () => {
       expect(result.output).toContain('OVERRIDE_ME=default-value');
     });
 
+    test('a --filter scoped blob exposes only the selected items (the documented sandbox recipe)', () => {
+      const captured = runVarlock(
+        ['load', '--format', 'json-full', '--compact', '--filter', 'PUBLIC_VAR,OVERRIDE_ME'],
+        { cwd: SCENARIO },
+      );
+      expect(captured.exitCode).toBe(0);
+      const result = runNodeApp({
+        cwd: join(SCENARIO_DIR, 'sandbox'),
+        env: {
+          __VARLOCK_ENV: captured.stdout.trim(),
+          _VARLOCK_USE_INJECTED_ENV: '1',
+        },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toContain(REUSED_MSG);
+      expect(result.output).toContain('PUBLIC_VAR=public-value');
+      expect(result.output).toContain('OVERRIDE_ME=default-value');
+      // SECRET_TOKEN was filtered out of the blob, so it must not be hydrated
+      expect(result.output).toContain('SECRET_OK=false');
+    });
+
     test('without the explicit flag, a foreign-directory blob is not silently reused', () => {
       const blob = captureBlob();
       const result = runNodeApp({


### PR DESCRIPTION
## What

When `varlock/auto-load` or `varlock run` finds an injected `__VARLOCK_ENV` blob (e.g. from a parent `varlock run`), it now consumes the blob directly instead of performing a second resolution, when it is safe to assume a fresh resolution would produce the same result:

- the blob was resolved in the same directory the app would resolve in (realpath compare against cwd / package.json `varlock.loadPath`)
- the blob has no resolution errors
- no blob config key's ambient env value has drifted from what the parent injected (an unchanged value is just the parent's own injection echoing back; a differing one was set deliberately mid-chain). Coerced overrides are handled: the blob records the raw pre-coercion override string (`overrideStr`, non-sensitive items only) so e.g. `FLAG=YES` coerced to boolean `true` is recognized as an echo whether the env carries "YES" or "true"
- no active filter: `_VARLOCK_FILTER` (the env-var form of `--filter`) disables reuse in both consumers, and is rejected in forced mode, so an unscoped blob can never bypass a filter

Any failed check falls back to CLI resolution exactly as before. Explicit control via `_VARLOCK_USE_INJECTED_ENV`:

- `1`: always trust the blob. This enables handing a (`--filter` scoped, optionally encrypted) blob into a sandbox with no `.env` files: auto-load hydrates a Node app from it (`process.env`, the `ENV` object, redaction, leak detection - no CLI needed), and `varlock run -- <command>` injects plain env vars from it for any non-Node workload. Missing/unusable blobs are hard errors in this mode, and `varlock run` flags that change what a resolution produces (`--path`, `--filter`, cache flags, `--include-internal`) disable reuse and are rejected when combined with it.
- `0`: always re-resolve.

Only `1`/`true` and `0`/`false` are recognized (case-insensitive, matching the `parseEnvToggle` convention); any other value is treated as unset, so a typo can never silently grant blob trust.

Decision logic lives in `lib/injected-env-reuse.ts`. `@internal` items are stripped from a reused blob on consumption (the inspection command `load --format json-full --include-internal` is a supported blob producer): never injected, ambient values dropped, and forwarded blobs re-serialized (re-encrypted with the ambient key when needed) so children cannot inherit them.

## Why

- Wrapping an auto-load app in `varlock run` paid for two full resolutions (process spawn + resolver plugins re-running).
- Passing just the blob into a sandbox and having auto-load hydrate everything was impossible (auto-load hard-exited when it couldn't resolve).

The runtime already trusted the blob unconditionally in `varlock/env` auto-init and `varlock/init-server`; auto-load was the only re-resolver, and the same-directory check keeps monorepo per-package resolution working.

## Also fixes

Two latent override-clobber bugs around command-local overrides under a parent run (`varlock run -- sh -c 'FOO=x node app.js'`):

- The runtime auto-init injects blob values into `process.env` during auto-load's own import chain, so the CLI it spawned inherited clobbered values. The spawned CLI now receives the pre-injection env snapshot.
- A fresh resolution under an injected blob only honored overrides for keys the parent had *recorded* as overrides, so an override introduced mid-chain on a key that was not overridden at the parent was discarded. load-graph now also treats any env value that diverged from the parent's injected value as a genuine override (a parent echo is equal by definition), while unchanged parent-injected values still never shadow fresh resolution.

## Docs

- JS integration page documents the reuse behavior and escape hatches.
- The E2B and Fly.io guides' "Passing resolved values" sections recommend the filtered blob (`--filter` scoped + `_VARLOCK_USE_INJECTED_ENV=1`). The Fly example shows plain-var, blob, and in-sprite `varlock run` execs directly, and notes that `sprite exec --env` silently truncates values at the first comma (verified against a live sprite), so shell delivery goes through `--file`.
- `_VARLOCK_USE_INJECTED_ENV` added to the reserved-variables reference and in-code registry.

## Testing

- 45 unit tests for the decision logic, override selection, and blob serialization (modes, decryption, basePath/loadPath matching, env drift, introduced overrides, coerced override forms).
- 19 end-to-end smoke tests including reuse under `varlock run`, `--inject blob`, drift fallback honoring both changed and newly introduced overrides, both escape hatches, nested `varlock run` reuse, `varlock run` hydrating a non-Node workload from a blob in a dir with no env files, the documented filtered-blob sandbox recipe, `_VARLOCK_FILTER` disabling reuse, and internal-item stripping.

