### PR TITLE
docs: correct third-party plugin support on plugins overview page

### DIFF
--- a/packages/varlock-website/src/content/docs/plugins/overview.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/overview.mdx
@@ -8,7 +8,7 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 Plugins allow extending the functionality of Varlock. See the [plugins guide](/guides/plugins/) for more details on using plugins.
 
-For now, only official Varlock plugins under the `@varlock` npm scope are supported. We plan to support third-party plugins in the future, along with loading plugins from different sources (e.g., local files, git, npm/jsr, http, etc.).
+The plugins listed below are the official ones, published under the `@varlock` npm scope. Third-party plugins are also supported. You can load them from npm or from a local path, and the [plugins guide](/guides/plugins/#installation) covers authoring and installing your own. Loading plugins from other sources (git, http, jsr) is not supported yet.
 
 ## Password managers
 

--- a/packages/varlock-website/src/content/docs/plugins/overview.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/overview.mdx
@@ -8,7 +8,7 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 Plugins allow extending the functionality of Varlock. See the [plugins guide](/guides/plugins/) for more details on using plugins.
 
-The plugins listed below are the official ones, published under the `@varlock` npm scope. Third-party plugins are also supported. You can load them from npm or from a local path, and the [plugins guide](/guides/plugins/#installation) covers authoring and installing your own. Loading plugins from other sources (git, http, jsr) is not supported yet.
+The plugins listed below are the official ones, published under the `@varlock` npm scope. Third-party plugins are also supported. You can load them from npm or from a local path. See the [plugins guide](/guides/plugins/#installation) for more information. Loading plugins from other sources (git, http, jsr) is not supported yet.
 
 ## Password managers
 


### PR DESCRIPTION
The plugins overview page states that only `@varlock`-scoped plugins are supported and that third-party plugins are planned for the future. That contradicts the plugins guide, which documents authoring third-party plugins and loading them from npm or a local path today, with a one-time confirmation prompt for non-`@varlock` packages.

Since the overview is the page linked from the docs nav, anyone evaluating whether they can write a plugin lands on the inaccurate version first.

Updated the sentence to describe what actually works, and narrowed the "not yet supported" claim to the sources that genuinely aren't wired up (git, http, jsr).