### PR TITLE
feat(printenv): add --template flag for rendering string templates

### DIFF
--- a/.bumpy/printenv-template.md
+++ b/.bumpy/printenv-template.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+printenv: new --template flag renders a string template with resolved values (with optional --escape json), e.g. auth headers JSON for an MCP headersHelper

--- a/packages/varlock-website/src/content/docs/guides/ai-tools/claude.mdx
+++ b/packages/varlock-website/src/content/docs/guides/ai-tools/claude.mdx
@@ -46,3 +46,48 @@ alias vclaude='varlock run -p ~/.env.claude --no-redact-stdout -- claude'
 ```
 
 `--no-redact-stdout` keeps Claude's own terminal output unredacted while secrets stay out of your shell history.
+
+## MCP server secrets
+
+MCP server configs (`.mcp.json`, `~/.claude.json`) support `${VAR}` expansion, but the variables are read from Claude Code's own process environment. That works if you launch `claude` via `varlock run`, but not for the desktop app, which is not launched from your shell. Instead, let varlock resolve secrets at the point where Claude Code uses them.
+
+### Remote servers: `headersHelper`
+
+For `http` (and `ws`) servers, Claude Code's [`headersHelper`](https://code.claude.com/docs/en/mcp) runs a command that prints a JSON object of headers. It runs when Claude Code connects to the server (once per session that uses it, not per request), and re-runs automatically if a call returns 401 or 403.
+
+Use `varlock printenv --template` to emit the headers JSON:
+
+```json title=".mcp.json"
+{
+  "mcpServers": {
+    "my-api": {
+      "type": "http",
+      "url": "https://mcp.example.com",
+      "headersHelper": "varlock printenv --template '{\"Authorization\": \"Bearer {{MY_MCP_TOKEN}}\"}' --escape json"
+    }
+  }
+}
+```
+
+The helper runs from the session's working directory, so varlock picks up the project's `.env.schema` automatically. For user-scope servers, or to be independent of the working directory, add `-p /absolute/path/to/project` (or `-p ~/.env.mcp` for a personal schema file). For the desktop app, also use an absolute path to the varlock binary. The [standalone binary](/getting-started/installation/#as-a-standalone-binary) is the safest choice there: the npm-installed CLI needs `node` on `PATH`, which the desktop app may not have.
+
+Claude Code gives the helper 10 seconds to run. A warm varlock cache resolves well within that; a cold resolve that prompts for biometric auth may not, so keep caching enabled for schemas used this way.
+
+### Local stdio servers: wrap the command
+
+For stdio servers, wrap the server command with `varlock run` in the server entry itself. This works no matter how Claude Code was launched, since each MCP server is a child process it spawns:
+
+```json title=".mcp.json"
+{
+  "mcpServers": {
+    "my-local-server": {
+      "command": "varlock",
+      "args": ["run", "-p", "/absolute/path/to/project", "--filter", "MY_SERVER_*", "--inject", "vars", "--", "npx", "-y", "some-mcp-server"]
+    }
+  }
+}
+```
+
+- `--filter` injects only the vars that server needs, so each server gets least-privilege access
+- `--inject vars` keeps the `__VARLOCK_ENV` blob out of a third-party server's environment
+- The server's stdout is a pipe, so [redaction](/guides/secrets/#cli-log-redaction) applies to sensitive values in its output; add `--no-redact-stdout` if that interferes with your server

--- a/packages/varlock-website/src/content/docs/reference/cli/load-and-run.mdx
+++ b/packages/varlock-website/src/content/docs/reference/cli/load-and-run.mdx
@@ -199,9 +199,11 @@ varlock printenv <VAR_NAME> [options]
 ```
 
 **Positional arguments:**
-- `<VAR_NAME>`: The variable to print. Required; printenv errors if omitted.
+- `<VAR_NAME>`: The variable to print. Required unless `--template` is used; printenv errors if both are omitted, or if both are given.
 
 **Options:**
+- `--template` / `-t`: Print a rendered string template instead of a single value. `{{KEY}}` placeholders are replaced with resolved values, and a template can reference multiple variables.
+- `--escape <lang>`: Escape substituted values for the given language (only valid with `--template`). Currently supports `json`, which escapes each value for embedding inside a JSON string literal. Only the value's content is escaped (no quotes are added), so placeholders used as bare values (like numbers) pass through unchanged.
 - [Common options](/reference/cli-commands/#common-options): `--path` / `-p`, `--clear-cache`, `--skip-cache`
 
 **Examples:**
@@ -217,6 +219,9 @@ varlock printenv -p ./envs -p ./overrides MY_VAR
 
 # Embed in a shell command using subshell expansion
 sh -c 'some-tool --token $(varlock printenv MY_TOKEN)'
+
+# Render a template referencing one or more variables
+varlock printenv --template '{"Authorization": "Bearer {{MY_TOKEN}}"}' --escape json
 ```
 
 :::note[Why not use `varlock run -- echo $MY_VAR`?]

--- a/packages/varlock/src/cli/commands/printenv.command.ts
+++ b/packages/varlock/src/cli/commands/printenv.command.ts
@@ -6,6 +6,32 @@ import { checkForSchemaErrors } from '../helpers/error-checks';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { CliExitError } from '../helpers/exit-error';
 
+const TEMPLATE_PLACEHOLDER_REGEX = /\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
+
+export type TemplateEscapeLang = 'json';
+
+export function extractTemplateKeys(template: string): Array<string> {
+  const keys = new Set<string>();
+  for (const match of template.matchAll(TEMPLATE_PLACEHOLDER_REGEX)) {
+    keys.add(match[1]);
+  }
+  return [...keys];
+}
+
+export function renderTemplate(
+  template: string,
+  values: Record<string, string>,
+  escapeLang?: TemplateEscapeLang,
+): string {
+  return template.replace(TEMPLATE_PLACEHOLDER_REGEX, (_placeholder, key) => {
+    const value = values[key] ?? '';
+    // escapes the value's content for embedding inside a JSON string literal;
+    // no quotes are added, so placeholders used as bare values pass through unchanged
+    if (escapeLang === 'json') return JSON.stringify(value).slice(1, -1);
+    return value;
+  });
+}
+
 export const commandSpec = define({
   name: 'printenv',
   description: 'Print the resolved value of a single environment variable',
@@ -14,6 +40,16 @@ export const commandSpec = define({
       type: 'positional',
       required: false,
       description: 'Variable to print',
+    },
+    template: {
+      type: 'string',
+      short: 't',
+      description: 'Print a rendered string template instead of a single value; {{KEY}} placeholders are replaced with resolved values',
+    },
+    escape: {
+      type: 'enum',
+      choices: ['json'],
+      description: 'Escape substituted values for the given language (only valid with --template); "json" escapes each value for embedding inside a JSON string literal',
     },
     path: {
       type: 'string',
@@ -31,7 +67,8 @@ export const commandSpec = define({
     },
   },
   examples: `
-Prints the resolved value of a single environment variable.
+Prints the resolved value of a single environment variable, or a rendered string
+template referencing multiple variables.
 Useful within larger shell commands where you need a single env var value.
 
 Examples:
@@ -39,18 +76,29 @@ Examples:
   varlock printenv --path .env.prod MY_VAR   # Use a specific .env file
   varlock printenv --path ./config/ MY_VAR   # Use a specific directory
   varlock printenv -p ./envs -p ./overrides MY_VAR  # Use multiple directories
+  varlock printenv --template '{"Authorization": "Bearer {{MY_TOKEN}}"}' --escape json  # Render a template
 
 📍 Note: Use sh -c to embed this in shell commands, e.g.:
        sh -c 'do-something --token $(varlock printenv MY_TOKEN)'
 
 💡 Tip: Unlike \`varlock run -- echo $MY_VAR\`, this works because the shell
        expansion happens after varlock has printed the value.
+
+💡 Tip: Use --escape json when a template emits JSON (e.g. headers for an MCP
+       headersHelper) so values cannot break out of their string literals
   `.trim(),
 });
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   const varName = ctx.values.key;
-  if (!varName) {
+  const template = ctx.values.template;
+  if (varName && template !== undefined) {
+    throw new CliExitError('Provide either a variable name or --template, not both');
+  }
+  if (ctx.values.escape !== undefined && template === undefined) {
+    throw new CliExitError('--escape is only valid with --template');
+  }
+  if (!varName && template === undefined) {
     throw new CliExitError('Missing required argument: variable name', {
       suggestion: 'Run `varlock printenv MY_VAR` to print the value of MY_VAR',
     });
@@ -63,25 +111,45 @@ export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) =
   });
   checkForSchemaErrors(envGraph);
 
-  if (!(varName in envGraph.configSchema)) {
-    throw new CliExitError(`Variable "${varName}" not found in schema`);
+  const keys = template !== undefined ? extractTemplateKeys(template) : [varName!];
+
+  const missingKeys = keys.filter((key) => !(key in envGraph.configSchema));
+  if (missingKeys.length > 0) {
+    throw new CliExitError(
+      `Variable${missingKeys.length > 1 ? 's' : ''} ${missingKeys.map((key) => `"${key}"`).join(', ')} not found in schema`,
+    );
   }
 
-  // Resolve only the requested item and its transitive dependencies
-  await envGraph.resolveItemWithDeps(varName);
+  // Resolve only the requested item(s) and their transitive dependencies
+  for (const key of keys) {
+    await envGraph.resolveItemWithDeps(key);
+  }
 
-  const item = envGraph.configSchema[varName];
-  if (item.validationState === 'error') {
-    for (const err of item.errors) {
-      console.error(`🚨 ${err.message}`);
+  let hasValidationErrors = false;
+  for (const key of keys) {
+    const item = envGraph.configSchema[key];
+    if (item.validationState === 'error') {
+      hasValidationErrors = true;
+      for (const err of item.errors) {
+        console.error(`🚨 ${err.message}`);
+      }
     }
-    return gracefulExit(1);
   }
+  if (hasValidationErrors) return gracefulExit(1);
 
-  const value = item.resolvedValue;
-  if (value === undefined || value === null) {
-    console.log('');
+  const stringValue = (key: string) => {
+    const value = envGraph.configSchema[key].resolvedValue;
+    return value === undefined || value === null ? '' : String(value);
+  };
+
+  if (template !== undefined) {
+    console.log(renderTemplate(
+      template,
+      Object.fromEntries(keys.map((key) => [key, stringValue(key)])),
+      // gunshi already validated the value against the enum choices
+      ctx.values.escape as TemplateEscapeLang | undefined,
+    ));
   } else {
-    console.log(String(value));
+    console.log(stringValue(varName!));
   }
 };

--- a/packages/varlock/src/cli/commands/test/printenv.command.test.ts
+++ b/packages/varlock/src/cli/commands/test/printenv.command.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from 'vitest';
+import { extractTemplateKeys, renderTemplate } from '../printenv.command.js';
+
+describe('extractTemplateKeys', () => {
+  test('extracts a single key', () => {
+    expect(extractTemplateKeys('Bearer {{MY_TOKEN}}')).toEqual(['MY_TOKEN']);
+  });
+
+  test('extracts multiple keys', () => {
+    expect(extractTemplateKeys('{{A}} and {{B_2}}')).toEqual(['A', 'B_2']);
+  });
+
+  test('dedupes repeated keys', () => {
+    expect(extractTemplateKeys('{{A}} {{A}}')).toEqual(['A']);
+  });
+
+  test('allows whitespace inside placeholders', () => {
+    expect(extractTemplateKeys('{{  MY_VAR  }}')).toEqual(['MY_VAR']);
+  });
+
+  test('ignores invalid placeholder names', () => {
+    expect(extractTemplateKeys('{{1BAD}} {{with-dash}} {single}')).toEqual([]);
+  });
+
+  test('returns empty array when no placeholders', () => {
+    expect(extractTemplateKeys('{"static": "json"}')).toEqual([]);
+  });
+});
+
+describe('renderTemplate', () => {
+  test('substitutes values into a JSON template', () => {
+    expect(renderTemplate(
+      '{"Authorization": "Bearer {{MY_TOKEN}}"}',
+      { MY_TOKEN: 'abc123' },
+    )).toBe('{"Authorization": "Bearer abc123"}');
+  });
+
+  test('substitutes multiple keys', () => {
+    expect(renderTemplate('{{A}}-{{B}}', { A: '1', B: '2' })).toBe('1-2');
+  });
+
+  test('substitutes empty string for missing values', () => {
+    expect(renderTemplate('x={{A}}', {})).toBe('x=');
+  });
+
+  test('leaves non-placeholder braces untouched', () => {
+    expect(renderTemplate('{"a": {"b": "{{KEY}}"}}', { KEY: 'v' })).toBe('{"a": {"b": "v"}}');
+  });
+
+  test('does not escape values by default', () => {
+    expect(renderTemplate('{{A}}', { A: 'has "quotes"' })).toBe('has "quotes"');
+  });
+
+  test('json escaping applies to all placeholders', () => {
+    expect(renderTemplate('"{{A}}"', { A: 'has "quotes" and \\slash\nnewline' }, 'json'))
+      .toBe('"has \\"quotes\\" and \\\\slash\\nnewline"');
+  });
+
+  test('json-escaped output parses back to the original value', () => {
+    const value = 'tricky "value" with \\ and \n and \t chars';
+    const rendered = renderTemplate('{"h": "{{A}}"}', { A: value }, 'json');
+    expect(JSON.parse(rendered).h).toBe(value);
+  });
+
+  test('json escaping leaves safe bare values unquoted', () => {
+    expect(renderTemplate('{"port": {{PORT}}}', { PORT: '3000' }, 'json')).toBe('{"port": 3000}');
+  });
+});

--- a/smoke-tests/tests/cli.test.ts
+++ b/smoke-tests/tests/cli.test.ts
@@ -161,6 +161,45 @@ describe('CLI Commands', () => {
       expect(result.exitCode).not.toBe(0);
       expect(result.output).toContain('Missing required argument');
     });
+
+    test('varlock printenv --template renders placeholders with resolved values', () => {
+      const result = runVarlock(
+        ['printenv', '--template', '{"Authorization": "Bearer {{SECRET_TOKEN}}", "X-Env": "{{NODE_ENV}}"}', '--escape', 'json'],
+        { cwd: 'smoke-test-basic' },
+      );
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({
+        Authorization: 'Bearer super-secret-token-12345',
+        'X-Env': 'test',
+      });
+    });
+
+    test('varlock printenv rejects --escape without --template', () => {
+      const result = runVarlock(
+        ['printenv', 'PUBLIC_VAR', '--escape', 'json'],
+        { cwd: 'smoke-test-basic' },
+      );
+      expect(result.exitCode).not.toBe(0);
+      expect(result.output).toContain('only valid with --template');
+    });
+
+    test('varlock printenv --template with unknown variable returns error', () => {
+      const result = runVarlock(
+        ['printenv', '--template', 'x={{DOES_NOT_EXIST}}'],
+        { cwd: 'smoke-test-basic' },
+      );
+      expect(result.exitCode).not.toBe(0);
+      expect(result.output).toContain('DOES_NOT_EXIST');
+    });
+
+    test('varlock printenv rejects a variable name combined with --template', () => {
+      const result = runVarlock(
+        ['printenv', 'PUBLIC_VAR', '--template', '{{PUBLIC_VAR}}'],
+        { cwd: 'smoke-test-basic' },
+      );
+      expect(result.exitCode).not.toBe(0);
+      expect(result.output).toContain('not both');
+    });
   });
 
   describe('generate-key command', () => {


### PR DESCRIPTION
## What

Adds a `--template` / `-t` flag to `varlock printenv` that renders a string template, replacing `{{KEY}}` placeholders with resolved values. A template can reference multiple variables; only the referenced items (and their deps) are resolved. An accompanying `--escape json` flag escapes each substituted value for embedding inside a JSON string literal (content-only, no quotes added, so bare-value placeholders like numbers pass through unchanged).

```bash
varlock printenv --template '{"Authorization": "Bearer {{MY_TOKEN}}"}' --escape json
```

## Why

The main driver is MCP client configs. Claude Code's `headersHelper` (and similar hooks in other clients) runs a shell command that must print a JSON object of auth headers. Today that takes a `printf`/subshell one-liner with hostile quoting; with this flag it is a single readable command. `{{KEY}}` syntax (rather than `${KEY}`) is deliberate: these commands get embedded in shell strings, and a double-quoted `${KEY}` would be expanded by the shell to an empty string before varlock ever runs.

Docs: flag reference in the CLI reference, plus a new "MCP server secrets" section in the Claude Code guide covering both the `headersHelper` pattern for remote servers and `varlock run` wrapping for local stdio servers.