### PR TITLE
Fix package.json entry points across all packages

### DIFF
--- a/.bumpy/fix-package-entry-points.md
+++ b/.bumpy/fix-package-entry-points.md
@@ -1,0 +1,26 @@
+---
+varlock: patch
+"@env-spec/parser": patch
+"@varlock/ci-env-info": patch
+"@varlock/astro-integration": patch
+"@varlock/cloudflare-integration": patch
+"@varlock/nextjs-integration": patch
+"@varlock/vite-integration": patch
+"@varlock/1password-plugin": patch
+"@varlock/akeyless-plugin": patch
+"@varlock/aws-secrets-plugin": patch
+"@varlock/azure-key-vault-plugin": patch
+"@varlock/bitwarden-plugin": patch
+"@varlock/dashlane-plugin": patch
+"@varlock/doppler-plugin": patch
+"@varlock/google-secret-manager-plugin": patch
+"@varlock/hashicorp-vault-plugin": patch
+"@varlock/infisical-plugin": patch
+"@varlock/keeper-plugin": patch
+"@varlock/kubernetes-plugin": patch
+"@varlock/pass-plugin": patch
+"@varlock/passbolt-plugin": patch
+"@varlock/proton-pass-plugin": patch
+---
+
+Fix package.json entry points - remove references to files that were never built and declare import/require conditions explicitly

--- a/packages/ci-env-info/package.json
+++ b/packages/ci-env-info/package.json
@@ -14,6 +14,7 @@
     ".": {
       "ts-src": "./src/index.ts",
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     }
   },

--- a/packages/env-spec-parser/package.json
+++ b/packages/env-spec-parser/package.json
@@ -10,6 +10,7 @@
     "directory": "packages/env-spec-parser"
   },
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": ["dist"],
   "exports": {
     ".": {

--- a/packages/integrations/astro/package.json
+++ b/packages/integrations/astro/package.json
@@ -11,7 +11,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   },
   "files": ["dist"],
   "scripts": {

--- a/packages/integrations/cloudflare/package.json
+++ b/packages/integrations/cloudflare/package.json
@@ -13,18 +13,22 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./sveltekit": {
       "types": "./dist/sveltekit.d.ts",
+      "import": "./dist/sveltekit.js",
       "default": "./dist/sveltekit.js"
     },
     "./init": {
       "types": "./dist/init.d.ts",
+      "import": "./dist/init.js",
       "default": "./dist/init.js"
     },
     "./ssr-entry-code": {
       "types": "./dist/shared-ssr-entry-code.d.ts",
+      "import": "./dist/shared-ssr-entry-code.js",
       "default": "./dist/shared-ssr-entry-code.js"
     }
   },

--- a/packages/integrations/nextjs/package.json
+++ b/packages/integrations/nextjs/package.json
@@ -10,10 +10,26 @@
   "main": "dist/next-env-compat.js",
   "types": "dist/next-env-compat.d.ts",
   "exports": {
-    ".": "./dist/next-env-compat.js",
-    "./plugin": "./dist/plugin.js",
-    "./loader": "./dist/loader.js",
-    "./dynamic-access": "./dist/dynamic-access.js"
+    ".": {
+      "types": "./dist/next-env-compat.d.ts",
+      "require": "./dist/next-env-compat.js",
+      "default": "./dist/next-env-compat.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin.d.ts",
+      "require": "./dist/plugin.js",
+      "default": "./dist/plugin.js"
+    },
+    "./loader": {
+      "types": "./dist/loader.d.ts",
+      "require": "./dist/loader.js",
+      "default": "./dist/loader.js"
+    },
+    "./dynamic-access": {
+      "types": "./dist/dynamic-access.d.ts",
+      "require": "./dist/dynamic-access.js",
+      "default": "./dist/dynamic-access.js"
+    }
   },
   "files": ["dist"],
   "scripts": {

--- a/packages/integrations/vite/package.json
+++ b/packages/integrations/vite/package.json
@@ -14,6 +14,7 @@
     ".": {
       "ts-src": "./src/index.ts",
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     }
   },

--- a/packages/plugins/1password/package.json
+++ b/packages/plugins/1password/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/1password"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/akeyless/package.json
+++ b/packages/plugins/akeyless/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/akeyless"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/aws-secrets/package.json
+++ b/packages/plugins/aws-secrets/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/aws-secrets"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/azure-key-vault/package.json
+++ b/packages/plugins/azure-key-vault/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/azure-key-vault"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/bitwarden/package.json
+++ b/packages/plugins/bitwarden/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/bitwarden"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/dashlane/package.json
+++ b/packages/plugins/dashlane/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/dashlane"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/doppler/package.json
+++ b/packages/plugins/doppler/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/doppler"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/google-secret-manager/package.json
+++ b/packages/plugins/google-secret-manager/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/google-secret-manager"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/hashicorp-vault/package.json
+++ b/packages/plugins/hashicorp-vault/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/hashicorp-vault"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/infisical/package.json
+++ b/packages/plugins/infisical/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/infisical"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/keeper/package.json
+++ b/packages/plugins/keeper/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/keeper"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/kubernetes/package.json
+++ b/packages/plugins/kubernetes/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/kubernetes"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/pass/package.json
+++ b/packages/plugins/pass/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/pass"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/passbolt/package.json
+++ b/packages/plugins/passbolt/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/passbolt"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/plugins/proton-pass/package.json
+++ b/packages/plugins/proton-pass/package.json
@@ -10,8 +10,6 @@
     "url": "https://github.com/dmno-dev/varlock.git",
     "directory": "packages/plugins/proton-pass"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     "./plugin": "./dist/plugin.cjs"
   },

--- a/packages/varlock/package.json
+++ b/packages/varlock/package.json
@@ -2,7 +2,8 @@
   "name": "varlock",
   "version": "1.17.0",
   "description": "AI-safe .env files: Schemas for agents, Secrets for humans.",
-  "main": "index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
   "author": "dmno-dev",
   "license": "MIT",
@@ -74,66 +75,79 @@
     ".": {
       "ts-src": "./src/index.ts",
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./env": {
       "ts-src": "./src/runtime/env.ts",
       "types": "./dist/runtime/env.d.ts",
+      "import": "./dist/runtime/env.js",
       "default": "./dist/runtime/env.js"
     },
     "./auto-load": {
       "ts-src": "./src/auto-load.ts",
       "types": "./dist/auto-load.d.ts",
+      "import": "./dist/auto-load.js",
       "default": "./dist/auto-load.js"
     },
     "./patch-console": {
       "ts-src": "./src/runtime/patch-console.ts",
       "types": "./dist/runtime/patch-console.d.ts",
+      "import": "./dist/runtime/patch-console.js",
       "default": "./dist/runtime/patch-console.js"
     },
     "./patch-response": {
       "ts-src": "./src/runtime/patch-response.ts",
       "types": "./dist/runtime/patch-response.d.ts",
+      "import": "./dist/runtime/patch-response.js",
       "default": "./dist/runtime/patch-response.js"
     },
     "./patch-server-response": {
       "ts-src": "./src/runtime/patch-server-response.ts",
       "types": "./dist/runtime/patch-server-response.d.ts",
+      "import": "./dist/runtime/patch-server-response.js",
       "default": "./dist/runtime/patch-server-response.js"
     },
     "./init-server": {
       "ts-src": "./src/runtime/init-server.ts",
       "types": "./dist/runtime/init-server.d.cts",
+      "require": "./dist/runtime/init-server.cjs",
       "default": "./dist/runtime/init-server.cjs"
     },
     "./init-edge": {
       "ts-src": "./src/runtime/init-edge.ts",
       "types": "./dist/runtime/init-edge.d.cts",
+      "require": "./dist/runtime/init-edge.cjs",
       "default": "./dist/runtime/init-edge.cjs"
     },
     "./encrypt-env": {
       "ts-src": "./src/runtime/crypto.ts",
       "types": "./dist/runtime/crypto.d.ts",
+      "import": "./dist/runtime/crypto.js",
       "default": "./dist/runtime/crypto.js"
     },
     "./exec-sync-varlock": {
       "ts-src": "./src/lib/exec-sync-varlock.ts",
       "types": "./dist/lib/exec-sync-varlock.d.ts",
+      "import": "./dist/lib/exec-sync-varlock.js",
       "default": "./dist/lib/exec-sync-varlock.js"
     },
     "./config": {
       "ts-src": "./src/config.ts",
       "types": "./dist/dotenv-compat.d.ts",
+      "import": "./dist/dotenv-compat.js",
       "default": "./dist/dotenv-compat.js"
     },
     "./config.js": {
       "ts-src": "./src/config.ts",
       "types": "./dist/dotenv-compat.d.ts",
+      "import": "./dist/dotenv-compat.js",
       "default": "./dist/dotenv-compat.js"
     },
     "./plugin-lib": {
       "ts-src": "./src/plugin-lib.ts",
       "types": "./dist/plugin-lib.d.ts",
+      "import": "./dist/plugin-lib.js",
       "default": "./dist/plugin-lib.js"
     },
     "./test-helpers": {

--- a/packages/varlock/package.json
+++ b/packages/varlock/package.json
@@ -2,7 +2,8 @@
   "name": "varlock",
   "version": "1.16.0",
   "description": "AI-safe .env files: Schemas for agents, Secrets for humans.",
-  "main": "index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
   "author": "dmno-dev",
   "license": "MIT",
@@ -69,66 +70,79 @@
     ".": {
       "ts-src": "./src/index.ts",
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./env": {
       "ts-src": "./src/runtime/env.ts",
       "types": "./dist/runtime/env.d.ts",
+      "import": "./dist/runtime/env.js",
       "default": "./dist/runtime/env.js"
     },
     "./auto-load": {
       "ts-src": "./src/auto-load.ts",
       "types": "./dist/auto-load.d.ts",
+      "import": "./dist/auto-load.js",
       "default": "./dist/auto-load.js"
     },
     "./patch-console": {
       "ts-src": "./src/runtime/patch-console.ts",
       "types": "./dist/runtime/patch-console.d.ts",
+      "import": "./dist/runtime/patch-console.js",
       "default": "./dist/runtime/patch-console.js"
     },
     "./patch-response": {
       "ts-src": "./src/runtime/patch-response.ts",
       "types": "./dist/runtime/patch-response.d.ts",
+      "import": "./dist/runtime/patch-response.js",
       "default": "./dist/runtime/patch-response.js"
     },
     "./patch-server-response": {
       "ts-src": "./src/runtime/patch-server-response.ts",
       "types": "./dist/runtime/patch-server-response.d.ts",
+      "import": "./dist/runtime/patch-server-response.js",
       "default": "./dist/runtime/patch-server-response.js"
     },
     "./init-server": {
       "ts-src": "./src/runtime/init-server.ts",
       "types": "./dist/runtime/init-server.d.cts",
+      "require": "./dist/runtime/init-server.cjs",
       "default": "./dist/runtime/init-server.cjs"
     },
     "./init-edge": {
       "ts-src": "./src/runtime/init-edge.ts",
       "types": "./dist/runtime/init-edge.d.cts",
+      "require": "./dist/runtime/init-edge.cjs",
       "default": "./dist/runtime/init-edge.cjs"
     },
     "./encrypt-env": {
       "ts-src": "./src/runtime/crypto.ts",
       "types": "./dist/runtime/crypto.d.ts",
+      "import": "./dist/runtime/crypto.js",
       "default": "./dist/runtime/crypto.js"
     },
     "./exec-sync-varlock": {
       "ts-src": "./src/lib/exec-sync-varlock.ts",
       "types": "./dist/lib/exec-sync-varlock.d.ts",
+      "import": "./dist/lib/exec-sync-varlock.js",
       "default": "./dist/lib/exec-sync-varlock.js"
     },
     "./config": {
       "ts-src": "./src/config.ts",
       "types": "./dist/dotenv-compat.d.ts",
+      "import": "./dist/dotenv-compat.js",
       "default": "./dist/dotenv-compat.js"
     },
     "./config.js": {
       "ts-src": "./src/config.ts",
       "types": "./dist/dotenv-compat.d.ts",
+      "import": "./dist/dotenv-compat.js",
       "default": "./dist/dotenv-compat.js"
     },
     "./plugin-lib": {
       "ts-src": "./src/plugin-lib.ts",
       "types": "./dist/plugin-lib.d.ts",
+      "import": "./dist/plugin-lib.js",
       "default": "./dist/plugin-lib.js"
     },
     "./test-helpers": {


### PR DESCRIPTION
> **Stack:** this is 1 of 2. #1021 (tsdown migration) is based on this branch and rewrites many of the same exports blocks, so this one merges first. Nothing in #1021 is required for this to stand on its own.

Prompted by [npmx-dev/npmx.dev#2837](https://github.com/npmx-dev/npmx.dev/issues/2837), where `varlock` shows up as CJS. Auditing every path referenced from every `package.json` turned up 33 dangling references across the monorepo.

## What was wrong

**Dead entry points.** `varlock` had `"main": "index.js"`, pointing at a file that has never existed. 15 plugin packages had `"main": "dist/index.js"` and `"types": "dist/index.d.ts"`, neither of which their builds emit (the only artifact is `dist/plugin.cjs`).

**Bare `default` conditions.** Most exports used `default` rather than naming `import`/`require`. npmx's [detection](https://github.com/npmx-dev/npmx.dev/blob/eecbd51/shared/utils/package-analysis.ts#L56-L57) walks the exports tree, sets `hasRequire` if any string ends in `.cjs`, and never consults `type: module`. Our `./init-server` and `./init-edge` are genuinely CJS, so with no `import` condition anywhere the whole package got classified `cjs`.

## Changes

- `varlock` - `main` now points at `./dist/index.js`, added top-level `types`. Explicit `import` on the 12 ESM subpaths, explicit `require` on the two `.cjs` ones. `default` is kept everywhere as the fallback, so resolution behavior is unchanged.
- 15 plugin packages - removed the `main`/`types` that pointed at files the build never produces. Their `./plugin` export stays a plain string, since `EnvGraphPlugin.pluginFilePath` reads it as one.
- `ci-env-info`, `vite`, `cloudflare`, `astro` - explicit `import` conditions; astro's bare string export expanded to carry `types`.
- `nextjs` - subpath exports had no `types` at all, so `@varlock/nextjs-integration/plugin` and friends resolved untyped. Now explicit `types`/`require`/`default`.
- `env-spec-parser` - added top-level `types`.

## Verification

Full build, `turbo test:ci` (8/8 packages, 2071 tests), `turbo typecheck` (26/27; `varlock-docs-mcp` fails on missing Cloudflare Worker types, pre-existing on `main`). Plus a resolver probe running all 14 `varlock` subpaths through Node under both `import.meta.resolve` and `require.resolve` - all resolve, unchanged from before.

## Note on the badge

npmx will now report `varlock` as `dual` rather than `cjs`. It can't reach plain `esm` while `init-server`/`init-edge` are exported as `.cjs`, and those genuinely are CJS. Dropping them from `exports` would break the resolution contract with older `@varlock/nextjs-integration`, so they stay. Their heuristic ignoring `type: module` when `default` is used is still a bug on their end; the issue stays open.
