### PR TITLE
fix: patch global Response with a proxy instead of a subclass

### DIFF
--- a/.bumpy/fix-response-patch-srvx-compat.md
+++ b/.bumpy/fix-response-patch-srvx-compat.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+fix `@preventLeak` breaking srvx-based servers (TanStack Start, Nitro) by patching the global Response with a proxy instead of a subclass

--- a/packages/varlock/src/runtime/patch-console.ts
+++ b/packages/varlock/src/runtime/patch-console.ts
@@ -44,7 +44,7 @@ export function patchGlobalConsole() {
   // ideally we would only turn this when the above method does not work, but it's not trivial to detect when it that is the case
   // so we'll turn it on all the time for now...
 
-  for (const logMethodName of ['trace', 'debug', 'info', 'log', 'info', 'warn', 'error']) {
+  for (const logMethodName of ['trace', 'debug', 'info', 'log', 'warn', 'error']) {
     // @ts-ignore
     const originalLogMethod = globalThis.console[logMethodName];
 

--- a/packages/varlock/src/runtime/patch-response.ts
+++ b/packages/varlock/src/runtime/patch-response.ts
@@ -13,23 +13,36 @@ export function patchGlobalResponse() {
   }
 
   const _UnpatchedResponse = globalThis.Response;
-  globalThis.Response = class VarlockPatchedResponse extends _UnpatchedResponse {
-    static _patchedByVarlock = true;
-    // Make native fetch() responses (which are instances of the original Response)
-    // pass instanceof checks against the patched globalThis.Response.
-    static [Symbol.hasInstance](instance: unknown) {
-      return instance instanceof _UnpatchedResponse;
-    }
-    constructor(body: any, init: any) {
+
+  function patchedJson(data: any, init: any) {
+    debug('⚡️ patched Response.json');
+    scanForLeaks(JSON.stringify(data), { method: 'patched Response.json' });
+    return _UnpatchedResponse.json(data, init);
+  }
+
+  // NOTE - we wrap the native class in a Proxy rather than swapping in a subclass.
+  // A subclass would make `globalThis.Response.prototype` a nearly empty object, and
+  // libraries that reflect over `Response.prototype`'s own properties to build their own
+  // Response-alike (srvx's `lazyInherit`, used by its node adapter) then wire up nothing
+  // and fall through to the native getters with a foreign `this`. See issue #983.
+  // With a proxy, `Response.prototype` is still the real native prototype, `instanceof`
+  // works without a `Symbol.hasInstance` override, and every instance we hand back is a
+  // genuine native Response with its internal slots intact.
+  globalThis.Response = new Proxy(_UnpatchedResponse, {
+    construct(target, args, newTarget) {
       debug('⚡️ patched Response constructor');
-      super(scanForLeaks(body, { method: 'patched Response constructor' }) as any, init);
-    }
-    static json(data: any, init: any) {
-      debug('⚡️ patched Response.json');
-      scanForLeaks(JSON.stringify(data), { method: 'patched Response.json' });
-      const r = _UnpatchedResponse.json(data, init);
-      Object.setPrototypeOf(r, Response.prototype);
-      return r;
-    }
-  };
+      const [body, init] = args;
+      const scannedBody = scanForLeaks(body, { method: 'patched Response constructor' });
+      return Reflect.construct(target, [scannedBody, init], newTarget);
+    },
+    get(target, prop, receiver) {
+      if (prop === '_patchedByVarlock') return true;
+      if (prop === 'json') return patchedJson;
+      return Reflect.get(target, prop, receiver);
+    },
+    has(target, prop) {
+      if (prop === '_patchedByVarlock') return true;
+      return Reflect.has(target, prop);
+    },
+  });
 }

--- a/packages/varlock/src/runtime/patch-response.ts
+++ b/packages/varlock/src/runtime/patch-response.ts
@@ -13,11 +13,12 @@ export function patchGlobalResponse() {
   }
 
   const _UnpatchedResponse = globalThis.Response;
+  const _UnpatchedResponseJson = _UnpatchedResponse.json;
 
   function patchedJson(data: any, init: any) {
     debug('⚡️ patched Response.json');
     scanForLeaks(JSON.stringify(data), { method: 'patched Response.json' });
-    return _UnpatchedResponse.json(data, init);
+    return Reflect.apply(_UnpatchedResponseJson, _UnpatchedResponse, [data, init]);
   }
 
   // NOTE - we wrap the native class in a Proxy rather than swapping in a subclass.
@@ -37,8 +38,12 @@ export function patchGlobalResponse() {
     },
     get(target, prop, receiver) {
       if (prop === '_patchedByVarlock') return true;
-      if (prop === 'json') return patchedJson;
-      return Reflect.get(target, prop, receiver);
+      const value = Reflect.get(target, prop, receiver);
+      if (prop !== 'json' || value !== _UnpatchedResponseJson) return value;
+
+      const descriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+      if (descriptor?.configurable === false && descriptor.writable === false) return value;
+      return patchedJson;
     },
     has(target, prop) {
       if (prop === '_patchedByVarlock') return true;

--- a/packages/varlock/src/runtime/test/patch-response.test.ts
+++ b/packages/varlock/src/runtime/test/patch-response.test.ts
@@ -6,16 +6,21 @@ import { varlockSettings } from '../env';
 
 describe('patchGlobalResponse', () => {
   let _originalResponse: typeof Response;
+  let _originalJsonDescriptor: PropertyDescriptor | undefined;
 
   beforeEach(() => {
+    // afterEach restores this reference, so each test starts from the unpatched native class
     _originalResponse = globalThis.Response;
-    // ensure the patch is fresh each test
-    delete (globalThis.Response as any)._patchedByVarlock;
-    globalThis.Response = _originalResponse;
+    _originalJsonDescriptor = Object.getOwnPropertyDescriptor(_originalResponse, 'json');
   });
 
   afterEach(() => {
     globalThis.Response = _originalResponse;
+    // writes through the patched proxy (e.g. `Response.json = wrapper`) land on the native
+    // class itself, so restore its original `json` to avoid cross-test pollution
+    if (_originalJsonDescriptor) {
+      Object.defineProperty(_originalResponse, 'json', _originalJsonDescriptor);
+    }
   });
 
   it('instanceof check passes for native Response instances after patching', () => {

--- a/packages/varlock/src/runtime/test/patch-response.test.ts
+++ b/packages/varlock/src/runtime/test/patch-response.test.ts
@@ -45,6 +45,49 @@ describe('patchGlobalResponse', () => {
     expect(globalThis.Response).toBe(patchedOnce);
   });
 
+  it('keeps the native prototype reachable by reflection (issue #983)', () => {
+    const nativeProto = globalThis.Response.prototype;
+    const nativeOwnProps = Object.getOwnPropertyNames(nativeProto);
+
+    patchGlobalResponse();
+
+    // srvx's node adapter snapshots globalThis.Response and builds its FastResponse by
+    // walking the *own* properties of `Response.prototype`. If we hand it a subclass
+    // prototype (which owns nothing but `constructor`) it wires up nothing and its
+    // instances fall through to the native getters, which throw on a foreign receiver.
+    expect(globalThis.Response.prototype).toBe(nativeProto);
+    expect(Object.getOwnPropertyNames(globalThis.Response.prototype)).toEqual(nativeOwnProps);
+  });
+
+  it('constructs real native Response instances', () => {
+    const NativeResponse = globalThis.Response;
+    patchGlobalResponse();
+
+    const r = new globalThis.Response('hello');
+    // internal slots are intact only if this is a genuine native instance
+    expect(r.status).toBe(200);
+    expect(r.body).toBeTruthy();
+    expect(Object.getPrototypeOf(r)).toBe(NativeResponse.prototype);
+  });
+
+  it('subclasses of the patched Response still work', () => {
+    patchGlobalResponse();
+
+    class SubResponse extends globalThis.Response {}
+    const r = new SubResponse('hello');
+    expect(r instanceof SubResponse).toBe(true);
+    expect(r instanceof globalThis.Response).toBe(true);
+    expect(r.status).toBe(200);
+  });
+
+  it('Response.json returns a usable response', () => {
+    patchGlobalResponse();
+
+    const r = globalThis.Response.json({ ok: true });
+    expect(r.headers.get('content-type')).toContain('application/json');
+    expect(r instanceof globalThis.Response).toBe(true);
+  });
+
   it('skips patching when preventLeaks is false', () => {
     const original = varlockSettings.preventLeaks;
     try {

--- a/packages/varlock/src/runtime/test/patch-response.test.ts
+++ b/packages/varlock/src/runtime/test/patch-response.test.ts
@@ -88,6 +88,38 @@ describe('patchGlobalResponse', () => {
     expect(r instanceof globalThis.Response).toBe(true);
   });
 
+  it('allows Response.json to be wrapped after patching', () => {
+    patchGlobalResponse();
+    const previousJson = globalThis.Response.json;
+    let wrapperCalled = false;
+
+    globalThis.Response.json = (data, init) => {
+      wrapperCalled = true;
+      return previousJson(data, init);
+    };
+
+    const r = globalThis.Response.json({ ok: true });
+    expect(wrapperCalled).toBe(true);
+    expect(r instanceof globalThis.Response).toBe(true);
+  });
+
+  it('respects a non-configurable Response.json replacement', () => {
+    class FakeResponse {
+      static json() {
+        return 'native';
+      }
+    }
+    globalThis.Response = FakeResponse as unknown as typeof Response;
+    patchGlobalResponse();
+    Object.defineProperty(globalThis.Response, 'json', {
+      value: () => 'replacement',
+      configurable: false,
+      writable: false,
+    });
+
+    expect(globalThis.Response.json({})).toBe('replacement');
+  });
+
   it('skips patching when preventLeaks is false', () => {
     const original = varlockSettings.preventLeaks;
     try {


### PR DESCRIPTION
Fixes #983

## The problem

`@preventLeak` broke srvx-based servers (TanStack Start's `FastResponse`, Nitro) with:

```
TypeError: Cannot read private member #state from an object whose class did not declare it
    at NodeResponse.get body [as body] (node:internal/deps/undici/undici:9767:21)
```

## Root cause

Not srvx-specific in principle: it's a conflict between `patchGlobalResponse()` and any library that reflects over `Response.prototype`.

The patch replaced `globalThis.Response` with a **subclass**, and a subclass's `.prototype` owns nothing but `constructor`. All the real members (`body`, `text()`, `clone()`, `bodyUsed`, ...) live one level up on the native prototype.

srvx's node adapter snapshots `globalThis.Response` at import time and builds its `FastResponse` via `lazyInherit()`, which walks only `Object.getOwnPropertyNames(source)`. Against the subclass prototype it finds nothing, forwards nothing, then does `Object.setPrototypeOf(NodeResponse.prototype, NativeResponse.prototype)`. So `fastResponse.body` falls straight through to undici's native getter with a `NodeResponse` receiver.

Ordering is exactly what the Vite integration produces: it patches at config-load time, well before the dev server imports srvx.

Node version changes the message, not the bug: Node 24's undici uses `#state` (the reported error), Node 22 uses a symbol and reports `Cannot read properties of undefined (reading 'body')`.

## The fix

Wrap the native class in a `Proxy` with a `construct` trap instead of subclassing it. `Response.prototype` stays the real native prototype, so reflection-based wrappers see what they expect, and every instance is a genuine native `Response` with its internal slots intact.

Two cleanups fall out of this:

- The `Symbol.hasInstance` override from #385 is removed. `instanceof` works natively now, because the proxy's `prototype` *is* the native one.
- The `Object.setPrototypeOf(r, Response.prototype)` call in `Response.json` is removed, for the same reason.

## Leak detection is unchanged

Verified end-to-end against a live srvx server:

- plain `new Response(secret)` -> caught by the construct trap
- srvx's fast path (bypasses `Response` entirely, writes straight to `nodeRes.write`) -> still caught by `patchGlobalServerResponse`
- srvx's own internal `new NativeResponse(...)` -> now routes through the trap too

Before/after on the same server, Node 24:

```
BEFORE  GET /middleware -> 500  TypeError: Cannot read private member #state ...
AFTER   GET /middleware -> 200  "<html>from inner handler</html>"
```

## Tests

Four regression tests added. The key one asserts `Response.prototype` keeps its native own-property set after patching, which is the invariant srvx depends on; the others cover native instance construction, subclassing, and `Response.json`.

## For reviewers

I could not scaffold a real TanStack Start app on Windows to confirm there is no *second* failure behind this one. The srvx incompatibility is real and fixed, but if the reporter still hits an error after this ships, it would be a separate issue.

## Review follow-ups

- Test hygiene: `Response.json` writes through the proxy land on the native class, so the suite now restores the original `json` descriptor between tests. Also dropped a now-dead `delete _patchedByVarlock` (the flag is virtual, served by the proxy's `get` trap).
- Drive-by: removed a duplicate `'info'` entry in `patch-console.ts`'s method list that caused `console.info` to be wrapped twice.
