### PR TITLE
Fix flaky randomString bias test

### DIFF
--- a/.bumpy/fix-flaky-randomstring-test.md
+++ b/.bumpy/fix-flaky-randomstring-test.md
@@ -1,0 +1,5 @@
+---
+varlock: none
+---
+
+true

--- a/packages/varlock/src/env-graph/test/random-resolvers.test.ts
+++ b/packages/varlock/src/env-graph/test/random-resolvers.test.ts
@@ -155,7 +155,14 @@ describe('randomString()', () => {
   });
 
   it('produces unbiased output for charsets that do not divide 256', async () => {
-    // 62-char default charset → 256 % 62 = 8 → without rejection sampling, chars 0-7 would be ~1.56x more likely
+    // 62-char default charset: 256 = 4*62 + 8, so naive `byte % 62` would map 5 byte
+    // values (instead of 4) onto each of the first 8 charset chars, making them 1.25x
+    // more likely. Rather than checking each char count (too noisy at any reasonable
+    // sample size), check the aggregate count of those 8 chars:
+    //   unbiased: n * 8/62  ≈ 1290 (stddev ~33.5)
+    //   biased:   n * 40/256 = 1562
+    // A threshold of 1425 sits ~4 stddevs from both, so it catches modulo bias
+    // reliably while false failures are astronomically unlikely (~1 in 30k runs).
     const g = new EnvGraph();
     const source = new DotEnvFileDataSource('.env.schema', {
       overrideContents: outdent`
@@ -171,13 +178,15 @@ describe('randomString()', () => {
     const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
     const counts = new Map<string, number>();
     for (const c of val) counts.set(c, (counts.get(c) ?? 0) + 1);
-    const expectedAvg = val.length / charset.length; // ~161
-    // each char should land within ±30% of expected (very loose bound; statistical safety)
+    // sanity: every charset char should appear (P(missing) ≈ e^-161 per char)
     for (const c of charset) {
-      const observed = counts.get(c) ?? 0;
-      expect(observed).toBeGreaterThan(expectedAvg * 0.7);
-      expect(observed).toBeLessThan(expectedAvg * 1.3);
+      expect(counts.get(c) ?? 0).toBeGreaterThan(0);
     }
+    let firstEightTotal = 0;
+    for (const c of charset.slice(0, 8)) {
+      firstEightTotal += counts.get(c) ?? 0;
+    }
+    expect(firstEightTotal).toBeLessThan(1425);
   });
 
   it('rejects zero length', async () => {


### PR DESCRIPTION
The unbiased-output test for randomString() checked every charset char against a +/-30% bound. At n=10000 that bound sits at ~3.8 sigma, and with 62 chars checked on both tails it fails by pure chance roughly once every 130 runs (seen in CI: 210 vs 209.68). The old assertion also could not catch the modulo bias it guards against: a naive byte % 62 puts over-represented chars at ~195 counts, under the old 209.7 ceiling.

Replaced it with an aggregate count of the first 8 charset chars, exactly the ones modulo bias inflates. Unbiased sampling lands around 1290 (stddev ~33.5), biased around 1562, so the 1425 threshold is ~4 sigma from both: false failures drop to ~1 in 30k runs while a simulated biased sampler trips it in 20/20 trials. Kept a loose sanity check that every charset char appears at least once.

No resolver changes; the implementation's rejection sampling was already correct.