### PR TITLE
Stop UPX-packing the Linux local-encryption binaries

### DIFF
--- a/.bumpy/no-upx-linux-binaries.md
+++ b/.bumpy/no-upx-linux-binaries.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Ship the Linux local-encryption helper binaries uncompressed. UPX packing caused antivirus false positives (Defender Wacatac.C!ml) during install.

--- a/.github/workflows/build-native-rust.yaml
+++ b/.github/workflows/build-native-rust.yaml
@@ -85,11 +85,6 @@ jobs:
         if: contains(matrix.target, 'musl')
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
-      - name: Install UPX
-        if: contains(matrix.os, 'ubuntu')
-        shell: bash
-        run: sudo apt-get update && sudo apt-get install -y upx-ucl
-
       - name: Build release binary
         working-directory: packages/encryption-binary-rust
         run: cargo build --release --target ${{ matrix.target }}
@@ -154,25 +149,15 @@ jobs:
           ARTIFACT_DIR="native-bins/${{ matrix.native-bin-subdir }}"
           mkdir -p "$ARTIFACT_DIR"
           cp "packages/encryption-binary-rust/target/${{ matrix.target }}/release/${{ matrix.binary-name }}" "$ARTIFACT_DIR/"
-          echo "=== Binary info (before UPX) ==="
-          RAW_SIZE=$(stat --format=%s "$ARTIFACT_DIR/${{ matrix.binary-name }}" 2>/dev/null || stat -f%z "$ARTIFACT_DIR/${{ matrix.binary-name }}")
-          echo "Size: $(( RAW_SIZE / 1024 )) KB ($RAW_SIZE bytes)"
+          # Binaries ship uncompressed on every platform. UPX packing triggers
+          # generic antivirus ML detections (Defender's Wacatac.C!ml and similar),
+          # and saves nothing on the wire since npm tarballs are already gzipped.
+          echo "=== Binary info ==="
+          SIZE=$(stat --format=%s "$ARTIFACT_DIR/${{ matrix.binary-name }}" 2>/dev/null || stat -f%z "$ARTIFACT_DIR/${{ matrix.binary-name }}")
+          echo "Size: $(( SIZE / 1024 )) KB ($SIZE bytes)"
           file "$ARTIFACT_DIR/${{ matrix.binary-name }}" || true
-          if [[ "${{ matrix.native-bin-subdir }}" != "win32-x64" ]]; then
-            echo "=== UPX compress ==="
-            upx --best "$ARTIFACT_DIR/${{ matrix.binary-name }}" || echo "UPX compression failed, continuing with uncompressed binary"
-          else
-            echo "=== UPX skipped (Windows) ==="
-          fi
-          FINAL_SIZE=$(stat --format=%s "$ARTIFACT_DIR/${{ matrix.binary-name }}" 2>/dev/null || stat -f%z "$ARTIFACT_DIR/${{ matrix.binary-name }}")
-          echo "=== Binary info (after UPX) ==="
-          echo "Size: $(( FINAL_SIZE / 1024 )) KB ($FINAL_SIZE bytes)"
-          if [ "$RAW_SIZE" != "$FINAL_SIZE" ]; then
-            RATIO=$(( FINAL_SIZE * 100 / RAW_SIZE ))
-            echo "Compression: ${RATIO}% of original"
-          fi
           echo ""
-          echo "📦 ${{ matrix.native-bin-subdir }}/${{ matrix.binary-name }}: $(( FINAL_SIZE / 1024 )) KB"
+          echo "📦 ${{ matrix.native-bin-subdir }}/${{ matrix.binary-name }}: $(( SIZE / 1024 )) KB"
 
       # Run Rust unit tests
       - name: Run unit tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
       # native source, the build/bundle scripts, AND the workflows that drive
       # them — anything that can change the produced binary. The leading `v1`
       # salt forces a full rebuild when something hashFiles can't see changes
-      # (runner image / Xcode / Rust / UPX toolchain) — bump it to invalidate.
+      # (runner image / Xcode / Rust toolchain) — bump it to invalidate.
       #
       # Note: the macOS .app bundle embeds a fixed constant version (hardcoded in
       # build-swift.ts, not the npm version), so the notarized bundle is

--- a/packages/encryption-binary-rust/README.md
+++ b/packages/encryption-binary-rust/README.md
@@ -21,13 +21,6 @@ Provides **NCrypt TPM-sealed** key protection on Windows when a TPM is available
   # Ubuntu/Debian
   sudo apt-get install musl-tools
   ```
-- **UPX** (optional, Linux binary compression only — not used on Windows):
-  ```sh
-  # Ubuntu/Debian
-  sudo apt-get install upx-ucl
-  # macOS (local dev only; CI does not UPX-compress macOS binaries)
-  brew install upx
-  ```
 
 ## Building
 
@@ -44,7 +37,7 @@ bun run build:windows-arm64 # aarch64-pc-windows-msvc
 
 Output goes to `packages/varlock/native-bins/<platform>/`.
 
-The build script automatically applies UPX compression on Linux (not macOS or Windows). Pass `--no-upx` to skip.
+Binaries ship uncompressed. Do not reintroduce UPX (or any other executable packer): packed binaries reliably trip generic antivirus ML detections such as Defender's `Wacatac.C!ml`, and they save nothing on the wire because npm tarballs are already gzipped (packed data does not compress further). See [#810](https://github.com/dmno-dev/varlock/issues/810) and [#1002](https://github.com/dmno-dev/varlock/issues/1002).
 
 ## Architecture
 
@@ -91,7 +84,7 @@ varlock-local-encrypt status
 
 ## CI
 
-Binaries are built in CI via `.github/workflows/build-native-rust.yaml` on native runners for each platform. Linux targets use musl for fully static binaries that work on any Linux distribution. Linux binaries are UPX-compressed in CI; Windows binaries are not (UPX triggers common antivirus false positives).
+Binaries are built in CI via `.github/workflows/build-native-rust.yaml` on native runners for each platform. Linux targets use musl for fully static binaries that work on any Linux distribution. No platform is UPX-compressed.
 
 ### Windows Authenticode signing (maintainers)
 

--- a/packages/encryption-binary-rust/scripts/build-rust.ts
+++ b/packages/encryption-binary-rust/scripts/build-rust.ts
@@ -11,7 +11,7 @@
  * The binary is placed in packages/varlock/native-bins/<platform>[-<arch>]/
  */
 
-import { execFileSync, execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs';
 
@@ -104,27 +104,14 @@ if (process.platform !== 'win32') {
   fs.chmodSync(destBinary, 0o755);
 }
 
-const rawStats = fs.statSync(destBinary);
-const rawSizeKB = Math.round(rawStats.size / 1024);
-
-// UPX compress on Linux only (macOS is not reliably supported; Windows UPX triggers AV false positives)
-const skipUpx = args.includes('--no-upx');
-const isMacOS = !target ? process.platform === 'darwin' : (target.includes('darwin') || target.includes('apple'));
-const isWindows = !target ? process.platform === 'win32' : target.includes('windows');
-if (!skipUpx && !isMacOS && !isWindows) {
-  try {
-    console.log('\nCompressing with UPX...');
-    execSync(`upx --best "${destBinary}"`, { stdio: 'inherit' });
-  } catch {
-    console.warn('UPX compression failed (is upx installed?), continuing with uncompressed binary');
-  }
-}
+// Note: binaries are intentionally shipped uncompressed. UPX packing triggers
+// generic antivirus ML detections (Defender's Wacatac.C!ml and similar), and it
+// saves nothing on the wire since npm tarballs are already gzipped.
 
 const stats = fs.statSync(destBinary);
 const sizeKB = Math.round(stats.size / 1024);
 
 console.log(`\nBuilt: ${destBinary}`);
-const sizeStr = rawSizeKB !== sizeKB ? `${sizeKB} KB (${rawSizeKB} KB before UPX)` : `${sizeKB} KB`;
-console.log(`Size: ${sizeStr}`);
+console.log(`Size: ${sizeKB} KB`);
 console.log(`Platform: ${subdir}`);
 console.log('Done!');

--- a/packages/varlock-website/src/content/docs/getting-started/installation.mdx
+++ b/packages/varlock-website/src/content/docs/getting-started/installation.mdx
@@ -57,8 +57,8 @@ Then run the setup wizard to help you get started:
 varlock init
 ```
 
-:::note[Windows Defender]
-If Windows flags `varlock-local-encrypt.exe`, see the [local encryption guide, Windows Defender false positives](/guides/local-encryption/#windows-defender-false-positives) for verification and recovery steps.
+:::note[Antivirus false positives]
+If Microsoft Defender or another scanner flags a `varlock-local-encrypt` binary on any platform, see the [local encryption guide, antivirus false positives](/guides/local-encryption/#antivirus-false-positives) for verification and recovery steps.
 :::
 
 **Installation script usage**

--- a/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
+++ b/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
@@ -163,23 +163,6 @@ On WSL, the standalone `install.sh` installs the Windows encryption helper (`var
 
 New keys automatically use TPM sealing when available. Existing **DPAPI** keys are **auto-upgraded to TPM sealing on the next successful decrypt** (public key unchanged, no re-encryption of `.env` values). To upgrade without decrypting, use `varlock-local-encrypt rewrap-key --key-id varlock-default`.
 
-#### Windows Defender false positives
-
-`varlock-local-encrypt.exe` is Varlock's official local-encryption helper (bundled with the npm package and standalone CLI). Windows Defender may flag it as `Trojan:Win32/Wacatac.C!ml` or similar, a common machine-learning false positive on new, unsigned executables. The binary is safe when obtained from official Varlock releases.
-
-**Verify the download:** each [GitHub release](https://github.com/dmno-dev/varlock/releases) includes `SHA256SUMS.txt` with hashes for all native helpers. After installing, compare your file:
-
-```powershell
-# PowerShell: run from the directory containing the .exe
-Get-FileHash varlock-local-encrypt.exe -Algorithm SHA256
-```
-
-Match the hash against the `native-bins/win32-x64/varlock-local-encrypt.exe` line in `SHA256SUMS.txt` for your release version.
-
-**If quarantined:** restore the file from Windows Security → Protection history, or add an exclusion for your project directory. Reinstall from npm or the official release if needed.
-
-**Permanent fix:** official builds are moving to Authenticode code signing, which greatly reduces these alerts. Until your installed version is signed, verification via `SHA256SUMS.txt` is the recommended way to confirm authenticity.
-
 ### Linux
 
 - Native Linux helper when available
@@ -208,3 +191,27 @@ If biometric/user-presence prompts are unavailable on Linux, complete policy set
 ```bash
 sudo varlock-local-encrypt setup --linux-biometrics
 ```
+
+## Antivirus false positives
+
+`varlock-local-encrypt` is Varlock's official local-encryption helper, bundled with the npm package and the standalone CLI. Microsoft Defender sometimes flags it as `Trojan:Win32/Wacatac.C!ml`, `Trojan:Script/Wacatac.C!ml`, or similar. These are generic machine-learning detections that fire on small, new, unsigned executables. The binary is safe when obtained from official Varlock releases.
+
+This can happen on any operating system, not just Windows. The npm package ships helper binaries for every supported platform, so a scanner running on macOS or Linux may flag the Windows or Linux binary even though that file will never be executed there.
+
+**Verify the download.** Each [GitHub release](https://github.com/dmno-dev/varlock/releases) includes `SHA256SUMS.txt` with hashes for all native helpers. Compare your installed file against the matching `native-bins/<platform>/...` line for your release version:
+
+```powershell
+# Windows PowerShell
+Get-FileHash varlock-local-encrypt.exe -Algorithm SHA256
+```
+
+```bash
+# macOS / Linux
+shasum -a 256 varlock-local-encrypt
+```
+
+**If a file was quarantined.** On Windows, restore it from Windows Security → Protection history, or add an exclusion for your project directory. On macOS and Linux, restore it through your endpoint security console. Reinstalling from npm or the official release also works once the exclusion is in place.
+
+**Reporting.** If you hit a detection on a current release, [file an issue](https://github.com/dmno-dev/varlock/issues) with the file path and the detection name. You can also [submit the file to Microsoft](https://www.microsoft.com/en-us/wdsi/filesubmission) as a false positive, which is what gets the definition corrected for everyone.
+
+**What we do to prevent this.** Windows binaries are Authenticode-signed via Azure Artifact Signing, macOS binaries are Developer ID signed and notarized, and no binary is compressed with an executable packer (packers such as UPX are a well-known trigger for these detections).


### PR DESCRIPTION
Fixes #1002.

## What

Stop UPX-packing the `linux-arm64` and `linux-x64` `varlock-local-encrypt` binaries, and generalize the antivirus docs section that was scoped to Windows only.

## Why

The file the reporter hit in #1002 is the `linux-arm64` binary in the published `varlock@1.16.1` tarball. The hash matches exactly:

```
f45067a432965dc333b4df0790356cfa035da5dda025a17d1a5f242668702a32  native-bins/linux-arm64/varlock-local-encrypt
```

That binary is UPX-packed, and so is `linux-x64`. UPX packing is a well-known trigger for Defender's generic `Wacatac.*!ml` ML detections. We already knew this: #811 disabled UPX for Windows for exactly this reason and left a comment saying so, but Linux was left on.

The reporter is on macOS. The npm package ships `native-bins` for every platform in one tarball, so a macOS install writes the Linux binaries to disk, and Defender for Endpoint scans them regardless of target platform. A macOS user got blocked by a binary macOS cannot execute.

UPX also buys essentially nothing here, because npm tarballs are gzipped and packed data does not compress further:

| binary | on disk now | gzipped now | unpacked | est. gzipped unpacked |
|---|---|---|---|---|
| linux-arm64 | 757 KB | 736 KB | 1478 KB | ~590-665 KB |
| linux-x64 | 778 KB | 768 KB | 1786 KB | ~715-805 KB |

Unpacked sizes are read from the UPX pack header. The gzip estimates use the 33% / 51% ratios measured on the unpacked `darwin` and `win32-x64` binaries in the same tarball. Net effect on the published tarball is roughly a wash. The cost is about 1.7 MB more on disk after install.

## Changes

- `build-rust.ts`: removed the compression block, the `--no-upx` flag, and the now-unused `execSync` import
- `build-native-rust.yaml`: removed the `Install UPX` step and the compress branch in `Prepare artifact`, collapsing the before/after size reporting into one measurement
- `release.yaml`: dropped the stale "UPX toolchain" mention in the cache-salt comment
- `encryption-binary-rust/README.md`: removed UPX from prerequisites, added a do-not-reintroduce note
- `local-encryption.mdx`: moved the false-positive section out from under the Windows heading to a top-level `## Antivirus false positives`, added macOS/Linux `shasum` verification and an explanation of why a scanner flags a binary for a platform you are not on
- `installation.mdx`: retargeted the note and its anchor

## Notes for review

- **No cache-salt bump needed.** `RUST_HASH` in `release.yaml` already covers `scripts/**` and `build-native-rust.yaml`, both of which changed, so the release binary cache invalidates on its own.
- **This does not unblock anyone already on 1.16.1.** Republishing does not retract the old tarball, so the two current Linux hashes should also be submitted to Microsoft's false-positive portal.
- **There was a latent inconsistency** worth noting: the local script skipped UPX by platform name while CI skipped only `win32-x64`, so adding a `win32-arm64` target would have silently reintroduced UPX on Windows. Moot now that the step is gone.
- Verified in the built HTML that the new `#antivirus-false-positives` anchor exists and the link from `installation.mdx` resolves to it.

#1003 tracks the structural follow-up: splitting `native-bins` into per-platform optional dependencies so a detection on one platform's binary can only ever affect that platform.
