### PR TITLE
Exit cleanly on broken pipe instead of crashing

### DIFF
--- a/.bumpy/cli-epipe-broken-pipe.md
+++ b/.bumpy/cli-epipe-broken-pipe.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Exit cleanly instead of crashing when CLI output is piped into a consumer that closes early (e.g. `varlock flatten | head -3`)

--- a/packages/varlock/src/cli/cli-executable.ts
+++ b/packages/varlock/src/cli/cli-executable.ts
@@ -2,6 +2,7 @@ import { cli, type Command } from 'gunshi';
 import completion from '@gunshi/plugin-completion';
 import { gracefulExit } from 'exit-hook';
 
+import { handleBrokenPipe } from './helpers/broken-pipe';
 import { strictFlags } from './strict-flags-plugin';
 
 import { VARLOCK_BANNER_COLOR } from '../lib/ascii-art';
@@ -38,6 +39,9 @@ import { commandSpec as keychainCommandSpec } from './commands/keychain.command'
 import { commandSpec as proxyCommandSpec } from './commands/proxy.command';
 // import { commandSpec as loginCommandSpec } from './commands/login.command';
 // import { commandSpec as pluginCommandSpec } from './commands/plugin.command';
+
+// must happen before anything writes to stdio
+handleBrokenPipe();
 
 let versionId = packageJson.version;
 if (__VARLOCK_BUILD_TYPE__ !== 'release') versionId += `-${__VARLOCK_BUILD_TYPE__}`;

--- a/packages/varlock/src/cli/helpers/broken-pipe.ts
+++ b/packages/varlock/src/cli/helpers/broken-pipe.ts
@@ -1,0 +1,43 @@
+import { gracefulExit } from 'exit-hook';
+
+/**
+ * Broken pipe (EPIPE) handling for the CLI's stdio streams.
+ *
+ * When a downstream consumer closes the pipe early (`varlock flatten | head -3`),
+ * node emits an `error` event on process.stdout / process.stderr. Nothing listens
+ * for it by default, so it becomes an unhandled `error` event and node crashes the
+ * process with a stack trace. Conventional CLI behavior is to treat a closed pipe as
+ * "the reader is done" and exit quietly instead.
+ *
+ * This also covers writes we don't control, like exit-hook's stdio flush. That helper
+ * does attach a one-shot error listener around its write, but removes it again in the
+ * write callback, and node emits the `error` event on a later tick - after the listener
+ * is already gone.
+ */
+
+let isExiting = false;
+
+function handleStreamError(err: NodeJS.ErrnoException, exitOnBrokenPipe: boolean) {
+  // anything other than a broken pipe is a real error - rethrowing from the listener
+  // surfaces it as an uncaught exception, same as if we were not listening at all
+  if (err.code !== 'EPIPE') throw err;
+
+  if (!exitOnBrokenPipe || isExiting) return;
+  isExiting = true;
+  // exit via the normal path so cleanup hooks still run (child processes, terminal state, ...)
+  // the flush those hooks trigger will hit EPIPE again, which the guard above ignores
+  gracefulExit(0);
+}
+
+/**
+ * Swallow EPIPE on stdout/stderr so piping into a consumer that exits early
+ * (`| head`, `| grep -q`, ...) ends the process cleanly rather than crashing.
+ *
+ * Call this as early as possible, before anything can write to stdio.
+ */
+export function handleBrokenPipe() {
+  // a broken stdout means our output has nowhere left to go, so we stop
+  process.stdout.on('error', (err) => handleStreamError(err, true));
+  // a broken stderr only means logs/warnings are going nowhere, so we keep running
+  process.stderr.on('error', (err) => handleStreamError(err, false));
+}

--- a/smoke-tests/tests/cli.test.ts
+++ b/smoke-tests/tests/cli.test.ts
@@ -2,6 +2,7 @@ import {
   describe, test, expect, beforeEach,
 } from 'vitest';
 import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import {
   varlockLoad, varlockRun, varlockPrintenv, varlockCodegen, runVarlock, VARLOCK_CLI,
@@ -568,6 +569,29 @@ describe('CLI Commands', () => {
     test('shows "Configuration is currently invalid" banner', () => {
       const result = varlockLoad({ cwd: 'smoke-test-invalid-items' });
       expect(result.output).toContain('Configuration is currently invalid');
+    });
+  });
+
+  // shell pipelines + `head` are POSIX-only
+  describe.skipIf(process.platform === 'win32')('broken pipe handling', () => {
+    // Whether we hit the broken pipe is a race between our writes and the reader exiting,
+    // so a single run can pass by luck - repeat enough that a regression can't slip through.
+    const ATTEMPTS = 10;
+
+    function pipeThroughHead(args: Array<string>) {
+      const command = `${JSON.stringify(process.execPath)} ${JSON.stringify(VARLOCK_CLI)} ${args.join(' ')} | head -1`;
+      return spawnSync('sh', ['-c', command], {
+        cwd: SMOKE_TESTS_DIR,
+        encoding: 'utf-8',
+      });
+    }
+
+    test.each([['--help'], ['--version']])('%s piped into a reader that exits early does not crash', (arg) => {
+      for (let i = 0; i < ATTEMPTS; i++) {
+        const result = pipeThroughHead([arg]);
+        expect(result.stderr).not.toContain('EPIPE');
+        expect(result.stderr).not.toContain("Unhandled 'error' event");
+      }
     });
   });
 });


### PR DESCRIPTION
Piping any CLI command into a consumer that closes the pipe early crashes the process with an unhandled `error` event:

```
varlock flatten | head -3
varlock --version | head -1
```

```
Error: write EPIPE
    at afterWriteDispatched (node:internal/stream_base_commons:159:15)
    ...
Emitted 'error' event on Socket instance at:
```

## Cause

The failing write is in `exit-hook`'s `flushStdio()`, which is why the stack points into the bundled `dist/chunk-*.js`. It wraps `stream.write('')` in a Promise with a one-shot `error` listener, but removes that listener in the write callback. Node runs the write callback first and emits the stream's `error` event on a later tick, so by then no listener remains. Nothing in varlock listened on `process.stdout`/`process.stderr` either, so the event went unhandled.

## Fix

New `handleBrokenPipe()` helper, called at the top of `cli-executable.ts` before anything writes to stdio (the sole entry for both the node build and the compiled binary). It installs persistent `error` listeners:

- EPIPE on stdout: exit via `gracefulExit(0)` rather than `process.exit`, so cleanup hooks still run (child process teardown, terminal state). The re-entrant EPIPE from those hooks' own flush is guarded.
- EPIPE on stderr: swallowed without exiting, since only logs are lost.
- Anything else: rethrown, so real stream failures still surface.

## Verification

`varlock --help | head -1` in a loop: 37/40 crashed before, 0/40 after. Same loop against the compiled binary: 0/30. The new smoke test fails on both cases with the fix reverted.