### PR TITLE
Ship native helper binaries as per-platform optional dependencies

### DIFF
--- a/.bumpy/_config.json
+++ b/.bumpy/_config.json
@@ -9,6 +9,9 @@
       "internalAuthors": ["theoephraim", "philmillman", "@app/copilot-swe-agent", "claude"]
     }
   ],
+  // the per-platform native binary packages must always publish in lockstep with
+  // varlock, which pins them as exact-version optionalDependencies
+  "fixed": [["varlock", "@varlock/native-helper-*"]],
   "packages": {
     // this is the vscode extension
     "env-spec-language": {

--- a/.bumpy/native-bins-optional-deps.md
+++ b/.bumpy/native-bins-optional-deps.md
@@ -6,4 +6,4 @@ varlock: minor
 "@varlock/native-helper-win32-x64": minor
 ---
 
-Native local-encryption helper binaries now ship as per-platform optional dependencies (@varlock/native-helper-*), so npm installs only download the binary for your own platform
+Native local-encryption helper binaries now ship as per-platform optional dependencies (@varlock/native-helper-*), so npm installs only download the binaries for your own platform (on Linux this includes the Windows helper, which WSL needs)

--- a/.bumpy/native-bins-optional-deps.md
+++ b/.bumpy/native-bins-optional-deps.md
@@ -1,0 +1,9 @@
+---
+varlock: minor
+"@varlock/native-helper-darwin": minor
+"@varlock/native-helper-linux-x64": minor
+"@varlock/native-helper-linux-arm64": minor
+"@varlock/native-helper-win32-x64": minor
+---
+
+Native local-encryption helper binaries now ship as per-platform optional dependencies (@varlock/native-helper-*), so npm installs only download the binary for your own platform

--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -60,12 +60,24 @@ jobs:
           set -euo pipefail
           TMP="$RUNNER_TEMP/varlock-npm"
           mkdir -p "$TMP" && cd "$TMP"
-          for i in $(seq 1 30); do
-            if npm view "varlock@${RELEASE_VERSION}" version >/dev/null 2>&1; then break; fi
-            echo "waiting for varlock@${RELEASE_VERSION} on npm ($i)..."; sleep 10
+          # wait for registry propagation of every package we are about to pack
+          wait_for() { # <pkg spec> <max attempts>
+            for i in $(seq 1 "$2"); do
+              if npm view "$1" version >/dev/null 2>&1; then return 0; fi
+              echo "waiting for $1 on npm ($i)..."; sleep 10
+            done
+            echo "::error::$1 not found on npm. Note: versions <= 1.16.x predate the per-platform @varlock/native-helper-* packages and cannot be re-cut by this workflow."
+            return 1
+          }
+          wait_for "varlock@${RELEASE_VERSION}" 30
+          for SUFFIX in darwin linux-x64 linux-arm64 win32-x64; do
+            # helpers publish before varlock, so short extra wait once varlock is visible
+            wait_for "@varlock/native-helper-${SUFFIX}@${RELEASE_VERSION}" 12
           done
           DEST="$GITHUB_WORKSPACE/packages/varlock/native-bins"
           rm -rf "$DEST"
+          # platform suffix -> tarball entry mapping; source of truth is
+          # packages/native-helpers/platforms.ts - keep in sync
           fetch() { # <platform suffix> <tarball entry>
             rm -rf package
             npm pack "@varlock/native-helper-$1@${RELEASE_VERSION}"

--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -6,10 +6,12 @@ name: Re-cut varlock CLI binaries
 # The normal release flow (release.yaml) builds and uploads these in the same run
 # as the npm publish, reusing the in-run signed/notarized native binaries. This
 # workflow is only for re-cutting binaries of an existing version — it pulls the
-# signed native binaries from the published npm packages (the per-platform
-# @varlock/native-helper-* packages, or the varlock tarball itself for versions
-# <= 1.16.x which bundled /native-bins) rather than rebuilding + re-signing
-# them, so it needs no macOS/Windows runner, no Azure, and no Apple credentials.
+# signed native binaries from the published @varlock/native-helper-* npm packages
+# rather than rebuilding + re-signing them, so it needs no macOS/Windows runner,
+# no Azure, and no Apple credentials.
+#
+# Only works for versions with per-platform helper packages (> 1.16.x); earlier
+# versions bundled the binaries inside the varlock tarball itself.
 on:
   workflow_dispatch:
     inputs:
@@ -64,25 +66,17 @@ jobs:
           done
           DEST="$GITHUB_WORKSPACE/packages/varlock/native-bins"
           rm -rf "$DEST"
-          npm pack "varlock@${RELEASE_VERSION}"
-          tar -xzf varlock-"${RELEASE_VERSION}".tgz
-          if [ -d package/native-bins ]; then
-            # versions <= 1.16.x bundled all binaries inside the varlock tarball
-            cp -R package/native-bins "$DEST"
-          else
-            # newer versions ship them as per-platform packages
-            fetch() { # <platform suffix> <tarball entry>
-              rm -rf package
-              npm pack "@varlock/native-helper-$1@${RELEASE_VERSION}"
-              tar -xzf "varlock-native-helper-$1-${RELEASE_VERSION}.tgz"
-              mkdir -p "$DEST/$1"
-              cp -R "package/$2" "$DEST/$1/$2"
-            }
-            fetch darwin VarlockEnclave.app
-            fetch linux-x64 varlock-local-encrypt
-            fetch linux-arm64 varlock-local-encrypt
-            fetch win32-x64 varlock-local-encrypt.exe
-          fi
+          fetch() { # <platform suffix> <tarball entry>
+            rm -rf package
+            npm pack "@varlock/native-helper-$1@${RELEASE_VERSION}"
+            tar -xzf "varlock-native-helper-$1-${RELEASE_VERSION}.tgz"
+            mkdir -p "$DEST/$1"
+            cp -R "package/$2" "$DEST/$1/$2"
+          }
+          fetch darwin VarlockEnclave.app
+          fetch linux-x64 varlock-local-encrypt
+          fetch linux-arm64 varlock-local-encrypt
+          fetch win32-x64 varlock-local-encrypt.exe
       - name: Restore native binary execute permissions
         run: |
           chmod +x packages/varlock/native-bins/darwin/VarlockEnclave.app/Contents/MacOS/varlock-local-encrypt

--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -6,9 +6,10 @@ name: Re-cut varlock CLI binaries
 # The normal release flow (release.yaml) builds and uploads these in the same run
 # as the npm publish, reusing the in-run signed/notarized native binaries. This
 # workflow is only for re-cutting binaries of an existing version — it pulls the
-# signed native binaries from the published npm package (varlock's `files`
-# includes /native-bins) rather than rebuilding + re-signing them, so it needs no
-# macOS/Windows runner, no Azure, and no Apple credentials.
+# signed native binaries from the published npm packages (the per-platform
+# @varlock/native-helper-* packages, or the varlock tarball itself for versions
+# <= 1.16.x which bundled /native-bins) rather than rebuilding + re-signing
+# them, so it needs no macOS/Windows runner, no Azure, and no Apple credentials.
 on:
   workflow_dispatch:
     inputs:
@@ -50,9 +51,9 @@ jobs:
           # see the matching step in release.yaml for why cosign is pinned too
           cosign-release: v3.0.6
 
-      # Pull the signed/notarized native binaries from the published npm package
+      # Pull the signed/notarized native binaries from the published npm packages
       # instead of rebuilding + re-signing them.
-      - name: Fetch native binaries from published npm package
+      - name: Fetch native binaries from published npm packages
         run: |
           set -euo pipefail
           TMP="$RUNNER_TEMP/varlock-npm"
@@ -61,10 +62,27 @@ jobs:
             if npm view "varlock@${RELEASE_VERSION}" version >/dev/null 2>&1; then break; fi
             echo "waiting for varlock@${RELEASE_VERSION} on npm ($i)..."; sleep 10
           done
+          DEST="$GITHUB_WORKSPACE/packages/varlock/native-bins"
+          rm -rf "$DEST"
           npm pack "varlock@${RELEASE_VERSION}"
-          tar -xzf varlock-*.tgz
-          rm -rf "$GITHUB_WORKSPACE/packages/varlock/native-bins"
-          cp -R package/native-bins "$GITHUB_WORKSPACE/packages/varlock/native-bins"
+          tar -xzf varlock-"${RELEASE_VERSION}".tgz
+          if [ -d package/native-bins ]; then
+            # versions <= 1.16.x bundled all binaries inside the varlock tarball
+            cp -R package/native-bins "$DEST"
+          else
+            # newer versions ship them as per-platform packages
+            fetch() { # <platform suffix> <tarball entry>
+              rm -rf package
+              npm pack "@varlock/native-helper-$1@${RELEASE_VERSION}"
+              tar -xzf "varlock-native-helper-$1-${RELEASE_VERSION}.tgz"
+              mkdir -p "$DEST/$1"
+              cp -R "package/$2" "$DEST/$1/$2"
+            }
+            fetch darwin VarlockEnclave.app
+            fetch linux-x64 varlock-local-encrypt
+            fetch linux-arm64 varlock-local-encrypt
+            fetch win32-x64 varlock-local-encrypt.exe
+          fi
       - name: Restore native binary execute permissions
         run: |
           chmod +x packages/varlock/native-bins/darwin/VarlockEnclave.app/Contents/MacOS/varlock-local-encrypt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -240,6 +240,14 @@ jobs:
     needs: [plan, notarize-native-macos, verify-native-macos, build-native-rust]
     if: always() && !failure() && !cancelled() && needs.plan.outputs.mode == 'publish'
     runs-on: ubuntu-latest
+    # Publishing runs in the `publish` environment so the OIDC tokens minted in
+    # this job carry an environment claim. npm trusted publishers for all
+    # published packages require that claim (managed via `fledgling sync`; the
+    # `fledgling` config lives in the root package.json), and the Azure federated
+    # credential for Marketplace publishing must be scoped to it too (subject
+    # `repo:dmno-dev/varlock:environment:publish`). Restricting the environment
+    # to the main branch in repo settings locks tokens down further.
+    environment: publish
     permissions:
       id-token: write  # Required for OIDC
       contents: write
@@ -391,7 +399,9 @@ jobs:
       # Authenticate to Azure via GitHub OIDC (workload identity federation) so the
       # VS Code Marketplace publish (`vsce publish --azure-credential`) can mint a
       # short-lived token instead of a long-lived VSCE_PAT. The federated credential
-      # on the Azure side is scoped to this repo's main branch; see docs below.
+      # on the Azure side must be scoped to this job's `publish` environment
+      # (subject `repo:dmno-dev/varlock:environment:publish`), since running in an
+      # environment changes the OIDC token's sub claim.
       - name: Azure login (OIDC) for Marketplace publishing
         if: needs.plan.outputs.mode == 'publish' && needs.plan.outputs.includes-vscode == 'true'
         uses: azure/login@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is a monorepo managed with bun workspaces and Turborepo:
 - `packages/varlock-website` — docs site (Astro); docs content lives in `src/content/docs/`
 - `packages/vscode-plugin` — VSCode extension for @env-spec language support
 - `packages/integrations/*` — framework integrations (nextjs, vite, astro, ...)
-- `packages/native-helpers/*` — per-platform npm packages carrying the native local-encryption binaries (published as `@varlock/native-helper-*`, versioned in lockstep with `varlock`)
+- `packages/native-helpers/*` — per-platform npm publishing shells for the native helper binaries (published as `@varlock/native-helper-*`, versioned in lockstep with `varlock`); the binaries themselves are built from `packages/encryption-binary-swift` (darwin) and `packages/encryption-binary-rust` (linux/win32)
 - `packages/utils`, `packages/plugins` — shared internals
 - `packages/varlock-docs-mcp` — docs MCP server for external varlock users; do **not** use it to look things up while working on this repo — read the docs source directly
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This is a monorepo managed with bun workspaces and Turborepo:
 - `packages/varlock-website` — docs site (Astro); docs content lives in `src/content/docs/`
 - `packages/vscode-plugin` — VSCode extension for @env-spec language support
 - `packages/integrations/*` — framework integrations (nextjs, vite, astro, ...)
+- `packages/native-helpers/*` — per-platform npm packages carrying the native local-encryption binaries (published as `@varlock/native-helper-*`, versioned in lockstep with `varlock`)
 - `packages/utils`, `packages/plugins` — shared internals
 - `packages/varlock-docs-mcp` — docs MCP server for external varlock users; do **not** use it to look things up while working on this repo — read the docs source directly
 

--- a/bun.lock
+++ b/bun.lock
@@ -164,6 +164,22 @@
         "vite": ">=5",
       },
     },
+    "packages/native-helpers/darwin": {
+      "name": "@varlock/native-helper-darwin",
+      "version": "1.16.1",
+    },
+    "packages/native-helpers/linux-arm64": {
+      "name": "@varlock/native-helper-linux-arm64",
+      "version": "1.16.1",
+    },
+    "packages/native-helpers/linux-x64": {
+      "name": "@varlock/native-helper-linux-x64",
+      "version": "1.16.1",
+    },
+    "packages/native-helpers/win32-x64": {
+      "name": "@varlock/native-helper-win32-x64",
+      "version": "1.16.1",
+    },
     "packages/plugins/1password": {
       "name": "@varlock/1password-plugin",
       "version": "2.0.3",
@@ -476,6 +492,12 @@
         "semver": "^7.7.4",
         "tsup": "catalog:",
         "vitest": "catalog:",
+      },
+      "optionalDependencies": {
+        "@varlock/native-helper-darwin": "workspace:*",
+        "@varlock/native-helper-linux-arm64": "workspace:*",
+        "@varlock/native-helper-linux-x64": "workspace:*",
+        "@varlock/native-helper-win32-x64": "workspace:*",
       },
     },
     "packages/varlock-docs-mcp": {
@@ -1501,6 +1523,14 @@
     "@varlock/keeper-plugin": ["@varlock/keeper-plugin@workspace:packages/plugins/keeper"],
 
     "@varlock/kubernetes-plugin": ["@varlock/kubernetes-plugin@workspace:packages/plugins/kubernetes"],
+
+    "@varlock/native-helper-darwin": ["@varlock/native-helper-darwin@workspace:packages/native-helpers/darwin"],
+
+    "@varlock/native-helper-linux-arm64": ["@varlock/native-helper-linux-arm64@workspace:packages/native-helpers/linux-arm64"],
+
+    "@varlock/native-helper-linux-x64": ["@varlock/native-helper-linux-x64@workspace:packages/native-helpers/linux-x64"],
+
+    "@varlock/native-helper-win32-x64": ["@varlock/native-helper-win32-x64@workspace:packages/native-helpers/win32-x64"],
 
     "@varlock/nextjs-integration": ["@varlock/nextjs-integration@workspace:packages/integrations/nextjs"],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "workspaces": [
     "packages/*",
     "packages/integrations/*",
+    "packages/native-helpers/*",
     "packages/plugins/*"
   ],
   "scripts": {

--- a/packages/encryption-binary-rust/README.md
+++ b/packages/encryption-binary-rust/README.md
@@ -2,6 +2,8 @@
 
 Cross-platform local encryption binary for Varlock (Windows and Linux).
 
+This package is the build system only and is not published. The built binaries ship to npm through the `@varlock/native-helper-{linux-x64,linux-arm64,win32-x64}` publishing shells (see [`packages/native-helpers/`](../native-helpers/)), and are bundled directly into the standalone CLI archives.
+
 Provides **NCrypt TPM-sealed** key protection on Windows when a TPM is available (with optional Windows Hello biometric), **DPAPI** as fallback, and TPM2 key protection on Linux, with a file-based plaintext fallback on both.
 
 ## Prerequisites

--- a/packages/encryption-binary-swift/README.md
+++ b/packages/encryption-binary-swift/README.md
@@ -2,6 +2,8 @@
 
 macOS native binary for varlock's local encryption, built in Swift.
 
+This package is the build system only and is not published. The built binary ships to npm through the [`@varlock/native-helper-darwin`](../native-helpers/darwin/) publishing shell (see [`packages/native-helpers/`](../native-helpers/)), and is bundled directly into the standalone CLI archives.
+
 ## Why Swift?
 
 Varlock uses the **Secure Enclave** for hardware-backed key storage on macOS. The Secure Enclave, Touch ID biometric prompts, and native UI (status bar menu, secure input dialogs) are only accessible through Apple's `Security`, `LocalAuthentication`, and `AppKit` frameworks — which are designed for Swift/Objective-C. Rust or other languages would require fragile FFI bindings with no stable C ABI to target.

--- a/packages/native-helpers/.gitignore
+++ b/packages/native-helpers/.gitignore
@@ -1,0 +1,6 @@
+# binaries are copied in from packages/varlock/native-bins by prepack.ts at pack time
+*/VarlockEnclave.app
+*/varlock-local-encrypt
+*/varlock-local-encrypt.exe
+*.tgz
+*/*.tgz

--- a/packages/native-helpers/README.md
+++ b/packages/native-helpers/README.md
@@ -1,0 +1,16 @@
+# native-helpers
+
+Publishing shells for the `@varlock/native-helper-*` npm packages: one per platform, installed automatically through `varlock`'s `optionalDependencies` so each user only downloads the binary for their own platform.
+
+These folders intentionally contain no binaries and no source code, just npm metadata (`os`/`cpu` constraints, version, files list). The binaries come from elsewhere:
+
+- **darwin**: built from [`packages/encryption-binary-swift`](../encryption-binary-swift/) (Secure Enclave, Touch ID)
+- **linux-x64 / linux-arm64 / win32-x64**: built from [`packages/encryption-binary-rust`](../encryption-binary-rust/) (TPM2/polkit on Linux, TPM/DPAPI + Windows Hello on Windows)
+
+CI builds, signs, and stages the binaries into `packages/varlock/native-bins/<platform>/` (local dev builds stage there too). At pack/publish time, each package's `prepack` script ([prepack.ts](./prepack.ts)) copies its binary in from that staging dir, and refuses to pack if the binary is missing.
+
+Notes:
+
+- `win32-x64` declares `os: ["win32", "linux"]` on purpose: WSL runs the Windows `.exe` through interop for DPAPI and Windows Hello support, so it must also install on Linux.
+- Versions are kept in lockstep with `varlock` via the bumpy `fixed` group in `.bumpy/_config.json`; `varlock` pins them as exact versions. Never bump these packages independently.
+- The source packages stay separate because they do not map 1:1 to npm packages (one Rust crate produces three of them), and because the shells are pure distribution metadata while the source packages are build systems.

--- a/packages/native-helpers/darwin/README.md
+++ b/packages/native-helpers/darwin/README.md
@@ -1,0 +1,7 @@
+# @varlock/native-helper-darwin
+
+macOS native helper for [varlock](https://varlock.dev)'s [local encryption](https://varlock.dev/guides/local-encryption/) (Secure Enclave, Touch ID).
+
+This package is installed automatically as an optional dependency of [`varlock`](https://www.npmjs.com/package/varlock). Do not install it directly.
+
+The binary (`VarlockEnclave.app`) is Developer ID signed and notarized. Checksums for every release are published in `SHA256SUMS.txt` on the matching [GitHub release](https://github.com/dmno-dev/varlock/releases).

--- a/packages/native-helpers/darwin/package.json
+++ b/packages/native-helpers/darwin/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@varlock/native-helper-darwin",
+  "version": "1.16.1",
+  "description": "varlock native helper binary for macOS (Secure Enclave local encryption). Installed automatically as an optional dependency of varlock.",
+  "author": "dmno-dev",
+  "license": "MIT",
+  "homepage": "https://varlock.dev",
+  "bugs": "https://github.com/dmno-dev/varlock/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dmno-dev/varlock.git",
+    "directory": "packages/native-helpers/darwin"
+  },
+  "os": ["darwin"],
+  "files": ["/VarlockEnclave.app"],
+  "preferUnplugged": true,
+  "scripts": {
+    "prepack": "bun run ../prepack.ts darwin"
+  }
+}

--- a/packages/native-helpers/darwin/package.json
+++ b/packages/native-helpers/darwin/package.json
@@ -15,6 +15,7 @@
   "files": ["/VarlockEnclave.app"],
   "preferUnplugged": true,
   "scripts": {
-    "prepack": "bun run ../prepack.ts darwin"
+    "prepack": "bun run ../prepack.ts darwin",
+    "postpack": "bun run ../postpack.ts darwin"
   }
 }

--- a/packages/native-helpers/linux-arm64/README.md
+++ b/packages/native-helpers/linux-arm64/README.md
@@ -1,0 +1,7 @@
+# @varlock/native-helper-linux-arm64
+
+Linux arm64 native helper for [varlock](https://varlock.dev)'s [local encryption](https://varlock.dev/guides/local-encryption/) (TPM2 sealing, polkit user presence).
+
+This package is installed automatically as an optional dependency of [`varlock`](https://www.npmjs.com/package/varlock). Do not install it directly.
+
+Checksums for every release are published in `SHA256SUMS.txt` on the matching [GitHub release](https://github.com/dmno-dev/varlock/releases).

--- a/packages/native-helpers/linux-arm64/package.json
+++ b/packages/native-helpers/linux-arm64/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@varlock/native-helper-linux-arm64",
+  "version": "1.16.1",
+  "description": "varlock native helper binary for Linux arm64 (TPM2/polkit local encryption). Installed automatically as an optional dependency of varlock.",
+  "author": "dmno-dev",
+  "license": "MIT",
+  "homepage": "https://varlock.dev",
+  "bugs": "https://github.com/dmno-dev/varlock/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dmno-dev/varlock.git",
+    "directory": "packages/native-helpers/linux-arm64"
+  },
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "files": ["/varlock-local-encrypt"],
+  "preferUnplugged": true,
+  "scripts": {
+    "prepack": "bun run ../prepack.ts linux-arm64"
+  }
+}

--- a/packages/native-helpers/linux-arm64/package.json
+++ b/packages/native-helpers/linux-arm64/package.json
@@ -16,6 +16,7 @@
   "files": ["/varlock-local-encrypt"],
   "preferUnplugged": true,
   "scripts": {
-    "prepack": "bun run ../prepack.ts linux-arm64"
+    "prepack": "bun run ../prepack.ts linux-arm64",
+    "postpack": "bun run ../postpack.ts linux-arm64"
   }
 }

--- a/packages/native-helpers/linux-x64/README.md
+++ b/packages/native-helpers/linux-x64/README.md
@@ -1,0 +1,7 @@
+# @varlock/native-helper-linux-x64
+
+Linux x64 native helper for [varlock](https://varlock.dev)'s [local encryption](https://varlock.dev/guides/local-encryption/) (TPM2 sealing, polkit user presence).
+
+This package is installed automatically as an optional dependency of [`varlock`](https://www.npmjs.com/package/varlock). Do not install it directly.
+
+Checksums for every release are published in `SHA256SUMS.txt` on the matching [GitHub release](https://github.com/dmno-dev/varlock/releases).

--- a/packages/native-helpers/linux-x64/package.json
+++ b/packages/native-helpers/linux-x64/package.json
@@ -16,6 +16,7 @@
   "files": ["/varlock-local-encrypt"],
   "preferUnplugged": true,
   "scripts": {
-    "prepack": "bun run ../prepack.ts linux-x64"
+    "prepack": "bun run ../prepack.ts linux-x64",
+    "postpack": "bun run ../postpack.ts linux-x64"
   }
 }

--- a/packages/native-helpers/linux-x64/package.json
+++ b/packages/native-helpers/linux-x64/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@varlock/native-helper-linux-x64",
+  "version": "1.16.1",
+  "description": "varlock native helper binary for Linux x64 (TPM2/polkit local encryption). Installed automatically as an optional dependency of varlock.",
+  "author": "dmno-dev",
+  "license": "MIT",
+  "homepage": "https://varlock.dev",
+  "bugs": "https://github.com/dmno-dev/varlock/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dmno-dev/varlock.git",
+    "directory": "packages/native-helpers/linux-x64"
+  },
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "files": ["/varlock-local-encrypt"],
+  "preferUnplugged": true,
+  "scripts": {
+    "prepack": "bun run ../prepack.ts linux-x64"
+  }
+}

--- a/packages/native-helpers/platforms.ts
+++ b/packages/native-helpers/platforms.ts
@@ -1,0 +1,7 @@
+/** npm package suffix -> the binary entry staged in packages/varlock/native-bins/<suffix>/ */
+export const SUBDIR_CONTENTS: Record<string, string> = {
+  darwin: 'VarlockEnclave.app',
+  'linux-x64': 'varlock-local-encrypt',
+  'linux-arm64': 'varlock-local-encrypt',
+  'win32-x64': 'varlock-local-encrypt.exe',
+};

--- a/packages/native-helpers/postpack.ts
+++ b/packages/native-helpers/postpack.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env bun
+/* eslint-disable no-console */
+/**
+ * Removes the binary that prepack.ts copied in, once the tarball is built.
+ * Leftover copies in these workspace dirs would otherwise shadow fresher
+ * build output during dev binary resolution (see binary-resolver.ts).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { SUBDIR_CONTENTS } from './platforms';
+
+const subdir = process.argv[2];
+if (!subdir || !(subdir in SUBDIR_CONTENTS)) {
+  console.error(`Usage: bun run postpack.ts <${Object.keys(SUBDIR_CONTENTS).join('|')}>`);
+  process.exit(1);
+}
+
+const destPath = path.resolve(import.meta.dir, subdir, SUBDIR_CONTENTS[subdir]);
+fs.rmSync(destPath, { recursive: true, force: true });
+console.log(`[native-helpers] cleaned up staged binary for ${subdir}`);

--- a/packages/native-helpers/prepack.ts
+++ b/packages/native-helpers/prepack.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+/**
+ * Copies a platform's native binary from the monorepo staging directory
+ * (packages/varlock/native-bins/<subdir>) into the platform package dir.
+ *
+ * Runs as the `prepack` script of each @varlock/native-helper-* package, so
+ * packing/publishing always picks up the freshly staged (signed) binary and
+ * an empty platform package can never be packed.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SUBDIR_CONTENTS: Record<string, string> = {
+  darwin: 'VarlockEnclave.app',
+  'linux-x64': 'varlock-local-encrypt',
+  'linux-arm64': 'varlock-local-encrypt',
+  'win32-x64': 'varlock-local-encrypt.exe',
+};
+
+const subdir = process.argv[2];
+if (!subdir || !(subdir in SUBDIR_CONTENTS)) {
+  console.error(`Usage: bun run prepack.ts <${Object.keys(SUBDIR_CONTENTS).join('|')}>`);
+  process.exit(1);
+}
+
+const entry = SUBDIR_CONTENTS[subdir];
+const srcPath = path.resolve(import.meta.dir, '..', 'varlock', 'native-bins', subdir, entry);
+const destPath = path.resolve(import.meta.dir, subdir, entry);
+
+if (!fs.existsSync(srcPath)) {
+  console.error(`[native-helpers] missing native binary: ${srcPath}`);
+  console.error('[native-helpers] build it (or restore it from CI artifacts) first - refusing to pack an empty platform package');
+  process.exit(1);
+}
+
+fs.rmSync(destPath, { recursive: true, force: true });
+fs.cpSync(srcPath, destPath, { recursive: true });
+
+// artifact download / extraction can strip the execute bit
+if (!subdir.startsWith('win32')) {
+  const mainBinary = subdir === 'darwin'
+    ? path.join(destPath, 'Contents', 'MacOS', 'varlock-local-encrypt')
+    : destPath;
+  fs.chmodSync(mainBinary, 0o755);
+}
+
+console.log(`[native-helpers] staged ${entry} for ${subdir}`);

--- a/packages/native-helpers/prepack.ts
+++ b/packages/native-helpers/prepack.ts
@@ -11,13 +11,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-
-const SUBDIR_CONTENTS: Record<string, string> = {
-  darwin: 'VarlockEnclave.app',
-  'linux-x64': 'varlock-local-encrypt',
-  'linux-arm64': 'varlock-local-encrypt',
-  'win32-x64': 'varlock-local-encrypt.exe',
-};
+import { SUBDIR_CONTENTS } from './platforms';
 
 const subdir = process.argv[2];
 if (!subdir || !(subdir in SUBDIR_CONTENTS)) {

--- a/packages/native-helpers/prepack.ts
+++ b/packages/native-helpers/prepack.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+/* eslint-disable no-console */
 /**
  * Copies a platform's native binary from the monorepo staging directory
  * (packages/varlock/native-bins/<subdir>) into the platform package dir.

--- a/packages/native-helpers/win32-x64/README.md
+++ b/packages/native-helpers/win32-x64/README.md
@@ -1,0 +1,9 @@
+# @varlock/native-helper-win32-x64
+
+Windows x64 native helper for [varlock](https://varlock.dev)'s [local encryption](https://varlock.dev/guides/local-encryption/) (TPM sealing / DPAPI, Windows Hello).
+
+This package is installed automatically as an optional dependency of [`varlock`](https://www.npmjs.com/package/varlock). Do not install it directly.
+
+It declares `os: ["win32", "linux"]` on purpose: under WSL, varlock runs the Windows `varlock-local-encrypt.exe` through WSL interop to get DPAPI and Windows Hello support, so the helper must also be installed on Linux.
+
+The binary is Authenticode-signed. Checksums for every release are published in `SHA256SUMS.txt` on the matching [GitHub release](https://github.com/dmno-dev/varlock/releases).

--- a/packages/native-helpers/win32-x64/package.json
+++ b/packages/native-helpers/win32-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@varlock/native-helper-win32-x64",
+  "version": "1.16.1",
+  "description": "varlock native helper binary for Windows x64 (TPM/DPAPI + Windows Hello local encryption). Also installs on Linux so WSL can use the Windows helper via interop. Installed automatically as an optional dependency of varlock.",
+  "author": "dmno-dev",
+  "license": "MIT",
+  "homepage": "https://varlock.dev",
+  "bugs": "https://github.com/dmno-dev/varlock/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dmno-dev/varlock.git",
+    "directory": "packages/native-helpers/win32-x64"
+  },
+  "os": [
+    "win32",
+    "linux"
+  ],
+  "files": ["/varlock-local-encrypt.exe"],
+  "preferUnplugged": true,
+  "scripts": {
+    "prepack": "bun run ../prepack.ts win32-x64"
+  }
+}

--- a/packages/native-helpers/win32-x64/package.json
+++ b/packages/native-helpers/win32-x64/package.json
@@ -18,6 +18,7 @@
   "files": ["/varlock-local-encrypt.exe"],
   "preferUnplugged": true,
   "scripts": {
-    "prepack": "bun run ../prepack.ts win32-x64"
+    "prepack": "bun run ../prepack.ts win32-x64",
+    "postpack": "bun run ../postpack.ts win32-x64"
   }
 }

--- a/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
+++ b/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
@@ -92,7 +92,7 @@ Varlock chooses the best available backend automatically:
 
 If native capabilities are unavailable, varlock falls back to file-based local encryption.
 
-With npm installs, the native helper arrives through per-platform optional dependencies (`@varlock/native-helper-*`), so only your platform's binary is downloaded. If your install skips optional dependencies (for example `--no-optional` / `--omit=optional`), the native helper is not installed and varlock uses the file-based fallback, with a warning printed when local encryption is used.
+With npm installs, the native helper arrives through per-platform optional dependencies (`@varlock/native-helper-*`), so only your platform's binary is downloaded. The one exception: Linux installs also receive the Windows helper, since WSL uses it for Windows Hello and TPM support. If your install skips optional dependencies (for example `--no-optional` / `--omit=optional`), the native helper is not installed and varlock uses the file-based fallback, with a warning printed when local encryption is used.
 
 **Verify encryption backend (macOS/Linux)**
 

--- a/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
+++ b/packages/varlock-website/src/content/docs/guides/local-encryption.mdx
@@ -92,6 +92,8 @@ Varlock chooses the best available backend automatically:
 
 If native capabilities are unavailable, varlock falls back to file-based local encryption.
 
+With npm installs, the native helper arrives through per-platform optional dependencies (`@varlock/native-helper-*`), so only your platform's binary is downloaded. If your install skips optional dependencies (for example `--no-optional` / `--omit=optional`), the native helper is not installed and varlock uses the file-based fallback, with a warning printed when local encryption is used.
+
 **Verify encryption backend (macOS/Linux)**
 
 ```bash
@@ -194,11 +196,11 @@ sudo varlock-local-encrypt setup --linux-biometrics
 
 ## Antivirus false positives
 
-`varlock-local-encrypt` is Varlock's official local-encryption helper, bundled with the npm package and the standalone CLI. Microsoft Defender sometimes flags it as `Trojan:Win32/Wacatac.C!ml`, `Trojan:Script/Wacatac.C!ml`, or similar. These are generic machine-learning detections that fire on small, new, unsigned executables. The binary is safe when obtained from official Varlock releases.
+`varlock-local-encrypt` is Varlock's official local-encryption helper, installed with the npm package and the standalone CLI. Microsoft Defender sometimes flags it as `Trojan:Win32/Wacatac.C!ml`, `Trojan:Script/Wacatac.C!ml`, or similar. These are generic machine-learning detections that fire on small, new, unsigned executables. The binary is safe when obtained from official Varlock releases.
 
-This can happen on any operating system, not just Windows. The npm package ships helper binaries for every supported platform, so a scanner running on macOS or Linux may flag the Windows or Linux binary even though that file will never be executed there.
+The npm package installs the helper through per-platform optional dependencies (`@varlock/native-helper-darwin`, `-linux-x64`, `-linux-arm64`, `-win32-x64`), so you only download the binary for your own platform. One exception: the Windows helper also installs on Linux, because WSL uses it for Windows Hello and TPM support. So a scanner on Linux may still see a Windows `.exe`, but a detection against one platform's binary can no longer block installs on the others.
 
-**Verify the download.** Each [GitHub release](https://github.com/dmno-dev/varlock/releases) includes `SHA256SUMS.txt` with hashes for all native helpers. Compare your installed file against the matching `native-bins/<platform>/...` line for your release version:
+**Verify the download.** Each [GitHub release](https://github.com/dmno-dev/varlock/releases) includes `SHA256SUMS.txt` with hashes for all native helpers. In npm installs the helper lives under `node_modules/@varlock/native-helper-<platform>/`; compare it against the matching `native-bins/<platform>/...` line for your release version:
 
 ```powershell
 # Windows PowerShell

--- a/packages/varlock/package.json
+++ b/packages/varlock/package.json
@@ -54,7 +54,6 @@
   "files": [
     "/bin",
     "/dist",
-    "/native-bins",
     "/skills"
   ],
   "bin": {
@@ -65,6 +64,12 @@
     "bun": ">=1.3.3"
   },
   "dependencies": {},
+  "optionalDependencies": {
+    "@varlock/native-helper-darwin": "workspace:*",
+    "@varlock/native-helper-linux-arm64": "workspace:*",
+    "@varlock/native-helper-linux-x64": "workspace:*",
+    "@varlock/native-helper-win32-x64": "workspace:*"
+  },
   "exports": {
     ".": {
       "ts-src": "./src/index.ts",

--- a/packages/varlock/scripts/pack-local-package.ts
+++ b/packages/varlock/scripts/pack-local-package.ts
@@ -57,28 +57,55 @@ function maybeBuildWslHelper() {
   });
 }
 
+// npm-name suffix -> native-bins staging entry, for the per-platform binary packages
+const PLATFORM_PACKAGES: Record<string, string> = {
+  darwin: 'VarlockEnclave.app',
+  'linux-x64': 'varlock-local-encrypt',
+  'linux-arm64': 'varlock-local-encrypt',
+  'win32-x64': 'varlock-local-encrypt.exe',
+};
+
+// bun pm pack resolves workspace:*/catalog: protocols (npm pack does not) and
+// runs prepack. Detect the produced tarball from the directory listing since
+// bun's pack output is not machine-parseable.
+function packPackage(dir: string): string {
+  const oldTgzs = fs.readdirSync(dir).filter((f) => f.endsWith('.tgz'));
+  for (const file of oldTgzs) {
+    fs.rmSync(path.join(dir, file));
+  }
+
+  run('bun pm pack', { cwd: dir, stdio: 'pipe' });
+
+  const tgzName = fs.readdirSync(dir).find((f) => f.endsWith('.tgz'));
+  if (!tgzName) {
+    throw new Error(`bun pm pack produced no tarball in ${dir}`);
+  }
+  return path.resolve(dir, tgzName);
+}
+
 function packVarlock(): string {
   run('bun run --filter varlock build', {
     cwd: REPO_ROOT,
     stdio: 'inherit',
   });
-
-  // Remove old tgz files so we can identify the new output deterministically.
-  const oldTgzs = fs.readdirSync(PKG_DIR).filter((f) => f.endsWith('.tgz'));
-  for (const file of oldTgzs) {
-    fs.rmSync(path.join(PKG_DIR, file));
-  }
-
-  const output = run('npm pack', { cwd: PKG_DIR, stdio: 'pipe' }).trim();
-  const tgzName = output.split('\n').at(-1)?.trim();
-  if (!tgzName || !tgzName.endsWith('.tgz')) {
-    throw new Error(`Unable to determine npm pack output from: ${output}`);
-  }
-
-  return path.resolve(PKG_DIR, tgzName);
+  return packPackage(PKG_DIR);
 }
 
-function printUsageHelp(tgzPath: string) {
+// Pack the per-platform binary packages whose binary is staged locally in
+// packages/varlock/native-bins (populated by the swift/rust build scripts).
+// Their prepack script copies the binary in and fails if it is missing.
+function packPlatformPackages(): Record<string, string> {
+  const packed: Record<string, string> = {};
+  for (const [suffix, entry] of Object.entries(PLATFORM_PACKAGES)) {
+    const stagedPath = path.join(PKG_DIR, 'native-bins', suffix, entry);
+    if (!fs.existsSync(stagedPath)) continue;
+    const pkgDir = path.join(REPO_ROOT, 'packages', 'native-helpers', suffix);
+    packed[`@varlock/native-helper-${suffix}`] = packPackage(pkgDir);
+  }
+  return packed;
+}
+
+function printUsageHelp(tgzPath: string, platformTgzs: Record<string, string>) {
   const fileRef = `file:${tgzPath}`;
 
   console.log('\n[pack-local] Local package tarball ready:');
@@ -87,8 +114,22 @@ function printUsageHelp(tgzPath: string) {
   console.log('\n[pack-local] Add this dependency value in your consuming app:');
   console.log(`  "varlock": "${fileRef}"`);
 
+  const platformEntries = Object.entries(platformTgzs);
+  if (platformEntries.length) {
+    console.log('\n[pack-local] Platform binary tarballs (native local-encryption helpers):');
+    console.log('[pack-local] To use one, add an override in your consuming app');
+    console.log('[pack-local] ("overrides" for npm/bun, "pnpm.overrides" for pnpm, "resolutions" for yarn):');
+    console.log('  "overrides": {');
+    console.log(platformEntries.map(([name, p]) => `    "${name}": "file:${p}"`).join(',\n'));
+    console.log('  }');
+  } else {
+    console.log('\n[pack-local] Note: no native binaries staged in native-bins/, so no platform');
+    console.log('[pack-local] packages were packed. Local encryption will use the file-based');
+    console.log('[pack-local] fallback (or build a native binary first, then re-run).');
+  }
+
   if (isWSL() && !fs.existsSync(WIN_HELPER_PATH)) {
-    console.log('\n[pack-local] Note: tarball currently has no WSL Windows helper binary at:');
+    console.log('\n[pack-local] Note: no WSL Windows helper binary staged at:');
     console.log(`  ${WIN_HELPER_PATH}`);
   }
 }
@@ -96,7 +137,8 @@ function printUsageHelp(tgzPath: string) {
 function main() {
   maybeBuildWslHelper();
   const tgzPath = packVarlock();
-  printUsageHelp(tgzPath);
+  const platformTgzs = packPlatformPackages();
+  printUsageHelp(tgzPath, platformTgzs);
 }
 
 main();

--- a/packages/varlock/scripts/pack-local-package.ts
+++ b/packages/varlock/scripts/pack-local-package.ts
@@ -3,6 +3,7 @@
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { SUBDIR_CONTENTS } from '../../native-helpers/platforms';
 
 const PKG_DIR = path.resolve(import.meta.dir, '..');
 const REPO_ROOT = path.resolve(PKG_DIR, '..', '..');
@@ -57,14 +58,6 @@ function maybeBuildWslHelper() {
   });
 }
 
-// npm-name suffix -> native-bins staging entry, for the per-platform binary packages
-const PLATFORM_PACKAGES: Record<string, string> = {
-  darwin: 'VarlockEnclave.app',
-  'linux-x64': 'varlock-local-encrypt',
-  'linux-arm64': 'varlock-local-encrypt',
-  'win32-x64': 'varlock-local-encrypt.exe',
-};
-
 // bun pm pack resolves workspace:*/catalog: protocols (npm pack does not) and
 // runs prepack. Detect the produced tarball from the directory listing since
 // bun's pack output is not machine-parseable.
@@ -96,7 +89,7 @@ function packVarlock(): string {
 // Their prepack script copies the binary in and fails if it is missing.
 function packPlatformPackages(): Record<string, string> {
   const packed: Record<string, string> = {};
-  for (const [suffix, entry] of Object.entries(PLATFORM_PACKAGES)) {
+  for (const [suffix, entry] of Object.entries(SUBDIR_CONTENTS)) {
     const stagedPath = path.join(PKG_DIR, 'native-bins', suffix, entry);
     if (!fs.existsSync(stagedPath)) continue;
     const pkgDir = path.join(REPO_ROOT, 'packages', 'native-helpers', suffix);

--- a/packages/varlock/src/lib/local-encrypt/binary-resolver.test.ts
+++ b/packages/varlock/src/lib/local-encrypt/binary-resolver.test.ts
@@ -1,0 +1,72 @@
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import { getPlatformPackageName } from './binary-resolver';
+import { isWSL } from './wsl-detect';
+
+vi.mock('./wsl-detect', () => ({ isWSL: vi.fn(() => false) }));
+
+function withPlatform(platform: string, arch: string, fn: () => void) {
+  const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  const origArch = Object.getOwnPropertyDescriptor(process, 'arch')!;
+  Object.defineProperty(process, 'platform', { value: platform });
+  Object.defineProperty(process, 'arch', { value: arch });
+  try {
+    fn();
+  } finally {
+    Object.defineProperty(process, 'platform', origPlatform);
+    Object.defineProperty(process, 'arch', origArch);
+  }
+}
+
+describe('getPlatformPackageName', () => {
+  beforeEach(() => {
+    vi.mocked(isWSL).mockReturnValue(false);
+  });
+
+  it('maps darwin (any arch) to the universal darwin package', () => {
+    withPlatform('darwin', 'arm64', () => {
+      expect(getPlatformPackageName()).toBe('@varlock/native-helper-darwin');
+    });
+    withPlatform('darwin', 'x64', () => {
+      expect(getPlatformPackageName()).toBe('@varlock/native-helper-darwin');
+    });
+  });
+
+  it('maps linux x64/arm64 to arch-specific packages', () => {
+    withPlatform('linux', 'x64', () => {
+      expect(getPlatformPackageName()).toBe('@varlock/native-helper-linux-x64');
+    });
+    withPlatform('linux', 'arm64', () => {
+      expect(getPlatformPackageName()).toBe('@varlock/native-helper-linux-arm64');
+    });
+  });
+
+  it('returns undefined for unsupported platforms/arches', () => {
+    withPlatform('linux', 'riscv64', () => {
+      expect(getPlatformPackageName()).toBeUndefined();
+    });
+    withPlatform('freebsd', 'x64', () => {
+      expect(getPlatformPackageName()).toBeUndefined();
+    });
+    withPlatform('win32', 'arm64', () => {
+      expect(getPlatformPackageName()).toBeUndefined();
+    });
+  });
+
+  it('maps win32 x64 to the win32 package', () => {
+    withPlatform('win32', 'x64', () => {
+      expect(getPlatformPackageName()).toBe('@varlock/native-helper-win32-x64');
+    });
+  });
+
+  it('maps WSL (any arch) to the win32 package for DPAPI/Hello via interop', () => {
+    vi.mocked(isWSL).mockReturnValue(true);
+    withPlatform('linux', 'x64', () => {
+      expect(getPlatformPackageName()).toBe('@varlock/native-helper-win32-x64');
+    });
+    withPlatform('linux', 'arm64', () => {
+      expect(getPlatformPackageName()).toBe('@varlock/native-helper-win32-x64');
+    });
+  });
+});

--- a/packages/varlock/src/lib/local-encrypt/binary-resolver.test.ts
+++ b/packages/varlock/src/lib/local-encrypt/binary-resolver.test.ts
@@ -1,7 +1,7 @@
 import {
   describe, it, expect, vi, beforeEach,
 } from 'vitest';
-import { getPlatformPackageName } from './binary-resolver';
+import { getInstalledPlatformPackageName, getPlatformPackageName } from './binary-resolver';
 import { isWSL } from './wsl-detect';
 
 vi.mock('./wsl-detect', () => ({ isWSL: vi.fn(() => false) }));
@@ -68,5 +68,11 @@ describe('getPlatformPackageName', () => {
     withPlatform('linux', 'arm64', () => {
       expect(getPlatformPackageName()).toBe('@varlock/native-helper-win32-x64');
     });
+  });
+});
+
+describe('getInstalledPlatformPackageName', () => {
+  it('does not report an optional dependency from a development checkout', () => {
+    expect(getInstalledPlatformPackageName()).toBeUndefined();
   });
 });

--- a/packages/varlock/src/lib/local-encrypt/binary-resolver.ts
+++ b/packages/varlock/src/lib/local-encrypt/binary-resolver.ts
@@ -4,8 +4,11 @@
  * Resolution order:
  * 1. SEA sibling: same directory as the running varlock binary (install.sh, standalone)
  * 1b. SEA libexec: ../libexec/ relative to the binary (homebrew convention)
- * 2. Bundled in npm package: native-bins/<platform>[-<arch>]/ within the varlock package
- * 3. Dev fallback: walk up from __dirname to find build output
+ * 2. Platform npm package: @varlock/native-helper-<platform> (installed via
+ *    varlock's optionalDependencies)
+ * 3. Bundled in npm package: native-bins/<platform>[-<arch>]/ within the varlock
+ *    package (legacy layout, and local dev builds staged by build scripts)
+ * 4. Dev fallback: walk up from __dirname to find build output
  *
  * Returns undefined if no binary is found (file-based fallback will be used instead).
  */
@@ -13,6 +16,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import { isWSL } from './wsl-detect';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -68,6 +72,24 @@ function getNativeBinSubdir(): string {
 }
 
 /**
+ * Get the per-platform npm package that carries the native binary for the
+ * current platform, or undefined if there is no package for it.
+ * WSL resolves the win32 package (published with os win32+linux) so the
+ * Windows helper is available for DPAPI + Windows Hello via interop.
+ */
+export function getPlatformPackageName(): string | undefined {
+  if (process.platform === 'darwin') return '@varlock/native-helper-darwin';
+  if (process.platform === 'win32') {
+    return process.arch === 'x64' ? '@varlock/native-helper-win32-x64' : undefined;
+  }
+  if (isWSL()) return '@varlock/native-helper-win32-x64';
+  if (process.platform === 'linux' && (process.arch === 'x64' || process.arch === 'arm64')) {
+    return `@varlock/native-helper-linux-${process.arch}`;
+  }
+  return undefined;
+}
+
+/**
  * Resolve the macOS .app bundle binary path, or fall back to bare binary.
  */
 function resolveMacOSBinary(dir: string): string | undefined {
@@ -117,8 +139,28 @@ function resolveSeaSibling(): string | undefined {
 }
 
 /**
- * Strategy 2: Look for the binary bundled in the varlock npm package.
+ * Strategy 2: Resolve the binary from the per-platform npm package
+ * (@varlock/native-helper-*), installed via varlock's optionalDependencies.
+ */
+function resolvePlatformPackage(): string | undefined {
+  const pkgName = getPlatformPackageName();
+  if (!pkgName) return undefined;
+  try {
+    // createRequire may be unavailable in some bundled/compiled contexts, and
+    // require.resolve throws when the optional dep was not installed
+    const esmRequire = createRequire(import.meta.url);
+    const pkgJsonPath = esmRequire.resolve(`${pkgName}/package.json`);
+    return resolveBinaryFromDir(path.dirname(pkgJsonPath));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Strategy 3: Look for the binary bundled in the varlock npm package.
  * native-bins/<platform-subdir>/
+ * This is the pre-split layout (varlock <= 1.16.x shipped all platforms in one
+ * tarball), and also where local dev build scripts stage binaries.
  */
 function resolveNpmBundled(): string | undefined {
   const packageRoot = resolvePackageRoot();
@@ -133,7 +175,7 @@ function resolveNpmBundled(): string | undefined {
 }
 
 /**
- * Strategy 3: Development fallback — look for build output in the monorepo.
+ * Strategy 4: Development fallback — look for build output in the monorepo.
  * Walks up from __dirname looking for native binary build output
  */
 function resolveDevFallback(): string | undefined {
@@ -198,6 +240,13 @@ export function resolveNativeBinary(): string | undefined {
     return _cachedBinaryPath;
   }
 
+  const platformPackage = resolvePlatformPackage();
+  if (platformPackage) {
+    debug(`resolved via platform package: ${platformPackage}`);
+    _cachedBinaryPath = ensureExecutable(platformPackage);
+    return _cachedBinaryPath;
+  }
+
   const npmBundled = resolveNpmBundled();
   if (npmBundled) {
     debug(`resolved via npm bundled: ${npmBundled}`);
@@ -216,6 +265,21 @@ export function resolveNativeBinary(): string | undefined {
   debug(`  SEA sibling dir: ${path.dirname(process.execPath)}`);
   const packageRoot = resolvePackageRoot();
   debug(`  npm bundled dir: ${path.join(packageRoot, 'native-bins', getNativeBinSubdir())}`);
+
+  // When varlock was installed from npm on a supported platform, the native
+  // helper should have arrived via optionalDependencies. Warn loudly (once,
+  // since the result is cached) rather than silently degrading to file-based
+  // encryption. Not triggered in monorepo dev (package root not in node_modules)
+  // or SEA/homebrew installs (resolved via sibling above).
+  const expectedPkg = getPlatformPackageName();
+  if (expectedPkg && packageRoot.split(path.sep).includes('node_modules')) {
+    process.stderr.write(
+      `[varlock] Native local-encryption helper not found (expected optional dependency "${expectedPkg}"). `
+      + 'Falling back to file-based encryption. '
+      + 'Reinstalling dependencies (without --no-optional / --omit=optional) usually fixes this.\n',
+    );
+  }
+
   _cachedBinaryPath = undefined;
   return undefined;
 }

--- a/packages/varlock/src/lib/local-encrypt/binary-resolver.ts
+++ b/packages/varlock/src/lib/local-encrypt/binary-resolver.ts
@@ -10,6 +10,10 @@
  *    package (legacy layout, and local dev builds staged by build scripts)
  * 4. Dev fallback: walk up from __dirname to find build output
  *
+ * In a dev checkout (varlock not under node_modules), strategies 2-4 are
+ * compared by binary mtime and the newest wins, so stale staged copies never
+ * shadow a fresh local build.
+ *
  * Returns undefined if no binary is found (file-based fallback will be used instead).
  */
 
@@ -199,6 +203,15 @@ function resolveDevFallback(): string | undefined {
   return undefined;
 }
 
+/** Modification time of a binary, or 0 if it cannot be statted */
+function getMtimeMs(binaryPath: string): number {
+  try {
+    return fs.statSync(binaryPath).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
 /**
  * Ensure the binary at the given path is executable.
  * GitHub Actions artifact upload/download strips execute permissions,
@@ -240,24 +253,29 @@ export function resolveNativeBinary(): string | undefined {
     return _cachedBinaryPath;
   }
 
+  const candidates: Array<{ binaryPath: string; via: string }> = [];
   const platformPackage = resolvePlatformPackage();
-  if (platformPackage) {
-    debug(`resolved via platform package: ${platformPackage}`);
-    _cachedBinaryPath = ensureExecutable(platformPackage);
-    return _cachedBinaryPath;
-  }
-
+  if (platformPackage) candidates.push({ binaryPath: platformPackage, via: 'platform package' });
   const npmBundled = resolveNpmBundled();
-  if (npmBundled) {
-    debug(`resolved via npm bundled: ${npmBundled}`);
-    _cachedBinaryPath = ensureExecutable(npmBundled);
-    return _cachedBinaryPath;
-  }
-
+  if (npmBundled) candidates.push({ binaryPath: npmBundled, via: 'npm bundled' });
   const devFallback = resolveDevFallback();
-  if (devFallback) {
-    debug(`resolved via dev fallback: ${devFallback}`);
-    _cachedBinaryPath = ensureExecutable(devFallback);
+  if (devFallback) candidates.push({ binaryPath: devFallback, via: 'dev fallback' });
+
+  if (candidates.length) {
+    let chosen = candidates[0];
+    // In a dev checkout (varlock not under node_modules), stale copies can
+    // linger in higher-priority locations (binaries staged into native-bins/ or
+    // copied into the native-helpers packages by pack flows) and would shadow a
+    // fresh build forever, so prefer the most recently modified candidate.
+    // npm installs keep strict priority order: their copies all come from the
+    // same published version and file timestamps are just install times.
+    const isDevCheckout = !resolvePackageRoot().split(path.sep).includes('node_modules');
+    if (isDevCheckout && candidates.length > 1) {
+      chosen = candidates.reduce((a, b) => (getMtimeMs(b.binaryPath) > getMtimeMs(a.binaryPath) ? b : a));
+      debug(`dev checkout with ${candidates.length} candidates — picking newest by mtime`);
+    }
+    debug(`resolved via ${chosen.via}: ${chosen.binaryPath}`);
+    _cachedBinaryPath = ensureExecutable(chosen.binaryPath);
     return _cachedBinaryPath;
   }
 

--- a/packages/varlock/src/lib/local-encrypt/binary-resolver.ts
+++ b/packages/varlock/src/lib/local-encrypt/binary-resolver.ts
@@ -97,6 +97,13 @@ export function getPlatformPackageName(): string | undefined {
   return PLATFORM_PACKAGE_SUFFIXES.has(subdir) ? `@varlock/native-helper-${subdir}` : undefined;
 }
 
+/** Get the expected helper package only when varlock is installed in node_modules. */
+export function getInstalledPlatformPackageName(): string | undefined {
+  const packageRoot = findVarlockPackageRoot();
+  if (!packageRoot?.split(path.sep).includes('node_modules')) return undefined;
+  return getPlatformPackageName();
+}
+
 /**
  * Resolve the macOS .app bundle binary path, or fall back to bare binary.
  */

--- a/packages/varlock/src/lib/local-encrypt/binary-resolver.ts
+++ b/packages/varlock/src/lib/local-encrypt/binary-resolver.ts
@@ -10,9 +10,10 @@
  *    package (legacy layout, and local dev builds staged by build scripts)
  * 4. Dev fallback: walk up from __dirname to find build output
  *
- * In a dev checkout (varlock not under node_modules), strategies 2-4 are
- * compared by binary mtime and the newest wins, so stale staged copies never
- * shadow a fresh local build.
+ * In a dev checkout (a real varlock package.json found outside node_modules),
+ * strategy 2 is skipped (the workspace helper packages only hold transient
+ * prepack copies) and strategies 3-4 are compared by binary mtime with the
+ * newest winning, so stale staged copies never shadow a fresh local build.
  *
  * Returns undefined if no binary is found (file-based fallback will be used instead).
  */
@@ -36,17 +37,24 @@ const BINARY_NAME = 'varlock-local-encrypt';
 const MACOS_APP_BUNDLE = 'VarlockEnclave.app';
 
 /**
- * Resolve the varlock package root by walking up from this module until we
- * find package.json with name=varlock. This is robust across src/dist layouts.
+ * Find the varlock package root by walking up from this module until we find
+ * package.json with name=varlock. This is robust across src/dist layouts.
+ * Returns undefined when no varlock package.json is found (e.g. varlock
+ * bundled into an app's build output).
  */
-function resolvePackageRoot(): string {
+let _cachedPackageRoot: string | undefined | null = null; // null = not yet resolved
+function findVarlockPackageRoot(): string | undefined {
+  if (_cachedPackageRoot !== null) return _cachedPackageRoot;
   let dir = __dirname;
   for (let i = 0; i < 10; i++) {
     const pkgJsonPath = path.join(dir, 'package.json');
     if (fs.existsSync(pkgJsonPath)) {
       try {
         const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8')) as { name?: string };
-        if (pkgJson.name === 'varlock') return dir;
+        if (pkgJson.name === 'varlock') {
+          _cachedPackageRoot = dir;
+          return dir;
+        }
       } catch {
         // Ignore invalid/unreadable package.json and continue walking upward
       }
@@ -55,9 +63,8 @@ function resolvePackageRoot(): string {
     if (parent === dir) break;
     dir = parent;
   }
-
-  // Last-resort fallback for unexpected layouts.
-  return path.resolve(__dirname, '..', '..', '..');
+  _cachedPackageRoot = undefined;
+  return undefined;
 }
 
 /** Get the binary name for the current platform */
@@ -75,22 +82,19 @@ function getNativeBinSubdir(): string {
   return `${process.platform}-${process.arch}`;
 }
 
+/** The native-bins subdirs that have a published @varlock/native-helper-* package */
+const PLATFORM_PACKAGE_SUFFIXES = new Set(['darwin', 'linux-x64', 'linux-arm64', 'win32-x64']);
+
 /**
  * Get the per-platform npm package that carries the native binary for the
  * current platform, or undefined if there is no package for it.
- * WSL resolves the win32 package (published with os win32+linux) so the
- * Windows helper is available for DPAPI + Windows Hello via interop.
+ * Derived from getNativeBinSubdir() so the two can never disagree; WSL maps to
+ * the win32 package (published with os win32+linux) so the Windows helper is
+ * available for DPAPI + Windows Hello via interop.
  */
 export function getPlatformPackageName(): string | undefined {
-  if (process.platform === 'darwin') return '@varlock/native-helper-darwin';
-  if (process.platform === 'win32') {
-    return process.arch === 'x64' ? '@varlock/native-helper-win32-x64' : undefined;
-  }
-  if (isWSL()) return '@varlock/native-helper-win32-x64';
-  if (process.platform === 'linux' && (process.arch === 'x64' || process.arch === 'arm64')) {
-    return `@varlock/native-helper-linux-${process.arch}`;
-  }
-  return undefined;
+  const subdir = getNativeBinSubdir();
+  return PLATFORM_PACKAGE_SUFFIXES.has(subdir) ? `@varlock/native-helper-${subdir}` : undefined;
 }
 
 /**
@@ -167,15 +171,9 @@ function resolvePlatformPackage(): string | undefined {
  * tarball), and also where local dev build scripts stage binaries.
  */
 function resolveNpmBundled(): string | undefined {
-  const packageRoot = resolvePackageRoot();
-  const nativeBinsDir = path.join(packageRoot, 'native-bins', getNativeBinSubdir());
-  if (fs.existsSync(nativeBinsDir)) return resolveBinaryFromDir(nativeBinsDir);
-
-  // Legacy/alternate layout: native-bins as a sibling of the package root.
-  const adjacentNativeBinsDir = path.join(path.dirname(packageRoot), 'native-bins', getNativeBinSubdir());
-  if (fs.existsSync(adjacentNativeBinsDir)) return resolveBinaryFromDir(adjacentNativeBinsDir);
-
-  return undefined;
+  const packageRoot = findVarlockPackageRoot();
+  if (!packageRoot) return undefined;
+  return resolveBinaryFromDir(path.join(packageRoot, 'native-bins', getNativeBinSubdir()));
 }
 
 /**
@@ -253,9 +251,19 @@ export function resolveNativeBinary(): string | undefined {
     return _cachedBinaryPath;
   }
 
+  // A dev checkout is the varlock monorepo itself (or a linked checkout): we
+  // found a real varlock package.json and it is not under node_modules.
+  const packageRoot = findVarlockPackageRoot();
+  const isDevCheckout = !!packageRoot && !packageRoot.split(path.sep).includes('node_modules');
+
   const candidates: Array<{ binaryPath: string; via: string }> = [];
-  const platformPackage = resolvePlatformPackage();
-  if (platformPackage) candidates.push({ binaryPath: platformPackage, via: 'platform package' });
+  if (!isDevCheckout) {
+    // In a dev checkout the workspace-linked @varlock/native-helper-* packages
+    // only ever hold transient copies made by their prepack script, so they are
+    // not considered; real dev binaries live in native-bins/ or build output.
+    const platformPackage = resolvePlatformPackage();
+    if (platformPackage) candidates.push({ binaryPath: platformPackage, via: 'platform package' });
+  }
   const npmBundled = resolveNpmBundled();
   if (npmBundled) candidates.push({ binaryPath: npmBundled, via: 'npm bundled' });
   const devFallback = resolveDevFallback();
@@ -263,16 +271,13 @@ export function resolveNativeBinary(): string | undefined {
 
   if (candidates.length) {
     let chosen = candidates[0];
-    // In a dev checkout (varlock not under node_modules), stale copies can
-    // linger in higher-priority locations (binaries staged into native-bins/ or
-    // copied into the native-helpers packages by pack flows) and would shadow a
+    // In a dev checkout, a stale binary staged into native-bins/ would shadow a
     // fresh build forever, so prefer the most recently modified candidate.
     // npm installs keep strict priority order: their copies all come from the
     // same published version and file timestamps are just install times.
-    const isDevCheckout = !resolvePackageRoot().split(path.sep).includes('node_modules');
     if (isDevCheckout && candidates.length > 1) {
       chosen = candidates.reduce((a, b) => (getMtimeMs(b.binaryPath) > getMtimeMs(a.binaryPath) ? b : a));
-      debug(`dev checkout with ${candidates.length} candidates — picking newest by mtime`);
+      debug(`dev checkout with ${candidates.length} candidates - picking newest by mtime`);
     }
     debug(`resolved via ${chosen.via}: ${chosen.binaryPath}`);
     _cachedBinaryPath = ensureExecutable(chosen.binaryPath);
@@ -281,22 +286,7 @@ export function resolveNativeBinary(): string | undefined {
 
   debug('NOT FOUND: no binary resolved from any strategy');
   debug(`  SEA sibling dir: ${path.dirname(process.execPath)}`);
-  const packageRoot = resolvePackageRoot();
-  debug(`  npm bundled dir: ${path.join(packageRoot, 'native-bins', getNativeBinSubdir())}`);
-
-  // When varlock was installed from npm on a supported platform, the native
-  // helper should have arrived via optionalDependencies. Warn loudly (once,
-  // since the result is cached) rather than silently degrading to file-based
-  // encryption. Not triggered in monorepo dev (package root not in node_modules)
-  // or SEA/homebrew installs (resolved via sibling above).
-  const expectedPkg = getPlatformPackageName();
-  if (expectedPkg && packageRoot.split(path.sep).includes('node_modules')) {
-    process.stderr.write(
-      `[varlock] Native local-encryption helper not found (expected optional dependency "${expectedPkg}"). `
-      + 'Falling back to file-based encryption. '
-      + 'Reinstalling dependencies (without --no-optional / --omit=optional) usually fixes this.\n',
-    );
-  }
+  if (packageRoot) debug(`  npm bundled dir: ${path.join(packageRoot, 'native-bins', getNativeBinSubdir())}`);
 
   _cachedBinaryPath = undefined;
   return undefined;

--- a/packages/varlock/src/lib/local-encrypt/index.ts
+++ b/packages/varlock/src/lib/local-encrypt/index.ts
@@ -12,7 +12,7 @@
 
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
-import { resolveNativeBinary, getPlatformPackageName } from './binary-resolver';
+import { resolveNativeBinary, getInstalledPlatformPackageName } from './binary-resolver';
 import { DaemonClient } from './daemon-client';
 import * as fileBackend from './file-backend';
 import { isWSL } from './wsl-detect';
@@ -444,9 +444,9 @@ function warnIfFileFallback(backend: BackendInfo) {
   if (warnedFileFallback || !backend.isFileFallback) return;
   if (process.env._VARLOCK_FORCE_FILE_ENCRYPTION_FALLBACK) return;
   warnedFileFallback = true;
-  // name the per-platform optional dep that should have carried the binary, so
-  // npm users whose install skipped optional deps know what is missing
-  const expectedPkg = getPlatformPackageName();
+  // Name the optional dependency only for package-manager installs. Standalone
+  // and development layouts deliver the helper through other paths.
+  const expectedPkg = getInstalledPlatformPackageName();
   const expectedNote = expectedPkg
     ? ` (native helper normally arrives via the "${expectedPkg}" optional dependency; installs with --no-optional / --omit=optional skip it)`
     : '';

--- a/packages/varlock/src/lib/local-encrypt/index.ts
+++ b/packages/varlock/src/lib/local-encrypt/index.ts
@@ -12,7 +12,7 @@
 
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
-import { resolveNativeBinary } from './binary-resolver';
+import { resolveNativeBinary, getPlatformPackageName } from './binary-resolver';
 import { DaemonClient } from './daemon-client';
 import * as fileBackend from './file-backend';
 import { isWSL } from './wsl-detect';
@@ -444,8 +444,14 @@ function warnIfFileFallback(backend: BackendInfo) {
   if (warnedFileFallback || !backend.isFileFallback) return;
   if (process.env._VARLOCK_FORCE_FILE_ENCRYPTION_FALLBACK) return;
   warnedFileFallback = true;
+  // name the per-platform optional dep that should have carried the binary, so
+  // npm users whose install skipped optional deps know what is missing
+  const expectedPkg = getPlatformPackageName();
+  const expectedNote = expectedPkg
+    ? ` (native helper normally arrives via the "${expectedPkg}" optional dependency; installs with --no-optional / --omit=optional skip it)`
+    : '';
   process.stderr.write(
-    '[varlock] Warning: native encryption binary not found, falling back to file-based encryption (not hardware-backed)\n',
+    `[varlock] Warning: native encryption binary not found, falling back to file-based encryption (not hardware-backed)${expectedNote}\n`,
   );
 }
 

--- a/packages/varlock/test/package-structure.test.ts
+++ b/packages/varlock/test/package-structure.test.ts
@@ -14,14 +14,18 @@ describe('package.json structure', () => {
     expect(packageJson.dependencies).toEqual({});
   });
 
-  it('should only have first-party native binary packages as optionalDependencies', () => {
+  it('should declare exactly the native helper platform packages as optionalDependencies', () => {
     const packageJsonPath = join(__dirname, '..', 'package.json');
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
 
-    const optionalDeps = Object.keys(packageJson.optionalDependencies ?? {});
-    expect(optionalDeps.length).toBeGreaterThan(0);
-    for (const dep of optionalDeps) {
-      expect(dep).toMatch(/^@varlock\/native-helper-/);
-    }
+    // the complete set, pinned via workspace:* (resolved to exact versions at
+    // pack time) - a missing platform, an unexpected extra, or a range pin
+    // would all break the release contract
+    expect(packageJson.optionalDependencies).toEqual({
+      '@varlock/native-helper-darwin': 'workspace:*',
+      '@varlock/native-helper-linux-arm64': 'workspace:*',
+      '@varlock/native-helper-linux-x64': 'workspace:*',
+      '@varlock/native-helper-win32-x64': 'workspace:*',
+    });
   });
 });

--- a/packages/varlock/test/package-structure.test.ts
+++ b/packages/varlock/test/package-structure.test.ts
@@ -13,4 +13,15 @@ describe('package.json structure', () => {
 
     expect(packageJson.dependencies).toEqual({});
   });
+
+  it('should only have first-party native binary packages as optionalDependencies', () => {
+    const packageJsonPath = join(__dirname, '..', 'package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+
+    const optionalDeps = Object.keys(packageJson.optionalDependencies ?? {});
+    expect(optionalDeps.length).toBeGreaterThan(0);
+    for (const dep of optionalDeps) {
+      expect(dep).toMatch(/^@varlock\/native-helper-/);
+    }
+  });
 });

--- a/scripts/check-release-packages.ts
+++ b/scripts/check-release-packages.ts
@@ -62,6 +62,8 @@ if (bumpyStatusRaw) {
             ...pkgJson.dependencies,
             ...pkgJson.devDependencies,
             ...pkgJson.peerDependencies,
+            // pulls the @varlock/native-helper-* platform packages into varlock previews
+            ...pkgJson.optionalDependencies,
           };
           return Object.entries(allDeps)
             .filter(([, version]) => typeof version === 'string' && (version as string).startsWith('workspace:'))
@@ -118,7 +120,11 @@ if (bumpyStatusRaw) {
 // filter out vscode extension which is not released via npm
 releasePackagePaths = releasePackagePaths.filter((p: string) => !p.endsWith('packages/vscode-plugin'));
 
-const includesVarlock = releasePackagePaths.some((p) => p.endsWith('packages/varlock'));
+// The platform binary packages also need the native binaries staged in CI,
+// so releasing any of them counts as "includes varlock" for workflow gating.
+const includesVarlock = releasePackagePaths.some(
+  (p) => p.endsWith('packages/varlock') || p.includes(`packages${path.sep}native-helpers${path.sep}`),
+);
 
 console.log('Packages to release:', releasePackagePaths);
 console.log('Includes varlock:', includesVarlock);

--- a/scripts/check-release-packages.ts
+++ b/scripts/check-release-packages.ts
@@ -122,8 +122,18 @@ releasePackagePaths = releasePackagePaths.filter((p: string) => !p.endsWith('pac
 
 // The platform binary packages also need the native binaries staged in CI,
 // so releasing any of them counts as "includes varlock" for workflow gating.
-const includesVarlock = releasePackagePaths.some(
-  (p) => p.endsWith('packages/varlock') || p.includes(`packages${path.sep}native-helpers${path.sep}`),
+// Match on package names (not directory paths) so relocating packages cannot
+// silently change release gating.
+function readPackageName(pkgPath: string): string | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(pkgPath, 'package.json'), 'utf-8')).name;
+  } catch {
+    return undefined;
+  }
+}
+const releaseNames = releasePackagePaths.map(readPackageName);
+const includesVarlock = releaseNames.some(
+  (name) => name === 'varlock' || name?.startsWith('@varlock/native-helper-'),
 );
 
 console.log('Packages to release:', releasePackagePaths);


### PR DESCRIPTION
Closes #1003. Follow-up to #1002/#1004.

The varlock npm tarball no longer bundles native binaries for all four platforms. They now ship as per-platform packages installed through `optionalDependencies`, the esbuild/swc pattern, so a user only downloads the binary for their own platform and an AV false positive on one platform's binary can no longer block installs on the others.

## What changed

- New workspace packages under `packages/native-helpers/`: `@varlock/native-helper-darwin`, `-linux-x64`, `-linux-arm64`, `-win32-x64`. The generic "native helper" naming is deliberate: the binaries may grow capabilities beyond local encryption. A shared `prepack` script copies the staged (signed) binary in from `packages/varlock/native-bins` at pack time and refuses to pack an empty package, so all CI build/cache/staging plumbing is unchanged.
- **WSL**: the win32-x64 package declares `os: ["win32", "linux"]` (no cpu constraint) so Linux installs also get the Windows helper, which WSL runs through interop for DPAPI/Windows Hello. This keeps parity with the current tarball, including WSL on arm64 Windows. Non-WSL Linux users pay ~483KB extra, still far less than the ~4.7MB of binaries everyone shipped before.
- `varlock` pins the platform packages as exact versions (`workspace:*` resolved at pack time by `bun pm pack`), and a bumpy `fixed` group keeps all five packages in version lockstep (verified: all plan to 1.17.0 together).
- `binary-resolver.ts` gains a platform-package resolution strategy (after SEA sibling, before the legacy `native-bins/` layout, which is kept for old installs and local dev builds). When an npm install is missing its native helper (e.g. `--no-optional`), the existing file-fallback warning (fired only when crypto ops actually run, never on the passive per-load capability probe) now names the missing optional dependency.
- `binary-release.yaml` (re-cut workflow) fetches binaries from the platform packages, waiting for registry propagation of all five packages and failing with a clear message for pre-split (<= 1.16.x) versions, which are unsupported rather than carrying a fallback (re-cuts only ever target the release that just failed, which always has the platform packages published).
- Preview releases (pkg-pr-new) include the platform packages whenever varlock is previewed.
- `pack:local` switches to `bun pm pack` (npm pack does not resolve `workspace:*`) and also packs platform tarballs for any locally staged binaries, printing an overrides snippet.
- Dev staleness fixes: in dev checkouts (a real varlock package.json found outside node_modules) the resolver skips the workspace helper packages (they only hold transient prepack copies), compares the staging dir vs build output by mtime and picks the newest, and the platform packages clean up their prepack-copied binary via `postpack`. Stale staged copies can no longer shadow a fresh swift/rust build.
- Docs: AV false-positives section and backend-selection notes updated. `SHA256SUMS.txt` generation and its `native-bins/<platform>/...` line labels are unchanged since the binaries are identical; the docs now map those lines to the installed `node_modules/@varlock/native-helper-<platform>/` paths.

The binary filenames themselves (`varlock-local-encrypt`, `VarlockEnclave.app`) are unchanged; only the npm package names are generic.

## Verified

- Platform package packs correctly via prepack (binary + README + manifest only); varlock tarball contains zero binaries and exact-pinned optional deps.
- Resolution chain exercised from both src and the bundled dist: platform package -> legacy layout -> dev fallback, ending at a real Secure Enclave `status` call.
- npm, bun, and pnpm all tolerate the optional deps being unresolvable (verified empirically), so installs and CI stay green even before the packages exist on npm; standalone CLI/Homebrew paths resolve via SEA sibling/libexec and are untouched.

## OIDC lockdown

The `release` publish job now runs in a `publish` GitHub environment, so its OIDC tokens carry an environment claim that npm trusted publishers (and the Azure federated credential for Marketplace publishing) can require. Before the next release:

- run `bunx fledgling sync` to reconcile all packages' npm trusted publishers with the config (workflow `release.yaml`, environment `publish`)
- update the Azure federated credential for Marketplace publishing to subject `repo:dmno-dev/varlock:environment:publish` (running in an environment changes the token's sub claim, so the current main-branch-scoped credential will stop matching)
- optionally restrict the `publish` environment to the `main` branch in repo settings for a further lockdown

## Release bootstrap (done)

npm trusted publishing (OIDC) cannot create new packages, so the four `@varlock/native-helper-*` names were claimed with manually published `0.0.0` placeholders and trusted publishing was configured via fledgling (pointed at `release.yaml` / the `publish` environment). The next lockstep release publishes the real versions via OIDC; if anything about the trust config were wrong, bumpy fails loudly at publish time rather than half-publishing.




