### PR TITLE
fix(telemetry): track proxy subcommands and stop dropping events on early exit

### DIFF
--- a/.bumpy/proxy-telemetry.md
+++ b/.bumpy/proxy-telemetry.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+track proxy subcommand usage in telemetry

--- a/.bumpy/telemetry-exit-race.md
+++ b/.bumpy/telemetry-exit-race.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+fix telemetry events being dropped when a command exits before the request finishes

--- a/packages/varlock/src/cli/commands/proxy.command.ts
+++ b/packages/varlock/src/cli/commands/proxy.command.ts
@@ -91,6 +91,7 @@ import { resetRedactionMap } from '../../runtime/env';
 import { REDACT_STDOUT_ARG, resolveStdoutRedaction, pipeRedactedStreams } from '../helpers/stdout-redaction';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { CliExitError } from '../helpers/exit-error';
+import { trackCommand } from '../helpers/telemetry';
 import {
   checkForConfigErrors,
   checkForNoEnvFiles,
@@ -1403,6 +1404,7 @@ function resolveProxyBindOptions(ctx: any): {
 }
 
 async function runAction(ctx: any) {
+  await trackCommand('proxy run', { command: 'proxy run' });
   const commandToRunAsArgs = getRunCommandArgs();
   const rawCommand = commandToRunAsArgs[0]!;
   const commandArgsOnly = commandToRunAsArgs.slice(1);
@@ -1648,6 +1650,7 @@ async function awaitProxiedChild(
 }
 
 async function startAction(ctx: any) {
+  await trackCommand('proxy start', { command: 'proxy start' });
   const policy = await prepareProxyPolicy(ctx.values.path);
   // Reload posture, resolved at launch (see resolveReloadMode). `manual` runs the
   // reload servicer so a human can `proxy reload` from another shell in the folder; a reload
@@ -1807,6 +1810,7 @@ async function startAction(ctx: any) {
  * never something that lands in output people paste or screenshot.
  */
 async function tokenAction(ctx: any) {
+  await trackCommand('proxy token', { command: 'proxy token' });
   const session = await resolveProxySessionForCommand({
     explicitSession: ctx.values.session,
     env: process.env,
@@ -1826,6 +1830,7 @@ async function tokenAction(ctx: any) {
 }
 
 async function envAction(ctx: any) {
+  await trackCommand('proxy env', { command: 'proxy env' });
   const session = await resolveProxySessionForCommand({
     explicitSession: ctx.values.session,
     env: process.env,
@@ -1943,6 +1948,7 @@ async function runRemoteThroughTunnel(ctx: any, cmd: {
 }
 
 async function statusAction(ctx: any) {
+  await trackCommand('proxy status', { command: 'proxy status' });
   const watch = ctx.values.watch ?? false;
   const asJson = (ctx.values.format ?? '').toLowerCase() === 'json';
   const printSnapshot = async () => {
@@ -2004,6 +2010,7 @@ async function statusAction(ctx: any) {
 }
 
 async function reloadAction(ctx: any) {
+  await trackCommand('proxy reload', { command: 'proxy reload' });
   const session = await resolveProxySessionForCommand({
     explicitSession: ctx.values.session,
     env: process.env,
@@ -2181,6 +2188,7 @@ async function stopOneSession(session: ProxySessionRecord): Promise<void> {
 }
 
 async function stopAction(ctx: any) {
+  await trackCommand('proxy stop', { command: 'proxy stop' });
   await cleanupStaleProxySessions();
 
   // Refuse an ambiguous target rather than silently honoring the destructive `--all`.
@@ -2219,6 +2227,7 @@ async function stopAction(ctx: any) {
 }
 
 async function pruneAction(ctx: any) {
+  await trackCommand('proxy prune', { command: 'proxy prune' });
   await cleanupStaleProxySessions();
 
   // Prune one specific session by id (any state, once it isn't running).
@@ -2269,6 +2278,7 @@ function formatAuditEntry(entry: ProxyAuditEntry): string {
 }
 
 async function auditAction(ctx: any) {
+  await trackCommand('proxy audit', { command: 'proxy audit' });
   const format = (ctx.values.format ?? 'text').toLowerCase();
   if (format !== 'text' && format !== 'json') {
     throw new CliExitError('Invalid --format for `proxy audit`. Use "text" or "json".');
@@ -2328,6 +2338,7 @@ function describeProxyRuleGate(rule: ProxyRule): string {
  * wouldn't be able to reach.
  */
 async function rulesAction(ctx: any) {
+  await trackCommand('proxy rules', { command: 'proxy rules' });
   const envGraph = await loadVarlockEnvGraph({
     entryFilePaths: ctx.values.path,
     // This command inspects the schema; don't subject it to the nested guard.

--- a/packages/varlock/src/cli/helpers/telemetry.ts
+++ b/packages/varlock/src/cli/helpers/telemetry.ts
@@ -6,7 +6,7 @@ import {
   mkdirSync,
 } from 'node:fs';
 import { asyncExitHook } from 'exit-hook';
-import { createDebug } from '../../lib/debug';
+import { createDebug, isDebugEnabled } from '../../lib/debug';
 import { name as ciName, isCI } from 'ci-info';
 import isDocker from 'is-docker';
 import isWSL from 'is-wsl';
@@ -505,14 +505,34 @@ function getTelemetryMeta() {
 
 
 const isOptedOut = checkIsOptedOut();
+const telemetryDebugEnabled = isDebugEnabled('varlock:telemetry');
 
-let lastTelemetryReq: Promise<any> | undefined;
+const pendingTelemetryReqs = new Set<Promise<any>>();
+
+// Register the exit hook at module load rather than per capture. Some commands trigger
+// gracefulExit() from within their own run fn (e.g. `varlock run` propagating a child's
+// exit code) while trackCommand fires afterwards in a `finally`; exit-hook snapshots its
+// callbacks when the exit starts, so a hook registered during that late trackCommand is
+// never awaited and the request gets killed. A pre-registered hook is always in the
+// snapshot; the setImmediate hop lets any late-fired request start before we wait on it.
+if (!isOptedOut) {
+  asyncExitHook(async () => {
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+    // will still exit if the timeout is met, but will finish early if the requests complete
+    await Promise.allSettled([...pendingTelemetryReqs]);
+  }, { wait: 500 });
+}
 
 async function posthogCapture(event: string, properties?: Record<string, any>) {
   // Telemetry must never break the CLI. trackCommand() is awaited in a `finally`,
-  // and the payload (incl. project/git/plugin data) is built even when opted out,
   // so any failure here is swallowed rather than surfaced to the caller.
   try {
+    // skip building the payload entirely when opted out - unless debug logging is on,
+    // in which case we still build and log it (useful for inspecting what would be sent)
+    if (isOptedOut && !telemetryDebugEnabled) return;
+
     const telemetryMeta = getTelemetryMeta();
     const usageContext = getTelemetryUsageContextPayload();
     const payload = {
@@ -531,14 +551,8 @@ async function posthogCapture(event: string, properties?: Record<string, any>) {
 
     if (isOptedOut) return;
 
-    // add exit hook, so we can give the request a little time to finish
-    const removeExitHook = asyncExitHook(async () => {
-      // will still exit if the timeout is met, but will finish early if the request completes
-      await lastTelemetryReq;
-    }, { wait: 500 });
-
     // Make the fetch call
-    lastTelemetryReq = fetch(`${CONFIG.POSTHOG_HOST}/i/v0/e/`, {
+    const telemetryReq = fetch(`${CONFIG.POSTHOG_HOST}/i/v0/e/`, {
       method: 'POST',
       body: JSON.stringify(payload),
       headers: {
@@ -554,8 +568,9 @@ async function posthogCapture(event: string, properties?: Record<string, any>) {
         debug('telemetry error:', error);
       })
       .finally(() => {
-        removeExitHook();
+        pendingTelemetryReqs.delete(telemetryReq);
       });
+    pendingTelemetryReqs.add(telemetryReq);
   } catch (err) {
     debug('telemetry capture error:', err);
   }

--- a/packages/varlock/src/cli/helpers/test/telemetry-send.test.ts
+++ b/packages/varlock/src/cli/helpers/test/telemetry-send.test.ts
@@ -1,0 +1,130 @@
+import {
+  describe, it, expect, vi, beforeEach, afterEach,
+} from 'vitest';
+
+vi.mock('exit-hook', () => ({
+  asyncExitHook: vi.fn(),
+  gracefulExit: vi.fn(),
+}));
+vi.mock('../telemetry-usage-context', () => ({
+  getTelemetryUsageContextPayload: vi.fn(() => ({})),
+  captureUsageContextFromEnvGraph: vi.fn(),
+}));
+vi.mock('../js-package-manager-utils', () => ({
+  detectJsPackageManager: vi.fn(),
+}));
+vi.mock('../../../lib/user-config-dir', async () => {
+  const os = await import('node:os');
+  const path = await import('node:path');
+  return {
+    getUserVarlockDir: () => path.join(os.tmpdir(), 'varlock-telemetry-send-test'),
+  };
+});
+
+import os from 'node:os';
+import path from 'node:path';
+import { asyncExitHook } from 'exit-hook';
+import { getTelemetryUsageContextPayload } from '../telemetry-usage-context';
+
+const flushImmediate = async () => new Promise((resolve) => {
+  setImmediate(resolve);
+});
+
+describe('telemetry send + exit hook', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let cwdSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.mocked(asyncExitHook).mockClear();
+    vi.mocked(getTelemetryUsageContextPayload).mockClear();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    // make sure the host machine's settings don't leak into the tests:
+    // point cwd at an empty temp path so the project-config walk finds nothing
+    // (including the developer's real ~/.varlock), and clear the opt-out env vars
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(path.join(os.tmpdir(), 'varlock-telemetry-send-cwd'));
+    vi.stubEnv('DEBUG', '');
+    vi.stubEnv('DO_NOT_TRACK', '');
+    vi.stubEnv('VARLOCK_TELEMETRY_DISABLED', '');
+    vi.stubEnv('PH_OPT_OUT', '');
+  });
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('awaits a request fired after the exit sequence has already started', async () => {
+    let resolveFetch!: (value: any) => void;
+    fetchMock.mockReturnValue(new Promise((resolve) => {
+      resolveFetch = resolve;
+    }));
+
+    const telemetry = await import('../telemetry');
+
+    // the hook must be registered at module load, so it is already in exit-hook's
+    // snapshot when a command calls gracefulExit() before trackCommand fires
+    expect(asyncExitHook).toHaveBeenCalledTimes(1);
+    const hookFn = vi.mocked(asyncExitHook).mock.calls[0][0];
+
+    // simulate exit-hook invoking the callback before any telemetry was sent
+    let hookSettled = false;
+    const hookPromise = Promise.resolve(hookFn(0)).then(() => {
+      hookSettled = true;
+    });
+
+    // telemetry fires late (e.g. from the command wrapper's `finally`)
+    await telemetry.trackCommand('test-command');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // the hook must still be waiting on the in-flight request
+    await flushImmediate();
+    await flushImmediate();
+    expect(hookSettled).toBe(false);
+
+    resolveFetch({ ok: true, text: async () => 'ok' });
+    await hookPromise;
+    expect(hookSettled).toBe(true);
+  });
+
+  it('waits for every in-flight request, not just the last one', async () => {
+    const resolvers: Array<(value: any) => void> = [];
+    fetchMock.mockImplementation(() => new Promise((resolve) => {
+      resolvers.push(resolve);
+    }));
+
+    const telemetry = await import('../telemetry');
+    const hookFn = vi.mocked(asyncExitHook).mock.calls[0][0];
+
+    await telemetry.trackCommand('first');
+    await telemetry.trackCommand('second');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    let hookSettled = false;
+    const hookPromise = Promise.resolve(hookFn(0)).then(() => {
+      hookSettled = true;
+    });
+
+    // resolving only one of the two requests must not release the hook
+    resolvers[0]({ ok: true, text: async () => 'ok' });
+    await flushImmediate();
+    await flushImmediate();
+    expect(hookSettled).toBe(false);
+
+    resolvers[1]({ ok: true, text: async () => 'ok' });
+    await hookPromise;
+    expect(hookSettled).toBe(true);
+  });
+
+  it('when opted out, bails before building the payload and registers no exit hook', async () => {
+    vi.stubEnv('VARLOCK_TELEMETRY_DISABLED', '1');
+
+    const telemetry = await import('../telemetry');
+    expect(asyncExitHook).not.toHaveBeenCalled();
+
+    await telemetry.trackCommand('test-command');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(getTelemetryUsageContextPayload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/varlock/src/lib/debug.ts
+++ b/packages/varlock/src/lib/debug.ts
@@ -85,6 +85,11 @@ const isEnabled = (namespace: string): boolean => {
   return enabled;
 };
 
+/** check whether debug output is enabled for a namespace (via the DEBUG env var) */
+export function isDebugEnabled(namespace: string): boolean {
+  return isEnabled(namespace);
+}
+
 export function createDebug(namespace: string): DebugFn {
   const enabled = isEnabled(namespace);
 


### PR DESCRIPTION
## What

Two telemetry reliability fixes:

**Proxy subcommands were never tracked.** gunshi dispatches nested subcommands straight to the leaf command's `run`, bypassing the `buildLazyCommand` wrapper that fires `cli_command_executed` for top-level commands. `cache` and `keychain` compensate with manual `trackCommand` calls, but `proxy` never did, so all ten verbs (`run`, `start`, `rules`, `env`, `token`, `status`, `audit`, `reload`, `stop`, `prune`) emitted zero telemetry. Each proxy action now calls `trackCommand('proxy <verb>')` at the start of its run, following the cache/keychain pattern. Firing at the start also matters because `proxy run`/`start` end via `gracefulExit()`.

**Events were dropped when a command exits before the request finishes.** Commands that call `gracefulExit()` inside their own run fn (`varlock run` propagating a child's exit code, `audit`, `scan`, `printenv`, error paths of `load`/`explain`, and the interactive-cancel paths in `init`/`encrypt`/`reveal`) start the exit sequence before `trackCommand` fires in the wrapper's `finally`. exit-hook snapshots its callbacks when the exit starts, so the hook registered during that late `trackCommand` was never awaited and the request got killed. The telemetry exit hook is now registered once at module load, so it is always in the snapshot; it waits one `setImmediate` tick for a late-fired request to start, then awaits all pending requests under the same 500ms cap. Pending requests are tracked in a set instead of a single variable, which also fixes a second event in the same process silently dropping the first.

## Also

- When opted out, `posthogCapture` now bails before building the payload (no metadata gathering, git parsing, or plugin attribute callbacks). If `DEBUG=varlock:telemetry` is set it still builds and logs the payload for inspection, then skips the send.
- New `isDebugEnabled()` export in `lib/debug.ts` to support that check.

## Notes for reviewers

- No command files changed for the exit-race fix; the single pre-registered hook covers every current and future `gracefulExit` site.
- New unit tests in `telemetry-send.test.ts` cover the late-fired request, multiple in-flight requests, and the opted-out early bail. They pin `process.cwd` to a temp path so the project-config walk can't pick up the developer's real `~/.varlock` opt-out.
- Verified `varlock run -- false` still exits 1 (exit-code propagation unchanged).