### PR TITLE
telemetry: honor the DO_NOT_TRACK env var

### DIFF
--- a/.bumpy/dnt-opt-out.md
+++ b/.bumpy/dnt-opt-out.md
@@ -1,0 +1,5 @@
+---
+'varlock': patch
+---
+
+Telemetry now honors the `DO_NOT_TRACK` environment variable, alongside the existing `VARLOCK_TELEMETRY_DISABLED` var and config file settings.

--- a/packages/varlock-website/src/content/docs/guides/telemetry.mdx
+++ b/packages/varlock-website/src/content/docs/guides/telemetry.mdx
@@ -48,6 +48,12 @@ export VARLOCK_TELEMETRY_DISABLED=true
 
 This could be set in a specific terminal session, while running a specific command, in a Dockerfile, or in a CI/CD pipeline.
 
+varlock also honors `DO_NOT_TRACK`, a convention shared by many command line tools such as Homebrew, Deno and Turborepo. The convention is described at [donottrack.sh](https://donottrack.sh/). Setting it opts you out of every tool that supports it, so you do not need to remember a separate variable for each one:
+
+```bash
+export DO_NOT_TRACK=1
+```
+
 ### With a project config file
 
 You can also opt out at the project level by creating a `.varlock/config.json` file in your project root with the following content:

--- a/packages/varlock-website/src/content/docs/reference/cli/project.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli/project.mdx
@@ -180,7 +180,7 @@ varlock telemetry enable
 ```
 
 :::note
-You can also temporarily opt out by setting the `VARLOCK_TELEMETRY_DISABLED` environment variable. See the [Telemetry guide](/guides/telemetry/) for more information about our analytics and privacy practices.
+You can also temporarily opt out by setting the `VARLOCK_TELEMETRY_DISABLED` or `DO_NOT_TRACK` environment variable. See the [Telemetry guide](/guides/telemetry/) for more information about our analytics and privacy practices.
 :::
 </div>
 

--- a/packages/varlock/src/cli/commands/telemetry.command.ts
+++ b/packages/varlock/src/cli/commands/telemetry.command.ts
@@ -27,7 +27,7 @@ Examples:
   varlock telemetry disable    # Opt out of telemetry
   varlock telemetry enable     # Opt in to telemetry
 
-💡 Tip: You can also temporarily opt out by setting VARLOCK_TELEMETRY_DISABLED=1
+💡 Tip: You can also temporarily opt out by setting VARLOCK_TELEMETRY_DISABLED=1 or DO_NOT_TRACK=1
 For more information, visit https://varlock.dev/guides/telemetry/
   `.trim(),
 });

--- a/packages/varlock/src/cli/helpers/telemetry.ts
+++ b/packages/varlock/src/cli/helpers/telemetry.ts
@@ -27,6 +27,10 @@ const debug = createDebug('varlock:telemetry');
 
 const TRUE_ENV_VAR_VALUES = ['true', '1', 't'];
 
+function isTrueEnvVarValue(value: string | undefined) {
+  return !!value && TRUE_ENV_VAR_VALUES.includes(value.toLowerCase());
+}
+
 
 const userVarlockDirPath = getUserVarlockDir();
 const userVarlockConfigFilePath = join(userVarlockDirPath, 'config.json');
@@ -172,6 +176,25 @@ function getAnonymousId() {
 }
 
 
+/**
+ * Checks the environment variables that opt a user out of telemetry.
+ *
+ * `DO_NOT_TRACK` is a cross-tool convention honored by Homebrew, Deno, Turborepo and
+ * others, described at https://donottrack.sh/. Setting it opts out of every
+ * tool that honors it, not just varlock. Its canonical
+ * value is `1`, but we accept the same true-ish values we already accept for
+ * `VARLOCK_TELEMETRY_DISABLED`.
+ *
+ * @internal exported for unit tests
+ */
+export function checkIsOptedOutViaEnv(env: NodeJS.ProcessEnv = process.env) {
+  return (
+    env.PH_OPT_OUT === 'true' // legacy
+    || isTrueEnvVarValue(env.VARLOCK_TELEMETRY_DISABLED)
+    || isTrueEnvVarValue(env.DO_NOT_TRACK)
+  );
+}
+
 function checkIsOptedOut() {
   // Check if this is a dev build, rather than a published npm package or standalone binary
   if (__VARLOCK_BUILD_TYPE__ === 'dev') {
@@ -179,14 +202,8 @@ function checkIsOptedOut() {
     return true;
   }
 
-  // Check environment variable
-  if (
-    process.env.PH_OPT_OUT === 'true' // legacy
-    || (
-      process.env.VARLOCK_TELEMETRY_DISABLED
-      && TRUE_ENV_VAR_VALUES.includes(process.env.VARLOCK_TELEMETRY_DISABLED.toLowerCase())
-    )
-  ) {
+  // Check environment variables
+  if (checkIsOptedOutViaEnv()) {
     debug('telemetry opted out - env var');
     return true;
   }

--- a/packages/varlock/src/cli/helpers/test/telemetry.test.ts
+++ b/packages/varlock/src/cli/helpers/test/telemetry.test.ts
@@ -9,6 +9,7 @@ vi.mock('../js-package-manager-utils', () => ({
 import { detectJsPackageManager } from '../js-package-manager-utils';
 import {
   getJsPackageManagerForTelemetry, normalizeGitRemoteUrl, getProjectSlugFromCi, bucketGitHost,
+  checkIsOptedOutViaEnv,
 } from '../telemetry';
 
 describe('getJsPackageManagerForTelemetry', () => {
@@ -91,6 +92,36 @@ describe('bucketGitHost', () => {
     expect(bucketGitHost(null)).toBeNull();
     expect(bucketGitHost(undefined)).toBeNull();
     expect(bucketGitHost('')).toBeNull();
+  });
+});
+
+describe('checkIsOptedOutViaEnv', () => {
+  it('opts out when DO_NOT_TRACK is set', () => {
+    // `1` is the canonical value from the DO_NOT_TRACK spec
+    expect(checkIsOptedOutViaEnv({ DO_NOT_TRACK: '1' })).toBe(true);
+    // and we accept the same true-ish values as our own env var
+    expect(checkIsOptedOutViaEnv({ DO_NOT_TRACK: 'true' })).toBe(true);
+    expect(checkIsOptedOutViaEnv({ DO_NOT_TRACK: 'TRUE' })).toBe(true);
+    expect(checkIsOptedOutViaEnv({ DO_NOT_TRACK: 't' })).toBe(true);
+  });
+
+  it('does not opt out when DO_NOT_TRACK is unset or not true-ish', () => {
+    expect(checkIsOptedOutViaEnv({})).toBe(false);
+    expect(checkIsOptedOutViaEnv({ DO_NOT_TRACK: '0' })).toBe(false);
+    expect(checkIsOptedOutViaEnv({ DO_NOT_TRACK: '' })).toBe(false);
+    expect(checkIsOptedOutViaEnv({ DO_NOT_TRACK: 'false' })).toBe(false);
+  });
+
+  it('still opts out via VARLOCK_TELEMETRY_DISABLED', () => {
+    expect(checkIsOptedOutViaEnv({ VARLOCK_TELEMETRY_DISABLED: '1' })).toBe(true);
+    expect(checkIsOptedOutViaEnv({ VARLOCK_TELEMETRY_DISABLED: 'true' })).toBe(true);
+    expect(checkIsOptedOutViaEnv({ VARLOCK_TELEMETRY_DISABLED: 't' })).toBe(true);
+    expect(checkIsOptedOutViaEnv({ VARLOCK_TELEMETRY_DISABLED: '0' })).toBe(false);
+  });
+
+  it('still opts out via the legacy PH_OPT_OUT var, which only matches "true"', () => {
+    expect(checkIsOptedOutViaEnv({ PH_OPT_OUT: 'true' })).toBe(true);
+    expect(checkIsOptedOutViaEnv({ PH_OPT_OUT: '1' })).toBe(false);
   });
 });
 


### PR DESCRIPTION
Thanks for varlock. The schema-driven approach to environment variables has been really useful.

`DO_NOT_TRACK` is an informal convention that a lot of command line tools follow _(Homebrew, Deno, Turborepo, Netlify CLI, Astro)_: the tool checks the `DO_NOT_TRACK` environment variable, and skips sending analytics when it is set. The point is that someone can set it once and opt out of every tool that honors it, instead of learning a different variable for each one. Homebrew, Deno, Turborepo, Netlify CLI and Astro all honor it today. varlock already has `VARLOCK_TELEMETRY_DISABLED`, a legacy `PH_OPT_OUT`, and config file flags, so this adds the standard variable next to them.

The change is in one function, `checkIsOptedOut()` in `packages/varlock/src/cli/helpers/telemetry.ts`. I pulled its environment variable check into a small exported helper so it could be unit tested without touching the real user config file, then added `DO_NOT_TRACK` there. The canonical value is `1`, but it is parsed with the same `TRUE_ENV_VAR_VALUES` list the existing variable uses, so `true` and `t` work too. Tests cover each branch: `DO_NOT_TRACK=1` opts out, `0` or unset or `false` does not, and the existing variables still behave the same. Docs are updated in the telemetry guide, the CLI reference, and the `varlock telemetry` command help.

📔 `PH_OPT_OUT` still matches only the exact string `true`, which is its existing behavior, and a test now asserts that so the legacy semantics do not drift. 