### PR TITLE
Fix two flaky CI test failures

### DIFF
--- a/.bumpy/flaky-test-timeouts.md
+++ b/.bumpy/flaky-test-timeouts.md
@@ -1,0 +1,6 @@
+---
+varlock: none
+"@varlock/nextjs-integration": none
+---
+
+true

--- a/packages/integrations/nextjs/test/fifo-sources.test.ts
+++ b/packages/integrations/nextjs/test/fifo-sources.test.ts
@@ -115,7 +115,9 @@ describe.skipIf(process.platform === 'win32')('FIFO env sources (e.g. 1Password 
     delete process.env.__VARLOCK_NEXT_WARNED_NON_REGULAR_FILES;
   });
 
-  it('never reads or watches FIFO sources during load and reload checks', async () => {
+  // generous timeout: first import of next-env-compat pays transform cost, which
+  // can exceed vitest's 5s default on slow CI runners
+  it('never reads or watches FIFO sources during load and reload checks', { timeout: 30_000 }, async () => {
     const { loadEnvConfig } = await import('../src/next-env-compat');
 
     loadEnvConfig(tmpDir, true);
@@ -143,7 +145,7 @@ describe.skipIf(process.platform === 'win32')('FIFO env sources (e.g. 1Password 
     expect(readFileSyncCallsFor(fifoExtraPath)).toHaveLength(0);
   });
 
-  it('logs a one-time notice that live reload is disabled for FIFO sources', async () => {
+  it('logs a one-time notice that live reload is disabled for FIFO sources', { timeout: 30_000 }, async () => {
     const { loadEnvConfig } = await import('../src/next-env-compat');
 
     loadEnvConfig(tmpDir, true);

--- a/packages/varlock/src/lib/cache/cache-lock-crossproc.test.ts
+++ b/packages/varlock/src/lib/cache/cache-lock-crossproc.test.ts
@@ -127,7 +127,13 @@ describe.runIf(hasBun)('orphaned lock left by a killed process', () => {
     child.kill('SIGINT');
     const outcome = await exited;
 
-    // the lock is gone rather than left for liveness detection to clean up
+    // the lock is gone rather than left for liveness detection to clean up.
+    // Polls briefly: `bun run` may interpose a wrapper process, so the observed
+    // exit can race the actual holder's cleanup by a few milliseconds.
+    const cleanupDeadline = Date.now() + 5_000;
+    while (fs.existsSync(keyLockPath()) && Date.now() < cleanupDeadline) {
+      await sleep(25);
+    }
     expect(fs.existsSync(keyLockPath())).toBe(false);
     // and Ctrl+C still ends the process (re-raised, not swallowed)
     expect(outcome.signal === 'SIGINT' || outcome.code === 130).toBe(true);


### PR DESCRIPTION
Two unrelated tests flaked in CI on 2026-08-07, both test-only fixes:

- **nextjs fifo-sources**: "never reads or watches FIFO sources..." hit vitest's default 5s timeout (5083ms) on a slow runner; the first import of next-env-compat pays the transform cost. Both tests in the suite now have an explicit 30s timeout.
- **varlock cache-lock-crossproc**: the SIGINT test asserted the lock dir was gone immediately after observing the child's exit. `bun run` can interpose a wrapper process, so the observed exit can race the actual holder's cleanup. The assertion now polls for up to 5s before failing.