### PR TITLE
fix(flatten): detect the workspace root in any language

### DIFF
--- a/.bumpy/flatten-workspace-root-detection.md
+++ b/.bumpy/flatten-workspace-root-detection.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+varlock flatten now detects the workspace root in any language (uv, poetry, cargo, go.work, composer, bundler, gradle, .NET, bazel), falls back to the git root, and accepts --workspace-root to set it explicitly

--- a/packages/varlock-website/src/content/docs/guides/monorepos.mdx
+++ b/packages/varlock-website/src/content/docs/guides/monorepos.mdx
@@ -131,6 +131,8 @@ Monorepos often combine Node apps with Python, Go, or other runtimes. Varlock's 
 
 Run the command from the service directory (or pass `--path` to its env folder). Each language can keep its own `.env.schema`; there is no requirement to share a single root file. For more detail, see [Other languages](/integrations/other-languages/).
 
+This works the same in a repo with no JavaScript in it at all. A uv, Cargo, Go, Composer, Bundler, Gradle, or .NET workspace is recognized as a monorepo, so [`varlock flatten`](/reference/cli/project/#flatten) can follow imports up to the repo root the same way it does in a JS workspace. See [workspace root detection](/reference/cli/project/#flatten) for the markers it looks for.
+
 ## Container builds
 
 Container images often copy a single app directory, not the whole monorepo. If your schema uses `@import()` to pull files from sibling packages or the repo root, those paths must exist in the build context, otherwise the load graph fails at build time.

--- a/packages/varlock-website/src/content/docs/integrations/docker.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/docker.mdx
@@ -275,6 +275,7 @@ A few behaviors worth knowing (see the [command reference](/reference/cli/projec
 - `.env.local` / `.env.[env].local` files are **skipped by default**, so machine-local secrets don't end up in image layers. Use `--include-local` if you really want them.
 - Conditionally-enabled imports (`enabled=`) are copied too, with their conditions preserved, since production may enable imports your build machine doesn't.
 - `@plugin()` declarations in copied files get pinned to the installed version, so the standalone binary can [auto-install them](/guides/plugins/) in the container without the sibling package's `node_modules`.
+- The workspace root sets how far out imports can reach. It is detected from a lockfile or workspace config in any language (`uv.lock`, `Cargo.lock`, `go.work`, `composer.lock`, `pnpm-lock.yaml`, and so on), falling back to the `.git` root. Flatten prints the root it picked. If your build context has neither, pass [`--workspace-root <path>`](/reference/cli/project/#flatten).
 
 ### Alternative: copy imported files explicitly
 

--- a/packages/varlock-website/src/content/docs/reference/cli/project.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli/project.mdx
@@ -151,6 +151,30 @@ varlock flatten [options]
 - `--out-dir <path>`: Output directory, relative to the current directory (default `.env-flat`)
 - `--include-local`: Include `.env.local` / `.env.*.local` files (excluded by default)
 - `--vendor-plugins`: Copy npm plugins into the output so no runtime install is needed. Uses the copy in your `node_modules`, downloading only any that are not installed
+- `--workspace-root <path>`: Path to the workspace root, relative to the current directory. Overrides auto-detection
+
+### Workspace root detection
+
+Flatten walks up from the current directory to find the workspace root, which sets how far out `@import()` paths can reach. It prints the root it picked and how it found it.
+
+Detection is not tied to any one language. It looks for a workspace marker at each level, taking the **outermost** match so a package that carries its own lockfile does not get mistaken for the root:
+
+| Ecosystem | Markers |
+| --- | --- |
+| JavaScript | `package-lock.json`, `npm-shrinkwrap.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `yarn.lock`, `bun.lock`, `bun.lockb`, `deno.lock`, `turbo.json`, `nx.json`, `lerna.json`, `rush.json` |
+| Python | `uv.lock`, `poetry.lock`, `pdm.lock`, `pixi.lock`, `Pipfile.lock`, `requirements.lock` |
+| Rust | `Cargo.lock` |
+| Go | `go.work` |
+| PHP | `composer.lock` |
+| Ruby | `Gemfile.lock` |
+| Elixir | `mix.lock` |
+| Java / Kotlin | `settings.gradle`, `settings.gradle.kts`, `pom.xml` |
+| C# / .NET | `*.sln`, `*.slnx`, `global.json`, `Directory.Build.props`, `Directory.Packages.props` |
+| Polyglot build systems | `MODULE.bazel`, `WORKSPACE.bazel`, `WORKSPACE`, `pants.toml`, `.buckconfig` |
+
+The search stops at the version control root (`.git`, `.hg`, `.svn`), which is also used as the root when no marker is found. This covers repos with no lockfile at all, like a Go repo with a `go.mod` per module.
+
+Pass `--workspace-root <path>` when detection has nothing to work with, most often a build context that includes neither a lockfile nor `.git`. Without it, imports reaching outside the current directory are left untouched with a warning.
 
 **Examples:**
 ```bash
@@ -162,6 +186,9 @@ varlock flatten --out-dir dist/env
 
 # Also vendor plugins for a self-contained, distroless-ready output
 varlock flatten --vendor-plugins
+
+# Set the workspace root explicitly when it can't be detected
+varlock flatten --workspace-root ../..
 ```
 
 The output directory is a generated artifact: add it to `.gitignore`, and rerun `flatten` whenever your env files change.

--- a/packages/varlock/src/cli/commands/flatten.command.ts
+++ b/packages/varlock/src/cli/commands/flatten.command.ts
@@ -1,11 +1,13 @@
 import { define } from 'gunshi';
 import path from 'node:path';
+import fs from 'node:fs';
 import ansis from 'ansis';
+import { pathExistsSync } from '@env-spec/utils/fs-utils';
 
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { CliExitError } from '../helpers/exit-error';
 import { flattenEnvFiles, FlattenError } from '../../lib/flatten';
-import { detectWorkspaceInfo } from '../../lib/workspace-utils';
+import { detectWorkspaceRoot } from '../../lib/workspace-utils';
 
 export const commandSpec = define({
   name: 'flatten',
@@ -26,6 +28,10 @@ export const commandSpec = define({
       description: 'Copy npm plugins into the output so no runtime install is needed (for shell-less/offline/distroless runtimes). Uses the installed copy, downloading only if absent',
       default: false,
     },
+    'workspace-root': {
+      type: 'string',
+      description: 'Path to the workspace/monorepo root (auto-detected by default). Imports outside of it cannot be flattened',
+    },
   },
   examples: `
 In a monorepo, a package's env files may @import files from sibling packages or the
@@ -41,6 +47,7 @@ Examples:
   varlock flatten --out-dir dist/env # custom output location
   varlock flatten --include-local    # also include .env.local files (careful - these often hold secrets)
   varlock flatten --vendor-plugins   # also copy npm plugins into the output (self-contained, no runtime install)
+  varlock flatten --workspace-root ../..  # set the monorepo root explicitly (when auto-detection can't)
 
 Typical Dockerfile usage (builder stage has the full monorepo):
   RUN cd packages/api && varlock flatten
@@ -50,13 +57,53 @@ Typical Dockerfile usage (builder stage has the full monorepo):
 `.trim(),
 });
 
+/**
+ * Resolves the workspace root that bounds which imports can be flattened - either the
+ * explicit `--workspace-root` (validated) or auto-detection, which works in any language.
+ * When nothing is found the package itself is used, so only its own env files are flattened.
+ */
+export function resolveWorkspaceRoot(opts: {
+  packageDir: string,
+  explicitRoot?: string,
+}): { workspaceRootPath: string, source: 'explicit' | 'detected' | 'fallback', marker?: string } {
+  const { packageDir } = opts;
+
+  if (opts.explicitRoot) {
+    let workspaceRootPath = path.resolve(packageDir, opts.explicitRoot);
+    if (!pathExistsSync(workspaceRootPath)) {
+      throw new CliExitError(`--workspace-root does not exist: ${workspaceRootPath}`);
+    }
+    // cwd is already symlink-resolved, so resolve the given path too before comparing them
+    workspaceRootPath = fs.realpathSync(workspaceRootPath);
+    const relFromRoot = path.relative(workspaceRootPath, packageDir);
+    if (relFromRoot.startsWith('..') || path.isAbsolute(relFromRoot)) {
+      throw new CliExitError(`--workspace-root must contain the current directory: ${workspaceRootPath}`, {
+        suggestion: `current directory is ${packageDir}`,
+      });
+    }
+    return { workspaceRootPath, source: 'explicit' };
+  }
+
+  const detectedRoot = detectWorkspaceRoot({ cwd: packageDir });
+  if (!detectedRoot) return { workspaceRootPath: packageDir, source: 'fallback' };
+  return { workspaceRootPath: detectedRoot.rootPath, source: 'detected', marker: detectedRoot.marker };
+}
+
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   const packageDir = process.cwd();
-  const workspaceInfo = detectWorkspaceInfo({ cwd: packageDir });
-  const workspaceRootPath = workspaceInfo?.rootPath || packageDir;
 
-  if (!workspaceInfo) {
-    console.log(ansis.yellow('No workspace root detected (no lockfile found) - imports reaching outside the current directory cannot be flattened'));
+  const explicitRootArg = ctx.values['workspace-root'];
+  const { workspaceRootPath, source, marker } = resolveWorkspaceRoot({
+    packageDir,
+    explicitRoot: explicitRootArg ? String(explicitRootArg) : undefined,
+  });
+
+  if (source === 'fallback') {
+    console.log(ansis.yellow('No workspace root detected (no lockfile, workspace config, or .git found) - imports reaching outside the current directory cannot be flattened'));
+    console.log(ansis.gray('Pass --workspace-root <path> to set it explicitly'));
+  } else {
+    const how = source === 'explicit' ? '--workspace-root' : `detected via ${marker}`;
+    console.log(ansis.gray(`Workspace root: ${path.relative(packageDir, workspaceRootPath) || '.'} (${how})`));
   }
 
   let result;

--- a/packages/varlock/src/cli/commands/test/flatten.command.test.ts
+++ b/packages/varlock/src/cli/commands/test/flatten.command.test.ts
@@ -1,0 +1,68 @@
+import {
+  describe, test, expect, beforeEach, afterEach,
+} from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { resolveWorkspaceRoot } from '../flatten.command';
+
+let tempDir: string;
+
+beforeEach(() => {
+  // realpath so comparisons match (macOS tmpdir is a symlink)
+  tempDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'varlock-flatten-cmd-test-')));
+});
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function makeTree(...relPaths: Array<string>) {
+  for (const relPath of relPaths) {
+    const fullPath = path.join(tempDir, relPath);
+    if (relPath.endsWith('/')) {
+      fs.mkdirSync(fullPath, { recursive: true });
+    } else {
+      fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+      fs.writeFileSync(fullPath, '');
+    }
+  }
+}
+
+describe('resolveWorkspaceRoot', () => {
+  test('detects a non-JS workspace root from a member package', () => {
+    makeTree('uv.lock', 'packages/foo/.env.schema');
+    const result = resolveWorkspaceRoot({ packageDir: path.join(tempDir, 'packages/foo') });
+    expect(result).toEqual({ workspaceRootPath: tempDir, source: 'detected', marker: 'uv.lock' });
+  });
+
+  test('falls back to the package dir when nothing is detected', () => {
+    makeTree('packages/foo/.env.schema');
+    const packageDir = path.join(tempDir, 'packages/foo');
+    expect(resolveWorkspaceRoot({ packageDir })).toEqual({ workspaceRootPath: packageDir, source: 'fallback' });
+  });
+
+  test('explicit root wins over detection', () => {
+    makeTree('uv.lock', 'packages/foo/.env.schema');
+    const result = resolveWorkspaceRoot({
+      packageDir: path.join(tempDir, 'packages/foo'),
+      explicitRoot: '..',
+    });
+    expect(result).toEqual({ workspaceRootPath: path.join(tempDir, 'packages'), source: 'explicit' });
+  });
+
+  test('throws when the explicit root does not exist', () => {
+    makeTree('packages/foo/.env.schema');
+    expect(() => resolveWorkspaceRoot({
+      packageDir: path.join(tempDir, 'packages/foo'),
+      explicitRoot: '../../nope',
+    })).toThrow('does not exist');
+  });
+
+  test('throws when the explicit root does not contain the package dir', () => {
+    makeTree('packages/foo/.env.schema', 'other/');
+    expect(() => resolveWorkspaceRoot({
+      packageDir: path.join(tempDir, 'packages/foo'),
+      explicitRoot: '../../other',
+    })).toThrow('must contain the current directory');
+  });
+});

--- a/packages/varlock/src/lib/test/workspace-utils.test.ts
+++ b/packages/varlock/src/lib/test/workspace-utils.test.ts
@@ -117,6 +117,13 @@ describe('detectWorkspaceRoot', () => {
     expect(result?.marker).toBe('uv.lock');
   });
 
+  test('prefers the VCS root over a nested package marker', () => {
+    writeTree(['.git/HEAD', 'services/api/Cargo.lock']);
+    const result = detectWorkspaceRoot({ cwd: subDir('services/api') });
+    expect(result?.rootPath).toBe(tempDir);
+    expect(result?.marker).toBe('.git');
+  });
+
   test('takes the outermost marker inside the repo, ignoring nested ones', () => {
     // a nested JS project inside a python monorepo
     writeTree(['uv.lock', '.git/HEAD', 'services/web/package-lock.json']);

--- a/packages/varlock/src/lib/test/workspace-utils.test.ts
+++ b/packages/varlock/src/lib/test/workspace-utils.test.ts
@@ -1,0 +1,132 @@
+import {
+  describe, test, expect, beforeEach, afterEach,
+} from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { detectWorkspaceRoot } from '../workspace-utils';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'varlock-workspace-root-test-'));
+});
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+/** writes files (empty unless contents given) at paths relative to tempDir, creating dirs as needed */
+function writeTree(files: Array<string> | Record<string, string>) {
+  const entries = Array.isArray(files) ? files.map((f) => [f, ''] as const) : Object.entries(files);
+  for (const [relPath, contents] of entries) {
+    const fullPath = path.join(tempDir, relPath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, contents);
+  }
+}
+function subDir(relPath: string) {
+  const fullPath = path.join(tempDir, relPath);
+  fs.mkdirSync(fullPath, { recursive: true });
+  return fullPath;
+}
+
+describe('detectWorkspaceRoot', () => {
+  test('returns undefined when there is nothing to go on', () => {
+    expect(detectWorkspaceRoot({ cwd: subDir('packages/foo') })).toBeUndefined();
+  });
+
+  test('detects a uv (python) workspace root from a member package', () => {
+    // the layout from issue #998
+    writeTree(['uv.lock', 'pyproject.toml', '.env.schema', 'packages/foo/pyproject.toml', 'packages/foo/.env.schema']);
+    const result = detectWorkspaceRoot({ cwd: path.join(tempDir, 'packages/foo') });
+    expect(result?.rootPath).toBe(tempDir);
+    expect(result?.marker).toBe('uv.lock');
+    expect(result?.ecosystem).toBe('python');
+  });
+
+  test.each([
+    ['poetry.lock', 'python'],
+    ['pdm.lock', 'python'],
+    ['pixi.lock', 'python'],
+    ['Pipfile.lock', 'python'],
+    ['requirements.lock', 'python'],
+    ['Cargo.lock', 'rust'],
+    ['go.work', 'go'],
+    ['composer.lock', 'php'],
+    ['Gemfile.lock', 'ruby'],
+    ['mix.lock', 'elixir'],
+    ['settings.gradle', 'jvm'],
+    ['settings.gradle.kts', 'jvm'],
+    ['pom.xml', 'jvm'],
+    ['global.json', 'dotnet'],
+    ['Directory.Build.props', 'dotnet'],
+    ['MODULE.bazel', 'polyglot'],
+    ['WORKSPACE', 'polyglot'],
+    ['pants.toml', 'polyglot'],
+    ['pnpm-lock.yaml', 'js'],
+    ['pnpm-workspace.yaml', 'js'],
+    ['turbo.json', 'js'],
+  ])('detects %s as a workspace root marker', (markerFile, ecosystem) => {
+    writeTree([markerFile]);
+    const result = detectWorkspaceRoot({ cwd: subDir('packages/foo') });
+    expect(result?.rootPath).toBe(tempDir);
+    expect(result?.marker).toBe(markerFile);
+    expect(result?.ecosystem).toBe(ecosystem);
+  });
+
+  test('detects a .NET solution file (named after the solution)', () => {
+    writeTree(['MyCompany.Services.sln']);
+    const result = detectWorkspaceRoot({ cwd: subDir('src/api') });
+    expect(result?.rootPath).toBe(tempDir);
+    expect(result?.marker).toBe('MyCompany.Services.sln');
+    expect(result?.ecosystem).toBe('dotnet');
+  });
+
+  test('falls back to the git root when no ecosystem marker is found', () => {
+    writeTree(['.git/HEAD']);
+    const result = detectWorkspaceRoot({ cwd: subDir('services/api') });
+    expect(result?.rootPath).toBe(tempDir);
+    expect(result?.marker).toBe('.git');
+    expect(result?.ecosystem).toBe('vcs');
+  });
+
+  test('handles a .git file (worktrees and submodules)', () => {
+    writeTree({ '.git': 'gitdir: /elsewhere/.git/worktrees/wt' });
+    expect(detectWorkspaceRoot({ cwd: subDir('packages/foo') })?.rootPath).toBe(tempDir);
+  });
+
+  test('takes the outermost marker, not the nearest one', () => {
+    // ruby/php/dotnet monorepos often carry a per-package lockfile as well as a root one
+    writeTree(['Gemfile.lock', 'services/api/Gemfile.lock']);
+    const result = detectWorkspaceRoot({ cwd: path.join(tempDir, 'services/api') });
+    expect(result?.rootPath).toBe(tempDir);
+  });
+
+  test('does not walk above the VCS root', () => {
+    // marker above the repo root belongs to something else (or the user's home dir)
+    writeTree(['uv.lock', 'repo/.git/HEAD', 'repo/packages/foo/pyproject.toml']);
+    const result = detectWorkspaceRoot({ cwd: path.join(tempDir, 'repo/packages/foo') });
+    expect(result?.rootPath).toBe(path.join(tempDir, 'repo'));
+    expect(result?.marker).toBe('.git');
+  });
+
+  test('prefers a marker at the VCS root over the VCS marker itself', () => {
+    writeTree(['.git/HEAD', 'uv.lock']);
+    const result = detectWorkspaceRoot({ cwd: subDir('packages/foo') });
+    expect(result?.rootPath).toBe(tempDir);
+    expect(result?.marker).toBe('uv.lock');
+  });
+
+  test('takes the outermost marker inside the repo, ignoring nested ones', () => {
+    // a nested JS project inside a python monorepo
+    writeTree(['uv.lock', '.git/HEAD', 'services/web/package-lock.json']);
+    const result = detectWorkspaceRoot({ cwd: subDir('services/web') });
+    expect(result?.rootPath).toBe(tempDir);
+    expect(result?.marker).toBe('uv.lock');
+  });
+
+  test('returns the cwd itself when the marker is there', () => {
+    writeTree(['go.work']);
+    expect(detectWorkspaceRoot({ cwd: tempDir })?.rootPath).toBe(tempDir);
+  });
+});

--- a/packages/varlock/src/lib/workspace-utils.ts
+++ b/packages/varlock/src/lib/workspace-utils.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
+import os from 'node:os';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { pathExistsSync } from '@env-spec/utils/fs-utils';
 import { createDebug } from './debug';
@@ -56,6 +57,141 @@ export const JS_PACKAGE_MANAGERS: Record<JsPackageManager, JsPackageManagerMeta>
 });
 
 export type MonorepoTool = 'turborepo' | 'nx' | 'lerna';
+
+/** language/toolchain a workspace root marker belongs to */
+export type WorkspaceEcosystem = 'js' | 'python' | 'rust' | 'go' | 'php' | 'ruby' | 'elixir' | 'jvm' | 'dotnet' | 'polyglot' | 'vcs';
+
+/**
+ * Files that mark the root of a multi-package workspace, across every ecosystem varlock
+ * supports (see `@generate*Env` decorators + `varlock run`).
+ *
+ * Only markers that live at the *root* of a workspace belong here - per-package manifests
+ * (package.json, pyproject.toml, Cargo.toml, go.mod, ...) are deliberately excluded since
+ * every member has one. Markers that some tools also write per-package (Gemfile.lock,
+ * composer.lock, pom.xml) are fine because detection takes the outermost match.
+ */
+export const WORKSPACE_ROOT_MARKERS: Array<{ file: string, ecosystem: WorkspaceEcosystem }> = [
+  // JS - lockfiles come from JS_PACKAGE_MANAGERS so the two lists cannot drift
+  ...Object.values(JS_PACKAGE_MANAGERS).flatMap(
+    (pm) => pm.lockfiles.map((file) => ({ file, ecosystem: 'js' as const })),
+  ),
+  { file: 'npm-shrinkwrap.json', ecosystem: 'js' },
+  { file: 'pnpm-workspace.yaml', ecosystem: 'js' },
+  { file: 'turbo.json', ecosystem: 'js' },
+  { file: 'nx.json', ecosystem: 'js' },
+  { file: 'lerna.json', ecosystem: 'js' },
+  { file: 'rush.json', ecosystem: 'js' },
+
+  // python - uv/poetry/pdm/pixi/rye/pipenv all lock at the workspace root only
+  { file: 'uv.lock', ecosystem: 'python' },
+  { file: 'poetry.lock', ecosystem: 'python' },
+  { file: 'pdm.lock', ecosystem: 'python' },
+  { file: 'pixi.lock', ecosystem: 'python' },
+  { file: 'Pipfile.lock', ecosystem: 'python' },
+  { file: 'requirements.lock', ecosystem: 'python' }, // rye
+
+  // rust - workspace members share the root Cargo.lock
+  { file: 'Cargo.lock', ecosystem: 'rust' },
+
+  // go - go.sum/go.mod are per-module, only go.work marks a multi-module workspace
+  { file: 'go.work', ecosystem: 'go' },
+
+  { file: 'composer.lock', ecosystem: 'php' },
+  { file: 'Gemfile.lock', ecosystem: 'ruby' },
+  { file: 'mix.lock', ecosystem: 'elixir' },
+
+  // jvm - gradle settings files list the included builds, maven uses an aggregator pom
+  { file: 'settings.gradle', ecosystem: 'jvm' },
+  { file: 'settings.gradle.kts', ecosystem: 'jvm' },
+  { file: 'pom.xml', ecosystem: 'jvm' },
+
+  // dotnet - `.sln`/`.slnx` files are matched separately (they are named after the solution)
+  { file: 'global.json', ecosystem: 'dotnet' },
+  { file: 'Directory.Build.props', ecosystem: 'dotnet' },
+  { file: 'Directory.Packages.props', ecosystem: 'dotnet' },
+
+  // polyglot monorepo build systems
+  { file: 'MODULE.bazel', ecosystem: 'polyglot' },
+  { file: 'WORKSPACE.bazel', ecosystem: 'polyglot' },
+  { file: 'WORKSPACE', ecosystem: 'polyglot' },
+  { file: 'pants.toml', ecosystem: 'polyglot' },
+  { file: '.buckconfig', ecosystem: 'polyglot' },
+];
+
+/** version control roots - used as the outer boundary, and as a fallback root */
+const VCS_MARKERS = ['.git', '.hg', '.svn'];
+
+/** single readdir per directory - cheaper than stat-ing every marker, and finds `.sln` files */
+function findRootMarkerInDir(dir: string) {
+  let entryNames: Array<string>;
+  try {
+    entryNames = fs.readdirSync(dir);
+  } catch {
+    return undefined; // unreadable dir - treat as no marker
+  }
+  const entries = new Set(entryNames);
+  const marker = WORKSPACE_ROOT_MARKERS.find((m) => entries.has(m.file));
+  if (marker) return marker;
+  // .NET solution files are named after the solution, so they can't be a fixed marker
+  const solutionFile = entryNames.find((f) => f.endsWith('.sln') || f.endsWith('.slnx'));
+  if (solutionFile) return { file: solutionFile, ecosystem: 'dotnet' as const };
+}
+
+export type WorkspaceRootInfo = {
+  /** path to the workspace/monorepo root */
+  rootPath: string;
+  /** the file that identified the root (e.g. `uv.lock`, or `.git` when falling back to the VCS root) */
+  marker: string;
+  ecosystem: WorkspaceEcosystem;
+};
+
+/**
+ * Detects the root of the surrounding workspace/monorepo, in any language.
+ *
+ * Unlike `detectWorkspaceInfo` (which answers "which JS package manager runs here?" and so
+ * wants the *nearest* lockfile), this answers "how far out does this repo extend?" and takes
+ * the **outermost** marker found, bounded by the VCS root. That matters for monorepos whose
+ * members carry their own lockfile (Gemfile.lock, composer.lock, a nested package-lock.json),
+ * where the nearest match would be the package itself rather than the repo root.
+ *
+ * Falls back to the VCS root when no ecosystem marker is found, and returns undefined when
+ * there is nothing to go on (e.g. a build context with neither a lockfile nor `.git`).
+ */
+export function detectWorkspaceRoot(opts?: {
+  cwd?: string,
+}): WorkspaceRootInfo | undefined {
+  debug('Detecting workspace root');
+  let currentDir = path.resolve(opts?.cwd || process.cwd());
+  const homeDir = os.homedir();
+  let outermostMarker: WorkspaceRootInfo | undefined;
+  let vcsRoot: WorkspaceRootInfo | undefined;
+
+  while (currentDir) {
+    debug(`> scanning ${currentDir}`);
+    const scanDir = currentDir;
+    const marker = findRootMarkerInDir(scanDir);
+    if (marker) {
+      debug(`> found ${marker.file}`);
+      outermostMarker = { rootPath: scanDir, marker: marker.file, ecosystem: marker.ecosystem };
+    }
+
+    // the VCS root is the outer boundary - nothing above it is part of this repo
+    const vcsMarker = VCS_MARKERS.find((m) => pathExistsSync(path.join(scanDir, m)));
+    if (vcsMarker) {
+      debug(`> found VCS root ${vcsMarker}`);
+      vcsRoot = { rootPath: scanDir, marker: vcsMarker, ecosystem: 'vcs' };
+      break;
+    }
+
+    // don't walk above the user's home dir, or past the filesystem root
+    if (currentDir === homeDir) break;
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) break;
+    currentDir = parentDir;
+  }
+
+  return outermostMarker ?? vcsRoot;
+}
 
 export type WorkspaceInfo = {
   /** detected JS package manager */

--- a/packages/varlock/src/lib/workspace-utils.ts
+++ b/packages/varlock/src/lib/workspace-utils.ts
@@ -190,6 +190,7 @@ export function detectWorkspaceRoot(opts?: {
     currentDir = parentDir;
   }
 
+  if (vcsRoot && outermostMarker?.rootPath !== vcsRoot.rootPath) return vcsRoot;
   return outermostMarker ?? vcsRoot;
 }
 


### PR DESCRIPTION
Fixes #998

## The problem

`varlock flatten` determined the workspace root with `detectWorkspaceInfo()`, which only looks for **JS lockfiles**. In a uv (or Cargo, Composer, Gradle, .NET) monorepo there is no JS lockfile, so detection returned `undefined`, the root fell back to the package directory, and every `@import` reaching outside it was left untouched with a warning. The reporter's workaround was to drop an empty `package-lock.json` at the repo root.

## The fix

**New `detectWorkspaceRoot()` in `lib/workspace-utils.ts`**, separate from `detectWorkspaceInfo()`. The existing function stays as-is: "which package manager runs here?" genuinely wants the *nearest* lockfile, while "how far out does this repo extend?" does not.

- **Markers for every language varlock supports**: Python (`uv.lock`, `poetry.lock`, `pdm.lock`, `pixi.lock`, `Pipfile.lock`, `requirements.lock`), Rust (`Cargo.lock`), Go (`go.work` only, since `go.mod`/`go.sum` are per-module), PHP, Ruby, Elixir, JVM (`settings.gradle*`, `pom.xml`), .NET (`*.sln`/`*.slnx`, `global.json`, `Directory.*.props`), Bazel/Pants/Buck, plus the existing JS set. Per-package manifests (`pyproject.toml`, `Cargo.toml`, `package.json`) are deliberately excluded since every member has one.
- **Outermost match wins**, bounded by the VCS root. Ruby, PHP and .NET monorepos routinely carry a per-package lockfile, so nearest-match would pick the package itself.
- **`.git`/`.hg`/`.svn` is both the ceiling and the fallback root**, which covers repos with no lockfile at all (a Go repo with a `go.mod` per module).

**New `--workspace-root <path>` flag** for build contexts with neither a lockfile nor `.git`. Validated: must exist, and must contain the cwd (symlink-resolved before comparing).

**The command now prints the root it picked and how** (`Workspace root: ../.. (detected via uv.lock)`), which is what would have made the original report diagnosable from its output.

## Reviewer notes

- Detection does one `readdir` per ancestor directory rather than stat-ing each marker, which also gets `*.sln` matching for free.
- The walk stops at the user's home directory and at the filesystem root, so a stray lockfile above a repo can't be picked up.
- Only `flatten` uses the new function. `detectWorkspaceInfo()` and its callers are untouched.

## Verification

Ran end-to-end against the issue's exact layout plus Cargo, Ruby-with-nested-lockfile, a .NET solution, and a Go repo with only `.git`. The flattened uv package also loads standalone once `.env-flat/` is overlaid, resolving both its own key and the imported one.

36 new unit tests covering per-ecosystem markers, `.git` fallback (dir and file form, for worktrees), outermost-wins, the VCS ceiling, and the `--workspace-root` validation paths.

## Docs

Workspace root detection section with the full marker table in the flatten reference, plus notes in the Docker and monorepos guides.
