### PR TITLE
fix(redaction): redact secrets from Error objects passed to console

### DIFF
--- a/.bumpy/redact-error-objects.md
+++ b/.bumpy/redact-error-objects.md
@@ -2,4 +2,4 @@
 varlock: patch
 ---
 
-Redact sensitive values from Error objects passed to console methods (message, stack, cause, and custom props)
+Redact sensitive values from Error objects passed to console methods, and fix console redaction of plain objects that could not survive a JSON round-trip (nested errors, circular references, bigints, dates)

--- a/.bumpy/redact-error-objects.md
+++ b/.bumpy/redact-error-objects.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Redact sensitive values from Error objects passed to console methods (message, stack, cause, and custom props)

--- a/framework-tests/frameworks/cloudflare/cloudflare-shared.ts
+++ b/framework-tests/frameworks/cloudflare/cloudflare-shared.ts
@@ -76,7 +76,15 @@ export function defineCloudflareTests(
       outputAssertions: [
         {
           description: 'sensitive value is redacted in console output',
-          shouldContain: ['secret-log-test::'],
+          shouldContain: [
+            'secret-log-test::',
+            // error object logged directly - redacted, not passed through raw
+            'error-log-test::',
+            // error nested in a plain object - message survives (not hollowed to `{}`)
+            'wrapped-error-test::',
+            // circular object - printed and redacted rather than bypassing redaction
+            'circular-log-test::',
+          ],
           shouldNotContain: ['super-secret-value'],
         },
       ],

--- a/framework-tests/frameworks/cloudflare/files/workers/basic-worker.ts
+++ b/framework-tests/frameworks/cloudflare/files/workers/basic-worker.ts
@@ -7,8 +7,16 @@ const TOP_LEVEL_HAS_SECRET = ENV.SECRET_KEY ? 'yes' : 'no';
 
 export default {
   async fetch(_request: Request, env: Record<string, string>): Promise<Response> {
-    // this should be redacted in varlock-wrangler output
+    // these should all be redacted in console output (see output assertions)
     console.log('secret-log-test::', ENV.SECRET_KEY);
+    // error objects reach the platform inspector as live objects in workerd
+    console.error(new Error(`error-log-test:: ${ENV.SECRET_KEY}`));
+    // nested error must keep its message/stack (not hollow out to `{ err: {} }`)
+    console.error('wrapped-log-test::', { err: new Error(`wrapped-error-test:: ${ENV.SECRET_KEY}`) });
+    // circular objects previously bypassed redaction entirely (JSON.stringify threw)
+    const circular: Record<string, any> = { label: 'circular-log-test::', token: ENV.SECRET_KEY };
+    circular.self = circular;
+    console.log(circular);
 
     return new Response([
       // varlock ENV proxy - non-sensitive vars

--- a/framework-tests/frameworks/cloudflare/wrangler.test.ts
+++ b/framework-tests/frameworks/cloudflare/wrangler.test.ts
@@ -64,7 +64,15 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
       },
       {
         description: 'sensitive value is redacted in console output',
-        shouldContain: ['secret-log-test::'],
+        shouldContain: [
+          'secret-log-test::',
+          // error object logged directly - redacted, not passed through raw
+          'error-log-test::',
+          // error nested in a plain object - message survives (not hollowed to `{}`)
+          'wrapped-error-test::',
+          // circular object - printed and redacted rather than bypassing redaction
+          'circular-log-test::',
+        ],
         shouldNotContain: ['super-secret-value'],
       },
     ],

--- a/packages/varlock-website/src/content/docs/guides/secrets.mdx
+++ b/packages/varlock-website/src/content/docs/guides/secrets.mdx
@@ -166,7 +166,16 @@ console.log(process.env.SECRET_KEY);
 // outputs "my▒▒▒▒▒" instead of "my-secret-value"
 ```
 
-This works by intercepting Node.js internal console internals, with an additional layer that wraps the console methods themselves to handle environments where `console.log` has been patched by the platform (e.g., AWS Lambda).
+This works by intercepting Node.js internal console internals, with an additional layer that wraps the console methods themselves to handle environments where `console.log` has been patched by the platform (e.g., AWS Lambda) or where those internals do not exist at all (edge runtimes like Cloudflare Workers and Vercel Edge).
+
+That second layer inspects each argument you pass, so it covers strings, arrays, plain objects, and `Error` objects. For errors, the `message`, `stack`, `cause` chain, and any custom properties attached to the error are all redacted:
+
+```js
+console.error(new Error(`request failed with key ${process.env.SECRET_KEY}`));
+// logs "Error: request failed with key my▒▒▒▒▒"
+```
+
+Varlock does not mutate the error you passed. It logs a redacted copy, which keeps the original prototype so `instanceof` checks and stack traces still behave normally.
 
 If you need to intentionally reveal a secret in logs (for example during debugging), you can use the `revealSensitiveConfig` helper:
 

--- a/packages/varlock-website/src/content/docs/guides/secrets.mdx
+++ b/packages/varlock-website/src/content/docs/guides/secrets.mdx
@@ -168,14 +168,7 @@ console.log(process.env.SECRET_KEY);
 
 This works by intercepting Node.js internal console internals, with an additional layer that wraps the console methods themselves to handle environments where `console.log` has been patched by the platform (e.g., AWS Lambda) or where those internals do not exist at all (edge runtimes like Cloudflare Workers and Vercel Edge).
 
-That second layer inspects each argument you pass, so it covers strings, arrays, plain objects, and `Error` objects. For errors, the `message`, `stack`, `cause` chain, and any custom properties attached to the error are all redacted:
-
-```js
-console.error(new Error(`request failed with key ${process.env.SECRET_KEY}`));
-// logs "Error: request failed with key my▒▒▒▒▒"
-```
-
-Varlock does not mutate the error you passed. It logs a redacted copy, which keeps the original prototype so `instanceof` checks and stack traces still behave normally.
+Redaction covers whatever you pass to the console methods: strings, arrays, plain objects, and `Error` objects (including messages, stack traces, and anything nested inside). Varlock logs a redacted copy rather than modifying what you passed in.
 
 If you need to intentionally reveal a secret in logs (for example during debugging), you can use the `revealSensitiveConfig` helper:
 

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -146,12 +146,70 @@ export function getRedactionMapInfo() {
 // we expose only the below const to end users
 
 
+function isErrorLike(o: any) {
+  // toString check also catches errors from another realm/context, where instanceof fails
+  return o instanceof Error || Object.prototype.toString.call(o) === '[object Error]';
+}
+
 /**
- * Redacts senstive config values from any string/array/object/etc
+ * Errors need special handling - their `message`/`stack` are non-enumerable so they do not
+ * survive a JSON round-trip, and their prototype is not `Object.prototype` so they used to
+ * fall through redaction untouched. That leaks secrets anywhere the console output is
+ * serialized from the object itself rather than from a pre-formatted string - edge runtimes
+ * (Cloudflare Workers, Vercel Edge), or any platform that has already patched console.log.
  *
- * NOTE - must be used only after varlock has loaded config
+ * We build a redacted copy instead of mutating the error, since the caller may still be
+ * using it. The copy is a real Error carrying the original prototype, so `instanceof` checks
+ * and console formatting keep working.
  * */
-export function redactSensitiveConfig(o: any): any {
+function redactError(err: any, seen: Map<any, any>): any {
+  // registered up front so circular `cause` chains (and repeat references) resolve
+  // to the copy rather than recursing forever or falling back to the raw error
+  if (seen.has(err)) return seen.get(err);
+  const copy = new Error();
+  Object.setPrototypeOf(copy, Object.getPrototypeOf(err));
+  seen.set(err, copy);
+
+  const keys: Array<string | symbol> = [
+    ...Object.getOwnPropertyNames(err),
+    ...Object.getOwnPropertySymbols(err),
+  ];
+  // `message`/`stack` are not own properties in every runtime, but always need redacting
+  for (const inheritedKey of ['message', 'stack']) {
+    if (!keys.includes(inheritedKey)) keys.push(inheritedKey);
+  }
+
+  let changed = false;
+  for (const key of keys) {
+    let value: any;
+    try {
+      value = err[key];
+    } catch (getterError) {
+      continue; // a getter that throws - nothing we can safely read or copy
+    }
+    const redactedValue = redactValue(value, seen); // eslint-disable-line no-use-before-define
+    if (redactedValue !== value) changed = true;
+    try {
+      Object.defineProperty(copy, key, {
+        value: redactedValue,
+        enumerable: Object.prototype.propertyIsEnumerable.call(err, key),
+        writable: true,
+        configurable: true,
+      });
+    } catch (defineError) {
+      // skip anything we cannot redefine on the copy
+    }
+  }
+
+  // nothing sensitive in here - hand back the original untouched
+  if (!changed) {
+    seen.set(err, err);
+    return err;
+  }
+  return copy;
+}
+
+function redactValue(o: any, seen: Map<any, any>): any {
   const { redactorFindReplace } = getRedactionState();
   if (!redactorFindReplace) return o;
   if (!o) return o;
@@ -160,12 +218,15 @@ export function redactSensitiveConfig(o: any): any {
   // we can probably redact safely from a few other datatypes - like set,map,etc?
   // objects are a bit tougher
   if (Array.isArray(o)) {
-    return o.map(redactSensitiveConfig);
+    return o.map((item) => redactValue(item, seen));
+  }
+  if (isErrorLike(o)) {
+    return redactError(o, seen);
   }
   // try to redact if it's a plain object - not necessarily great for perf...
   if (o && typeof (o) === 'object' && Object.getPrototypeOf(o) === Object.prototype) {
     try {
-      return JSON.parse(redactSensitiveConfig(JSON.stringify(o)));
+      return JSON.parse(redactValue(JSON.stringify(o), seen));
     } catch (err) {
       return o;
     }
@@ -177,6 +238,18 @@ export function redactSensitiveConfig(o: any): any {
   }
 
   return o;
+}
+
+/**
+ * Redacts senstive config values from any string/array/object/error/etc
+ *
+ * NOTE - must be used only after varlock has loaded config
+ * */
+export function redactSensitiveConfig(o: any): any {
+  const { redactorFindReplace } = getRedactionState();
+  if (!redactorFindReplace) return o;
+  if (!o) return o;
+  return redactValue(o, new Map());
 }
 
 /**

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -196,7 +196,9 @@ const ARRAY_INDEX_KEY_REGEX = /^(?:0|[1-9]\d*)$/;
 /** enumerable own string/symbol keys that a console inspector would print (excluding array indices) */
 function inspectableOwnKeys(o: any, skipIndices: boolean): Array<string | symbol> {
   return [
-    ...Object.keys(o).filter((key) => !(skipIndices && ARRAY_INDEX_KEY_REGEX.test(key))),
+    ...Object.keys(o).filter((key) => !(
+      skipIndices && ARRAY_INDEX_KEY_REGEX.test(key) && Number(key) < o.length
+    )),
     ...Object.getOwnPropertySymbols(o).filter((s) => Object.prototype.propertyIsEnumerable.call(o, s)),
   ];
 }

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -172,6 +172,35 @@ function redactPropertyKey(key: string | symbol, seen: Map<any, any>): string | 
   return redactedDescription === key.description ? key : Symbol(redactedDescription);
 }
 
+/** copies own props from source to target, redacting keys and values - returns whether anything changed */
+function redactAssignProps(source: any, target: any, keys: Array<string | symbol>, seen: Map<any, any>): boolean {
+  let changed = false;
+  for (const key of keys) {
+    const redactedKey = redactPropertyKey(key, seen);
+    if (redactedKey !== key) changed = true;
+    let value: any;
+    try {
+      value = source[key];
+    } catch (getterError) {
+      continue; // a getter that throws - nothing we can safely read or copy
+    }
+    const redactedValue = redactValue(value, seen); // eslint-disable-line no-use-before-define
+    if (redactedValue !== value) changed = true;
+    target[redactedKey] = redactedValue;
+  }
+  return changed;
+}
+
+const ARRAY_INDEX_KEY_REGEX = /^(?:0|[1-9]\d*)$/;
+
+/** enumerable own string/symbol keys that a console inspector would print (excluding array indices) */
+function inspectableOwnKeys(o: any, skipIndices: boolean): Array<string | symbol> {
+  return [
+    ...Object.keys(o).filter((key) => !(skipIndices && ARRAY_INDEX_KEY_REGEX.test(key))),
+    ...Object.getOwnPropertySymbols(o).filter((s) => Object.prototype.propertyIsEnumerable.call(o, s)),
+  ];
+}
+
 /**
  * Errors need special handling - their `message`/`stack` are non-enumerable so they do not
  * survive a JSON round-trip, and their prototype is not `Object.prototype` so they used to
@@ -250,6 +279,8 @@ function redactValue(o: any, seen: Map<any, any>): any {
       copy[i] = redactValue(o[i], seen);
       if (copy[i] !== o[i]) changed = true;
     }
+    // custom props hung off the array are printed by console inspectors too
+    if (redactAssignProps(o, copy, inspectableOwnKeys(o, true), seen)) changed = true;
     if (!changed) {
       seen.set(o, o);
       return o;
@@ -268,25 +299,7 @@ function redactValue(o: any, seen: Map<any, any>): any {
     if (seen.has(o)) return seen.get(o);
     const copy: Record<string | symbol, any> = objectPrototype === null ? Object.create(null) : {};
     seen.set(o, copy);
-    let changed = false;
-    const keys: Array<string | symbol> = [
-      ...Object.keys(o),
-      // symbol-keyed props are shown by console inspectors, so they need redacting too
-      ...Object.getOwnPropertySymbols(o).filter((s) => Object.prototype.propertyIsEnumerable.call(o, s)),
-    ];
-    for (const key of keys) {
-      const redactedKey = redactPropertyKey(key, seen);
-      if (redactedKey !== key) changed = true;
-      let value: any;
-      try {
-        value = o[key];
-      } catch (getterError) {
-        continue; // a getter that throws - nothing we can safely read or copy
-      }
-      const redactedValue = redactValue(value, seen);
-      if (redactedValue !== value) changed = true;
-      copy[redactedKey] = redactedValue;
-    }
+    const changed = redactAssignProps(o, copy, inspectableOwnKeys(o, false), seen);
     // nothing sensitive in here - hand back the original untouched
     if (!changed) {
       seen.set(o, o);

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -239,32 +239,60 @@ function redactValue(o: any, seen: Map<any, any>): any {
 
   // TODO: handle more cases?
   // we can probably redact safely from a few other datatypes - like set,map,etc?
-  // objects are a bit tougher
   if (Array.isArray(o)) {
-    return o.map((item) => redactValue(item, seen));
+    if (seen.has(o)) return seen.get(o);
+    const copy = new Array(o.length);
+    // registered before recursing so circular references resolve to the copy
+    // instead of recursing forever
+    seen.set(o, copy);
+    let changed = false;
+    for (let i = 0; i < o.length; i++) {
+      copy[i] = redactValue(o[i], seen);
+      if (copy[i] !== o[i]) changed = true;
+    }
+    if (!changed) {
+      seen.set(o, o);
+      return o;
+    }
+    return copy;
   }
   if (isErrorLike(o)) {
     return redactError(o, seen);
   }
-  // try to redact if it's a plain object - not necessarily great for perf...
-  if (o && typeof (o) === 'object' && Object.getPrototypeOf(o) === Object.prototype) {
-    try {
-      return JSON.parse(redactValue(JSON.stringify(o), seen));
-    } catch (err) {
-      if (seen.has(o)) return seen.get(o);
-      const copy: Record<string, any> = {};
-      seen.set(o, copy);
-      for (const key of Object.keys(o)) {
-        let value: any;
-        try {
-          value = o[key];
-        } catch (getterError) {
-          continue;
-        }
-        copy[redactPropertyKey(key, seen) as string] = redactValue(value, seen);
+  // walk plain objects structurally rather than JSON round-tripping - JSON.stringify
+  // drops non-enumerable props (hollowing out nested errors), mangles dates/undefined,
+  // and throws on bigints and circular references
+  // (null-prototype objects included - e.g. querystring.parse results)
+  const objectPrototype = typeof (o) === 'object' ? Object.getPrototypeOf(o) : undefined;
+  if (objectPrototype === Object.prototype || objectPrototype === null) {
+    if (seen.has(o)) return seen.get(o);
+    const copy: Record<string | symbol, any> = objectPrototype === null ? Object.create(null) : {};
+    seen.set(o, copy);
+    let changed = false;
+    const keys: Array<string | symbol> = [
+      ...Object.keys(o),
+      // symbol-keyed props are shown by console inspectors, so they need redacting too
+      ...Object.getOwnPropertySymbols(o).filter((s) => Object.prototype.propertyIsEnumerable.call(o, s)),
+    ];
+    for (const key of keys) {
+      const redactedKey = redactPropertyKey(key, seen);
+      if (redactedKey !== key) changed = true;
+      let value: any;
+      try {
+        value = o[key];
+      } catch (getterError) {
+        continue; // a getter that throws - nothing we can safely read or copy
       }
-      return copy;
+      const redactedValue = redactValue(value, seen);
+      if (redactedValue !== value) changed = true;
+      copy[redactedKey] = redactedValue;
     }
+    // nothing sensitive in here - hand back the original untouched
+    if (!changed) {
+      seen.set(o, o);
+      return o;
+    }
+    return copy;
   }
 
   const type = typeof o;

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -147,8 +147,29 @@ export function getRedactionMapInfo() {
 
 
 function isErrorLike(o: any) {
-  // toString check also catches errors from another realm/context, where instanceof fails
-  return o instanceof Error || Object.prototype.toString.call(o) === '[object Error]';
+  if (o instanceof Error) return true;
+
+  // Cross-realm errors fail instanceof. Find the realm's Error.prototype without relying on
+  // Object.prototype.toString, which can be masked by an own Symbol.toStringTag.
+  let prototype = Object.getPrototypeOf(o);
+  while (prototype) {
+    const constructor = Object.getOwnPropertyDescriptor(prototype, 'constructor')?.value;
+    if (
+      typeof constructor === 'function'
+      && constructor.name === 'Error'
+      && Object.prototype.hasOwnProperty.call(prototype, 'message')
+      && Object.getOwnPropertyDescriptor(prototype, 'name')?.value === 'Error'
+    ) return true;
+    prototype = Object.getPrototypeOf(prototype);
+  }
+  return false;
+}
+
+function redactPropertyKey(key: string | symbol, seen: Map<any, any>): string | symbol {
+  if (typeof key === 'string') return redactValue(key, seen); // eslint-disable-line no-use-before-define
+  if (key.description === undefined) return key;
+  const redactedDescription = redactValue(key.description, seen); // eslint-disable-line no-use-before-define
+  return redactedDescription === key.description ? key : Symbol(redactedDescription);
 }
 
 /**
@@ -181,6 +202,8 @@ function redactError(err: any, seen: Map<any, any>): any {
 
   let changed = false;
   for (const key of keys) {
+    const redactedKey = redactPropertyKey(key, seen);
+    if (redactedKey !== key) changed = true;
     let value: any;
     try {
       value = err[key];
@@ -190,7 +213,7 @@ function redactError(err: any, seen: Map<any, any>): any {
     const redactedValue = redactValue(value, seen); // eslint-disable-line no-use-before-define
     if (redactedValue !== value) changed = true;
     try {
-      Object.defineProperty(copy, key, {
+      Object.defineProperty(copy, redactedKey, {
         value: redactedValue,
         enumerable: Object.prototype.propertyIsEnumerable.call(err, key),
         writable: true,
@@ -228,7 +251,19 @@ function redactValue(o: any, seen: Map<any, any>): any {
     try {
       return JSON.parse(redactValue(JSON.stringify(o), seen));
     } catch (err) {
-      return o;
+      if (seen.has(o)) return seen.get(o);
+      const copy: Record<string, any> = {};
+      seen.set(o, copy);
+      for (const key of Object.keys(o)) {
+        let value: any;
+        try {
+          value = o[key];
+        } catch (getterError) {
+          continue;
+        }
+        copy[redactPropertyKey(key, seen) as string] = redactValue(value, seen);
+      }
+      return copy;
     }
   }
 

--- a/packages/varlock/src/runtime/test/patch-console-errors.test.ts
+++ b/packages/varlock/src/runtime/test/patch-console-errors.test.ts
@@ -58,6 +58,14 @@ describe('patchGlobalConsole per-argument redaction (edge-style console)', () =>
     expect(logged[0][0].stack).not.toContain(SECRET_VALUE);
   });
 
+  it('redacts an error wrapped in a plain object, keeping message and stack', () => {
+    const err = new Error(`boom ${SECRET_VALUE}`);
+    console.error('failed', { err });
+    expect(logged[0][1].err.message).toBe(`boom ${REDACTED_SECRET}`);
+    expect(logged[0][1].err.stack).toBeTruthy();
+    expect(logged[0][1].err.stack).not.toContain(SECRET_VALUE);
+  });
+
   it('redacts a thrown error caught and logged directly', () => {
     try {
       throw new Error(`auth failed with ${SECRET_VALUE}`);

--- a/packages/varlock/src/runtime/test/patch-console-errors.test.ts
+++ b/packages/varlock/src/runtime/test/patch-console-errors.test.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-console -- calling the patched console methods is the point here */
+
+import {
+  describe, it, expect, beforeEach, afterEach,
+} from 'vitest';
+import { resetRedactionMap } from '../env';
+import { patchGlobalConsole } from '../patch-console';
+import type { SerializedEnvGraph } from '../../env-graph';
+
+const SECRET_VALUE = 'super-secret-value-12345';
+const REDACTED_SECRET = 'su▒▒▒▒▒';
+
+/**
+ * Edge runtimes (Cloudflare Workers, Vercel Edge) have no `kWriteToConsole` internal, so
+ * only the per-argument console patch applies and each argument reaches the platform
+ * inspector as an object. Same story anywhere console.log was already patched by something
+ * else (AWS Lambda). This stands in a bare console to exercise exactly that path.
+ */
+describe('patchGlobalConsole per-argument redaction (edge-style console)', () => {
+  const originalConsole = globalThis.console;
+  let logged: Array<Array<any>>;
+
+  beforeEach(() => {
+    logged = [];
+    const record = (...args: Array<any>) => {
+      logged.push(args);
+    };
+    const fakeConsole: any = {};
+    for (const method of ['trace', 'debug', 'info', 'log', 'warn', 'error']) {
+      fakeConsole[method] = record;
+    }
+    globalThis.console = fakeConsole;
+
+    resetRedactionMap({
+      config: { API_KEY: { isSensitive: true, value: SECRET_VALUE } },
+    } as unknown as SerializedEnvGraph);
+    patchGlobalConsole();
+  });
+
+  afterEach(() => {
+    globalThis.console = originalConsole;
+  });
+
+  it('redacts a secret passed as a bare string', () => {
+    console.log('token:', SECRET_VALUE);
+    expect(logged[0]).toEqual(['token:', REDACTED_SECRET]);
+  });
+
+  it('redacts a secret inside an error message', () => {
+    console.error('request failed', new Error(`boom ${SECRET_VALUE}`));
+    expect(logged[0][1].message).toBe(`boom ${REDACTED_SECRET}`);
+  });
+
+  it('redacts a secret inside an error stack', () => {
+    const err = new Error('request failed');
+    err.stack = `Error: request failed\n    at fetchThing (https://example.com/?token=${SECRET_VALUE})`;
+    console.error(err);
+    expect(logged[0][0].stack).not.toContain(SECRET_VALUE);
+  });
+
+  it('redacts a thrown error caught and logged directly', () => {
+    try {
+      throw new Error(`auth failed with ${SECRET_VALUE}`);
+    } catch (err) {
+      console.error(err);
+    }
+    expect(logged[0][0].message).toBe(`auth failed with ${REDACTED_SECRET}`);
+    expect(logged[0][0]).toBeInstanceOf(Error);
+  });
+});

--- a/packages/varlock/src/runtime/test/redact-errors.test.ts
+++ b/packages/varlock/src/runtime/test/redact-errors.test.ts
@@ -1,6 +1,7 @@
 import {
   describe, it, expect, beforeEach,
 } from 'vitest';
+import { runInNewContext } from 'node:vm';
 import { resetRedactionMap, redactSensitiveConfig } from '../env';
 import type { SerializedEnvGraph } from '../../env-graph';
 
@@ -71,6 +72,37 @@ describe('redactSensitiveConfig - errors', () => {
     expect(redacted.requestUrl).toBe(`https://example.com/?token=${REDACTED_SECRET}`);
     expect(redacted.headers.authorization).toBe(`Bearer ${REDACTED_SECRET}`);
     expect(redacted.attempts).toBe(3);
+  });
+
+  it('redacts secrets in custom property names and symbol descriptions', () => {
+    const err: any = new Error('request failed');
+    err[`token-${SECRET_VALUE}`] = 'string key';
+    err[Symbol(`token-${SECRET_VALUE}`)] = 'symbol key';
+
+    const redacted = redactSensitiveConfig(err);
+    expect(Object.getOwnPropertyNames(redacted).join()).not.toContain(SECRET_VALUE);
+    expect(Object.getOwnPropertySymbols(redacted).map((key) => key.description).join()).not.toContain(SECRET_VALUE);
+    expect(Object.getOwnPropertyNames(err).join()).toContain(SECRET_VALUE);
+  });
+
+  it('redacts circular plain objects attached to an error', () => {
+    const details: any = { token: SECRET_VALUE };
+    details.self = details;
+    const err: any = Object.assign(new Error('request failed'), { details });
+
+    const redacted = redactSensitiveConfig(err);
+    expect(redacted.details.token).toBe(REDACTED_SECRET);
+    expect(redacted.details.self).toBe(redacted.details);
+    expect(err.details.token).toBe(SECRET_VALUE);
+  });
+
+  it('recognizes cross-realm errors with a custom toStringTag', () => {
+    const err = runInNewContext(`new Error('request failed: ${SECRET_VALUE}')`);
+    err[Symbol.toStringTag] = 'Masked';
+
+    const redacted = redactSensitiveConfig(err);
+    expect(redacted.message).toBe(`request failed: ${REDACTED_SECRET}`);
+    expect(err.message).toContain(SECRET_VALUE);
   });
 
   it('preserves enumerability so custom props still show up in log output', () => {

--- a/packages/varlock/src/runtime/test/redact-errors.test.ts
+++ b/packages/varlock/src/runtime/test/redact-errors.test.ts
@@ -1,0 +1,129 @@
+import {
+  describe, it, expect, beforeEach,
+} from 'vitest';
+import { resetRedactionMap, redactSensitiveConfig } from '../env';
+import type { SerializedEnvGraph } from '../../env-graph';
+
+const SECRET_VALUE = 'super-secret-value-12345';
+const REDACTED_SECRET = 'su▒▒▒▒▒';
+
+/** everything an inspector could pull off an error, flattened into one string */
+function inspectableString(err: any) {
+  const keys = [...new Set([...Object.getOwnPropertyNames(err), 'message', 'stack'])];
+  return keys.map((key) => `${key}=${String(err[key])}`).join('\n');
+}
+
+describe('redactSensitiveConfig - errors', () => {
+  beforeEach(() => {
+    resetRedactionMap({
+      config: {
+        API_KEY: { isSensitive: true, value: SECRET_VALUE },
+      },
+    } as unknown as SerializedEnvGraph);
+  });
+
+  it('redacts a secret in an error message', () => {
+    const redacted = redactSensitiveConfig(new Error(`request failed: ${SECRET_VALUE}`));
+    expect(redacted.message).toBe(`request failed: ${REDACTED_SECRET}`);
+    expect(inspectableString(redacted)).not.toContain(SECRET_VALUE);
+  });
+
+  it('redacts a secret in an error stack', () => {
+    const err = new Error('request failed');
+    err.stack = `Error: request failed\n    at fetchThing (https://example.com/?token=${SECRET_VALUE})`;
+    const redacted = redactSensitiveConfig(err);
+    expect(redacted.stack).toContain(REDACTED_SECRET);
+    expect(redacted.stack).not.toContain(SECRET_VALUE);
+  });
+
+  it('does not mutate the original error', () => {
+    const err = new Error(`boom ${SECRET_VALUE}`);
+    redactSensitiveConfig(err);
+    expect(err.message).toBe(`boom ${SECRET_VALUE}`);
+  });
+
+  it('returns the same object when nothing is sensitive', () => {
+    const err = new Error('nothing to hide here');
+    expect(redactSensitiveConfig(err)).toBe(err);
+  });
+
+  it('keeps the copy a real error with the original prototype and name', () => {
+    class CustomError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'CustomError';
+      }
+    }
+    const redacted = redactSensitiveConfig(new CustomError(`boom ${SECRET_VALUE}`));
+    expect(redacted).toBeInstanceOf(CustomError);
+    expect(redacted).toBeInstanceOf(Error);
+    expect(redacted.name).toBe('CustomError');
+    expect(redacted.stack).toBeTruthy();
+  });
+
+  it('redacts custom properties attached to an error', () => {
+    const err = Object.assign(new Error('request failed'), {
+      requestUrl: `https://example.com/?token=${SECRET_VALUE}`,
+      headers: { authorization: `Bearer ${SECRET_VALUE}` },
+      attempts: 3,
+    });
+    const redacted = redactSensitiveConfig(err);
+    expect(redacted.requestUrl).toBe(`https://example.com/?token=${REDACTED_SECRET}`);
+    expect(redacted.headers.authorization).toBe(`Bearer ${REDACTED_SECRET}`);
+    expect(redacted.attempts).toBe(3);
+  });
+
+  it('preserves enumerability so custom props still show up in log output', () => {
+    const err = Object.assign(new Error(`boom ${SECRET_VALUE}`), { code: 'E_BOOM' });
+    const redacted = redactSensitiveConfig(err);
+    expect(Object.keys(redacted)).toContain('code');
+    expect(Object.keys(redacted)).not.toContain('message');
+    expect(Object.keys(redacted)).not.toContain('stack');
+  });
+
+  it('redacts a nested `cause` error', () => {
+    const err = new Error('outer', { cause: new Error(`inner ${SECRET_VALUE}`) });
+    const redacted = redactSensitiveConfig(err);
+    expect(redacted.cause).toBeInstanceOf(Error);
+    expect(redacted.cause.message).toBe(`inner ${REDACTED_SECRET}`);
+  });
+
+  it('redacts errors nested in arrays', () => {
+    const [redacted] = redactSensitiveConfig([new Error(`boom ${SECRET_VALUE}`)]);
+    expect(redacted.message).toBe(`boom ${REDACTED_SECRET}`);
+  });
+
+  it('redacts errors held in an AggregateError', () => {
+    const redacted = redactSensitiveConfig(
+      new AggregateError([new Error(`boom ${SECRET_VALUE}`)], 'all failed'),
+    );
+    expect(redacted.errors[0].message).toBe(`boom ${REDACTED_SECRET}`);
+  });
+
+  it('redacts every reference when the same error appears more than once', () => {
+    const err = new Error(`boom ${SECRET_VALUE}`);
+    const [first, second] = redactSensitiveConfig([err, err]);
+    expect(first.message).toBe(`boom ${REDACTED_SECRET}`);
+    expect(second.message).toBe(`boom ${REDACTED_SECRET}`);
+  });
+
+  it('handles a circular cause chain without hanging or leaking', () => {
+    const err: any = new Error(`boom ${SECRET_VALUE}`);
+    err.cause = err;
+    const redacted = redactSensitiveConfig(err);
+    expect(redacted.message).toBe(`boom ${REDACTED_SECRET}`);
+    expect(redacted.cause).toBe(redacted);
+  });
+
+  it('skips getters that throw rather than blowing up', () => {
+    const err = new Error(`boom ${SECRET_VALUE}`);
+    Object.defineProperty(err, 'explode', {
+      get() { throw new Error('nope'); },
+      enumerable: true,
+      configurable: true,
+    });
+    const redacted = redactSensitiveConfig(err);
+    expect(redacted.message).toBe(`boom ${REDACTED_SECRET}`);
+    expect('explode' in redacted).toBe(false);
+  });
+});

--- a/packages/varlock/src/runtime/test/redact-objects.test.ts
+++ b/packages/varlock/src/runtime/test/redact-objects.test.ts
@@ -107,4 +107,24 @@ describe('redactSensitiveConfig - plain objects and arrays (structural walk)', (
     const clean = ['a', 'b', { c: 1 }];
     expect(redactSensitiveConfig(clean)).toBe(clean);
   });
+
+  it('redacts custom own properties hung off an array', () => {
+    const arr: any = ['clean'];
+    arr.token = SECRET_VALUE;
+    const sym = Symbol('symkey');
+    arr[sym] = `sym ${SECRET_VALUE}`;
+    const redacted = redactSensitiveConfig(arr);
+    expect(Array.isArray(redacted)).toBe(true);
+    expect(redacted[0]).toBe('clean');
+    expect(redacted.token).toBe(REDACTED_SECRET);
+    expect(redacted[sym]).toBe(`sym ${REDACTED_SECRET}`);
+  });
+
+  it('redacts secrets in custom array property keys', () => {
+    const arr: any = [];
+    arr[`token-${SECRET_VALUE}`] = 'x';
+    const redacted = redactSensitiveConfig(arr);
+    expect(redacted[`token-${REDACTED_SECRET}`]).toBe('x');
+    expect(redacted[`token-${SECRET_VALUE}`]).toBe(undefined);
+  });
 });

--- a/packages/varlock/src/runtime/test/redact-objects.test.ts
+++ b/packages/varlock/src/runtime/test/redact-objects.test.ts
@@ -1,0 +1,110 @@
+import {
+  describe, it, expect, beforeEach,
+} from 'vitest';
+import { resetRedactionMap, redactSensitiveConfig } from '../env';
+import type { SerializedEnvGraph } from '../../env-graph';
+
+const SECRET_VALUE = 'super-secret-value-12345';
+const REDACTED_SECRET = 'su▒▒▒▒▒';
+
+describe('redactSensitiveConfig - plain objects and arrays (structural walk)', () => {
+  beforeEach(() => {
+    resetRedactionMap({
+      config: {
+        API_KEY: { isSensitive: true, value: SECRET_VALUE },
+      },
+    } as unknown as SerializedEnvGraph);
+  });
+
+  it('redacts secrets in nested object values', () => {
+    const redacted = redactSensitiveConfig({ outer: { token: `key=${SECRET_VALUE}` } });
+    expect(redacted.outer.token).toBe(`key=${REDACTED_SECRET}`);
+  });
+
+  it('redacts secrets in object keys', () => {
+    const redacted = redactSensitiveConfig({ [SECRET_VALUE]: 'value' });
+    expect(Object.keys(redacted)).toEqual([REDACTED_SECRET]);
+  });
+
+  it('does not mutate the original object', () => {
+    const original = { token: SECRET_VALUE };
+    redactSensitiveConfig(original);
+    expect(original.token).toBe(SECRET_VALUE);
+  });
+
+  it('returns the same object when nothing is sensitive', () => {
+    const clean = { a: 1, b: 'hello', nested: { c: [1, 2, 3] } };
+    expect(redactSensitiveConfig(clean)).toBe(clean);
+  });
+
+  it('redacts an error nested inside a plain object, keeping message and stack', () => {
+    const err = new Error(`boom ${SECRET_VALUE}`);
+    const redacted = redactSensitiveConfig({ err });
+    expect(redacted.err).toBeInstanceOf(Error);
+    expect(redacted.err.message).toBe(`boom ${REDACTED_SECRET}`);
+    expect(redacted.err.stack).toBeTruthy();
+    expect(redacted.err.stack).not.toContain(SECRET_VALUE);
+  });
+
+  it('handles circular objects', () => {
+    const obj: any = { token: SECRET_VALUE };
+    obj.self = obj;
+    const redacted = redactSensitiveConfig(obj);
+    expect(redacted.token).toBe(REDACTED_SECRET);
+    expect(redacted.self).toBe(redacted);
+  });
+
+  it('handles circular arrays', () => {
+    const arr: Array<any> = [SECRET_VALUE];
+    arr.push(arr);
+    const redacted = redactSensitiveConfig(arr);
+    expect(redacted[0]).toBe(REDACTED_SECRET);
+    expect(redacted[1]).toBe(redacted);
+  });
+
+  it('resolves repeat references to a single copy', () => {
+    const shared = { token: SECRET_VALUE };
+    const redacted = redactSensitiveConfig({ a: shared, b: shared });
+    expect(redacted.a.token).toBe(REDACTED_SECRET);
+    expect(redacted.a).toBe(redacted.b);
+  });
+
+  it('preserves bigints alongside redacted values', () => {
+    const redacted = redactSensitiveConfig({ token: SECRET_VALUE, big: 10n });
+    expect(redacted.token).toBe(REDACTED_SECRET);
+    expect(redacted.big).toBe(10n);
+  });
+
+  it('preserves Date instances and undefined values', () => {
+    const date = new Date('2026-01-01');
+    const redacted = redactSensitiveConfig({ token: SECRET_VALUE, date, missing: undefined });
+    expect(redacted.date).toBe(date);
+    expect('missing' in redacted).toBe(true);
+    expect(redacted.missing).toBe(undefined);
+  });
+
+  it('redacts values under enumerable symbol keys', () => {
+    const sym = Symbol('label');
+    const redacted = redactSensitiveConfig({ [sym]: `key=${SECRET_VALUE}` });
+    expect(redacted[sym]).toBe(`key=${REDACTED_SECRET}`);
+  });
+
+  it('redacts null-prototype objects, keeping the null prototype', () => {
+    const obj = Object.create(null);
+    obj.token = SECRET_VALUE;
+    const redacted = redactSensitiveConfig(obj);
+    expect(redacted.token).toBe(REDACTED_SECRET);
+    expect(Object.getPrototypeOf(redacted)).toBe(null);
+  });
+
+  it('redacts arrays of objects', () => {
+    const redacted = redactSensitiveConfig([{ token: SECRET_VALUE }, 'clean']);
+    expect(redacted[0].token).toBe(REDACTED_SECRET);
+    expect(redacted[1]).toBe('clean');
+  });
+
+  it('returns the same array when nothing is sensitive', () => {
+    const clean = ['a', 'b', { c: 1 }];
+    expect(redactSensitiveConfig(clean)).toBe(clean);
+  });
+});

--- a/packages/varlock/src/runtime/test/redact-objects.test.ts
+++ b/packages/varlock/src/runtime/test/redact-objects.test.ts
@@ -127,4 +127,11 @@ describe('redactSensitiveConfig - plain objects and arrays (structural walk)', (
     expect(redacted[`token-${REDACTED_SECRET}`]).toBe('x');
     expect(redacted[`token-${SECRET_VALUE}`]).toBe(undefined);
   });
+
+  it('redacts decimal-looking array properties outside the array-index range', () => {
+    const arr: any = [];
+    arr['4294967295'] = SECRET_VALUE;
+    const redacted = redactSensitiveConfig(arr);
+    expect(redacted['4294967295']).toBe(REDACTED_SECRET);
+  });
 });


### PR DESCRIPTION
## The gap

`redactSensitiveConfig` handled strings, arrays, and plain objects (`Object.getPrototypeOf(o) === Object.prototype`). An `Error` matched none of those and fell out the bottom of the function untouched.

This was invisible on Node because `patchGlobalConsole` has two layers, and the `kWriteToConsole` layer redacts the already-formatted output string. Edge runtimes (Cloudflare Workers, Vercel Edge) have no such internal, so only the per-argument layer runs and each argument reaches the platform inspector as a live object. There, `console.error(new Error(\`boom ${SECRET}\`))` printed the secret. The same holds anywhere the platform pre-patches `console.log` (AWS Lambda).

It shows up as an odd asymmetry in practice: `console.log('x:', err.message)` redacts fine (it's a string), while `console.log('x:', err)` does not.

## The fix

`redactError` builds a redacted copy covering `message`, `stack`, the `cause` chain, own symbols, and any custom properties hung off the error.

- The copy is a real `Error` with the original prototype re-attached, so `instanceof` checks, subclass names, and native-error inspector checks still pass.
- The caller's error is never mutated - it may still be in use downstream.
- Clean errors are returned by identity, so nothing is allocated when there is no secret to redact.
- Repeat references and circular `cause` chains resolve through a shared `Map`, so `[err, err]` can't leave one copy redacted and the other raw.
- Getters that throw are skipped rather than taking down the log call.

`redactSensitiveConfig` keeps its single-argument public signature (it is used as `.map(redactSensitiveConfig)` in the console patch, where a second parameter would receive the array index); the recursion state lives in an internal `redactValue`.

## Plain objects: structural walk instead of JSON round-trip

The plain-object branch used `JSON.parse(redact(JSON.stringify(o)))`. That had several problems in the same family:

- A nested error hollowed out to `{}` (`message`/`stack` are non-enumerable, so `console.error('failed', { err })` lost the error entirely)
- `JSON.stringify` throws on circular references and bigints; the catch previously returned the object raw, which on edge was a leak of the same shape as the error gap
- Dates became strings, `undefined` values disappeared

The branch now walks objects and arrays structurally: string values and keys are redacted, nested errors go through `redactError`, and the shared `seen` map resolves circular and repeat references. Clean objects return by identity. Null-prototype objects (e.g. `querystring.parse` results), enumerable symbol-keyed props, and custom props hung off arrays are covered too, since console inspectors print all of them.

Perf is a wash: the walk costs about the same as the JSON round-trip it replaces (faster under Bun, slightly slower on large objects under V8), and both are on the order of the `util.inspect` traversal the console call performs anyway.

## Verification

Confirmed end-to-end in real workerd via `wrangler dev` (built `init-edge` bundle, secret seeded through the env graph), covering both the error work and the object walk. Zero occurrences of the raw secret in the captured output across all cases:

- bare errors, errors as a second argument, and caught-and-logged throws redact with stack frames intact
- `console.error('failed', { err })` now prints the redacted message and full stack instead of `{ err: {} }`
- circular objects and arrays print with `[Circular *1]` refs instead of leaking raw (or stack-overflowing)
- bigints survive as `10n`, dates print as real dates, null-prototype objects and symbol-keyed props print redacted

Tests added:
- `redact-errors.test.ts` - message, stack, cause chains, custom props, enumerability, subclasses, `AggregateError`, repeat refs, circular refs, throwing getters, no-mutation, identity on clean errors
- `redact-objects.test.ts` - nested errors keep message/stack, circular objects and arrays, repeat refs, bigints, dates, undefined, symbol keys, null-prototype objects, key redaction, identity on clean values
- `patch-console-errors.test.ts` - drives the per-argument path against a bare console, i.e. the edge shape where the gap lived
- cloudflare framework tests - the basic worker fixture now logs a bare error, an error nested in a plain object, and a circular object holding the secret, with output assertions across the wrangler-only and vite 6/7/8 suites (guards the end-to-end wiring in real workerd)

## Not changed

Secrets held on arbitrary class instances (neither plain objects nor errors) still pass through untouched - unknown classes can't be safely deep-copied.
