### PR TITLE
Skip pullfrog reviews on automated bumpy version PRs

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -16,6 +16,11 @@ permissions:
 
 jobs:
   pullfrog:
+    # Skip runs triggered by bumpy-bot (the automated "Versioned release" PRs on
+    # bumpy/version-packages). Every push to main refreshes that PR, which would
+    # otherwise trigger a paid re-review each time. Human-triggered runs on that
+    # PR (e.g. an @pullfrog mention) still execute, since the triggerer is the human.
+    if: ${{ !contains(inputs.prompt, '"triggerer":"bumpy-bot"') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
Pullfrog auto-reviews the bumpy `🐸 Versioned release` PRs, and every push to main refreshes that PR and triggers another paid incremental re-review.

This adds a job-level guard to `pullfrog.yml` that skips runs dispatched with `"triggerer":"bumpy-bot"`. Human-triggered runs on the version PR (e.g. an `@pullfrog` mention) still execute, since the triggerer is the human.