### PR TITLE
Catch sensitive values split across response chunks

### DIFF
--- a/.bumpy/fix-split-chunk-leak-scan.md
+++ b/.bumpy/fix-split-chunk-leak-scan.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Fix leak detection missing sensitive values split across response chunks

--- a/packages/varlock-website/src/content/docs/guides/secrets.mdx
+++ b/packages/varlock-website/src/content/docs/guides/secrets.mdx
@@ -188,6 +188,8 @@ This works by patching:
 - **Node.js `ServerResponse`**: intercepts `write()` and `end()` calls, scanning text and JSON response bodies (including gzip-compressed responses)
 - **Global `Response` constructor**: intercepts the `Response` class used in edge runtimes (e.g., Cloudflare Workers), scanning bodies passed to the constructor and `Response.json()`
 
+Streamed responses are scanned across chunk boundaries, so a sensitive value that gets split between two writes is still detected. When the end of a chunk looks like the start of a sensitive value, that trailing text is held back for up to 100ms (or until the next chunk arrives) so the full value can be caught before any of it is sent.
+
 Our [framework integrations](/integrations/overview/) automatically apply the appropriate patches for your environment. For example, a Next.js integration will scan both server-rendered pages and API route responses.
 
 To disable leak prevention, set the [`@preventLeaks`](/reference/root-decorators/#preventleaks) root decorator to `false`.

--- a/packages/varlock-website/src/content/docs/guides/secrets.mdx
+++ b/packages/varlock-website/src/content/docs/guides/secrets.mdx
@@ -188,7 +188,7 @@ This works by patching:
 - **Node.js `ServerResponse`**: intercepts `write()` and `end()` calls, scanning text and JSON response bodies (including gzip-compressed responses)
 - **Global `Response` constructor**: intercepts the `Response` class used in edge runtimes (e.g., Cloudflare Workers), scanning bodies passed to the constructor and `Response.json()`
 
-Streamed responses are scanned across chunk boundaries, so a sensitive value that gets split between two writes is still detected. When the end of a chunk looks like the start of a sensitive value, that trailing text is held back for up to 100ms (or until the next chunk arrives) so the full value can be caught before any of it is sent.
+Streamed responses are scanned across chunk boundaries, so a sensitive value that gets split between two writes is still detected. When the end of a chunk looks like the start of a sensitive value, that trailing text is held back briefly (up to 15ms, or until the next chunk arrives) so the full value can be caught before any of it is sent.
 
 Our [framework integrations](/integrations/overview/) automatically apply the appropriate patches for your environment. For example, a Next.js integration will scan both server-rendered pages and API route responses.
 

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -254,12 +254,25 @@ export function scanForLeaks(
       return toScan;
     }
     const chunkDecoder = new TextDecoder();
+    // a sensitive value can be split across stream chunks, and the scan matches complete
+    // values only - so each chunk is scanned with the tail of the previous one prepended
+    let carry = '';
     return toScan.pipeThrough(
       new TransformStream({
         transform(chunk, controller) {
-          const chunkStr = chunkDecoder.decode(chunk);
-          scanStrForLeaks(chunkStr);
+          // stream mode holds an incomplete multi-byte char until the rest of it arrives
+          const chunkStr = typeof chunk === 'string'
+            ? chunk
+            : chunkDecoder.decode(chunk, { stream: true });
+          const toScanStr = carry + chunkStr;
+          scanStrForLeaks(toScanStr);
+          const carryLength = getRedactionHoldbackLength(toScanStr);
+          carry = carryLength ? toScanStr.slice(-carryLength) : '';
           controller.enqueue(chunk);
+        },
+        flush() {
+          const tail = chunkDecoder.decode();
+          if (tail) scanStrForLeaks(carry + tail);
         },
       }),
     );

--- a/packages/varlock/src/runtime/patch-server-response.ts
+++ b/packages/varlock/src/runtime/patch-server-response.ts
@@ -106,22 +106,37 @@ function decodeDecompressedDelta(state: ScanState, decompressed: Buffer, isFinal
 }
 
 /**
- * Number of bytes at the end of `chunk` that are the start of an incomplete UTF-8 character
- * (0 when the chunk ends on a character boundary). These are the bytes a streaming
- * TextDecoder holds back until the rest of the character arrives.
+ * Number of bytes at the end of `chunk` that a streaming TextDecoder holds back as the start
+ * of an incomplete UTF-8 character (0 when the chunk ends on a character boundary). Invalid
+ * sequences are NOT counted: bad lead bytes (0xC0/0xC1, 0xF5+) and out-of-range second bytes
+ * are replaced by the decoder immediately rather than held, so counting them would trigger
+ * re-encoding (see ScanState.reEncode) and mutate malformed bytes that should pass through.
  */
 function incompleteTrailingUtf8Bytes(chunk: Uint8Array): number {
-  /* eslint-disable no-bitwise */
   for (let i = 1; i <= 3 && i <= chunk.length; i++) {
     const byte = chunk[chunk.length - i];
-    if ((byte & 0b11000000) === 0b10000000) continue; // continuation byte - keep looking for the lead
-    if ((byte & 0b11100000) === 0b11000000) return i < 2 ? i : 0; // 2-byte lead
-    if ((byte & 0b11110000) === 0b11100000) return i < 3 ? i : 0; // 3-byte lead
-    if ((byte & 0b11111000) === 0b11110000) return i < 4 ? i : 0; // 4-byte lead
-    return 0; // ascii or invalid lead - the decoder holds nothing
+    if (byte >= 0x80 && byte <= 0xbf) continue; // continuation byte - keep looking for the lead
+    let seqLength;
+    if (byte >= 0xc2 && byte <= 0xdf) seqLength = 2;
+    else if (byte >= 0xe0 && byte <= 0xef) seqLength = 3;
+    else if (byte >= 0xf0 && byte <= 0xf4) seqLength = 4;
+    else return 0; // ascii or an invalid lead byte - nothing is held
+    if (seqLength <= i) return 0; // the sequence completes within this chunk
+    if (i >= 2) {
+      // the decoder only waits for more bytes while the second byte is in range for its
+      // lead (overlong/surrogate/out-of-range encodings error immediately instead)
+      const second = chunk[chunk.length - i + 1];
+      let lo = 0x80;
+      let hi = 0xbf;
+      if (byte === 0xe0) lo = 0xa0;
+      else if (byte === 0xed) hi = 0x9f;
+      else if (byte === 0xf0) lo = 0x90;
+      else if (byte === 0xf4) hi = 0x8f;
+      if (second < lo || second > hi) return 0;
+    }
+    return i;
   }
   return 0;
-  /* eslint-enable no-bitwise */
 }
 
 function clearPendingFlush(state: ScanState) {
@@ -250,7 +265,11 @@ export function patchGlobalServerResponse(opts?: {
     let chunkType: 'string' | 'encoded' | 'compressed' | null = null;
     if (typeof rawChunk === 'string') {
       chunkType = 'string';
-      chunkStr = rawChunk;
+      // a string write while the decoder holds tail bytes of a split character means the byte
+      // stream is malformed - flush the held bytes in place (as a replacement char) so they
+      // are not dropped or reordered, which also realigns raw output with the decoded text
+      chunkStr = decodeChunk(state) + rawChunk;
+      state.reEncode = false;
     } else if (!compressionType) {
       chunkType = 'encoded';
       chunkStr = decodeChunk(state, rawChunk);
@@ -300,9 +319,12 @@ export function patchGlobalServerResponse(opts?: {
           redactInsteadOfThrow: opts?.redactInsteadOfThrow,
           meta: { method: 'patched ServerResponse.write', file: reqUrl },
         });
-        // when nothing was redacted or withheld we pass the original chunk straight
-        // through, so a clean response stays byte-for-byte identical
-        if (emit !== chunkStr) {
+        // when nothing was redacted, withheld, or flushed we pass the original chunk
+        // straight through, so a clean response stays byte-for-byte identical
+        // (for string chunks compare against the raw string - `chunkStr` may carry a
+        // flushed decoder tail that the outgoing chunk needs to pick up)
+        const originalStr = chunkType === 'string' ? rawChunk as string : chunkStr;
+        if (emit !== originalStr) {
           if (!emit) {
             // the whole chunk is being withheld - report it as written and fire the
             // write callback, since it will go out with the next chunk (or on flush)
@@ -383,7 +405,12 @@ export function patchGlobalServerResponse(opts?: {
         redactInsteadOfThrow: opts?.redactInsteadOfThrow,
         meta: { method: 'patched ServerResponse.end', file: (this as any).req?.url },
       });
-      if (emit !== chunkStr) {
+      // for a string (or absent) final chunk, `chunkStr` may carry a flushed decoder tail
+      // that the outgoing chunk needs to pick up, so compare against what was actually passed
+      let originalStr = '';
+      if (typeof endChunk === 'string') originalStr = endChunk;
+      else if (isBinaryChunk) originalStr = chunkStr;
+      if (emit !== originalStr) {
         if (typeof endChunk === 'string') {
           args[0] = emit;
         } else if (isBinaryChunk) {

--- a/packages/varlock/src/runtime/patch-server-response.ts
+++ b/packages/varlock/src/runtime/patch-server-response.ts
@@ -4,11 +4,21 @@
 
 import zlib from 'node:zlib';
 import { ServerResponse } from 'node:http';
-import { redactSensitiveConfig, scanForLeaks, varlockSettings } from './env';
+import {
+  getRedactionHoldbackLength, redactSensitiveConfig, scanForLeaks, varlockSettings,
+} from './env';
 import { debug } from './lib/debug';
 
 // NOTE - previously was using a symbol but got weird because of multiple builds and contexts...
 const patchedKey = '_patchedByVarlock';
+
+/**
+ * How long to hold back a possible partial secret before writing it out anyway. Chunks that
+ * split a secret arrive back-to-back in practice, so this only fires when a response genuinely
+ * pauses right after emitting something that looks like the start of a secret (e.g. SSE) -
+ * without it, that trailing text would sit unsent until the next chunk or `end()`.
+ */
+const PENDING_FLUSH_TIMEOUT_MS = 100;
 
 /**
  * Returns a sync decompressor for a Content-Encoding value, or undefined if unsupported.
@@ -35,6 +45,92 @@ function getDecompressor(encoding: string): ((buf: Buffer) => Buffer) | undefine
   }
   return undefined;
 }
+
+/**
+ * Per-response scanning state. A sensitive value can be split across `write()` calls (streaming
+ * SSR flushes at arbitrary boundaries) or across a final `write()` and `end()`, and the scanner
+ * matches complete values only - so each scan has to see a little of what came before it.
+ */
+type ScanState = {
+  /** decoded text that was scanned but is being withheld from the response, because it looks
+   * like the start of a sensitive value and the rest may arrive in the next chunk */
+  pending: string,
+  /** decoded text already sent, retained only so the next scan can match across the boundary */
+  carry: string,
+  /** streaming decoder, so a multi-byte character split across chunks doesn't decode to garbage
+   * (created lazily - responses that never hit the binary path don't need one) */
+  decoder: TextDecoder | undefined,
+  zlibChunks: Array<Buffer>,
+  /** length of the decompressed output already scanned, so each chunk only rescans the new tail */
+  decompressedLength: number,
+  flushTimer: ReturnType<typeof setTimeout> | undefined,
+};
+
+function getScanState(res: any): ScanState {
+  res._varlockScanState ||= {
+    pending: '',
+    carry: '',
+    decoder: undefined,
+    zlibChunks: [],
+    decompressedLength: 0,
+    flushTimer: undefined,
+  } satisfies ScanState;
+  return res._varlockScanState;
+}
+
+/** decodes binary chunks in stream mode, holding an incomplete multi-byte char until the rest
+ * of it arrives - passing no chunk flushes whatever is still held (as a replacement char) */
+function decodeChunk(state: ScanState, chunk?: Uint8Array, isFinal?: boolean) {
+  if (!chunk && !state.decoder) return '';
+  state.decoder ||= new TextDecoder();
+  if (!chunk) return state.decoder.decode();
+  return state.decoder.decode(chunk, { stream: !isFinal });
+}
+
+function clearPendingFlush(state: ScanState) {
+  if (state.flushTimer !== undefined) {
+    clearTimeout(state.flushTimer);
+    state.flushTimer = undefined;
+  }
+}
+
+/**
+ * Scans `chunkStr` together with whatever was withheld or retained from previous chunks, and
+ * returns the text that should actually go out. When `canHoldBack` is set, a trailing partial
+ * match of a sensitive value is withheld (moved to `state.pending`) so a value split across the
+ * boundary can still be redacted rather than half-sent.
+ */
+function scanChunk(state: ScanState, chunkStr: string, o: {
+  canHoldBack: boolean,
+  redactInsteadOfThrow?: boolean,
+  meta: { method: string, file?: string },
+}): string {
+  let emitPart = state.pending + chunkStr;
+  try {
+    scanForLeaks(state.carry + emitPart, o.meta);
+  } catch (err) {
+    if (!o.redactInsteadOfThrow) throw err;
+    emitPart = redactSensitiveConfig(emitPart);
+    // a value straddling `carry` is partly out the door already and can't be scrubbed
+    // retroactively, so anything still detectable after redaction fails closed
+    scanForLeaks(state.carry + emitPart, o.meta);
+  }
+
+  // only what is still in hand can be withheld - anything already sent is capped out
+  const holdbackLength = o.canHoldBack
+    ? Math.min(getRedactionHoldbackLength(state.carry + emitPart), emitPart.length)
+    : 0;
+  state.pending = holdbackLength ? emitPart.slice(-holdbackLength) : '';
+  const emit = holdbackLength ? emitPart.slice(0, -holdbackLength) : emitPart;
+
+  // retain any sent text still needed to span the next boundary (what `pending` doesn't cover)
+  const sent = state.carry + emit;
+  const carryLength = Math.max(0, getRedactionHoldbackLength(sent + state.pending) - state.pending.length);
+  state.carry = carryLength ? sent.slice(-carryLength) : '';
+
+  return emit;
+}
+
 export function patchGlobalServerResponse(opts?: {
   ignoreUrlPatterns?: Array<RegExp>,
   redactInsteadOfThrow?: boolean,
@@ -52,6 +148,24 @@ export function patchGlobalServerResponse(opts?: {
   Object.defineProperty(ServerResponse.prototype, patchedKey, { value: true });
 
   const serverResponseWrite = ServerResponse.prototype.write;
+
+  function schedulePendingFlush(res: any, state: ScanState) {
+    clearPendingFlush(state);
+    if (!state.pending) return;
+    state.flushTimer = setTimeout(() => {
+      state.flushTimer = undefined;
+      const text = state.pending;
+      state.pending = '';
+      if (!text || res.writableEnded || res.destroyed) return;
+      // it's going out unscrubbed now, so keep it in `carry` for the next scan
+      const sent = state.carry + text;
+      const carryLength = getRedactionHoldbackLength(sent);
+      state.carry = carryLength ? sent.slice(-carryLength) : '';
+      (serverResponseWrite as any).call(res, text);
+    }, PENDING_FLUSH_TIMEOUT_MS);
+    // don't let a pending flush keep the process alive
+    state.flushTimer.unref?.();
+  }
 
   // @ts-ignore
   ServerResponse.prototype.write = function varlockPatchedServerResponseWrite(...args) {
@@ -84,6 +198,9 @@ export function patchGlobalServerResponse(opts?: {
       return serverResponseWrite.apply(this, args);
     }
 
+    const state = getScanState(this);
+    clearPendingFlush(state);
+
     // have to deal with compressed data, which is awkward but possible
     const compressionType = this.getHeader('Content-Encoding');
     let chunkStr;
@@ -93,24 +210,22 @@ export function patchGlobalServerResponse(opts?: {
       chunkStr = rawChunk;
     } else if (!compressionType) {
       chunkType = 'encoded';
-      const decoder = new TextDecoder();
-      chunkStr = decoder.decode(rawChunk);
+      chunkStr = decodeChunk(state, rawChunk);
     } else {
       const decompress = getDecompressor(String(compressionType).toLowerCase());
       if (decompress) {
         chunkType = 'compressed';
         // TODO: figure out how we can decompress one chunk at a time instead of storing everything
-        (this as any)._zlibChunks ||= [];
-        (this as any)._zlibChunks.push(rawChunk);
+        state.zlibChunks.push(rawChunk);
         // NOTE - we must attempt to decode from the very FIRST chunk: small responses
         // arrive as a single complete compressed chunk, so skipping it means never
         // scanning at all (and browsers always send Accept-Encoding: gzip). A genuinely
         // partial stream fails to decode here and gets scanned once more chunks arrive.
         try {
-          const decompressedChunk = decompress(Buffer.concat((this as any)._zlibChunks || []));
+          const decompressedChunk = decompress(Buffer.concat(state.zlibChunks));
           const fullDecompressedData = decompressedChunk.toString('utf-8');
-          chunkStr = fullDecompressedData.substring((this as any)._lastChunkEndIndex || 0);
-          (this as any)._lastChunkEndIndex = fullDecompressedData.length;
+          chunkStr = fullDecompressedData.substring(state.decompressedLength);
+          state.decompressedLength = fullDecompressedData.length;
         } catch (err) {
           // partial compressed data that doesn't decode yet — scanned when more chunks arrive
         }
@@ -119,36 +234,47 @@ export function patchGlobalServerResponse(opts?: {
         debug(`⚠️ leak scan skipped - unsupported content-encoding: ${compressionType}`);
       }
     }
-    if (chunkStr) {
+
+    if (chunkStr !== undefined && chunkType) {
       // console.log('scanning!', chunkStr.substring(0, 1000));
 
+      // a string written with an explicit non-utf8 encoding can't be sliced or re-encoded
+      // safely (e.g. splitting base64 mid-quantum), so it is scanned but never withheld
+      const encodingArg = typeof args[1] === 'string' ? args[1] : undefined;
+      const canHoldBack = chunkType === 'encoded' || !encodingArg || /^utf-?8$/i.test(encodingArg);
 
-      try {
-        scanForLeaks(chunkStr, { method: 'patched ServerResponse.write', file: (this as any).req.url });
-      } catch (err) {
-        // console.log('found secret in chunk', chunkType, chunkStr);
-        // console.log(this)
-        if (opts?.redactInsteadOfThrow) {
-          chunkStr = redactSensitiveConfig(chunkStr);
-          if (chunkType === 'string') {
-            args[0] = chunkStr;
-          } else if (chunkType === 'encoded') {
-            const encoder = new TextEncoder();
-            args[0] = encoder.encode(chunkStr);
-          } else if (chunkType === 'compressed') {
-            // we can't reliably scrub inside a compressed stream (re-compressing a single
-            // chunk corrupts the stream state), so fail closed — killing the response
-            // beats serving the secret, even in dev
-            // TODO: pass chunks through our own compression stream so we can scrub + re-encode
-            throw err;
-          } else {
-            throw new Error(`unable to scrub - unknown chunk type ${chunkType}`);
+      if (chunkType === 'compressed') {
+        // we can't reliably scrub or withhold anything inside a compressed stream (re-compressing
+        // a single chunk corrupts the stream state), so fail closed even in redact mode:
+        // killing the response beats serving the secret
+        // TODO: pass chunks through our own compression stream so we can scrub + re-encode
+        scanChunk(state, chunkStr, {
+          canHoldBack: false,
+          meta: { method: 'patched ServerResponse.write', file: reqUrl },
+        });
+      } else {
+        const emit = scanChunk(state, chunkStr, {
+          canHoldBack,
+          redactInsteadOfThrow: opts?.redactInsteadOfThrow,
+          meta: { method: 'patched ServerResponse.write', file: reqUrl },
+        });
+        // when nothing was redacted or withheld we pass the original chunk straight
+        // through, so a clean response stays byte-for-byte identical
+        if (emit !== chunkStr) {
+          if (!emit) {
+            // the whole chunk is being withheld - report it as written and fire the
+            // write callback, since it will go out with the next chunk (or on flush)
+            const cb = args.find((arg: any) => typeof arg === 'function');
+            if (cb) process.nextTick(cb);
+            schedulePendingFlush(this, state);
+            return true;
           }
-        } else {
-          throw err;
+          args[0] = chunkType === 'encoded' ? new TextEncoder().encode(emit) : emit;
         }
       }
     }
+
+    schedulePendingFlush(this, state);
 
     // @ts-ignore
     return serverResponseWrite.apply(this, args);
@@ -160,21 +286,74 @@ export function patchGlobalServerResponse(opts?: {
   ServerResponse.prototype.end = function patchedServerResponseEnd(...args) {
     // console.log('⚡️ patched ServerResponse.end');
     const endChunk = args[0];
+    const state = getScanState(this);
+    clearPendingFlush(state);
+
     // this just needs to work (so far) for nextjs sending json bodies, so does not need to handle all cases...
+    const compressionType = this.getHeader('Content-Encoding');
+    const isBinaryChunk = !!endChunk && (Buffer.isBuffer(endChunk) || endChunk instanceof Uint8Array);
     let chunkStr: string | undefined;
+
+    if (isBinaryChunk && compressionType) {
+      const decompress = getDecompressor(String(compressionType).toLowerCase());
+      let decompressed: string | undefined;
+      if (decompress) {
+        state.zlibChunks.push(endChunk as Buffer);
+        try {
+          decompressed = decompress(Buffer.concat(state.zlibChunks)).toString('utf-8');
+        } catch (err) {
+          // stream didn't decode, nothing more we can do at this point
+        }
+      }
+      if (decompressed !== undefined) {
+        // compressed output can't be scrubbed, so a detected leak always throws (see write above)
+        scanForLeaks(state.carry + decompressed.substring(state.decompressedLength), {
+          method: 'patched ServerResponse.end',
+          file: (this as any).req?.url,
+        });
+      }
+      // @ts-ignore
+      return serverResponseEnd.apply(this, args);
+    }
+
     if (endChunk && typeof endChunk === 'string') {
-      chunkStr = endChunk;
-    } else if (endChunk && (Buffer.isBuffer(endChunk) || endChunk instanceof Uint8Array)) {
-      // decode Buffer/Uint8Array like write does when uncompressed
-      const decoder = new TextDecoder();
-      chunkStr = decoder.decode(endChunk);
+      // any bytes the streaming decoder is still holding came before this chunk
+      chunkStr = decodeChunk(state) + endChunk;
+    } else if (isBinaryChunk) {
+      // decode Buffer/Uint8Array like write does when uncompressed (final decode, so
+      // a trailing incomplete char is flushed rather than held)
+      chunkStr = decodeChunk(state, endChunk as Uint8Array, true);
+    } else {
+      // no body chunk (`end()` / `end(cb)`) - still need to flush anything withheld
+      chunkStr = decodeChunk(state);
     }
-    if (chunkStr) {
-      // TODO: currently this throws the error and then things just hang... do we want to try to return an error type response instead?
-      scanForLeaks(chunkStr, { method: 'patched ServerResponse.end' });
+
+    if (chunkStr || state.pending) {
+      // last chunk, so nothing can be withheld for later - it all goes out now
+      const emit = scanChunk(state, chunkStr, {
+        canHoldBack: false,
+        redactInsteadOfThrow: opts?.redactInsteadOfThrow,
+        meta: { method: 'patched ServerResponse.end', file: (this as any).req?.url },
+      });
+      if (emit !== chunkStr) {
+        if (typeof endChunk === 'string') {
+          args[0] = emit;
+        } else if (isBinaryChunk) {
+          args[0] = new TextEncoder().encode(emit);
+        } else {
+          // `end()` or `end(cb)` becomes `end(text)` / `end(text, cb)`
+          args.unshift(emit);
+        }
+        // redaction changes the body length, and frameworks do set Content-Length for
+        // bodies sent in a single `end()` call (next.js does for non-streamed payloads).
+        // Leaving the original length would hang the client waiting on bytes never sent.
+        if (!this.headersSent && this.getHeader('content-length') !== undefined) {
+          this.setHeader('content-length', Buffer.byteLength(emit));
+        }
+      }
     }
+
     // @ts-ignore
     return serverResponseEnd.apply(this, args);
   };
 }
-

--- a/packages/varlock/src/runtime/patch-server-response.ts
+++ b/packages/varlock/src/runtime/patch-server-response.ts
@@ -13,12 +13,15 @@ import { debug } from './lib/debug';
 const patchedKey = '_patchedByVarlock';
 
 /**
- * How long to hold back a possible partial secret before writing it out anyway. Chunks that
- * split a secret arrive back-to-back in practice, so this only fires when a response genuinely
- * pauses right after emitting something that looks like the start of a secret (e.g. SSE) -
- * without it, that trailing text would sit unsent until the next chunk or `end()`.
+ * How long to hold back a possible partial secret before writing it out anyway. This is a
+ * flush valve, not a detection window: chunks that split a secret arrive within the same tick
+ * or a few ms of each other (renderer buffer splits, piped upstream fragments), so a short
+ * timeout covers them while keeping the worst-case stall of a lookalike tail imperceptible.
+ * It only fires when a response genuinely pauses right after emitting something that looks
+ * like the start of a secret (e.g. an unframed SSE-style stream) - without it, that trailing
+ * text would sit unsent until the next chunk or `end()`.
  */
-const PENDING_FLUSH_TIMEOUT_MS = 100;
+const PENDING_FLUSH_TIMEOUT_MS = 15;
 
 /**
  * Returns a sync decompressor for a Content-Encoding value, or undefined if unsupported.

--- a/packages/varlock/src/runtime/patch-server-response.ts
+++ b/packages/varlock/src/runtime/patch-server-response.ts
@@ -61,7 +61,9 @@ type ScanState = {
    * (created lazily - responses that never hit the binary path don't need one) */
   decoder: TextDecoder | undefined,
   zlibChunks: Array<Buffer>,
-  /** length of the decompressed output already scanned, so each chunk only rescans the new tail */
+  /** streaming decoder for decompressed deltas, which may end inside a multi-byte character */
+  decompressedDecoder: TextDecoder | undefined,
+  /** byte length of the decompressed output already scanned, so each chunk only scans new bytes */
   decompressedLength: number,
   flushTimer: ReturnType<typeof setTimeout> | undefined,
 };
@@ -72,6 +74,7 @@ function getScanState(res: any): ScanState {
     carry: '',
     decoder: undefined,
     zlibChunks: [],
+    decompressedDecoder: undefined,
     decompressedLength: 0,
     flushTimer: undefined,
   } satisfies ScanState;
@@ -85,6 +88,13 @@ function decodeChunk(state: ScanState, chunk?: Uint8Array, isFinal?: boolean) {
   state.decoder ||= new TextDecoder();
   if (!chunk) return state.decoder.decode();
   return state.decoder.decode(chunk, { stream: !isFinal });
+}
+
+function decodeDecompressedDelta(state: ScanState, decompressed: Buffer, isFinal = false) {
+  state.decompressedDecoder ||= new TextDecoder();
+  const delta = decompressed.subarray(state.decompressedLength);
+  state.decompressedLength = decompressed.byteLength;
+  return state.decompressedDecoder.decode(delta, { stream: !isFinal });
 }
 
 function clearPendingFlush(state: ScanState) {
@@ -201,6 +211,12 @@ export function patchGlobalServerResponse(opts?: {
     const state = getScanState(this);
     clearPendingFlush(state);
 
+    // A later chunk may be redacted to a different length. Once write() sends the
+    // headers, Content-Length cannot be corrected, so use chunked framing instead.
+    if (opts?.redactInsteadOfThrow && !this.headersSent && this.getHeader('content-length') !== undefined) {
+      this.removeHeader('content-length');
+    }
+
     // have to deal with compressed data, which is awkward but possible
     const compressionType = this.getHeader('Content-Encoding');
     let chunkStr;
@@ -223,9 +239,7 @@ export function patchGlobalServerResponse(opts?: {
         // partial stream fails to decode here and gets scanned once more chunks arrive.
         try {
           const decompressedChunk = decompress(Buffer.concat(state.zlibChunks));
-          const fullDecompressedData = decompressedChunk.toString('utf-8');
-          chunkStr = fullDecompressedData.substring(state.decompressedLength);
-          state.decompressedLength = fullDecompressedData.length;
+          chunkStr = decodeDecompressedDelta(state, decompressedChunk);
         } catch (err) {
           // partial compressed data that doesn't decode yet — scanned when more chunks arrive
         }
@@ -296,18 +310,18 @@ export function patchGlobalServerResponse(opts?: {
 
     if (isBinaryChunk && compressionType) {
       const decompress = getDecompressor(String(compressionType).toLowerCase());
-      let decompressed: string | undefined;
+      let decompressed: Buffer | undefined;
       if (decompress) {
         state.zlibChunks.push(endChunk as Buffer);
         try {
-          decompressed = decompress(Buffer.concat(state.zlibChunks)).toString('utf-8');
+          decompressed = decompress(Buffer.concat(state.zlibChunks));
         } catch (err) {
           // stream didn't decode, nothing more we can do at this point
         }
       }
       if (decompressed !== undefined) {
         // compressed output can't be scrubbed, so a detected leak always throws (see write above)
-        scanForLeaks(state.carry + decompressed.substring(state.decompressedLength), {
+        scanForLeaks(state.carry + decodeDecompressedDelta(state, decompressed, true), {
           method: 'patched ServerResponse.end',
           file: (this as any).req?.url,
         });

--- a/packages/varlock/src/runtime/patch-server-response.ts
+++ b/packages/varlock/src/runtime/patch-server-response.ts
@@ -63,6 +63,10 @@ type ScanState = {
   /** streaming decoder, so a multi-byte character split across chunks doesn't decode to garbage
    * (created lazily - responses that never hit the binary path don't need one) */
   decoder: TextDecoder | undefined,
+  /** set once a binary chunk ends mid-character: the decoder is holding its tail bytes, so raw
+   * chunks no longer line up with the decoded text and all further output must be re-encoded
+   * from it (otherwise the held bytes would go out twice if a later chunk gets rewritten) */
+  reEncode: boolean,
   zlibChunks: Array<Buffer>,
   /** streaming decoder for decompressed deltas, which may end inside a multi-byte character */
   decompressedDecoder: TextDecoder | undefined,
@@ -76,6 +80,7 @@ function getScanState(res: any): ScanState {
     pending: '',
     carry: '',
     decoder: undefined,
+    reEncode: false,
     zlibChunks: [],
     decompressedDecoder: undefined,
     decompressedLength: 0,
@@ -98,6 +103,25 @@ function decodeDecompressedDelta(state: ScanState, decompressed: Buffer, isFinal
   const delta = decompressed.subarray(state.decompressedLength);
   state.decompressedLength = decompressed.byteLength;
   return state.decompressedDecoder.decode(delta, { stream: !isFinal });
+}
+
+/**
+ * Number of bytes at the end of `chunk` that are the start of an incomplete UTF-8 character
+ * (0 when the chunk ends on a character boundary). These are the bytes a streaming
+ * TextDecoder holds back until the rest of the character arrives.
+ */
+function incompleteTrailingUtf8Bytes(chunk: Uint8Array): number {
+  /* eslint-disable no-bitwise */
+  for (let i = 1; i <= 3 && i <= chunk.length; i++) {
+    const byte = chunk[chunk.length - i];
+    if ((byte & 0b11000000) === 0b10000000) continue; // continuation byte - keep looking for the lead
+    if ((byte & 0b11100000) === 0b11000000) return i < 2 ? i : 0; // 2-byte lead
+    if ((byte & 0b11110000) === 0b11100000) return i < 3 ? i : 0; // 3-byte lead
+    if ((byte & 0b11111000) === 0b11110000) return i < 4 ? i : 0; // 4-byte lead
+    return 0; // ascii or invalid lead - the decoder holds nothing
+  }
+  return 0;
+  /* eslint-enable no-bitwise */
 }
 
 function clearPendingFlush(state: ScanState) {
@@ -230,6 +254,7 @@ export function patchGlobalServerResponse(opts?: {
     } else if (!compressionType) {
       chunkType = 'encoded';
       chunkStr = decodeChunk(state, rawChunk);
+      if (!state.reEncode && incompleteTrailingUtf8Bytes(rawChunk)) state.reEncode = true;
     } else {
       const decompress = getDecompressor(String(compressionType).toLowerCase());
       if (decompress) {
@@ -287,6 +312,11 @@ export function patchGlobalServerResponse(opts?: {
             return true;
           }
           args[0] = chunkType === 'encoded' ? new TextEncoder().encode(emit) : emit;
+        } else if (chunkType === 'encoded' && state.reEncode && emit) {
+          // the decoder is holding tail bytes of a split character, so the raw chunk no
+          // longer lines up with the decoded text - emit re-encoded text instead of the
+          // raw bytes to keep the outgoing byte stream consistent
+          args[0] = new TextEncoder().encode(emit);
         }
       }
     }
@@ -319,7 +349,8 @@ export function patchGlobalServerResponse(opts?: {
         try {
           decompressed = decompress(Buffer.concat(state.zlibChunks));
         } catch (err) {
-          // stream didn't decode, nothing more we can do at this point
+          // stream didn't decode, nothing more we can do at this point (fails open)
+          debug(`⚠️ leak scan skipped - compressed response did not decode at end() (${compressionType})`);
         }
       }
       if (decompressed !== undefined) {
@@ -367,6 +398,10 @@ export function patchGlobalServerResponse(opts?: {
         if (!this.headersSent && this.getHeader('content-length') !== undefined) {
           this.setHeader('content-length', Buffer.byteLength(emit));
         }
+      } else if (isBinaryChunk && state.reEncode && emit) {
+        // raw bytes stopped lining up with the decoded text earlier in the response
+        // (a chunk ended mid-character), so the final chunk is re-encoded too
+        args[0] = new TextEncoder().encode(emit);
       }
     }
 

--- a/packages/varlock/src/runtime/patch-server-response.ts
+++ b/packages/varlock/src/runtime/patch-server-response.ts
@@ -334,11 +334,20 @@ export function patchGlobalServerResponse(opts?: {
             return true;
           }
           args[0] = chunkType === 'encoded' ? new TextEncoder().encode(emit) : emit;
-        } else if (chunkType === 'encoded' && state.reEncode && emit) {
+        } else if (chunkType === 'encoded' && state.reEncode) {
           // the decoder is holding tail bytes of a split character, so the raw chunk no
           // longer lines up with the decoded text - emit re-encoded text instead of the
           // raw bytes to keep the outgoing byte stream consistent
-          args[0] = new TextEncoder().encode(emit);
+          if (emit) {
+            args[0] = new TextEncoder().encode(emit);
+          } else if ((rawChunk as Uint8Array).length) {
+            // the chunk is entirely held by the decoder (all of it is one incomplete
+            // character) - like the withheld path above, report it as written; its
+            // bytes go out once the character completes or the held tail is flushed
+            const cb = args.find((arg: any) => typeof arg === 'function');
+            if (cb) process.nextTick(cb);
+            return true;
+          }
         }
       }
     }

--- a/packages/varlock/src/runtime/test/fuzz-helpers.ts
+++ b/packages/varlock/src/runtime/test/fuzz-helpers.ts
@@ -1,0 +1,58 @@
+/*
+  Deterministic fuzz helpers for the response scanner tests: given a seed, produce a
+  reproducible random chunking of a text fixture so any failure can be replayed exactly.
+*/
+
+/** small deterministic PRNG (LCG) - no Math.random, so failures are reproducible by seed */
+export function makeRand(seed: number) {
+  let state = seed;
+  return () => {
+    state = (state * 1664525 + 1013904223) % 4294967296;
+    return state / 4294967296;
+  };
+}
+
+/**
+ * Splits `text` into randomized write() chunks mixing string and Buffer pieces. String
+ * pieces always break at character boundaries; Buffer pieces may be split further at
+ * arbitrary byte offsets (including mid-character), but only between adjacent Buffers,
+ * matching what a real byte stream can produce.
+ */
+export function randomChunks(text: string, rand: () => number): Array<string | Buffer> {
+  const chars = Array.from(text);
+  const chunks: Array<string | Buffer> = [];
+  let i = 0;
+  while (i < chars.length) {
+    const take = 1 + Math.floor(rand() * 8);
+    const piece = chars.slice(i, i + take).join('');
+    i += take;
+    if (rand() < 0.5) {
+      chunks.push(piece);
+    } else {
+      let buf = Buffer.from(piece);
+      while (buf.length > 1 && rand() < 0.4) {
+        const cut = 1 + Math.floor(rand() * (buf.length - 1));
+        chunks.push(buf.subarray(0, cut));
+        buf = buf.subarray(cut);
+      }
+      chunks.push(buf);
+    }
+  }
+  return chunks;
+}
+
+/** writes the chunks to a response-like object, ending via end(chunk) or write+bare end() */
+export function writeChunks(
+  res: { write: (chunk: any) => any, end: (chunk?: any) => any },
+  chunks: Array<string | Buffer>,
+  rand: () => number,
+) {
+  const last = chunks[chunks.length - 1];
+  for (const chunk of chunks.slice(0, -1)) res.write(chunk);
+  if (rand() < 0.5) {
+    res.end(last);
+  } else {
+    res.write(last);
+    res.end();
+  }
+}

--- a/packages/varlock/src/runtime/test/patch-server-response-redact.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response-redact.test.ts
@@ -73,6 +73,13 @@ beforeAll(async () => {
       // ends mid-lookalike but never completes the secret - must arrive intact
       res.write(`<html>${SECRET.slice(0, 12)}`);
       res.end('-not-a-secret</html>');
+    } else if (req.url === '/multibyte-split-then-redact') {
+      // first chunk ends mid-character (its lead byte must not go out raw), and the
+      // chunk completing it contains a secret, so the rest gets re-encoded on redaction
+      const buf = Buffer.from(`<html>é leak: ${SECRET}</html>`);
+      const mid = buf.indexOf(0xc3) + 1; // one byte into the 2-byte é
+      res.write(buf.subarray(0, mid));
+      res.end(buf.subarray(mid));
     } else if (req.url === '/gzip-leak') {
       res.setHeader('content-encoding', 'gzip');
       try {
@@ -145,6 +152,15 @@ describe('patchGlobalServerResponse with redactInsteadOfThrow', () => {
     expect(body).toContain('▒');
     expect(resp.headers.get('content-length')).toBeNull();
     expect(resp.headers.get('transfer-encoding')).toBe('chunked');
+  });
+
+  it('does not duplicate bytes when a chunk splits a character before a redaction', async () => {
+    const body = await (await fetch(`${baseUrl}/multibyte-split-then-redact`)).text();
+    expect(body).not.toContain(SECRET);
+    expect(body).toContain('▒');
+    // a duplicated lead byte would decode as a replacement char before the é
+    expect(body.startsWith('<html>é leak: ')).toBe(true);
+    expect(body).not.toContain('�');
   });
 
   it('leaves text that only looks like the start of a secret intact', async () => {

--- a/packages/varlock/src/runtime/test/patch-server-response-redact.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response-redact.test.ts
@@ -64,6 +64,11 @@ beforeAll(async () => {
       const body = `<html>leak: ${SECRET}</html>`;
       res.setHeader('content-length', Buffer.byteLength(body));
       res.end(body);
+    } else if (req.url === '/content-length-split-leak') {
+      const body = `<html>leak: ${SECRET}</html>`;
+      res.setHeader('content-length', Buffer.byteLength(body));
+      res.write(`<html>leak: ${SECRET.slice(0, 10)}`);
+      res.end(`${SECRET.slice(10)}</html>`);
     } else if (req.url === '/partial-lookalike') {
       // ends mid-lookalike but never completes the secret - must arrive intact
       res.write(`<html>${SECRET.slice(0, 12)}`);
@@ -131,6 +136,15 @@ describe('patchGlobalServerResponse with redactInsteadOfThrow', () => {
     expect(body).not.toContain(SECRET);
     expect(body).toContain('▒');
     expect(resp.headers.get('content-length')).toBe(String(Buffer.byteLength(body)));
+  });
+
+  it('switches from Content-Length when a split response may be redacted', async () => {
+    const resp = await fetch(`${baseUrl}/content-length-split-leak`);
+    const body = await resp.text();
+    expect(body).not.toContain(SECRET);
+    expect(body).toContain('▒');
+    expect(resp.headers.get('content-length')).toBeNull();
+    expect(resp.headers.get('transfer-encoding')).toBe('chunked');
   });
 
   it('leaves text that only looks like the start of a secret intact', async () => {

--- a/packages/varlock/src/runtime/test/patch-server-response-redact.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response-redact.test.ts
@@ -13,7 +13,8 @@ import {
 } from 'vitest';
 
 import { patchGlobalServerResponse } from '../patch-server-response';
-import { resetRedactionMap } from '../env';
+import { redactSensitiveConfig, resetRedactionMap } from '../env';
+import { makeRand, randomChunks, writeChunks } from './fuzz-helpers';
 
 const SECRET = 'redact-mode-secret-xyz789';
 
@@ -27,6 +28,8 @@ const FAKE_GRAPH = {
 
 const htmlClean = `<html><body>${'filler '.repeat(100)}no secrets here</body></html>`;
 const htmlWithSecret = `<html><body>leak: ${SECRET}</body></html>`;
+// multi-byte chars exercise the decoder-alignment paths alongside redaction
+const fuzzLeakText = `<html>héllo 🔐 leak: ${SECRET} more ünïcode text</html>`;
 
 let server: http.Server;
 let baseUrl: string;
@@ -90,6 +93,10 @@ beforeAll(async () => {
         // kill the connection like a framework's error handling would
         res.destroy();
       }
+    } else if (req.url?.startsWith('/fuzz-redact')) {
+      const seed = Number(new URL(req.url, 'http://localhost').searchParams.get('seed'));
+      const rand = makeRand(seed);
+      writeChunks(res, randomChunks(fuzzLeakText, rand), rand);
     } else {
       res.end('not found');
     }
@@ -161,6 +168,15 @@ describe('patchGlobalServerResponse with redactInsteadOfThrow', () => {
     // a duplicated lead byte would decode as a replacement char before the é
     expect(body.startsWith('<html>é leak: ')).toBe(true);
     expect(body).not.toContain('�');
+  });
+
+  it('fuzz: random chunkings redact the secret and leave everything else intact', async () => {
+    const expected = redactSensitiveConfig(fuzzLeakText);
+    expect(expected).not.toContain(SECRET);
+    for (let seed = 1; seed <= 30; seed++) {
+      const body = await (await fetch(`${baseUrl}/fuzz-redact?seed=${seed}`)).text();
+      expect(body, `seed ${seed}`).toBe(expected);
+    }
   });
 
   it('leaves text that only looks like the start of a secret intact', async () => {

--- a/packages/varlock/src/runtime/test/patch-server-response-redact.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response-redact.test.ts
@@ -47,6 +47,27 @@ beforeAll(async () => {
       res.write(gz.subarray(0, 15));
       res.write(gz.subarray(15));
       res.end();
+    } else if (req.url === '/split-write-end') {
+      // secret straddles the write/end boundary - neither chunk contains it on its own
+      res.write(`<html>leak: ${SECRET.slice(0, 10)}`);
+      res.end(`${SECRET.slice(10)}</html>`);
+    } else if (req.url === '/split-write-write') {
+      res.write(`<html>leak: ${SECRET.slice(0, 10)}`);
+      res.write(`${SECRET.slice(10)}</html>`);
+      res.end();
+    } else if (req.url === '/split-char-by-char') {
+      res.write('<html>leak: ');
+      for (const char of SECRET) res.write(char);
+      res.end('</html>');
+    } else if (req.url === '/content-length-leak') {
+      // how next.js sends a non-streamed payload: Content-Length set, then a single end()
+      const body = `<html>leak: ${SECRET}</html>`;
+      res.setHeader('content-length', Buffer.byteLength(body));
+      res.end(body);
+    } else if (req.url === '/partial-lookalike') {
+      // ends mid-lookalike but never completes the secret - must arrive intact
+      res.write(`<html>${SECRET.slice(0, 12)}`);
+      res.end('-not-a-secret</html>');
     } else if (req.url === '/gzip-leak') {
       res.setHeader('content-encoding', 'gzip');
       try {
@@ -83,6 +104,38 @@ describe('patchGlobalServerResponse with redactInsteadOfThrow', () => {
     const body = await resp.text();
     expect(body).not.toContain(SECRET);
     expect(body).toContain('▒'); // redaction marker in place of the secret
+  });
+
+  it('redacts a secret split across write() and end()', async () => {
+    const body = await (await fetch(`${baseUrl}/split-write-end`)).text();
+    expect(body).not.toContain(SECRET);
+    expect(body).toContain('▒');
+  });
+
+  it('redacts a secret split across two write() calls', async () => {
+    const body = await (await fetch(`${baseUrl}/split-write-write`)).text();
+    expect(body).not.toContain(SECRET);
+    expect(body).toContain('▒');
+  });
+
+  it('redacts a secret written one character at a time', async () => {
+    const body = await (await fetch(`${baseUrl}/split-char-by-char`)).text();
+    expect(body).not.toContain(SECRET);
+    expect(body).toContain('▒');
+  });
+
+  it('corrects Content-Length when redaction shortens the body', async () => {
+    // a stale Content-Length leaves the client waiting on bytes that never arrive
+    const resp = await fetch(`${baseUrl}/content-length-leak`);
+    const body = await resp.text();
+    expect(body).not.toContain(SECRET);
+    expect(body).toContain('▒');
+    expect(resp.headers.get('content-length')).toBe(String(Buffer.byteLength(body)));
+  });
+
+  it('leaves text that only looks like the start of a secret intact', async () => {
+    const body = await (await fetch(`${baseUrl}/partial-lookalike`)).text();
+    expect(body).toBe(`<html>${SECRET.slice(0, 12)}-not-a-secret</html>`);
   });
 
   it('passes a clean gzip response through intact', async () => {

--- a/packages/varlock/src/runtime/test/patch-server-response.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response.test.ts
@@ -287,6 +287,12 @@ describe('patched ServerResponse - pass-through integrity', () => {
         res.write(buf.subarray(0, buf.length - 1)); // ends with the é lead byte
         res.write('mid');
         res.end('tail</html>');
+      } else if (req.url === '/lone-partial-lead') {
+        // a binary chunk that is nothing but the start of a split character - its raw
+        // bytes must not go out, or the flush on the next string chunk duplicates them
+        res.write(Buffer.from('<html>'));
+        res.write(Buffer.from([0xc3])); // é lead byte alone, decodes to ''
+        res.end('mid</html>');
       } else if (req.url === '/invalid-lead-byte') {
         // 0xC0 is never a valid UTF-8 lead: the decoder replaces it immediately and holds
         // nothing, so the raw bytes must pass through untouched (no re-encode trigger)
@@ -336,6 +342,11 @@ describe('patched ServerResponse - pass-through integrity', () => {
   it('flushes held bytes in place when the response switches to string chunks', async () => {
     const body = await (await fetch(`${baseUrl}/binary-then-string`)).text();
     expect(body).toBe('<html>�midtail</html>');
+  });
+
+  it('does not emit a wholly-held binary chunk twice', async () => {
+    const body = await (await fetch(`${baseUrl}/lone-partial-lead`)).text();
+    expect(body).toBe('<html>�mid</html>');
   });
 
   it('passes invalid UTF-8 lead bytes through untouched', async () => {

--- a/packages/varlock/src/runtime/test/patch-server-response.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response.test.ts
@@ -223,6 +223,33 @@ describe('patched ServerResponse - sensitive values split across chunks', () => 
     expect(() => res.write(`<html>${head}`)).not.toThrow();
     expect(() => res.end('-but-not-really</html>')).not.toThrow();
   });
+
+  it('still detects the secret when its head was already flushed by the holdback timer', async () => {
+    const res = makeRes();
+    expect(() => res.write(`<html>leaked: ${head}`)).not.toThrow();
+    // wait past the holdback window so the timer flushes the withheld head, which
+    // moves it into `carry` - the completing chunk must still be caught there
+    await new Promise((resolve) => {
+      setTimeout(resolve, 60);
+    });
+    expect(() => res.write(`${tail}</html>`)).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('reports success and fires the callback when a whole chunk is withheld', async () => {
+    const res = makeRes();
+    // the entire chunk is a possible secret prefix, so nothing goes out yet - but the
+    // caller must still see a normal successful write or streams piping into the
+    // response would stall waiting on the callback
+    let cbFired = false;
+    const returned = res.write(head, () => {
+      cbFired = true;
+    });
+    expect(returned).toBe(true);
+    await new Promise((resolve) => {
+      process.nextTick(resolve);
+    });
+    expect(cbFired).toBe(true);
+  });
 });
 
 /*
@@ -252,6 +279,11 @@ describe('patched ServerResponse - pass-through integrity', () => {
         const mid = 8; // lands inside the 2-byte é
         res.write(buf.subarray(0, mid));
         res.write(buf.subarray(mid));
+        res.end();
+      } else if (req.url === '/withheld-then-bare-end') {
+        // tail is withheld as a lookalike, and end() carries no chunk of its own -
+        // the withheld text must still be flushed as the final chunk
+        res.write(`<html>${SECRET.slice(0, 12)}`);
         res.end();
       } else if (req.url === '/slow-lookalike') {
         // pauses right after a partial match, so the held-back text must still be flushed
@@ -287,6 +319,11 @@ describe('patched ServerResponse - pass-through integrity', () => {
   it('delivers multi-byte characters split across chunks intact', async () => {
     const body = await (await fetch(`${baseUrl}/multibyte`)).text();
     expect(body).toBe(`<html>${multibyte}</html>`);
+  });
+
+  it('delivers withheld text when end() carries no chunk', async () => {
+    const body = await (await fetch(`${baseUrl}/withheld-then-bare-end`)).text();
+    expect(body).toBe(`<html>${SECRET.slice(0, 12)}`);
   });
 
   it('flushes withheld text without waiting for the response to end', async () => {

--- a/packages/varlock/src/runtime/test/patch-server-response.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response.test.ts
@@ -15,6 +15,7 @@ import {
 
 import { patchGlobalServerResponse } from '../patch-server-response';
 import { resetRedactionMap } from '../env';
+import { makeRand, randomChunks, writeChunks } from './fuzz-helpers';
 
 const SECRET = 'super-secret-value-abc123';
 const UNICODE_SECRET = 'super-sëcret-value-abc123';
@@ -265,6 +266,9 @@ describe('patched ServerResponse - pass-through integrity', () => {
 
   const partial = `${SECRET.slice(0, 12)}-not-a-secret`;
   const multibyte = 'héllo wörld 🔐 ünïcode';
+  // multi-byte chars exercise the decoder-alignment paths, the lookalike exercises holdback
+  const fuzzCleanText = `<html>héllo wörld 🔐 ünïcode ${'filler '.repeat(20)}${SECRET.slice(0, 12)}-lookalike</html>`;
+  const fuzzLeakText = `<html>héllo 🔐 leak: ${SECRET} more ünïcode text</html>`;
 
   beforeAll(async () => {
     server = http.createServer(async (req, res) => {
@@ -303,6 +307,19 @@ describe('patched ServerResponse - pass-through integrity', () => {
         // the withheld text must still be flushed as the final chunk
         res.write(`<html>${SECRET.slice(0, 12)}`);
         res.end();
+      } else if (req.url?.startsWith('/fuzz-clean')) {
+        const seed = Number(new URL(req.url, 'http://localhost').searchParams.get('seed'));
+        const rand = makeRand(seed);
+        writeChunks(res, randomChunks(fuzzCleanText, rand), rand);
+      } else if (req.url?.startsWith('/fuzz-leak')) {
+        const seed = Number(new URL(req.url, 'http://localhost').searchParams.get('seed'));
+        const rand = makeRand(seed);
+        try {
+          writeChunks(res, randomChunks(fuzzLeakText, rand), rand);
+        } catch (err) {
+          // leak detected mid-write - kill the response like a real server error path
+          res.destroy();
+        }
       } else if (req.url === '/slow-lookalike') {
         // pauses right after a partial match, so the held-back text must still be flushed
         res.write(`<html>${SECRET.slice(0, 12)}`);
@@ -358,6 +375,34 @@ describe('patched ServerResponse - pass-through integrity', () => {
   it('delivers withheld text when end() carries no chunk', async () => {
     const body = await (await fetch(`${baseUrl}/withheld-then-bare-end`)).text();
     expect(body).toBe(`<html>${SECRET.slice(0, 12)}`);
+  });
+
+  it('fuzz: random chunkings of a clean response arrive byte-for-byte intact', async () => {
+    for (let seed = 1; seed <= 30; seed++) {
+      const resp = await fetch(`${baseUrl}/fuzz-clean?seed=${seed}`);
+      const bytes = Buffer.from(await resp.arrayBuffer());
+      expect(bytes.toString('utf8'), `seed ${seed}`).toBe(fuzzCleanText);
+      expect(bytes.equals(Buffer.from(fuzzCleanText)), `seed ${seed}`).toBe(true);
+    }
+  });
+
+  it('fuzz: random chunkings never deliver the secret (throw mode)', async () => {
+    for (let seed = 1; seed <= 30; seed++) {
+      let received = '';
+      try {
+        const resp = await fetch(`${baseUrl}/fuzz-leak?seed=${seed}`);
+        const reader = resp.body!.getReader();
+        const decoder = new TextDecoder();
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          received += decoder.decode(value, { stream: true });
+        }
+      } catch (err) {
+        // connection killed mid-response - whatever arrived is in `received`
+      }
+      expect(received.includes(SECRET), `seed ${seed}`).toBe(false);
+    }
   });
 
   it('flushes withheld text without waiting for the response to end', async () => {

--- a/packages/varlock/src/runtime/test/patch-server-response.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response.test.ts
@@ -280,6 +280,18 @@ describe('patched ServerResponse - pass-through integrity', () => {
         res.write(buf.subarray(0, mid));
         res.write(buf.subarray(mid));
         res.end();
+      } else if (req.url === '/binary-then-string') {
+        // a binary chunk ends mid-character and the rest arrives as strings - the held
+        // bytes must flush in place (as a replacement char), not be dropped or reordered
+        const buf = Buffer.from('<html>é');
+        res.write(buf.subarray(0, buf.length - 1)); // ends with the é lead byte
+        res.write('mid');
+        res.end('tail</html>');
+      } else if (req.url === '/invalid-lead-byte') {
+        // 0xC0 is never a valid UTF-8 lead: the decoder replaces it immediately and holds
+        // nothing, so the raw bytes must pass through untouched (no re-encode trigger)
+        res.write(Buffer.concat([Buffer.from('<html>x'), Buffer.from([0xc0])]));
+        res.end('</html>');
       } else if (req.url === '/withheld-then-bare-end') {
         // tail is withheld as a lookalike, and end() carries no chunk of its own -
         // the withheld text must still be flushed as the final chunk
@@ -319,6 +331,17 @@ describe('patched ServerResponse - pass-through integrity', () => {
   it('delivers multi-byte characters split across chunks intact', async () => {
     const body = await (await fetch(`${baseUrl}/multibyte`)).text();
     expect(body).toBe(`<html>${multibyte}</html>`);
+  });
+
+  it('flushes held bytes in place when the response switches to string chunks', async () => {
+    const body = await (await fetch(`${baseUrl}/binary-then-string`)).text();
+    expect(body).toBe('<html>�midtail</html>');
+  });
+
+  it('passes invalid UTF-8 lead bytes through untouched', async () => {
+    const resp = await fetch(`${baseUrl}/invalid-lead-byte`);
+    const bytes = Buffer.from(await resp.arrayBuffer());
+    expect(bytes).toEqual(Buffer.concat([Buffer.from('<html>x'), Buffer.from([0xc0]), Buffer.from('</html>')]));
   });
 
   it('delivers withheld text when end() carries no chunk', async () => {

--- a/packages/varlock/src/runtime/test/patch-server-response.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response.test.ts
@@ -7,10 +7,10 @@
   separate test file (vitest isolates files into separate workers).
 */
 import zlib from 'node:zlib';
-import { IncomingMessage, ServerResponse } from 'node:http';
+import http, { IncomingMessage, ServerResponse } from 'node:http';
 import { Socket } from 'node:net';
 import {
-  describe, it, expect, beforeAll,
+  describe, it, expect, beforeAll, afterAll,
 } from 'vitest';
 
 import { patchGlobalServerResponse } from '../patch-server-response';
@@ -133,5 +133,150 @@ describe('patched ServerResponse.end', () => {
   it('throws when a sensitive value appears in a Buffer end chunk', () => {
     const res = makeRes({ 'content-type': 'application/json' });
     expect(() => res.end(Buffer.from(JSON.stringify({ leaked: SECRET })))).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+});
+
+// a scan that only ever sees one chunk at a time misses any value that straddles a boundary,
+// which is the normal case for streaming SSR (chunks flush at arbitrary points)
+describe('patched ServerResponse - sensitive values split across chunks', () => {
+  const SPLIT_AT = 10;
+  const head = SECRET.slice(0, SPLIT_AT);
+  const tail = SECRET.slice(SPLIT_AT);
+
+  it('detects a secret split across write() and end()', () => {
+    const res = makeRes();
+    expect(() => res.write(`<html>leaked: ${head}`)).not.toThrow();
+    expect(() => res.end(`${tail}</html>`)).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('detects a secret split across two write() calls', () => {
+    const res = makeRes();
+    expect(() => res.write(`<html>leaked: ${head}`)).not.toThrow();
+    expect(() => res.write(`${tail}</html>`)).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('detects a secret split across Buffer chunks', () => {
+    const res = makeRes();
+    expect(() => res.write(Buffer.from(`<html>leaked: ${head}`))).not.toThrow();
+    expect(() => res.write(Buffer.from(`${tail}</html>`))).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('detects a secret written one character at a time', () => {
+    const res = makeRes();
+    const chars = SECRET.split('');
+    const lastChar = chars.pop();
+    for (const char of chars) {
+      expect(() => res.write(char)).not.toThrow();
+    }
+    expect(() => res.write(lastChar)).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('detects a secret split across gzip flush boundaries', async () => {
+    const gz = zlib.createGzip();
+    const compressed: Array<Buffer> = [];
+    gz.on('data', (c) => compressed.push(c));
+    // Z_SYNC_FLUSH ends the first block on a byte boundary, which is how a server
+    // streaming a compressed response emits a chunk mid-body
+    const first = await new Promise<Buffer>((resolve) => {
+      gz.write(`<html>leaked: ${head}`);
+      gz.flush(zlib.constants.Z_SYNC_FLUSH, () => resolve(Buffer.concat(compressed.splice(0))));
+    });
+    const second = await new Promise<Buffer>((resolve) => {
+      gz.on('end', () => resolve(Buffer.concat(compressed)));
+      gz.end(`${tail}</html>`);
+    });
+
+    const res = makeRes({ 'content-encoding': 'gzip' });
+    // each half decompresses on its own without ever containing the whole secret
+    expect(() => res.write(first)).not.toThrow();
+    expect(() => res.write(second)).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('does not false-positive on text that merely starts like a secret', () => {
+    const res = makeRes();
+    expect(() => res.write(`<html>${head}`)).not.toThrow();
+    expect(() => res.end('-but-not-really</html>')).not.toThrow();
+  });
+});
+
+/*
+  Trailing text that looks like the start of a secret is withheld until the next chunk
+  (so a split value can be caught before any of it is sent), which makes response
+  integrity worth verifying over a real socket rather than a detached ServerResponse.
+*/
+describe('patched ServerResponse - pass-through integrity', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  /** resolves once the test has read the withheld text, so the handler can finish */
+  let releaseSlowResponse: () => void;
+
+  const partial = `${SECRET.slice(0, 12)}-not-a-secret`;
+  const multibyte = 'héllo wörld 🔐 ünïcode';
+
+  beforeAll(async () => {
+    server = http.createServer(async (req, res) => {
+      res.setHeader('content-type', 'text/html');
+      if (req.url === '/partial-lookalike') {
+        // ends mid-lookalike, so the tail is withheld until end() flushes it
+        res.write(`<html>${SECRET.slice(0, 12)}`);
+        res.end('-not-a-secret</html>');
+      } else if (req.url === '/multibyte') {
+        // split a multi-byte character across two Buffer chunks
+        const buf = Buffer.from(`<html>${multibyte}</html>`);
+        const mid = 8; // lands inside the 2-byte é
+        res.write(buf.subarray(0, mid));
+        res.write(buf.subarray(mid));
+        res.end();
+      } else if (req.url === '/slow-lookalike') {
+        // pauses right after a partial match, so the held-back text must still be flushed
+        res.write(`<html>${SECRET.slice(0, 12)}`);
+        await new Promise<void>((resolve) => {
+          releaseSlowResponse = resolve;
+        });
+        res.end('-not-a-secret</html>');
+      } else {
+        res.end('not found');
+      }
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => resolve());
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('expected address info');
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    releaseSlowResponse?.();
+    await new Promise((resolve) => {
+      server.close(resolve);
+    });
+  });
+
+  it('delivers withheld text once the response ends', async () => {
+    const body = await (await fetch(`${baseUrl}/partial-lookalike`)).text();
+    expect(body).toBe(`<html>${partial}</html>`);
+  });
+
+  it('delivers multi-byte characters split across chunks intact', async () => {
+    const body = await (await fetch(`${baseUrl}/multibyte`)).text();
+    expect(body).toBe(`<html>${multibyte}</html>`);
+  });
+
+  it('flushes withheld text without waiting for the response to end', async () => {
+    const resp = await fetch(`${baseUrl}/slow-lookalike`);
+    const reader = resp.body!.getReader();
+    const decoder = new TextDecoder();
+    let received = '';
+    // the handler will not call end() until we release it, so this only completes
+    // if the held-back tail is flushed on its own
+    while (!received.includes(SECRET.slice(0, 12))) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      received += decoder.decode(value, { stream: true });
+    }
+    expect(received).toContain(SECRET.slice(0, 12));
+    releaseSlowResponse();
+    await reader.cancel();
   });
 });

--- a/packages/varlock/src/runtime/test/patch-server-response.test.ts
+++ b/packages/varlock/src/runtime/test/patch-server-response.test.ts
@@ -17,12 +17,14 @@ import { patchGlobalServerResponse } from '../patch-server-response';
 import { resetRedactionMap } from '../env';
 
 const SECRET = 'super-secret-value-abc123';
+const UNICODE_SECRET = 'super-sëcret-value-abc123';
 
 const FAKE_GRAPH = {
   sources: [],
   settings: {},
   config: {
     SECRET_KEY: { value: SECRET, isSensitive: true },
+    UNICODE_SECRET_KEY: { value: UNICODE_SECRET, isSensitive: true },
     PUBLIC_KEY: { value: 'public-value', isSensitive: false },
   },
 } as any;
@@ -39,6 +41,21 @@ function makeRes(headers: Record<string, string> = {}) {
   res.setHeader('content-type', 'text/html');
   for (const [key, value] of Object.entries(headers)) res.setHeader(key, value);
   return res;
+}
+
+async function gzipInTwoFlushes(input: Buffer, splitAt: number) {
+  const gz = zlib.createGzip();
+  const compressed: Array<Buffer> = [];
+  gz.on('data', (chunk) => compressed.push(chunk));
+  const first = await new Promise<Buffer>((resolve) => {
+    gz.write(input.subarray(0, splitAt));
+    gz.flush(zlib.constants.Z_SYNC_FLUSH, () => resolve(Buffer.concat(compressed.splice(0))));
+  });
+  const second = await new Promise<Buffer>((resolve) => {
+    gz.on('end', () => resolve(Buffer.concat(compressed)));
+    gz.end(input.subarray(splitAt));
+  });
+  return [first, second] as const;
 }
 
 beforeAll(() => {
@@ -172,25 +189,34 @@ describe('patched ServerResponse - sensitive values split across chunks', () => 
   });
 
   it('detects a secret split across gzip flush boundaries', async () => {
-    const gz = zlib.createGzip();
-    const compressed: Array<Buffer> = [];
-    gz.on('data', (c) => compressed.push(c));
+    const input = Buffer.from(`<html>leaked: ${SECRET}</html>`);
+    const splitAt = Buffer.byteLength(`<html>leaked: ${head}`);
     // Z_SYNC_FLUSH ends the first block on a byte boundary, which is how a server
     // streaming a compressed response emits a chunk mid-body
-    const first = await new Promise<Buffer>((resolve) => {
-      gz.write(`<html>leaked: ${head}`);
-      gz.flush(zlib.constants.Z_SYNC_FLUSH, () => resolve(Buffer.concat(compressed.splice(0))));
-    });
-    const second = await new Promise<Buffer>((resolve) => {
-      gz.on('end', () => resolve(Buffer.concat(compressed)));
-      gz.end(`${tail}</html>`);
-    });
+    const [first, second] = await gzipInTwoFlushes(input, splitAt);
 
     const res = makeRes({ 'content-encoding': 'gzip' });
     // each half decompresses on its own without ever containing the whole secret
     expect(() => res.write(first)).not.toThrow();
     expect(() => res.write(second)).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
   });
+
+  it.each(['write', 'end'] as const)(
+    'detects a Unicode secret when a compressed delta ends mid-character before %s()',
+    async (completionMethod) => {
+      const input = Buffer.from(`<html>leaked: ${UNICODE_SECRET}</html>`);
+      const splitAt = input.indexOf(Buffer.from('ë')) + 1;
+      const [first, second] = await gzipInTwoFlushes(input, splitAt);
+      const firstDecompressed = zlib.unzipSync(first, {
+        finishFlush: zlib.constants.Z_SYNC_FLUSH,
+      });
+      expect(firstDecompressed.subarray(-1)).toEqual(Buffer.from('ë').subarray(0, 1));
+
+      const res = makeRes({ 'content-encoding': 'gzip' });
+      expect(() => res.write(first)).not.toThrow();
+      expect(() => res[completionMethod](second)).toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+    },
+  );
 
   it('does not false-positive on text that merely starts like a secret', () => {
     const res = makeRes();

--- a/packages/varlock/src/runtime/test/scan-for-leaks.test.ts
+++ b/packages/varlock/src/runtime/test/scan-for-leaks.test.ts
@@ -71,6 +71,49 @@ describe('scanForLeaks', () => {
     await expect(reader.read()).rejects.toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
   });
 
+  it('detects a leaked secret split across ReadableStream chunks', async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(`data ${SECRET_VALUE.slice(0, 10)}`));
+        controller.enqueue(new TextEncoder().encode(SECRET_VALUE.slice(10)));
+        controller.close();
+      },
+    });
+
+    const scanned = scanForLeaks(stream as any) as ReadableStream;
+    const reader = scanned.getReader();
+
+    await expect((async () => {
+      // first chunk holds only a partial value, so the read after it is the one that throws
+      for (;;) {
+        const { done } = await reader.read();
+        if (done) return;
+      }
+    })()).rejects.toThrow(/DETECTED LEAKED SENSITIVE CONFIG/);
+  });
+
+  it('passes a stream whose chunks split a multi-byte character through intact', async () => {
+    const text = 'héllo wörld 🔐';
+    const bytes = new TextEncoder().encode(text);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(bytes.slice(0, 2)); // splits the 2-byte é
+        controller.enqueue(bytes.slice(2));
+        controller.close();
+      },
+    });
+
+    const scanned = scanForLeaks(stream as any) as ReadableStream;
+    const reader = scanned.getReader();
+    const received: Array<number> = [];
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      received.push(...value);
+    }
+    expect(new TextDecoder().decode(new Uint8Array(received))).toBe(text);
+  });
+
   it('passes a clean ReadableStream through', async () => {
     const stream = new ReadableStream({
       start(controller) {


### PR DESCRIPTION
Varlock's response leak scanner checked each `ServerResponse.write()` / `end()` chunk in isolation, and detection is a substring match against complete values. A sensitive value split across a chunk boundary was therefore present in neither scan and went out to the client, even though the same value in a single chunk was blocked. Streaming SSR flushes at arbitrary points, so this is the normal case for the workload the patch was written for, not an edge case.

The application controls where chunks break, not a remote caller, so this is a gap in a safety net rather than a new way to reach secrets. It still means the net silently fails open on its main use case.

## What changed

- Each chunk is scanned with the tail of the previous one, so a value spanning a boundary matches. Covers `write`→`end`, `write`→`write`, and the gzip/br/zstd delta path.
- Trailing text that looks like the start of a sensitive value is held back rather than sent, and prepended to the next chunk, so a split value can be redacted instead of half-delivered. Held-back text is flushed on a 15ms unref'd timer so a stream that pauses mid-lookalike (SSE, long-poll) is not stalled; fragments that split a secret arrive within the same tick or a few ms, so the short window covers them while keeping the worst-case stall imperceptible. This reuses `getRedactionHoldbackLength`, already used by CLI output redaction.
- Same carry-over in the `ReadableStream` scanner in `env.ts`, which the edge `Response` patch and the Cloudflare integration use.

Fixed alongside it, in the same code paths:

- `end()` never decompressed compressed chunks, so a secret in a final compressed chunk was not scanned at all.
- Binary chunks now decode with a per-response streaming `TextDecoder`. A multi-byte character split across chunks previously decoded to replacement characters, a second source of missed matches and a corruption risk once chunks get rewritten. Once a chunk ends mid-character, the response switches to emitting re-encoded decoded text, so the held tail bytes can't be sent twice when a later chunk gets rewritten.
- `end()` now redacts under `redactInsteadOfThrow` instead of always throwing, matching `write()`. This is required for the split `write`→`end` case to be redactable, and it replaces the hung request the old code left behind (there was a TODO on that line about it). It affects Next.js dev only; production and every other integration still throw.
- When redaction shortens the body, `Content-Length` is recomputed. Next.js sets `Content-Length` for non-streamed payloads and sends them in a single `end()`, so a stale length left the client waiting on bytes that never arrived.

Clean responses stay byte-for-byte identical: the outgoing chunk is only rewritten when something was actually redacted or held back.

## Testing

17 new tests across the three runtime test files, each confirmed to fail against the unpatched source and pass with the fix. A seeded fuzz suite (30 chunkings per property over a real socket) additionally asserts that clean responses arrive byte-for-byte intact, throw mode never delivers the secret, and redact mode produces exactly the redacted text; it reproduces every byte-integrity bug fixed during review when run against the earlier revisions. Regression guards cover held-back text delivered intact, multi-byte splits, the timed flush arriving before `end()`, the write callback firing when a whole chunk is withheld, bare `end()` flushing withheld text, detection still working after a timed flush, `Content-Length` correction, and text that merely starts like a secret not being flagged.

Full framework test suite run locally: 670 passed across Astro 5/6/7, Next.js 14/15/16 (webpack + turbopack), Vite 5/6/7/8, Cloudflare, TanStack Start, SvelteKit, Expo, and vanilla-node. Two suites hit harness `beforeAll` timeouts under concurrent load and passed on a targeted re-run (200/200).

Reported by @7thParkk.




