### PR TITLE
docs: Cloudflare page tsconfig include note for generated types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Docs content lives in `packages/varlock-website/src/content/docs/` (`.mdx`). Whe
 - Avoid marketing and AI-flavored filler: `seamless`, `comprehensive`, `powerful`, `robust`, `leverage`, `out of the box`, `by design`, `effortless`, `unlock` (metaphorical), "whether you need X, Y, or Z", "instead of wrestling with", and similar. Say what the thing does plainly.
 - Be concise, but never at the cost of completeness. Keep every flag, command, caveat, and link a user or their agent needs to stay unblocked.
 - Never edit code fences, `ansi`/`diff` blocks, generated fixtures, frontmatter structure, or MDX component markup for tone. Prose only.
-- Run `bun run --filter varlock-website astro build` to confirm the docs still build after non-trivial edits.
+- Run `bun run --filter @varlock/website build` to confirm the docs still build after non-trivial edits (the package is named `@varlock/website`, not `varlock-website`).
 
 ## Linting
 

--- a/packages/varlock-website/src/content/docs/integrations/cloudflare.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/cloudflare.mdx
@@ -223,6 +223,37 @@ On Unix, secrets are passed to wrangler commands via a named pipe (FIFO) and nev
 Generates Cloudflare Worker types (the `Env` interface) including all varlock-managed environment variables, so your `env.MY_VAR` access is properly typed alongside other Cloudflare bindings (KV, D1, etc.).
 </div>
 </div>
+
+----
+
+## Type-safety and IntelliSense
+
+To enable type-safety and IntelliSense for `ENV`, enable the [`@generateTsTypes` root decorator](/reference/root-decorators/#generatetstypes) in your `.env.schema`. If your schema was created using `varlock init`, it will include this by default.
+
+```diff lang="env-spec" title=".env.schema"
++# @generateTsTypes(path='env.d.ts')
+# ---
+# your config items...
+```
+
+:::caution[Add the generated file to your tsconfig]
+Worker projects scaffolded by `npm create cloudflare` ship a `tsconfig.json` whose `include` list only covers `src` and the wrangler-generated `worker-configuration.d.ts`. The generated `env.d.ts` sits at the project root, so TypeScript never loads it and `ENV` stays untyped. Add it to the `include` array:
+
+```diff lang="json" title="tsconfig.json"
+{
+  "include": [
++    "env.d.ts",
+    "worker-configuration.d.ts",
+    "src/**/*.ts"
+  ]
+}
+```
+:::
+
+This types the `ENV` object. For the native `env` parameter in your fetch handler, use [`varlock-wrangler types`](#varlock-wrangler-types) to generate an `Env` interface that includes your varlock-managed vars alongside your other Cloudflare bindings.
+
+----
+
 ## Log redaction and leak prevention
 
 Both integration approaches automatically enable **log redaction** (sensitive values are masked in console output) and **response leak detection** (responses are scanned for accidentally exposed secrets). These are enabled by default and can be disabled in your `.env.schema` using root decorators:
@@ -345,6 +376,10 @@ Your worker is missing the Node.js compatibility layer. Add `nodejs_compat` to `
 ### `.dev.vars` conflicts with the Vite plugin
 
 Delete `.dev.vars` and `.dev.vars.<environment>` files when using the Vite plugin or `varlock-wrangler dev`. Varlock owns env injection; leftover Wrangler env files cause hard errors.
+
+### `Property 'SOMEVAR' does not exist on type 'TypedEnvSchema'`
+
+The generated types file is not being loaded by TypeScript. Make sure the [`@generateTsTypes` root decorator](/reference/root-decorators/#generatetstypes) is enabled in your `.env.schema`, and that the generated file (usually `env.d.ts`) is listed in your `tsconfig.json` `include` array. See [Type-safety and IntelliSense](#type-safety-and-intellisense) above.
 
 ### Vars or secrets missing after deploy
 

--- a/packages/varlock-website/src/content/docs/integrations/cloudflare.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/cloudflare.mdx
@@ -236,8 +236,8 @@ To enable type-safety and IntelliSense for `ENV`, enable the [`@generateTsTypes`
 # your config items...
 ```
 
-:::caution[Add the generated file to your tsconfig]
-Worker projects scaffolded by `npm create cloudflare` ship a `tsconfig.json` whose `include` list only covers `src` and the wrangler-generated `worker-configuration.d.ts`. The generated `env.d.ts` sits at the project root, so TypeScript never loads it and `ENV` stays untyped. Add it to the `include` array:
+:::caution[Not seeing types on `ENV`?]
+If `ENV` stays untyped after the file is generated, TypeScript probably isn't loading it. Worker templates scaffolded by `npm create cloudflare` typically use an explicit `include` list that won't pick up a generated `env.d.ts` at the project root. Add it to the `include` array of the tsconfig that covers the code reading `ENV`:
 
 ```diff lang="json" title="tsconfig.json"
 {
@@ -248,6 +248,8 @@ Worker projects scaffolded by `npm create cloudflare` ship a `tsconfig.json` who
   ]
 }
 ```
+
+Some framework templates split their TypeScript setup into multiple referenced configs (for example `tsconfig.app.json` and `tsconfig.worker.json`). In that layout, editing the root config has no effect; add `env.d.ts` to whichever config owns the source files where you use `ENV` (or both).
 :::
 
 This types the `ENV` object. For the native `env` parameter in your fetch handler, use [`varlock-wrangler types`](#varlock-wrangler-types) to generate an `Env` interface that includes your varlock-managed vars alongside your other Cloudflare bindings.
@@ -379,7 +381,7 @@ Delete `.dev.vars` and `.dev.vars.<environment>` files when using the Vite plugi
 
 ### `Property 'SOMEVAR' does not exist on type 'TypedEnvSchema'`
 
-The generated types file is not being loaded by TypeScript. Make sure the [`@generateTsTypes` root decorator](/reference/root-decorators/#generatetstypes) is enabled in your `.env.schema`, and that the generated file (usually `env.d.ts`) is listed in your `tsconfig.json` `include` array. See [Type-safety and IntelliSense](#type-safety-and-intellisense) above.
+The generated types file is not being loaded by TypeScript. Make sure the [`@generateTsTypes` root decorator](/reference/root-decorators/#generatetstypes) is enabled in your `.env.schema`, and that the generated file (usually `env.d.ts`) is listed in the `include` array of the tsconfig that covers the code where the error appears. See [Type-safety and IntelliSense](#type-safety-and-intellisense) above.
 
 ### Vars or secrets missing after deploy
 


### PR DESCRIPTION
Dogfooding a Workers project surfaced a gap: the generated `env.d.ts` must be picked up by your tsconfig before the `ENV` TypedEnvSchema augmentation works, and the Cloudflare integration page never mentioned type generation at all. Worker templates scaffolded by `npm create cloudflare` typically use an explicit `include` list that won't pick up a generated file at the project root.

- Add a "Type-safety and IntelliSense" section to the Cloudflare integration page (matching the other integration pages), with a conditional caution: if `ENV` stays untyped, add `env.d.ts` to the `include` of the tsconfig covering the code that reads it, including a note for framework templates that split into referenced configs (`tsconfig.app.json` / `tsconfig.worker.json`). Also points to `varlock-wrangler types` for the native `env` parameter
- Add a matching troubleshooting entry for the `Property 'SOMEVAR' does not exist on type 'TypedEnvSchema'` error
- Fix the stale website build command in AGENTS.md (`--filter varlock-website` -> `--filter @varlock/website`)