### PR TITLE
perf(cli): actually lazy-load command implementations

### DIFF
--- a/.bumpy/lazy-command-loading.md
+++ b/.bumpy/lazy-command-loading.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+lazy-load CLI command implementations so startup does not parse every command

--- a/packages/varlock/src/cli/cli-executable.ts
+++ b/packages/varlock/src/cli/cli-executable.ts
@@ -9,7 +9,7 @@ import { VARLOCK_BANNER_COLOR } from '../lib/ascii-art';
 import { CliExitError } from './helpers/exit-error';
 import { fmt } from './helpers/pretty-format';
 import { trackCommand, trackInstall } from './helpers/telemetry';
-import { InvalidEnvError } from './helpers/error-checks';
+import { InvalidEnvError } from './helpers/invalid-env-error';
 import { isArgError, toCliExitError } from './helpers/arg-errors';
 import { checkBunVersion } from '../lib/check-bun-version';
 import { checkLocalVersionMismatch } from '../lib/check-local-version';

--- a/packages/varlock/src/cli/cli-executable.ts
+++ b/packages/varlock/src/cli/cli-executable.ts
@@ -1,4 +1,4 @@
-import { cli, type Command } from 'gunshi';
+import { cli, lazy } from 'gunshi';
 import completion from '@gunshi/plugin-completion';
 import { gracefulExit } from 'exit-hook';
 
@@ -16,30 +16,34 @@ import { checkLocalVersionMismatch } from '../lib/check-local-version';
 import packageJson from '../../package.json';
 import { enforceProxyContextGuards } from './helpers/proxy-context-guard';
 
-// we'll import just the spec from each, so the implementations can be lazy loaded
-import { commandSpec as initCommandSpec } from './commands/init.command';
-import { commandSpec as loadCommandSpec } from './commands/load.command';
-import { commandSpec as runCommandSpec } from './commands/run.command';
-import { commandSpec as printenvCommandSpec } from './commands/printenv.command';
-import { commandSpec as encryptCommandSpec } from './commands/encrypt.command';
-import { commandSpec as lockCommandSpec } from './commands/lock.command';
-import { commandSpec as revealCommandSpec } from './commands/reveal.command';
-// import { commandSpec as doctorCommandSpec } from './commands/doctor.command';
-import { commandSpec as helpCommandSpec } from './commands/help.command';
-import { commandSpec as telemetryCommandSpec } from './commands/telemetry.command';
-import { commandSpec as explainCommandSpec } from './commands/explain.command';
-import { commandSpec as flattenCommandSpec } from './commands/flatten.command';
-import { commandSpec as scanCommandSpec } from './commands/scan.command';
-import { commandSpec as codegenCommandSpec } from './commands/codegen.command';
-import { commandSpec as typegenCommandSpec } from './commands/typegen.command';
-import { commandSpec as installPluginCommandSpec } from './commands/install-plugin.command';
-import { commandSpec as auditCommandSpec } from './commands/audit.command';
-import { commandSpec as generateKeyCommandSpec } from './commands/generate-key.command';
-import { commandSpec as cacheCommandSpec } from './commands/cache.command';
-import { commandSpec as keychainCommandSpec } from './commands/keychain.command';
-import { commandSpec as proxyCommandSpec } from './commands/proxy.command';
-// import { commandSpec as loginCommandSpec } from './commands/login.command';
-// import { commandSpec as pluginCommandSpec } from './commands/plugin.command';
+// Only the spec (name/description/args/examples) is imported eagerly - each command's
+// implementation lives in a sibling `*.command.ts` that is pulled in via a dynamic
+// import when that command actually runs. Keeping the two in separate modules is what
+// makes the split real: importing anything from `*.command.ts` here would drag the whole
+// implementation into the entry chunk and collapse the dynamic import away.
+import { commandSpec as initCommandSpec } from './commands/init.command-spec';
+import { commandSpec as loadCommandSpec } from './commands/load.command-spec';
+import { commandSpec as runCommandSpec } from './commands/run.command-spec';
+import { commandSpec as printenvCommandSpec } from './commands/printenv.command-spec';
+import { commandSpec as encryptCommandSpec } from './commands/encrypt.command-spec';
+import { commandSpec as lockCommandSpec } from './commands/lock.command-spec';
+import { commandSpec as revealCommandSpec } from './commands/reveal.command-spec';
+// import { commandSpec as doctorCommandSpec } from './commands/doctor.command-spec';
+import { commandSpec as helpCommandSpec } from './commands/help.command-spec';
+import { commandSpec as telemetryCommandSpec } from './commands/telemetry.command-spec';
+import { commandSpec as explainCommandSpec } from './commands/explain.command-spec';
+import { commandSpec as flattenCommandSpec } from './commands/flatten.command-spec';
+import { commandSpec as scanCommandSpec } from './commands/scan.command-spec';
+import { commandSpec as codegenCommandSpec } from './commands/codegen.command-spec';
+import { commandSpec as typegenCommandSpec } from './commands/typegen.command-spec';
+import { commandSpec as installPluginCommandSpec } from './commands/install-plugin.command-spec';
+import { commandSpec as auditCommandSpec } from './commands/audit.command-spec';
+import { commandSpec as generateKeyCommandSpec } from './commands/generate-key.command-spec';
+import { commandSpec as cacheCommandSpec } from './commands/cache.command-spec';
+import { commandSpec as keychainCommandSpec } from './commands/keychain.command-spec';
+import { commandSpec as proxyCommandSpec } from './commands/proxy.command-spec';
+// import { commandSpec as loginCommandSpec } from './commands/login.command-spec';
+// import { commandSpec as pluginCommandSpec } from './commands/plugin.command-spec';
 
 // must happen before anything writes to stdio
 handleBrokenPipe();
@@ -47,44 +51,30 @@ handleBrokenPipe();
 let versionId = packageJson.version;
 if (__VARLOCK_BUILD_TYPE__ !== 'release') versionId += `-${__VARLOCK_BUILD_TYPE__}`;
 
-// TODO: this is not splitting the bundle correctly to actually lazy load the command fns
-function buildLazyCommand(
-  commandSpec: Command<any>,
-  loadCommandFn: () => Promise<{ commandSpec: Command<any>, commandFn: any }>,
-) {
-  return {
-    ...commandSpec,
-    run: async (...args: Array<any>) => {
-      const commandSpecAndFn = await loadCommandFn();
-      return await commandSpecAndFn.commandFn(...args);
-    },
-  };
-}
-
 const subCommands = new Map();
-subCommands.set('init', buildLazyCommand(initCommandSpec, async () => await import('./commands/init.command')));
-subCommands.set('load', buildLazyCommand(loadCommandSpec, async () => await import('./commands/load.command')));
-subCommands.set('run', buildLazyCommand(runCommandSpec, async () => await import('./commands/run.command')));
-subCommands.set('printenv', buildLazyCommand(printenvCommandSpec, async () => await import('./commands/printenv.command')));
-subCommands.set('encrypt', buildLazyCommand(encryptCommandSpec, async () => await import('./commands/encrypt.command')));
-subCommands.set('lock', buildLazyCommand(lockCommandSpec, async () => await import('./commands/lock.command')));
-subCommands.set('reveal', buildLazyCommand(revealCommandSpec, async () => await import('./commands/reveal.command')));
-// subCommands.set('doctor', buildLazyCommand(doctorCommandSpec, async () => await import('./commands/doctor.command')));
-subCommands.set('explain', buildLazyCommand(explainCommandSpec, async () => await import('./commands/explain.command')));
-subCommands.set('flatten', buildLazyCommand(flattenCommandSpec, async () => await import('./commands/flatten.command')));
-subCommands.set('help', buildLazyCommand(helpCommandSpec, async () => await import('./commands/help.command')));
-subCommands.set('telemetry', buildLazyCommand(telemetryCommandSpec, async () => await import('./commands/telemetry.command')));
-subCommands.set('scan', buildLazyCommand(scanCommandSpec, async () => await import('./commands/scan.command')));
-subCommands.set('audit', buildLazyCommand(auditCommandSpec, async () => await import('./commands/audit.command')));
-subCommands.set('codegen', buildLazyCommand(codegenCommandSpec, async () => await import('./commands/codegen.command')));
-subCommands.set('typegen', buildLazyCommand(typegenCommandSpec, async () => await import('./commands/typegen.command')));
-subCommands.set('install-plugin', buildLazyCommand(installPluginCommandSpec, async () => await import('./commands/install-plugin.command')));
-subCommands.set('generate-key', buildLazyCommand(generateKeyCommandSpec, async () => await import('./commands/generate-key.command')));
-subCommands.set('cache', buildLazyCommand(cacheCommandSpec, async () => await import('./commands/cache.command')));
-subCommands.set('keychain', buildLazyCommand(keychainCommandSpec, async () => await import('./commands/keychain.command')));
-subCommands.set('proxy', buildLazyCommand(proxyCommandSpec, async () => await import('./commands/proxy.command')));
-// subCommands.set('login', buildLazyCommand(loginCommandSpec, async () => await import('./commands/login.command')));
-// subCommands.set('plugin', buildLazyCommand(pluginCommandSpec, async () => await import('./commands/plugin.command')));
+subCommands.set('init', lazy(async () => (await import('./commands/init.command')).commandFn, initCommandSpec));
+subCommands.set('load', lazy(async () => (await import('./commands/load.command')).commandFn, loadCommandSpec));
+subCommands.set('run', lazy(async () => (await import('./commands/run.command')).commandFn, runCommandSpec));
+subCommands.set('printenv', lazy(async () => (await import('./commands/printenv.command')).commandFn, printenvCommandSpec));
+subCommands.set('encrypt', lazy(async () => (await import('./commands/encrypt.command')).commandFn, encryptCommandSpec));
+subCommands.set('lock', lazy(async () => (await import('./commands/lock.command')).commandFn, lockCommandSpec));
+subCommands.set('reveal', lazy(async () => (await import('./commands/reveal.command')).commandFn, revealCommandSpec));
+// subCommands.set('doctor', lazy(async () => (await import('./commands/doctor.command')).commandFn, doctorCommandSpec));
+subCommands.set('explain', lazy(async () => (await import('./commands/explain.command')).commandFn, explainCommandSpec));
+subCommands.set('flatten', lazy(async () => (await import('./commands/flatten.command')).commandFn, flattenCommandSpec));
+subCommands.set('help', lazy(async () => (await import('./commands/help.command')).commandFn, helpCommandSpec));
+subCommands.set('telemetry', lazy(async () => (await import('./commands/telemetry.command')).commandFn, telemetryCommandSpec));
+subCommands.set('scan', lazy(async () => (await import('./commands/scan.command')).commandFn, scanCommandSpec));
+subCommands.set('audit', lazy(async () => (await import('./commands/audit.command')).commandFn, auditCommandSpec));
+subCommands.set('codegen', lazy(async () => (await import('./commands/codegen.command')).commandFn, codegenCommandSpec));
+subCommands.set('typegen', lazy(async () => (await import('./commands/typegen.command')).commandFn, typegenCommandSpec));
+subCommands.set('install-plugin', lazy(async () => (await import('./commands/install-plugin.command')).commandFn, installPluginCommandSpec));
+subCommands.set('generate-key', lazy(async () => (await import('./commands/generate-key.command')).commandFn, generateKeyCommandSpec));
+subCommands.set('cache', lazy(async () => (await import('./commands/cache.command')).commandFn, cacheCommandSpec));
+subCommands.set('keychain', lazy(async () => (await import('./commands/keychain.command')).commandFn, keychainCommandSpec));
+subCommands.set('proxy', lazy(async () => (await import('./commands/proxy.command')).commandFn, proxyCommandSpec));
+// subCommands.set('login', lazy(async () => (await import('./commands/login.command')).commandFn, loginCommandSpec));
+// subCommands.set('plugin', lazy(async () => (await import('./commands/plugin.command')).commandFn, pluginCommandSpec));
 
 (async function go() {
   try {

--- a/packages/varlock/src/cli/commands/audit.command-spec.ts
+++ b/packages/varlock/src/cli/commands/audit.command-spec.ts
@@ -1,0 +1,36 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'audit',
+  description: 'Audit code env var usage against your .env.schema',
+  args: {
+    targets: {
+      type: 'positional',
+      required: false,
+      multiple: true,
+      description: 'Directories to scan for env var references (defaults to the current project)',
+    },
+    path: {
+      type: 'string',
+      short: 'p',
+      description: 'Path to a specific .env file or directory to use as the schema entry point',
+    },
+    ignore: {
+      type: 'string',
+      short: 'i',
+      multiple: true,
+      description: 'Directory to exclude from code scanning (can be specified multiple times)',
+    },
+  },
+  examples: `
+Scans your source code for environment variable references and compares them
+to keys defined in your varlock schema.
+
+Examples:
+  varlock audit                          # Audit current project
+  varlock audit --path .env.prod         # Audit using a specific env entry point
+  varlock audit ./src ./lib              # Only scan specific directories
+  varlock audit --ignore vendor          # Exclude a directory from scanning
+  varlock audit -i vendor -i generated   # Exclude multiple directories
+`.trim(),
+});

--- a/packages/varlock/src/cli/commands/audit.command.ts
+++ b/packages/varlock/src/cli/commands/audit.command.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import ansis from 'ansis';
-import { define } from 'gunshi';
 
 import { FileBasedDataSource } from '../../env-graph';
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
@@ -15,41 +14,9 @@ import {
 import { gracefulExit } from 'exit-hook';
 import { diffSchemaAndCodeKeys } from '../helpers/audit-diff';
 import { isWellKnownEnvKey } from '../helpers/well-known-env-keys';
+import { commandSpec } from './audit.command-spec';
 
-export const commandSpec = define({
-  name: 'audit',
-  description: 'Audit code env var usage against your .env.schema',
-  args: {
-    targets: {
-      type: 'positional',
-      required: false,
-      multiple: true,
-      description: 'Directories to scan for env var references (defaults to the current project)',
-    },
-    path: {
-      type: 'string',
-      short: 'p',
-      description: 'Path to a specific .env file or directory to use as the schema entry point',
-    },
-    ignore: {
-      type: 'string',
-      short: 'i',
-      multiple: true,
-      description: 'Directory to exclude from code scanning (can be specified multiple times)',
-    },
-  },
-  examples: `
-Scans your source code for environment variable references and compares them
-to keys defined in your varlock schema.
-
-Examples:
-  varlock audit                          # Audit current project
-  varlock audit --path .env.prod         # Audit using a specific env entry point
-  varlock audit ./src ./lib              # Only scan specific directories
-  varlock audit --ignore vendor          # Exclude a directory from scanning
-  varlock audit -i vendor -i generated   # Exclude multiple directories
-`.trim(),
-});
+export { commandSpec };
 
 function formatReference(cwd: string, ref: EnvVarReference): string {
   const relPath = path.relative(cwd, ref.filePath);

--- a/packages/varlock/src/cli/commands/cache.command-spec.ts
+++ b/packages/varlock/src/cli/commands/cache.command-spec.ts
@@ -1,0 +1,50 @@
+import { define, lazy } from 'gunshi';
+
+// --- `varlock cache status` -------------------------------------------------
+
+export const statusCommandSpec = define({
+  name: 'status',
+  description: 'Print a cache status summary (non-interactive)',
+});
+
+// --- `varlock cache clear` --------------------------------------------------
+
+export const clearCommandSpec = define({
+  name: 'clear',
+  description: 'Clear cache entries',
+  args: {
+    plugin: {
+      type: 'string',
+      description: 'Clear cache for a specific plugin only',
+    },
+    yes: {
+      type: 'boolean',
+      short: 'y',
+      description: 'Skip confirmation prompts (required when non-interactive)',
+    },
+  },
+  examples: `
+  varlock cache clear --yes                       # Clear all entries (no prompt)
+  varlock cache clear --plugin 1password --yes    # Clear cache for a specific plugin
+`.trim(),
+});
+
+// --- `varlock cache` (parent) -----------------------------------------------
+
+export const commandSpec = define({
+  name: 'cache',
+  description: 'Manage the varlock cache',
+  subCommands: {
+    status: lazy(async () => (await import('./cache.command')).statusCommandFn, statusCommandSpec),
+    clear: lazy(async () => (await import('./cache.command')).clearCommandFn, clearCommandSpec),
+  },
+  examples: `
+Manage the encrypted value cache used by cache() and plugin authors.
+
+Examples:
+  varlock cache                                   # Interactive cache browser (or status summary if non-TTY)
+  varlock cache status                            # Print cache status summary (non-interactive)
+  varlock cache clear --yes                       # Clear all entries (no prompt)
+  varlock cache clear --plugin 1password --yes    # Clear cache for a specific plugin
+`.trim(),
+});

--- a/packages/varlock/src/cli/commands/cache.command.ts
+++ b/packages/varlock/src/cli/commands/cache.command.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import ansis from 'ansis';
-import { define } from 'gunshi';
 import { isCancel } from '@clack/prompts';
 
 import { CacheStore, createEnvKeyCacheStore, getCacheEnvKey } from '../../lib/cache';
@@ -10,6 +9,7 @@ import { formatTimeAgo, formatDuration } from '../../lib/formatting';
 import * as localEncrypt from '../../lib/local-encrypt';
 import { select, confirm } from '../helpers/prompts';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
+import { commandSpec, statusCommandSpec, clearCommandSpec } from './cache.command-spec';
 
 type CacheEntry = { key: string; cachedAt: number; expiresAt: number };
 
@@ -128,99 +128,60 @@ function resolveStore(): CacheStore | null {
 
 // --- `varlock cache status` -------------------------------------------------
 
-const statusCommand = define({
-  name: 'status',
-  description: 'Print a cache status summary (non-interactive)',
-  run: async () => {
-    const store = resolveStore();
-    if (!store) return;
-    printStatus(store);
-  },
-});
+export const statusCommandFn: TypedGunshiCommandFn<typeof statusCommandSpec> = async () => {
+  const store = resolveStore();
+  if (!store) return;
+  printStatus(store);
+};
 
 // --- `varlock cache clear` --------------------------------------------------
 
-const clearCommand = define({
-  name: 'clear',
-  description: 'Clear cache entries',
-  args: {
-    plugin: {
-      type: 'string',
-      description: 'Clear cache for a specific plugin only',
-    },
-    yes: {
-      type: 'boolean',
-      short: 'y',
-      description: 'Skip confirmation prompts (required when non-interactive)',
-    },
-  },
-  examples: `
-  varlock cache clear --yes                       # Clear all entries (no prompt)
-  varlock cache clear --plugin 1password --yes    # Clear cache for a specific plugin
-`.trim(),
-  run: async (ctx) => {
-    const store = resolveStore();
-    if (!store) return;
+export const clearCommandFn: TypedGunshiCommandFn<typeof clearCommandSpec> = async (ctx) => {
+  const store = resolveStore();
+  if (!store) return;
 
-    const pluginName = ctx.values.plugin;
-    const skipConfirm = ctx.values.yes;
-    const target = pluginName
-      ? `cache entries for plugin "${pluginName}"`
-      : 'cache entries';
+  const pluginName = ctx.values.plugin;
+  const skipConfirm = ctx.values.yes;
+  const target = pluginName
+    ? `cache entries for plugin "${pluginName}"`
+    : 'cache entries';
 
-    // require either --yes or an interactive confirm
-    if (!skipConfirm) {
-      if (!isInteractive()) {
-        console.error(ansis.red(`Refusing to clear ${target} without confirmation.`));
-        console.error('  Re-run with --yes to confirm, or run interactively.');
-        process.exitCode = 1;
-        return;
-      }
-      const confirmed = await confirm({
-        message: `Clear all ${target}? This cannot be undone.`,
-        initialValue: false,
-      });
-      if (isCancel(confirmed) || !confirmed) {
-        console.log(ansis.gray('  Aborted.'));
-        return;
-      }
-    }
-
-    try {
-      // a full clear also drops lock dirs. locks go first: clearing entries
-      // itself takes the file lock, and a wedged lock is often exactly why the
-      // user is running this command
-      if (!pluginName) store.clearLocks();
-      const count = pluginName
-        ? await store.clearByPrefix(`plugin:${pluginName}:`)
-        : await store.clearAll();
-      console.log(`  Cleared ${count} ${target}`);
-    } catch (err) {
-      console.error(ansis.red(`Failed to clear ${target}: ${err instanceof Error ? err.message : err}`));
+  // require either --yes or an interactive confirm
+  if (!skipConfirm) {
+    if (!isInteractive()) {
+      console.error(ansis.red(`Refusing to clear ${target} without confirmation.`));
+      console.error('  Re-run with --yes to confirm, or run interactively.');
       process.exitCode = 1;
+      return;
     }
-  },
-});
+    const confirmed = await confirm({
+      message: `Clear all ${target}? This cannot be undone.`,
+      initialValue: false,
+    });
+    if (isCancel(confirmed) || !confirmed) {
+      console.log(ansis.gray('  Aborted.'));
+      return;
+    }
+  }
+
+  try {
+    // a full clear also drops lock dirs. locks go first: clearing entries
+    // itself takes the file lock, and a wedged lock is often exactly why the
+    // user is running this command
+    if (!pluginName) store.clearLocks();
+    const count = pluginName
+      ? await store.clearByPrefix(`plugin:${pluginName}:`)
+      : await store.clearAll();
+    console.log(`  Cleared ${count} ${target}`);
+  } catch (err) {
+    console.error(ansis.red(`Failed to clear ${target}: ${err instanceof Error ? err.message : err}`));
+    process.exitCode = 1;
+  }
+};
 
 // --- `varlock cache` (parent) -----------------------------------------------
 
-export const commandSpec = define({
-  name: 'cache',
-  description: 'Manage the varlock cache',
-  subCommands: {
-    status: statusCommand,
-    clear: clearCommand,
-  },
-  examples: `
-Manage the encrypted value cache used by cache() and plugin authors.
-
-Examples:
-  varlock cache                                   # Interactive cache browser (or status summary if non-TTY)
-  varlock cache status                            # Print cache status summary (non-interactive)
-  varlock cache clear --yes                       # Clear all entries (no prompt)
-  varlock cache clear --plugin 1password --yes    # Clear cache for a specific plugin
-`.trim(),
-});
+export { commandSpec };
 
 /**
  * Default `varlock cache` with no subcommand: interactive browser when on a TTY,

--- a/packages/varlock/src/cli/commands/codegen.command-spec.ts
+++ b/packages/varlock/src/cli/commands/codegen.command-spec.ts
@@ -1,0 +1,33 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'codegen',
+  description: 'Generate code (types and env modules) from your env schema',
+  args: {
+    path: {
+      type: 'string',
+      short: 'p',
+      multiple: true,
+      description: 'Path to a specific .env file or directory to use as the entry point (can be specified multiple times)',
+    },
+  },
+  examples: `
+Generates code from your .env schema files.
+Uses only non-environment-specific schema info, so output is deterministic
+regardless of which environment is active.
+
+Add a per-language decorator to your schema for each output you want:
+  @generateTsTypes(path=env.d.ts)
+  @generatePythonEnv(path=env.py)
+  @generateRustEnv(path=src/env.rs)
+  @generateGoEnv(path=env/env.go)
+  @generatePhpEnv(path=Env.php)
+
+This is useful when you have \`auto=false\` set on a generator decorator to
+disable automatic generation during \`varlock load\` or \`varlock run\`.
+
+Examples:
+  varlock codegen                    # Generate using the default schema
+  varlock codegen --path .env.prod   # Generate from a specific .env file
+`.trim(),
+});

--- a/packages/varlock/src/cli/commands/codegen.command.ts
+++ b/packages/varlock/src/cli/commands/codegen.command.ts
@@ -1,41 +1,11 @@
-import { define } from 'gunshi';
 
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
 import { checkForNoEnvFiles, checkForSchemaErrors } from '../helpers/error-checks';
 import { CliExitError } from '../helpers/exit-error';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
+import { commandSpec } from './codegen.command-spec';
 
-export const commandSpec = define({
-  name: 'codegen',
-  description: 'Generate code (types and env modules) from your env schema',
-  args: {
-    path: {
-      type: 'string',
-      short: 'p',
-      multiple: true,
-      description: 'Path to a specific .env file or directory to use as the entry point (can be specified multiple times)',
-    },
-  },
-  examples: `
-Generates code from your .env schema files.
-Uses only non-environment-specific schema info, so output is deterministic
-regardless of which environment is active.
-
-Add a per-language decorator to your schema for each output you want:
-  @generateTsTypes(path=env.d.ts)
-  @generatePythonEnv(path=env.py)
-  @generateRustEnv(path=src/env.rs)
-  @generateGoEnv(path=env/env.go)
-  @generatePhpEnv(path=Env.php)
-
-This is useful when you have \`auto=false\` set on a generator decorator to
-disable automatic generation during \`varlock load\` or \`varlock run\`.
-
-Examples:
-  varlock codegen                    # Generate using the default schema
-  varlock codegen --path .env.prod   # Generate from a specific .env file
-`.trim(),
-});
+export { commandSpec };
 
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {

--- a/packages/varlock/src/cli/commands/doctor.command-spec.ts
+++ b/packages/varlock/src/cli/commands/doctor.command-spec.ts
@@ -1,0 +1,7 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'doctor',
+  description: 'Debug and diagnose issues with your env file(s) and system',
+  args: {},
+});

--- a/packages/varlock/src/cli/commands/doctor.command.ts
+++ b/packages/varlock/src/cli/commands/doctor.command.ts
@@ -1,12 +1,8 @@
-import { define } from 'gunshi';
 import { isBundledSEA } from '../helpers/install-detection';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
+import { commandSpec } from './doctor.command-spec';
 
-export const commandSpec = define({
-  name: 'doctor',
-  description: 'Debug and diagnose issues with your env file(s) and system',
-  args: {},
-});
+export { commandSpec };
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   console.log('');

--- a/packages/varlock/src/cli/commands/encrypt.command-spec.ts
+++ b/packages/varlock/src/cli/commands/encrypt.command-spec.ts
@@ -1,0 +1,33 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'encrypt',
+  description: 'Encrypt a value using device-local encryption',
+  args: {
+    'key-id': {
+      type: 'string',
+      description: 'Encryption key ID',
+      default: 'varlock-default',
+      // Hidden until multi-key round-trips: the varlock("local:...") reference does not
+      // encode a keyId, and the load-time resolver always decrypts with the default key,
+      // so encrypting with a non-default key produces values that cannot be loaded back.
+      hidden: true,
+    },
+    file: {
+      type: 'string',
+      description: 'Path to a .env file — encrypts all sensitive plaintext values in-place',
+    },
+  },
+  examples: `
+Encrypts a value using device-local encryption (Secure Enclave / TPM / file-based),
+producing a varlock("local:...") reference that is safe to commit.
+
+Single-value mode reads from stdin (or prompts interactively) so secrets stay out of
+shell history. --file mode encrypts all @sensitive plaintext values in a .env file in place.
+
+Examples:
+  echo "$MY_SECRET" | varlock encrypt    # Encrypt a value from stdin (non-interactive, agent-friendly)
+  varlock encrypt                        # Prompt interactively for a value
+  varlock encrypt --file .env.local      # Encrypt @sensitive plaintext values in a file in-place
+`.trim(),
+});

--- a/packages/varlock/src/cli/commands/encrypt.command.ts
+++ b/packages/varlock/src/cli/commands/encrypt.command.ts
@@ -1,4 +1,3 @@
-import { define } from 'gunshi';
 import { isCancel } from '@clack/prompts';
 import ansis from 'ansis';
 import path from 'node:path';
@@ -16,38 +15,9 @@ import { multiselect, password } from '../helpers/prompts';
 import { gracefulExit } from 'exit-hook';
 import * as localEncrypt from '../../lib/local-encrypt';
 import { writeBackValue } from '../../lib/local-encrypt/write-back';
+import { commandSpec } from './encrypt.command-spec';
 
-export const commandSpec = define({
-  name: 'encrypt',
-  description: 'Encrypt a value using device-local encryption',
-  args: {
-    'key-id': {
-      type: 'string',
-      description: 'Encryption key ID',
-      default: 'varlock-default',
-      // Hidden until multi-key round-trips: the varlock("local:...") reference does not
-      // encode a keyId, and the load-time resolver always decrypts with the default key,
-      // so encrypting with a non-default key produces values that cannot be loaded back.
-      hidden: true,
-    },
-    file: {
-      type: 'string',
-      description: 'Path to a .env file — encrypts all sensitive plaintext values in-place',
-    },
-  },
-  examples: `
-Encrypts a value using device-local encryption (Secure Enclave / TPM / file-based),
-producing a varlock("local:...") reference that is safe to commit.
-
-Single-value mode reads from stdin (or prompts interactively) so secrets stay out of
-shell history. --file mode encrypts all @sensitive plaintext values in a .env file in place.
-
-Examples:
-  echo "$MY_SECRET" | varlock encrypt    # Encrypt a value from stdin (non-interactive, agent-friendly)
-  varlock encrypt                        # Prompt interactively for a value
-  varlock encrypt --file .env.local      # Encrypt @sensitive plaintext values in a file in-place
-`.trim(),
-});
+export { commandSpec };
 
 async function encryptFile(keyId: string, filePath: string) {
   const resolvedPath = path.resolve(filePath);

--- a/packages/varlock/src/cli/commands/explain.command-spec.ts
+++ b/packages/varlock/src/cli/commands/explain.command-spec.ts
@@ -1,0 +1,32 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'explain',
+  description: 'Show detailed information about how a config item is resolved',
+  args: {
+    key: {
+      type: 'positional',
+      required: false,
+      description: 'Config item to explain',
+    },
+    env: {
+      type: 'string',
+      description: 'Set the environment (e.g., production, development, etc)',
+    },
+    path: {
+      type: 'string',
+      short: 'p',
+      multiple: true,
+      description: 'Path to a specific .env file or directory to use as the entry point (can be specified multiple times)',
+    },
+  },
+  examples: `
+Shows detailed information about all definitions, sources, and overrides
+that feed into a single config item. Useful for debugging why a value
+is not what you expect.
+
+Examples:
+  varlock explain DATABASE_URL          # Explain how DATABASE_URL is resolved
+  varlock explain --env production API_KEY  # Explain in production context
+`.trim(),
+});

--- a/packages/varlock/src/cli/commands/explain.command.ts
+++ b/packages/varlock/src/cli/commands/explain.command.ts
@@ -1,5 +1,4 @@
 import ansis from 'ansis';
-import { define } from 'gunshi';
 import { gracefulExit } from 'exit-hook';
 
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
@@ -13,6 +12,7 @@ import { CliExitError } from '../helpers/exit-error';
 import { StaticValueResolver } from '../../env-graph/lib/resolver';
 import type { ConfigItem } from '../../env-graph/lib/config-item';
 import _ from '@env-spec/utils/my-dash';
+import { commandSpec } from './explain.command-spec';
 
 /** Human-readable explanation of how an item's sensitivity was determined */
 function describeSensitiveSource(item: ConfigItem): string {
@@ -34,36 +34,7 @@ function describeInternalSource(item: ConfigItem): string {
     : `set by the \`${item.dataType?.name}\` data type`;
 }
 
-export const commandSpec = define({
-  name: 'explain',
-  description: 'Show detailed information about how a config item is resolved',
-  args: {
-    key: {
-      type: 'positional',
-      required: false,
-      description: 'Config item to explain',
-    },
-    env: {
-      type: 'string',
-      description: 'Set the environment (e.g., production, development, etc)',
-    },
-    path: {
-      type: 'string',
-      short: 'p',
-      multiple: true,
-      description: 'Path to a specific .env file or directory to use as the entry point (can be specified multiple times)',
-    },
-  },
-  examples: `
-Shows detailed information about all definitions, sources, and overrides
-that feed into a single config item. Useful for debugging why a value
-is not what you expect.
-
-Examples:
-  varlock explain DATABASE_URL          # Explain how DATABASE_URL is resolved
-  varlock explain --env production API_KEY  # Explain in production context
-`.trim(),
-});
+export { commandSpec };
 
 function describeResolver(resolver: any, indent = ''): string {
   if (resolver instanceof StaticValueResolver) {

--- a/packages/varlock/src/cli/commands/flatten.command-spec.ts
+++ b/packages/varlock/src/cli/commands/flatten.command-spec.ts
@@ -1,0 +1,44 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'flatten',
+  description: 'Copy env files imported from outside this package into a self-contained directory, rewriting @import paths',
+  args: {
+    'out-dir': {
+      type: 'string',
+      description: 'Output directory (relative to cwd unless absolute)',
+      default: '.env-flat',
+    },
+    'include-local': {
+      type: 'boolean',
+      description: 'Include .env.local / .env.*.local files (excluded by default)',
+      default: false,
+    },
+    'vendor-plugins': {
+      type: 'boolean',
+      description: 'Copy npm plugins into the output so no runtime install is needed (for shell-less/offline/distroless runtimes). Uses the installed copy, downloading only if absent',
+      default: false,
+    },
+  },
+  examples: `
+In a monorepo, a package's env files may @import files from sibling packages or the
+workspace root. Those files are not available in contexts where only the package itself
+is present, like the final stage of a Docker build.
+
+\`varlock flatten\` copies everything reachable via @import into one self-contained
+directory and rewrites the @import paths, so that directory can travel with the package.
+Values are never resolved - this is a purely structural transform, safe to run in CI.
+
+Examples:
+  varlock flatten                    # flatten env files from the current directory into .env-flat/
+  varlock flatten --out-dir dist/env # custom output location
+  varlock flatten --include-local    # also include .env.local files (careful - these often hold secrets)
+  varlock flatten --vendor-plugins   # also copy npm plugins into the output (self-contained, no runtime install)
+
+Typical Dockerfile usage (builder stage has the full monorepo):
+  RUN cd packages/api && varlock flatten
+  # final stage:
+  COPY --from=builder /repo/packages/api /app
+  COPY --from=builder /repo/packages/api/.env-flat/ /app/
+`.trim(),
+});

--- a/packages/varlock/src/cli/commands/flatten.command.ts
+++ b/packages/varlock/src/cli/commands/flatten.command.ts
@@ -1,53 +1,12 @@
-import { define } from 'gunshi';
 import path from 'node:path';
 import ansis from 'ansis';
 
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { CliExitError } from '../helpers/exit-error';
 import { flattenEnvFiles, FlattenError } from '../../lib/flatten';
+import { commandSpec } from './flatten.command-spec';
 
-export const commandSpec = define({
-  name: 'flatten',
-  description: 'Copy env files imported from outside this package into a self-contained directory, rewriting @import paths',
-  args: {
-    'out-dir': {
-      type: 'string',
-      description: 'Output directory (relative to cwd unless absolute)',
-      default: '.env-flat',
-    },
-    'include-local': {
-      type: 'boolean',
-      description: 'Include .env.local / .env.*.local files (excluded by default)',
-      default: false,
-    },
-    'vendor-plugins': {
-      type: 'boolean',
-      description: 'Copy npm plugins into the output so no runtime install is needed (for shell-less/offline/distroless runtimes). Uses the installed copy, downloading only if absent',
-      default: false,
-    },
-  },
-  examples: `
-In a monorepo, a package's env files may @import files from sibling packages or the
-workspace root. Those files are not available in contexts where only the package itself
-is present, like the final stage of a Docker build.
-
-\`varlock flatten\` copies everything reachable via @import into one self-contained
-directory and rewrites the @import paths, so that directory can travel with the package.
-Values are never resolved - this is a purely structural transform, safe to run in CI.
-
-Examples:
-  varlock flatten                    # flatten env files from the current directory into .env-flat/
-  varlock flatten --out-dir dist/env # custom output location
-  varlock flatten --include-local    # also include .env.local files (careful - these often hold secrets)
-  varlock flatten --vendor-plugins   # also copy npm plugins into the output (self-contained, no runtime install)
-
-Typical Dockerfile usage (builder stage has the full monorepo):
-  RUN cd packages/api && varlock flatten
-  # final stage:
-  COPY --from=builder /repo/packages/api /app
-  COPY --from=builder /repo/packages/api/.env-flat/ /app/
-`.trim(),
-});
+export { commandSpec };
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   const packageDir = process.cwd();

--- a/packages/varlock/src/cli/commands/generate-key.command-spec.ts
+++ b/packages/varlock/src/cli/commands/generate-key.command-spec.ts
@@ -1,0 +1,19 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'generate-key',
+  description: 'Generate an encryption key for encrypting the env blob in deployments',
+  args: {
+    plain: {
+      type: 'boolean',
+      description: 'Print only the key (for piping into other commands)',
+    },
+  },
+  examples: `
+Generates a random 256-bit hex key for \`_VARLOCK_ENV_KEY\`.
+
+Examples:
+  varlock generate-key              # Human-readable output
+  varlock generate-key --plain      # Key only, for piping
+  `.trim(),
+});

--- a/packages/varlock/src/cli/commands/generate-key.command.ts
+++ b/packages/varlock/src/cli/commands/generate-key.command.ts
@@ -1,25 +1,9 @@
 import { randomBytes } from 'node:crypto';
-import { define } from 'gunshi';
 
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
+import { commandSpec } from './generate-key.command-spec';
 
-export const commandSpec = define({
-  name: 'generate-key',
-  description: 'Generate an encryption key for encrypting the env blob in deployments',
-  args: {
-    plain: {
-      type: 'boolean',
-      description: 'Print only the key (for piping into other commands)',
-    },
-  },
-  examples: `
-Generates a random 256-bit hex key for \`_VARLOCK_ENV_KEY\`.
-
-Examples:
-  varlock generate-key              # Human-readable output
-  varlock generate-key --plain      # Key only, for piping
-  `.trim(),
-});
+export { commandSpec };
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   const key = randomBytes(32).toString('hex');

--- a/packages/varlock/src/cli/commands/help.command-spec.ts
+++ b/packages/varlock/src/cli/commands/help.command-spec.ts
@@ -1,0 +1,7 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'help',
+  description: 'Show help info for varlock',
+  args: {},
+});

--- a/packages/varlock/src/cli/commands/help.command.ts
+++ b/packages/varlock/src/cli/commands/help.command.ts
@@ -1,11 +1,7 @@
-import { define } from 'gunshi';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
+import { commandSpec } from './help.command-spec';
 
-export const commandSpec = define({
-  name: 'help',
-  description: 'Show help info for varlock',
-  args: {},
-});
+export { commandSpec };
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   // no-op - we'll trigger help from main entry point

--- a/packages/varlock/src/cli/commands/init.command-spec.ts
+++ b/packages/varlock/src/cli/commands/init.command-spec.ts
@@ -1,0 +1,28 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'init',
+  description: 'Set up varlock in the current project',
+  args: {
+    agent: {
+      type: 'boolean',
+      description: 'Run in non-interactive mode for agent/automation workflows',
+    },
+  },
+  examples: `
+This command starts an interactive onboarding process to help you get started with Varlock.
+It will:
+  - Scan for existing .env files in your project
+  - Help create a .env.schema file from your .env.example or .env.sample file
+  - Install varlock as a dependency in package.json (if applicable)
+
+📍 Run this command in directories that contain .env or .env.* files
+
+Examples:
+  varlock init                    # Run in the current directory
+  varlock init --agent            # Run non-interactively (agent/automation friendly)
+  cd path/to/your/project && varlock init
+
+For more information, visit https://varlock.dev/getting-started/installation
+  `.trim(),
+});

--- a/packages/varlock/src/cli/commands/init.command.ts
+++ b/packages/varlock/src/cli/commands/init.command.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import ansis from 'ansis';
 import { isCancel, select } from '@clack/prompts';
-import { define } from 'gunshi';
 import { gracefulExit } from 'exit-hook';
 
 import { envSpecUpdater, parseEnvSpecDotEnvFile } from '@env-spec/parser';
@@ -24,33 +23,9 @@ import { tryCatch } from '@env-spec/utils/try-catch';
 import { scanCodeForEnvVars } from '../helpers/env-var-scanner';
 import { isWellKnownEnvKey } from '../helpers/well-known-env-keys';
 import { detectTypegenDecorator } from '../helpers/typegen-lang-detect';
+import { commandSpec } from './init.command-spec';
 
-export const commandSpec = define({
-  name: 'init',
-  description: 'Set up varlock in the current project',
-  args: {
-    agent: {
-      type: 'boolean',
-      description: 'Run in non-interactive mode for agent/automation workflows',
-    },
-  },
-  examples: `
-This command starts an interactive onboarding process to help you get started with Varlock.
-It will:
-  - Scan for existing .env files in your project
-  - Help create a .env.schema file from your .env.example or .env.sample file
-  - Install varlock as a dependency in package.json (if applicable)
-
-📍 Run this command in directories that contain .env or .env.* files
-
-Examples:
-  varlock init                    # Run in the current directory
-  varlock init --agent            # Run non-interactively (agent/automation friendly)
-  cd path/to/your/project && varlock init
-
-For more information, visit https://varlock.dev/getting-started/installation
-  `.trim(),
-});
+export { commandSpec };
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   const agentMode = Boolean(ctx.values.agent);

--- a/packages/varlock/src/cli/commands/install-plugin.command-spec.ts
+++ b/packages/varlock/src/cli/commands/install-plugin.command-spec.ts
@@ -1,0 +1,23 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'install-plugin',
+  description: 'Download and cache a plugin from npm for use with the standalone binary',
+  args: {
+    plugin: {
+      type: 'positional',
+      description: 'Plugin to install, in the format name@version (e.g. my-plugin@1.2.3)',
+    },
+  },
+  examples: `
+Pre-downloads a plugin into the local varlock plugin cache so it is available without
+needing an interactive confirmation prompt. This is useful in CI environments or any
+other non-interactive workflow where the standalone binary is used.
+
+The plugin must be specified with an exact version number.
+
+Examples:
+  varlock install-plugin my-plugin@1.2.3
+  varlock install-plugin @my-scope/my-plugin@2.0.0
+`.trim(),
+});

--- a/packages/varlock/src/cli/commands/install-plugin.command.ts
+++ b/packages/varlock/src/cli/commands/install-plugin.command.ts
@@ -1,4 +1,3 @@
-import { define } from 'gunshi';
 import ansis from 'ansis';
 import { isValid as semverIsValid } from 'verkit';
 
@@ -7,28 +6,9 @@ import { CliExitError } from '../helpers/exit-error';
 import { isBundledSEA } from '../helpers/install-detection';
 import { fmt } from '../helpers/pretty-format';
 import { downloadPluginToCache } from '../../env-graph/lib/plugins';
+import { commandSpec } from './install-plugin.command-spec';
 
-export const commandSpec = define({
-  name: 'install-plugin',
-  description: 'Download and cache a plugin from npm for use with the standalone binary',
-  args: {
-    plugin: {
-      type: 'positional',
-      description: 'Plugin to install, in the format name@version (e.g. my-plugin@1.2.3)',
-    },
-  },
-  examples: `
-Pre-downloads a plugin into the local varlock plugin cache so it is available without
-needing an interactive confirmation prompt. This is useful in CI environments or any
-other non-interactive workflow where the standalone binary is used.
-
-The plugin must be specified with an exact version number.
-
-Examples:
-  varlock install-plugin my-plugin@1.2.3
-  varlock install-plugin @my-scope/my-plugin@2.0.0
-`.trim(),
-});
+export { commandSpec };
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   if (!isBundledSEA()) {

--- a/packages/varlock/src/cli/commands/keychain.command-spec.ts
+++ b/packages/varlock/src/cli/commands/keychain.command-spec.ts
@@ -1,0 +1,143 @@
+import { define, lazy } from 'gunshi';
+
+// --- `varlock keychain list` ------------------------------------------------
+
+export const listCommandSpec = define({
+  name: 'list',
+  description: 'List matching macOS Keychain items (metadata only)',
+  args: {
+    query: {
+      type: 'positional',
+      required: false,
+      description: 'Filter items by service name',
+    },
+    keychain: {
+      type: 'string',
+      description: 'Keychain name to search, such as Login or System',
+    },
+  },
+});
+
+// --- `varlock keychain fix-access` ------------------------------------------
+
+export const fixAccessCommandSpec = define({
+  name: 'fix-access',
+  description: "Grant Varlock's helper access to existing keychain() items",
+  args: {
+    service: {
+      type: 'string',
+      default: 'varlock',
+      description: 'Keychain service name (default: varlock)',
+    },
+    account: {
+      type: 'string',
+      description: 'Keychain account name',
+    },
+    keychain: {
+      type: 'string',
+      description: 'Keychain name to search, such as Login or System',
+    },
+    path: {
+      type: 'string',
+      description: 'Env file to fix access for every explicit keychain() ref',
+    },
+  },
+});
+
+// --- `varlock keychain set` -------------------------------------------------
+
+export const setCommandSpec = define({
+  name: 'set',
+  description: 'Store a secret in macOS Keychain and optionally write a keychain() ref',
+  args: {
+    key: {
+      type: 'positional',
+      required: false,
+      description: 'Env var key to store (used to generate the account name and ref)',
+    },
+    service: {
+      type: 'string',
+      default: 'varlock',
+      description: 'Keychain service name (default: varlock)',
+    },
+    account: {
+      type: 'string',
+      description: 'Keychain account name (defaults to <project>:<profile>:<KEY>)',
+    },
+    profile: {
+      type: 'string',
+      default: 'local',
+      description: 'Profile name used in generated account names',
+    },
+    project: {
+      type: 'string',
+      description: 'Project slug used in generated account names (default: current directory name)',
+    },
+    'write-to': {
+      type: 'string',
+      description: 'Env file to write the keychain() ref to',
+    },
+    force: {
+      type: 'boolean',
+      description: 'Overwrite existing Keychain item and env ref',
+    },
+  },
+});
+
+// --- `varlock keychain import` ----------------------------------------------
+
+export const importCommandSpec = define({
+  name: 'import',
+  description: 'Migrate sensitive plaintext values from an env file into macOS Keychain',
+  args: {
+    file: {
+      type: 'positional',
+      required: false,
+      description: 'Plaintext env file to import secrets from',
+    },
+    'write-to': {
+      type: 'string',
+      description: 'Write refs to a different env file instead of editing the source in place',
+    },
+    service: {
+      type: 'string',
+      default: 'varlock',
+      description: 'Keychain service name (default: varlock)',
+    },
+    profile: {
+      type: 'string',
+      default: 'local',
+      description: 'Profile name used in generated account names',
+    },
+    project: {
+      type: 'string',
+      description: 'Project slug used in generated account names (default: current directory name)',
+    },
+    force: {
+      type: 'boolean',
+      description: 'Overwrite existing Keychain items (and refs in a --write-to target)',
+    },
+  },
+});
+
+// --- `varlock keychain` (parent) --------------------------------------------
+
+export const commandSpec = define({
+  name: 'keychain',
+  description: 'Manage macOS Keychain items used by keychain()',
+  subCommands: {
+    list: lazy(async () => (await import('./keychain.command')).listCommandFn, listCommandSpec),
+    'fix-access': lazy(async () => (await import('./keychain.command')).fixAccessCommandFn, fixAccessCommandSpec),
+    set: lazy(async () => (await import('./keychain.command')).setCommandFn, setCommandSpec),
+    import: lazy(async () => (await import('./keychain.command')).importCommandFn, importCommandSpec),
+  },
+  examples: `
+Examples:
+  varlock keychain list
+  varlock keychain fix-access --account "my-project:jb:API_KEY"
+  varlock keychain fix-access --path .env.jb
+  varlock keychain import .env --profile jb            # migrate .env in place
+  varlock keychain import .env --profile jb --write-to .env.jb
+  varlock keychain set API_KEY --profile jb --write-to .env.jb
+`.trim(),
+});

--- a/packages/varlock/src/cli/commands/keychain.command.ts
+++ b/packages/varlock/src/cli/commands/keychain.command.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import ansis from 'ansis';
-import { define } from 'gunshi';
 import { isCancel } from '@clack/prompts';
 import {
   parseEnvSpecDotEnvFile,
@@ -18,6 +17,9 @@ import { DaemonError } from '../../lib/local-encrypt/daemon-client';
 import { CliExitError } from '../helpers/exit-error';
 import { password } from '../helpers/prompts';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
+import {
+  commandSpec, listCommandSpec, fixAccessCommandSpec, setCommandSpec, importCommandSpec,
+} from './keychain.command-spec';
 
 type KeychainRef = {
   key?: string;
@@ -433,214 +435,88 @@ function resolveProject(project?: string): string {
 
 // --- `varlock keychain list` ------------------------------------------------
 
-const listCommand = define({
-  name: 'list',
-  description: 'List matching macOS Keychain items (metadata only)',
-  args: {
-    query: {
-      type: 'positional',
-      required: false,
-      description: 'Filter items by service name',
-    },
-    keychain: {
-      type: 'string',
-      description: 'Keychain name to search, such as Login or System',
-    },
-  },
-  run: async (ctx) => {
-    assertMacOS();
-    await listKeychainItems(ctx.values.query, ctx.values.keychain);
-  },
-});
+export const listCommandFn: TypedGunshiCommandFn<typeof listCommandSpec> = async (ctx) => {
+  assertMacOS();
+  await listKeychainItems(ctx.values.query, ctx.values.keychain);
+};
 
 // --- `varlock keychain fix-access` ------------------------------------------
 
-const fixAccessCommand = define({
-  name: 'fix-access',
-  description: "Grant Varlock's helper access to existing keychain() items",
-  args: {
-    service: {
-      type: 'string',
-      default: 'varlock',
-      description: 'Keychain service name (default: varlock)',
-    },
-    account: {
-      type: 'string',
-      description: 'Keychain account name',
-    },
-    keychain: {
-      type: 'string',
-      description: 'Keychain name to search, such as Login or System',
-    },
-    path: {
-      type: 'string',
-      description: 'Env file to fix access for every explicit keychain() ref',
-    },
-  },
-  run: async (ctx) => {
-    assertMacOS();
+export const fixAccessCommandFn: TypedGunshiCommandFn<typeof fixAccessCommandSpec> = async (ctx) => {
+  assertMacOS();
 
-    if (ctx.values.path) {
-      const refs = extractKeychainRefsFromFile(path.resolve(ctx.values.path));
-      if (refs.length === 0) {
-        console.log(ansis.gray('No explicit keychain() refs found.'));
-        return;
-      }
-      await fixAccessForRefs(refs);
+  if (ctx.values.path) {
+    const refs = extractKeychainRefsFromFile(path.resolve(ctx.values.path));
+    if (refs.length === 0) {
+      console.log(ansis.gray('No explicit keychain() refs found.'));
       return;
     }
+    await fixAccessForRefs(refs);
+    return;
+  }
 
-    if (!ctx.values.account) {
-      throw new CliExitError('Missing --account for keychain fix-access', {
-        suggestion: 'Use --account "project:profile:KEY" or --path .env.profile',
-      });
-    }
+  if (!ctx.values.account) {
+    throw new CliExitError('Missing --account for keychain fix-access', {
+      suggestion: 'Use --account "project:profile:KEY" or --path .env.profile',
+    });
+  }
 
-    await fixAccessForRefs([
-      {
-        service: ctx.values.service,
-        account: ctx.values.account,
-        keychain: ctx.values.keychain,
-      },
-    ]);
-  },
-});
+  await fixAccessForRefs([
+    {
+      service: ctx.values.service,
+      account: ctx.values.account,
+      keychain: ctx.values.keychain,
+    },
+  ]);
+};
 
 // --- `varlock keychain set` -------------------------------------------------
 
-const setCommand = define({
-  name: 'set',
-  description: 'Store a secret in macOS Keychain and optionally write a keychain() ref',
-  args: {
-    key: {
-      type: 'positional',
-      required: false,
-      description: 'Env var key to store (used to generate the account name and ref)',
-    },
-    service: {
-      type: 'string',
-      default: 'varlock',
-      description: 'Keychain service name (default: varlock)',
-    },
-    account: {
-      type: 'string',
-      description: 'Keychain account name (defaults to <project>:<profile>:<KEY>)',
-    },
-    profile: {
-      type: 'string',
-      default: 'local',
-      description: 'Profile name used in generated account names',
-    },
-    project: {
-      type: 'string',
-      description: 'Project slug used in generated account names (default: current directory name)',
-    },
-    'write-to': {
-      type: 'string',
-      description: 'Env file to write the keychain() ref to',
-    },
-    force: {
-      type: 'boolean',
-      description: 'Overwrite existing Keychain item and env ref',
-    },
-  },
-  run: async (ctx) => {
-    assertMacOS();
+export const setCommandFn: TypedGunshiCommandFn<typeof setCommandSpec> = async (ctx) => {
+  assertMacOS();
 
-    const { key, service, account } = ctx.values;
-    const targetAccount = account
-      ?? (key ? getGeneratedAccount(resolveProject(ctx.values.project), ctx.values.profile, key) : undefined);
-    if (!targetAccount) {
-      throw new CliExitError('Missing env var key or --account for keychain set', {
-        suggestion: 'Use `varlock keychain set API_KEY --profile local` or `varlock keychain set --account name`.',
-      });
-    }
-
-    await setKeychainSecret({
-      key,
-      service,
-      account: targetAccount,
-      write: ctx.values['write-to'],
-      force: Boolean(ctx.values.force),
+  const { key, service, account } = ctx.values;
+  const targetAccount = account
+    ?? (key ? getGeneratedAccount(resolveProject(ctx.values.project), ctx.values.profile, key) : undefined);
+  if (!targetAccount) {
+    throw new CliExitError('Missing env var key or --account for keychain set', {
+      suggestion: 'Use `varlock keychain set API_KEY --profile local` or `varlock keychain set --account name`.',
     });
-  },
-});
+  }
+
+  await setKeychainSecret({
+    key,
+    service,
+    account: targetAccount,
+    write: ctx.values['write-to'],
+    force: Boolean(ctx.values.force),
+  });
+};
 
 // --- `varlock keychain import` ----------------------------------------------
 
-const importCommand = define({
-  name: 'import',
-  description: 'Migrate sensitive plaintext values from an env file into macOS Keychain',
-  args: {
-    file: {
-      type: 'positional',
-      required: false,
-      description: 'Plaintext env file to import secrets from',
-    },
-    'write-to': {
-      type: 'string',
-      description: 'Write refs to a different env file instead of editing the source in place',
-    },
-    service: {
-      type: 'string',
-      default: 'varlock',
-      description: 'Keychain service name (default: varlock)',
-    },
-    profile: {
-      type: 'string',
-      default: 'local',
-      description: 'Profile name used in generated account names',
-    },
-    project: {
-      type: 'string',
-      description: 'Project slug used in generated account names (default: current directory name)',
-    },
-    force: {
-      type: 'boolean',
-      description: 'Overwrite existing Keychain items (and refs in a --write-to target)',
-    },
-  },
-  run: async (ctx) => {
-    assertMacOS();
+export const importCommandFn: TypedGunshiCommandFn<typeof importCommandSpec> = async (ctx) => {
+  assertMacOS();
 
-    if (!ctx.values.file) {
-      throw new CliExitError('Missing env file to import from', {
-        suggestion: 'Use `varlock keychain import .env` (edits the file in place) or add `--write-to .env.profile`.',
-      });
-    }
-
-    await importPlaintextEnv({
-      from: ctx.values.file,
-      write: ctx.values['write-to'],
-      service: ctx.values.service,
-      profile: ctx.values.profile,
-      project: resolveProject(ctx.values.project),
-      force: Boolean(ctx.values.force),
+  if (!ctx.values.file) {
+    throw new CliExitError('Missing env file to import from', {
+      suggestion: 'Use `varlock keychain import .env` (edits the file in place) or add `--write-to .env.profile`.',
     });
-  },
-});
+  }
+
+  await importPlaintextEnv({
+    from: ctx.values.file,
+    write: ctx.values['write-to'],
+    service: ctx.values.service,
+    profile: ctx.values.profile,
+    project: resolveProject(ctx.values.project),
+    force: Boolean(ctx.values.force),
+  });
+};
 
 // --- `varlock keychain` (parent) --------------------------------------------
 
-export const commandSpec = define({
-  name: 'keychain',
-  description: 'Manage macOS Keychain items used by keychain()',
-  subCommands: {
-    list: listCommand,
-    'fix-access': fixAccessCommand,
-    set: setCommand,
-    import: importCommand,
-  },
-  examples: `
-Examples:
-  varlock keychain list
-  varlock keychain fix-access --account "my-project:jb:API_KEY"
-  varlock keychain fix-access --path .env.jb
-  varlock keychain import .env --profile jb            # migrate .env in place
-  varlock keychain import .env --profile jb --write-to .env.jb
-  varlock keychain set API_KEY --profile jb --write-to .env.jb
-`.trim(),
-});
+export { commandSpec };
 
 /** Default `varlock keychain` with no subcommand: list matching items. */
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async () => {

--- a/packages/varlock/src/cli/commands/load.command-spec.ts
+++ b/packages/varlock/src/cli/commands/load.command-spec.ts
@@ -1,0 +1,82 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'load',
+  description: 'Load env according to schema and resolve values',
+  args: {
+    format: {
+      type: 'enum',
+      short: 'f',
+      choices: ['pretty', 'json', 'env', 'shell', 'json-full'],
+      description: 'Format of output',
+      default: 'pretty',
+    },
+    agent: {
+      type: 'boolean',
+      description: 'Agent-safe mode: redact sensitive values (defaults to JSON format if --format is not set)',
+    },
+    compact: {
+      type: 'boolean',
+      description: 'Use compact format (for json-full: no indentation, for env/shell: skip undefined values)',
+    },
+    'show-all': {
+      type: 'boolean',
+      description: 'When load is failing, show all items rather than only failing items',
+    },
+    'include-internal': {
+      type: 'boolean',
+      description: 'Include @internal items in --format json-full output (excluded by default, since json-full is commonly consumed programmatically - e.g. by framework integrations - not just for local human inspection)',
+    },
+    filter: {
+      type: 'string',
+      description: 'Filter which items are shown: comma-separated key names/globs (e.g. STRIPE_*), negations (!KEY), decorator selectors (@sensitive, @required), and tag selectors (#tagname, set via @tag(tagname)). Can also be set via the _VARLOCK_FILTER env var (this flag takes precedence)',
+    },
+    env: {
+      type: 'string',
+      description: 'Set the environment (e.g., production, development, etc) - will be overridden by @currentEnv in the schema if present',
+    },
+    path: {
+      type: 'string',
+      short: 'p',
+      multiple: true,
+      description: 'Path to a specific .env file or directory to use as the entry point (can be specified multiple times)',
+    },
+    'summary-stderr': {
+      type: 'boolean',
+      description: 'Also output the pretty (redacted) summary to stderr (useful alongside --format json-full to get both machine-readable output on stdout and a human-readable summary on stderr)',
+    },
+    'summary-file': {
+      type: 'string',
+      description: 'Also write the pretty (redacted) summary to a file path (useful for CI, e.g. $GITHUB_STEP_SUMMARY)',
+    },
+    'clear-cache': {
+      type: 'boolean',
+      description: 'Clear cache and re-resolve all values',
+    },
+    'skip-cache': {
+      type: 'boolean',
+      description: 'Skip cache entirely for this invocation',
+    },
+  },
+  examples: `
+Loads and validates environment variables according to your .env files, and prints the results.
+Useful for debugging locally, and in CI to print out a summary of env vars.
+
+Examples:
+  varlock load                    # Load and validate with pretty output
+  varlock load --format json      # Output in JSON format
+  eval "$(varlock load --format shell)"  # Load vars into current shell (useful with direnv)
+  varlock load --show-all         # Show all items when validation fails
+  varlock load --path .env.prod   # Load from a specific .env file
+  varlock load -p ./envs -p ./overrides  # Load from multiple directories
+  varlock load --compact          # Use compact format - skips undefined values, no indentation for json-full
+  varlock load --env production   # Load for a specific environment (⚠️ ignored if using @currentEnv!)
+  varlock load --format json-full --summary-stderr   # JSON on stdout + redacted human summary on stderr
+  varlock load --format json-full --summary-file /tmp/summary.txt   # JSON on stdout + redacted human summary written to file
+  varlock load --agent            # Agent-safe JSON output with sensitive values redacted
+  varlock load --format json-full --include-internal   # Include @internal items for local debugging
+  varlock load --filter="STRIPE_*,!STRIPE_DEBUG_KEY"  # Only STRIPE_* keys, excluding one
+  varlock load --filter="@sensitive"  # Only items marked @sensitive
+  varlock load --filter="#billing"    # Only items tagged @tag(billing)
+`.trim(),
+});

--- a/packages/varlock/src/cli/commands/load.command.ts
+++ b/packages/varlock/src/cli/commands/load.command.ts
@@ -1,5 +1,4 @@
 import { writeFileSync } from 'node:fs';
-import { define } from 'gunshi';
 import { gracefulExit } from 'exit-hook';
 
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
@@ -17,87 +16,9 @@ import {
   PROXY_SESSION_UUID_ENV_VAR,
 } from '../../proxy/env-vars';
 import { getActiveProxySession } from '../../proxy/session-registry';
+import { commandSpec } from './load.command-spec';
 
-export const commandSpec = define({
-  name: 'load',
-  description: 'Load env according to schema and resolve values',
-  args: {
-    format: {
-      type: 'enum',
-      short: 'f',
-      choices: ['pretty', 'json', 'env', 'shell', 'json-full'],
-      description: 'Format of output',
-      default: 'pretty',
-    },
-    agent: {
-      type: 'boolean',
-      description: 'Agent-safe mode: redact sensitive values (defaults to JSON format if --format is not set)',
-    },
-    compact: {
-      type: 'boolean',
-      description: 'Use compact format (for json-full: no indentation, for env/shell: skip undefined values)',
-    },
-    'show-all': {
-      type: 'boolean',
-      description: 'When load is failing, show all items rather than only failing items',
-    },
-    'include-internal': {
-      type: 'boolean',
-      description: 'Include @internal items in --format json-full output (excluded by default, since json-full is commonly consumed programmatically - e.g. by framework integrations - not just for local human inspection)',
-    },
-    filter: {
-      type: 'string',
-      description: 'Filter which items are shown: comma-separated key names/globs (e.g. STRIPE_*), negations (!KEY), decorator selectors (@sensitive, @required), and tag selectors (#tagname, set via @tag(tagname)). Can also be set via the _VARLOCK_FILTER env var (this flag takes precedence)',
-    },
-    env: {
-      type: 'string',
-      description: 'Set the environment (e.g., production, development, etc) - will be overridden by @currentEnv in the schema if present',
-    },
-    path: {
-      type: 'string',
-      short: 'p',
-      multiple: true,
-      description: 'Path to a specific .env file or directory to use as the entry point (can be specified multiple times)',
-    },
-    'summary-stderr': {
-      type: 'boolean',
-      description: 'Also output the pretty (redacted) summary to stderr (useful alongside --format json-full to get both machine-readable output on stdout and a human-readable summary on stderr)',
-    },
-    'summary-file': {
-      type: 'string',
-      description: 'Also write the pretty (redacted) summary to a file path (useful for CI, e.g. $GITHUB_STEP_SUMMARY)',
-    },
-    'clear-cache': {
-      type: 'boolean',
-      description: 'Clear cache and re-resolve all values',
-    },
-    'skip-cache': {
-      type: 'boolean',
-      description: 'Skip cache entirely for this invocation',
-    },
-  },
-  examples: `
-Loads and validates environment variables according to your .env files, and prints the results.
-Useful for debugging locally, and in CI to print out a summary of env vars.
-
-Examples:
-  varlock load                    # Load and validate with pretty output
-  varlock load --format json      # Output in JSON format
-  eval "$(varlock load --format shell)"  # Load vars into current shell (useful with direnv)
-  varlock load --show-all         # Show all items when validation fails
-  varlock load --path .env.prod   # Load from a specific .env file
-  varlock load -p ./envs -p ./overrides  # Load from multiple directories
-  varlock load --compact          # Use compact format - skips undefined values, no indentation for json-full
-  varlock load --env production   # Load for a specific environment (⚠️ ignored if using @currentEnv!)
-  varlock load --format json-full --summary-stderr   # JSON on stdout + redacted human summary on stderr
-  varlock load --format json-full --summary-file /tmp/summary.txt   # JSON on stdout + redacted human summary written to file
-  varlock load --agent            # Agent-safe JSON output with sensitive values redacted
-  varlock load --format json-full --include-internal   # Include @internal items for local debugging
-  varlock load --filter="STRIPE_*,!STRIPE_DEBUG_KEY"  # Only STRIPE_* keys, excluding one
-  varlock load --filter="@sensitive"  # Only items marked @sensitive
-  varlock load --filter="#billing"    # Only items tagged @tag(billing)
-`.trim(),
-});
+export { commandSpec };
 
 
 /**

--- a/packages/varlock/src/cli/commands/lock.command-spec.ts
+++ b/packages/varlock/src/cli/commands/lock.command-spec.ts
@@ -1,0 +1,6 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'lock',
+  description: 'Lock the encryption daemon, requiring biometric for next decrypt',
+});

--- a/packages/varlock/src/cli/commands/lock.command.ts
+++ b/packages/varlock/src/cli/commands/lock.command.ts
@@ -1,13 +1,10 @@
 
-import { define } from 'gunshi';
 
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import * as localEncrypt from '../../lib/local-encrypt';
+import { commandSpec } from './lock.command-spec';
 
-export const commandSpec = define({
-  name: 'lock',
-  description: 'Lock the encryption daemon, requiring biometric for next decrypt',
-});
+export { commandSpec };
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async () => {
   const backend = localEncrypt.getBackendInfo();

--- a/packages/varlock/src/cli/commands/login.command-spec.ts
+++ b/packages/varlock/src/cli/commands/login.command-spec.ts
@@ -1,0 +1,7 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'login',
+  description: 'Authenticate (using GitHub)',
+  args: {},
+});

--- a/packages/varlock/src/cli/commands/login.command.ts
+++ b/packages/varlock/src/cli/commands/login.command.ts
@@ -1,20 +1,16 @@
 
 import { setTimeout as delay } from 'node:timers/promises';
 import ansis from 'ansis';
-import { define } from 'gunshi';
 import { logLines } from '../helpers/pretty-format';
 import { CONFIG } from '../../config';
 import { openUrl } from '../helpers/open-url';
 import { keyPressed } from '../helpers/key-press';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { gracefulExit } from 'exit-hook';
+import { commandSpec } from './login.command-spec';
 
 
-export const commandSpec = define({
-  name: 'login',
-  description: 'Authenticate (using GitHub)',
-  args: {},
-});
+export { commandSpec };
 
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {

--- a/packages/varlock/src/cli/commands/plugin.command-spec.ts
+++ b/packages/varlock/src/cli/commands/plugin.command-spec.ts
@@ -1,0 +1,10 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'plugin',
+  description: 'Run a CLI command for an installed plugin',
+  args: {
+    pluginId: { type: 'positional', description: 'ID of the plugin to run a command for' },
+    command: { type: 'positional', description: 'Command to run for the plugin' },
+  },
+});

--- a/packages/varlock/src/cli/commands/plugin.command.ts
+++ b/packages/varlock/src/cli/commands/plugin.command.ts
@@ -1,16 +1,9 @@
-import { define } from 'gunshi';
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { checkForSchemaErrors } from '../helpers/error-checks';
+import { commandSpec } from './plugin.command-spec';
 
-export const commandSpec = define({
-  name: 'plugin',
-  description: 'Run a CLI command for an installed plugin',
-  args: {
-    pluginId: { type: 'positional', description: 'ID of the plugin to run a command for' },
-    command: { type: 'positional', description: 'Command to run for the plugin' },
-  },
-});
+export { commandSpec };
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   console.log('');

--- a/packages/varlock/src/cli/commands/printenv.command-spec.ts
+++ b/packages/varlock/src/cli/commands/printenv.command-spec.ts
@@ -1,0 +1,58 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'printenv',
+  description: 'Print the resolved value of a single environment variable',
+  args: {
+    key: {
+      type: 'positional',
+      required: false,
+      description: 'Variable to print',
+    },
+    template: {
+      type: 'string',
+      short: 't',
+      description: 'Print a rendered string template instead of a single value; {{KEY}} placeholders are replaced with resolved values',
+    },
+    escape: {
+      type: 'enum',
+      choices: ['json'],
+      description: 'Escape substituted values for the given language (only valid with --template); "json" escapes each value for embedding inside a JSON string literal',
+    },
+    path: {
+      type: 'string',
+      short: 'p',
+      multiple: true,
+      description: 'Path to a specific .env file or directory (with trailing slash) to use as the entry point (can be specified multiple times)',
+    },
+    'clear-cache': {
+      type: 'boolean',
+      description: 'Clear cache and re-resolve all values',
+    },
+    'skip-cache': {
+      type: 'boolean',
+      description: 'Skip cache entirely for this invocation',
+    },
+  },
+  examples: `
+Prints the resolved value of a single environment variable, or a rendered string
+template referencing multiple variables.
+Useful within larger shell commands where you need a single env var value.
+
+Examples:
+  varlock printenv MY_VAR                    # Print the value of MY_VAR
+  varlock printenv --path .env.prod MY_VAR   # Use a specific .env file
+  varlock printenv --path ./config/ MY_VAR   # Use a specific directory
+  varlock printenv -p ./envs -p ./overrides MY_VAR  # Use multiple directories
+  varlock printenv --template '{"Authorization": "Bearer {{MY_TOKEN}}"}' --escape json  # Render a template
+
+📍 Note: Use sh -c to embed this in shell commands, e.g.:
+       sh -c 'do-something --token $(varlock printenv MY_TOKEN)'
+
+💡 Tip: Unlike \`varlock run -- echo $MY_VAR\`, this works because the shell
+       expansion happens after varlock has printed the value.
+
+💡 Tip: Use --escape json when a template emits JSON (e.g. headers for an MCP
+       headersHelper) so values cannot break out of their string literals
+  `.trim(),
+});

--- a/packages/varlock/src/cli/commands/printenv.command.ts
+++ b/packages/varlock/src/cli/commands/printenv.command.ts
@@ -1,10 +1,10 @@
-import { define } from 'gunshi';
 import { gracefulExit } from 'exit-hook';
 
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
 import { checkForSchemaErrors } from '../helpers/error-checks';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { CliExitError } from '../helpers/exit-error';
+import { commandSpec } from './printenv.command-spec';
 
 const TEMPLATE_PLACEHOLDER_REGEX = /\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
 
@@ -32,62 +32,7 @@ export function renderTemplate(
   });
 }
 
-export const commandSpec = define({
-  name: 'printenv',
-  description: 'Print the resolved value of a single environment variable',
-  args: {
-    key: {
-      type: 'positional',
-      required: false,
-      description: 'Variable to print',
-    },
-    template: {
-      type: 'string',
-      short: 't',
-      description: 'Print a rendered string template instead of a single value; {{KEY}} placeholders are replaced with resolved values',
-    },
-    escape: {
-      type: 'enum',
-      choices: ['json'],
-      description: 'Escape substituted values for the given language (only valid with --template); "json" escapes each value for embedding inside a JSON string literal',
-    },
-    path: {
-      type: 'string',
-      short: 'p',
-      multiple: true,
-      description: 'Path to a specific .env file or directory (with trailing slash) to use as the entry point (can be specified multiple times)',
-    },
-    'clear-cache': {
-      type: 'boolean',
-      description: 'Clear cache and re-resolve all values',
-    },
-    'skip-cache': {
-      type: 'boolean',
-      description: 'Skip cache entirely for this invocation',
-    },
-  },
-  examples: `
-Prints the resolved value of a single environment variable, or a rendered string
-template referencing multiple variables.
-Useful within larger shell commands where you need a single env var value.
-
-Examples:
-  varlock printenv MY_VAR                    # Print the value of MY_VAR
-  varlock printenv --path .env.prod MY_VAR   # Use a specific .env file
-  varlock printenv --path ./config/ MY_VAR   # Use a specific directory
-  varlock printenv -p ./envs -p ./overrides MY_VAR  # Use multiple directories
-  varlock printenv --template '{"Authorization": "Bearer {{MY_TOKEN}}"}' --escape json  # Render a template
-
-📍 Note: Use sh -c to embed this in shell commands, e.g.:
-       sh -c 'do-something --token $(varlock printenv MY_TOKEN)'
-
-💡 Tip: Unlike \`varlock run -- echo $MY_VAR\`, this works because the shell
-       expansion happens after varlock has printed the value.
-
-💡 Tip: Use --escape json when a template emits JSON (e.g. headers for an MCP
-       headersHelper) so values cannot break out of their string literals
-  `.trim(),
-});
+export { commandSpec };
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   const varName = ctx.values.key;

--- a/packages/varlock/src/cli/commands/proxy.command-spec.ts
+++ b/packages/varlock/src/cli/commands/proxy.command-spec.ts
@@ -1,0 +1,287 @@
+import { define, lazy } from 'gunshi';
+
+import { REDACT_STDOUT_ARG } from '../helpers/redact-stdout-arg';
+
+// Flags shared by several subcommands. Kept as small fragments spread into each
+// subcommand's args so every verb declares only the flags it actually reads;
+// native gunshi subcommands then give per-verb help + shell completion, which a
+// single flat arg bag can't.
+const sessionArg = {
+  session: {
+    type: 'string',
+    short: 's',
+    description: 'Proxy session ID/alias',
+  },
+} as const;
+
+const pathArg = {
+  path: {
+    type: 'string',
+    short: 'p',
+    multiple: true,
+    description: 'Path to a specific .env file or directory to use as the entry point (repeatable)',
+  },
+} as const;
+
+const allowReloadArg = {
+  'allow-reload': {
+    type: 'boolean',
+    negatable: true,
+    description: 'Force the reload posture: `--allow-reload` = `manual` (human-applied from a trusted terminal; '
+      + 'reloads requested from inside the agent are refused), `--no-allow-reload` = `off`. Otherwise '
+      + '`@proxyConfig={reload=...}` applies, defaulting to `auto` (manual for an interactive `proxy start`, off '
+      + 'for headless or one-shot `proxy run`).',
+  },
+} as const;
+
+// Fix the proxy's loopback port / CA-cert location so a caller can wire tools to a
+// known endpoint before it boots. Only meaningful when STARTING a proxy (proxy start,
+// or proxy run that isn't attaching), so only those verbs declare them.
+const bindArgs = {
+  port: {
+    type: 'string',
+    description: 'Fixed loopback port for the proxy (else an ephemeral one), so you can point tools at a known '
+      + 'HTTP(S)_PROXY before it starts. Fails to start if the port is in use.',
+  },
+  'cert-dir': {
+    type: 'string',
+    description: 'Directory to write the CA cert into (`ca-cert.pem` + `combined-ca.pem`), so tools can trust a '
+      + 'known CA path before the proxy starts (else a fresh temp dir).',
+  },
+  'persist-ca': {
+    type: 'boolean',
+    description: 'Keep the CA in `--cert-dir` (including `ca-key.pem`, mode 0600) and reuse it on the next start, '
+      + 'so a restart does not invalidate clients that already trust it. For long-lived brokers; the private key '
+      + 'normally never touches disk, so only use this where the proxy runs alone.',
+  },
+  expose: {
+    type: 'custom',
+    // Bare `--expose` → bind 0.0.0.0; `--expose=<addr>` → a specific interface.
+    parse: (value: string) => (value === '' || value == null ? '0.0.0.0' : value),
+    description: 'Make this proxy reachable from another machine, so a client elsewhere can run through it '
+      + '(`proxy run --url`). Binds off-loopback (bare `--expose` = 0.0.0.0; `--expose=<addr>` picks an interface) '
+      + 'and serves the built-in WebSocket tunnel for clients behind HTTP-only ingress. Mints a per-session '
+      + 'data-plane token clients must present (pin it with VARLOCK_PROXY_TOKEN, or read it back with `proxy '
+      + 'token`). The control endpoint stays loopback-only.',
+  },
+} as const;
+
+// The remote analog of `--session`: which proxy to target when it runs elsewhere.
+const remoteArgs = {
+  url: {
+    type: 'string',
+    description: 'Run through a proxy running elsewhere (a broker started with `--expose`): its tunnel URL '
+      + '(wss://... or ws://...). Reached over the built-in WebSocket tunnel. Requires --token.',
+  },
+  token: {
+    type: 'string',
+    description: 'Data-plane token for `--url` (or set VARLOCK_PROXY_TOKEN). The broker prints it on start.',
+  },
+} as const;
+
+export const runCommandSpec = define({
+  name: 'run',
+  description: 'Run a command through the proxy: attach to this directory\'s session, start one, or `--url` a remote broker',
+  args: {
+    ...sessionArg,
+    ...pathArg,
+    ...allowReloadArg,
+    ...bindArgs,
+    ...remoteArgs,
+    new: {
+      type: 'boolean',
+      description: 'Start a fresh proxy instead of attaching to a running one for this directory',
+    },
+    sandbox: {
+      type: 'custom',
+      // Bare `--sandbox` → built-in; `--sandbox=docker|podman` → container backend.
+      parse: (value: string) => (value === '' || value == null ? 'builtin' : value),
+      description: 'Run the child in a sandbox whose only egress is the proxy. Bare `--sandbox` uses the '
+        + 'built-in minimal OS jail (macOS `sandbox-exec`); `--sandbox=docker` (or `=podman`) runs the child in '
+        + 'a container on an internal network, with a dumb forwarder bridging to the host proxy (secrets stay on '
+        + 'the host). Opt-in.',
+    },
+    'sandbox-image': {
+      type: 'string',
+      description: 'For `--sandbox=docker|podman`: the container image the child runs in (must contain your '
+        + 'command, e.g. a devcontainer image with `claude` installed).',
+    },
+    inject: {
+      type: 'string',
+      short: 'i',
+      description: 'Control what gets injected into the child env: "all" (default), "vars", or "blob"',
+    },
+    ...REDACT_STDOUT_ARG,
+  },
+  examples: `
+  varlock proxy run -- claude                   # attach to a running proxy for this dir, else start one
+  varlock proxy run --session abc12 -- claude   # attach to a specific session (approvals prompt in its terminal)
+  varlock proxy run --new -- claude             # force a fresh, separate proxy
+  varlock proxy run --sandbox -- claude         # run the child in a minimal OS sandbox (macOS)
+  varlock proxy run --sandbox=docker --sandbox-image my-agent -- claude   # run the child in a container
+  `.trim(),
+});
+
+export const startCommandSpec = define({
+  name: 'start',
+  description: 'Start a proxy daemon with a live request log that `proxy run` can attach to',
+  args: {
+    ...pathArg,
+    ...allowReloadArg,
+    ...bindArgs,
+  },
+});
+
+export const rulesCommandSpec = define({
+  name: 'rules',
+  description: 'Summarize the effective @proxy config for this schema (no proxy started)',
+  args: {
+    ...pathArg,
+  },
+});
+
+export const envCommandSpec = define({
+  name: 'env',
+  description: 'Print a running session\'s proxy env (shell exports or json)',
+  args: {
+    ...sessionArg,
+    format: {
+      type: 'string',
+      short: 'f',
+      description: 'Output format: shell (default) or json',
+    },
+    full: {
+      type: 'boolean',
+      description: 'Emit the full env a proxied agent runs with (real values for non-secrets, placeholders for '
+        + 'secrets), not just the wiring. Use this to build the env for a remote sandbox; combine with '
+        + '--proxy-url / --cert-dir to repoint it.',
+    },
+    'proxy-url': {
+      type: 'string',
+      description: 'Repoint the proxy-URL vars for a guest that reaches the proxy elsewhere '
+        + '(e.g. http://127.0.0.1:8888 for a tunnel). Implies --full. Default: this session\'s own address.',
+    },
+    'cert-dir': {
+      type: 'string',
+      description: 'Repoint the CA-path vars at the dir a guest reads the bundle from. Implies --full. '
+        + 'Default: this session\'s own cert dir.',
+    },
+  },
+});
+
+export const statusCommandSpec = define({
+  name: 'status',
+  description: 'Show proxy session status',
+  args: {
+    ...sessionArg,
+    all: {
+      type: 'boolean',
+      description: 'Include ended sessions',
+    },
+    format: {
+      type: 'string',
+      short: 'f',
+      description: 'Output json instead of the table',
+    },
+    watch: {
+      type: 'boolean',
+      description: 'Continuously refresh the status output',
+    },
+    interval: {
+      type: 'string',
+      description: 'Polling interval in milliseconds for `--watch` (default: 1000)',
+    },
+  },
+});
+
+export const auditCommandSpec = define({
+  name: 'audit',
+  description: 'Show a proxy session\'s audit log',
+  args: {
+    ...sessionArg,
+    format: {
+      type: 'string',
+      short: 'f',
+      description: 'Output format: text (default) or json',
+    },
+  },
+});
+
+export const reloadCommandSpec = define({
+  name: 'reload',
+  description: 'Re-resolve the schema and hot-swap a running session\'s policy',
+  args: {
+    ...sessionArg,
+    ...pathArg,
+  },
+});
+
+export const stopCommandSpec = define({
+  name: 'stop',
+  description: 'Stop one or all proxy sessions',
+  args: {
+    ...sessionArg,
+    all: {
+      type: 'boolean',
+      description: 'Stop all sessions',
+    },
+  },
+});
+
+export const pruneCommandSpec = define({
+  name: 'prune',
+  description: 'Delete ended session records (and their audit logs)',
+  args: {
+    ...sessionArg,
+    yes: {
+      type: 'boolean',
+      short: 'y',
+      description: 'Skip the confirmation prompt',
+    },
+  },
+});
+
+export const tokenCommandSpec = define({
+  name: 'token',
+  description: 'Print a session\'s data-plane token (for `proxy run --url`)',
+  args: { ...sessionArg },
+});
+
+export const commandSpec = define({
+  name: 'proxy',
+  description: 'Manage proxy sessions for placeholder-based agent workflows',
+  subCommands: {
+    run: lazy(async () => (await import('./proxy.command')).runAction, runCommandSpec),
+    start: lazy(async () => (await import('./proxy.command')).startAction, startCommandSpec),
+    rules: lazy(async () => (await import('./proxy.command')).rulesAction, rulesCommandSpec),
+    env: lazy(async () => (await import('./proxy.command')).envAction, envCommandSpec),
+    token: lazy(async () => (await import('./proxy.command')).tokenAction, tokenCommandSpec),
+    status: lazy(async () => (await import('./proxy.command')).statusAction, statusCommandSpec),
+    audit: lazy(async () => (await import('./proxy.command')).auditAction, auditCommandSpec),
+    reload: lazy(async () => (await import('./proxy.command')).reloadAction, reloadCommandSpec),
+    stop: lazy(async () => (await import('./proxy.command')).stopAction, stopCommandSpec),
+    prune: lazy(async () => (await import('./proxy.command')).pruneAction, pruneCommandSpec),
+  },
+  examples: `
+Proxy command surface:
+  varlock proxy run -- claude                   # attaches to a running proxy for this dir, else starts one
+  varlock proxy run --session abc12 -- claude   # attach to a specific session (approvals prompt in its terminal)
+  varlock proxy run --new -- claude             # force a fresh, separate proxy
+  varlock proxy run --sandbox -- claude         # run the child in a minimal OS sandbox (macOS)
+  varlock proxy run --sandbox=docker --sandbox-image my-agent -- claude   # run the child in a container
+  varlock proxy start
+  varlock proxy rules                           # summarize the effective @proxy config (no proxy started)
+  varlock proxy env --session abc12             # this session's wiring env (source locally)
+  varlock proxy env --full --proxy-url http://127.0.0.1:8888 --cert-dir /home/user/certs --format json   # full env for a remote sandbox
+  varlock proxy start --expose                  # broker: reachable off-loopback, serving the WS tunnel
+  varlock proxy token                           # read the broker's data-plane token
+  varlock proxy run --url wss://8000-abc.e2b.app -- claude   # guest: run through a remote broker (token via VARLOCK_PROXY_TOKEN)
+  varlock proxy status
+  varlock proxy audit --session abc12
+  varlock proxy reload --session abc12
+  varlock proxy stop --session abc12
+  varlock proxy stop --all
+  varlock proxy prune                           # delete ALL ended session records (+ audit logs)
+  varlock proxy prune --session abc12           # delete one session's record
+  `.trim(),
+});

--- a/packages/varlock/src/cli/commands/proxy.command.ts
+++ b/packages/varlock/src/cli/commands/proxy.command.ts
@@ -8,7 +8,6 @@ import { mkdtemp, writeFile } from 'node:fs/promises';
 import { request as httpRequest } from 'node:http';
 
 import ansis from 'ansis';
-import { define } from 'gunshi';
 import { gracefulExit } from 'exit-hook';
 
 import { exec } from '../../lib/exec';
@@ -84,11 +83,12 @@ import { fetchTunnelBootstrap, startTunnelClientListener } from '../../proxy/tun
 import {
   parseSandboxSpec, isContainerKind, checkSandboxAvailable, type SandboxSpec,
 } from '../../proxy/sandbox';
+import { commandSpec } from './proxy.command-spec';
 import type { ProxyManagedItem, ProxyRule } from '../../proxy/types';
 import { generateProxyPlaceholderForItem } from '../../proxy/placeholder';
 import { isVarlockReservedKey } from '../../env-graph/lib/reserved-vars';
 import { resetRedactionMap } from '../../runtime/env';
-import { REDACT_STDOUT_ARG, resolveStdoutRedaction, pipeRedactedStreams } from '../helpers/stdout-redaction';
+import { resolveStdoutRedaction, pipeRedactedStreams } from '../helpers/stdout-redaction';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { CliExitError } from '../helpers/exit-error';
 import {
@@ -1402,7 +1402,7 @@ function resolveProxyBindOptions(ctx: any): {
   return out;
 }
 
-async function runAction(ctx: any) {
+export async function runAction(ctx: any) {
   const commandToRunAsArgs = getRunCommandArgs();
   const rawCommand = commandToRunAsArgs[0]!;
   const commandArgsOnly = commandToRunAsArgs.slice(1);
@@ -1647,7 +1647,7 @@ async function awaitProxiedChild(
   return exitCode;
 }
 
-async function startAction(ctx: any) {
+export async function startAction(ctx: any) {
   const policy = await prepareProxyPolicy(ctx.values.path);
   // Reload posture, resolved at launch (see resolveReloadMode). `manual` runs the
   // reload servicer so a human can `proxy reload` from another shell in the folder; a reload
@@ -1806,7 +1806,7 @@ async function startAction(ctx: any) {
  * over it, the placeholder env), so reading it should be an explicit act and
  * never something that lands in output people paste or screenshot.
  */
-async function tokenAction(ctx: any) {
+export async function tokenAction(ctx: any) {
   const session = await resolveProxySessionForCommand({
     explicitSession: ctx.values.session,
     env: process.env,
@@ -1825,7 +1825,7 @@ async function tokenAction(ctx: any) {
   console.log(session.dataPlaneToken);
 }
 
-async function envAction(ctx: any) {
+export async function envAction(ctx: any) {
   const session = await resolveProxySessionForCommand({
     explicitSession: ctx.values.session,
     env: process.env,
@@ -1942,7 +1942,7 @@ async function runRemoteThroughTunnel(ctx: any, cmd: {
   return gracefulExit(exitCode);
 }
 
-async function statusAction(ctx: any) {
+export async function statusAction(ctx: any) {
   const watch = ctx.values.watch ?? false;
   const asJson = (ctx.values.format ?? '').toLowerCase() === 'json';
   const printSnapshot = async () => {
@@ -2003,7 +2003,7 @@ async function statusAction(ctx: any) {
   process.off('SIGTERM', stopWatching);
 }
 
-async function reloadAction(ctx: any) {
+export async function reloadAction(ctx: any) {
   const session = await resolveProxySessionForCommand({
     explicitSession: ctx.values.session,
     env: process.env,
@@ -2180,7 +2180,7 @@ async function stopOneSession(session: ProxySessionRecord): Promise<void> {
   );
 }
 
-async function stopAction(ctx: any) {
+export async function stopAction(ctx: any) {
   await cleanupStaleProxySessions();
 
   // Refuse an ambiguous target rather than silently honoring the destructive `--all`.
@@ -2218,7 +2218,7 @@ async function stopAction(ctx: any) {
   await stopOneSession(session);
 }
 
-async function pruneAction(ctx: any) {
+export async function pruneAction(ctx: any) {
   await cleanupStaleProxySessions();
 
   // Prune one specific session by id (any state, once it isn't running).
@@ -2268,7 +2268,7 @@ function formatAuditEntry(entry: ProxyAuditEntry): string {
   return `${entry.ts} ${entry.decision.padEnd(16)} ${entry.method.padEnd(7)} ${entry.host}${entry.path}${injected}${rule}`;
 }
 
-async function auditAction(ctx: any) {
+export async function auditAction(ctx: any) {
   const format = (ctx.values.format ?? 'text').toLowerCase();
   if (format !== 'text' && format !== 'json') {
     throw new CliExitError('Invalid --format for `proxy audit`. Use "text" or "json".');
@@ -2327,7 +2327,7 @@ function describeProxyRuleGate(rule: ProxyRule): string {
  * after the fail-closed validation, and for seeing what an agent would and
  * wouldn't be able to reach.
  */
-async function rulesAction(ctx: any) {
+export async function rulesAction(ctx: any) {
   const envGraph = await loadVarlockEnvGraph({
     entryFilePaths: ctx.values.path,
     // This command inspects the schema; don't subject it to the nested guard.
@@ -2389,299 +2389,7 @@ async function rulesAction(ctx: any) {
   }
 }
 
-// Flags shared by several subcommands. Kept as small fragments spread into each
-// subcommand's args so every verb declares only the flags it actually reads;
-// native gunshi subcommands then give per-verb help + shell completion, which a
-// single flat arg bag can't.
-const sessionArg = {
-  session: {
-    type: 'string',
-    short: 's',
-    description: 'Proxy session ID/alias',
-  },
-} as const;
-
-const pathArg = {
-  path: {
-    type: 'string',
-    short: 'p',
-    multiple: true,
-    description: 'Path to a specific .env file or directory to use as the entry point (repeatable)',
-  },
-} as const;
-
-const allowReloadArg = {
-  'allow-reload': {
-    type: 'boolean',
-    negatable: true,
-    description: 'Force the reload posture: `--allow-reload` = `manual` (human-applied from a trusted terminal; '
-      + 'reloads requested from inside the agent are refused), `--no-allow-reload` = `off`. Otherwise '
-      + '`@proxyConfig={reload=...}` applies, defaulting to `auto` (manual for an interactive `proxy start`, off '
-      + 'for headless or one-shot `proxy run`).',
-  },
-} as const;
-
-// Fix the proxy's loopback port / CA-cert location so a caller can wire tools to a
-// known endpoint before it boots. Only meaningful when STARTING a proxy (proxy start,
-// or proxy run that isn't attaching), so only those verbs declare them.
-const bindArgs = {
-  port: {
-    type: 'string',
-    description: 'Fixed loopback port for the proxy (else an ephemeral one), so you can point tools at a known '
-      + 'HTTP(S)_PROXY before it starts. Fails to start if the port is in use.',
-  },
-  'cert-dir': {
-    type: 'string',
-    description: 'Directory to write the CA cert into (`ca-cert.pem` + `combined-ca.pem`), so tools can trust a '
-      + 'known CA path before the proxy starts (else a fresh temp dir).',
-  },
-  'persist-ca': {
-    type: 'boolean',
-    description: 'Keep the CA in `--cert-dir` (including `ca-key.pem`, mode 0600) and reuse it on the next start, '
-      + 'so a restart does not invalidate clients that already trust it. For long-lived brokers; the private key '
-      + 'normally never touches disk, so only use this where the proxy runs alone.',
-  },
-  expose: {
-    type: 'custom',
-    // Bare `--expose` → bind 0.0.0.0; `--expose=<addr>` → a specific interface.
-    parse: (value: string) => (value === '' || value == null ? '0.0.0.0' : value),
-    description: 'Make this proxy reachable from another machine, so a client elsewhere can run through it '
-      + '(`proxy run --url`). Binds off-loopback (bare `--expose` = 0.0.0.0; `--expose=<addr>` picks an interface) '
-      + 'and serves the built-in WebSocket tunnel for clients behind HTTP-only ingress. Mints a per-session '
-      + 'data-plane token clients must present (pin it with VARLOCK_PROXY_TOKEN, or read it back with `proxy '
-      + 'token`). The control endpoint stays loopback-only.',
-  },
-} as const;
-
-// The remote analog of `--session`: which proxy to target when it runs elsewhere.
-const remoteArgs = {
-  url: {
-    type: 'string',
-    description: 'Run through a proxy running elsewhere (a broker started with `--expose`): its tunnel URL '
-      + '(wss://... or ws://...). Reached over the built-in WebSocket tunnel. Requires --token.',
-  },
-  token: {
-    type: 'string',
-    description: 'Data-plane token for `--url` (or set VARLOCK_PROXY_TOKEN). The broker prints it on start.',
-  },
-} as const;
-
-const runCommand = define({
-  name: 'run',
-  description: 'Run a command through the proxy: attach to this directory\'s session, start one, or `--url` a remote broker',
-  args: {
-    ...sessionArg,
-    ...pathArg,
-    ...allowReloadArg,
-    ...bindArgs,
-    ...remoteArgs,
-    new: {
-      type: 'boolean',
-      description: 'Start a fresh proxy instead of attaching to a running one for this directory',
-    },
-    sandbox: {
-      type: 'custom',
-      // Bare `--sandbox` → built-in; `--sandbox=docker|podman` → container backend.
-      parse: (value: string) => (value === '' || value == null ? 'builtin' : value),
-      description: 'Run the child in a sandbox whose only egress is the proxy. Bare `--sandbox` uses the '
-        + 'built-in minimal OS jail (macOS `sandbox-exec`); `--sandbox=docker` (or `=podman`) runs the child in '
-        + 'a container on an internal network, with a dumb forwarder bridging to the host proxy (secrets stay on '
-        + 'the host). Opt-in.',
-    },
-    'sandbox-image': {
-      type: 'string',
-      description: 'For `--sandbox=docker|podman`: the container image the child runs in (must contain your '
-        + 'command, e.g. a devcontainer image with `claude` installed).',
-    },
-    inject: {
-      type: 'string',
-      short: 'i',
-      description: 'Control what gets injected into the child env: "all" (default), "vars", or "blob"',
-    },
-    ...REDACT_STDOUT_ARG,
-  },
-  examples: `
-  varlock proxy run -- claude                   # attach to a running proxy for this dir, else start one
-  varlock proxy run --session abc12 -- claude   # attach to a specific session (approvals prompt in its terminal)
-  varlock proxy run --new -- claude             # force a fresh, separate proxy
-  varlock proxy run --sandbox -- claude         # run the child in a minimal OS sandbox (macOS)
-  varlock proxy run --sandbox=docker --sandbox-image my-agent -- claude   # run the child in a container
-  `.trim(),
-  run: (ctx: any) => runAction(ctx),
-});
-
-const startCommand = define({
-  name: 'start',
-  description: 'Start a proxy daemon with a live request log that `proxy run` can attach to',
-  args: {
-    ...pathArg,
-    ...allowReloadArg,
-    ...bindArgs,
-  },
-  run: (ctx: any) => startAction(ctx),
-});
-
-const rulesCommand = define({
-  name: 'rules',
-  description: 'Summarize the effective @proxy config for this schema (no proxy started)',
-  args: {
-    ...pathArg,
-  },
-  run: (ctx: any) => rulesAction(ctx),
-});
-
-const envCommand = define({
-  name: 'env',
-  description: 'Print a running session\'s proxy env (shell exports or json)',
-  args: {
-    ...sessionArg,
-    format: {
-      type: 'string',
-      short: 'f',
-      description: 'Output format: shell (default) or json',
-    },
-    full: {
-      type: 'boolean',
-      description: 'Emit the full env a proxied agent runs with (real values for non-secrets, placeholders for '
-        + 'secrets), not just the wiring. Use this to build the env for a remote sandbox; combine with '
-        + '--proxy-url / --cert-dir to repoint it.',
-    },
-    'proxy-url': {
-      type: 'string',
-      description: 'Repoint the proxy-URL vars for a guest that reaches the proxy elsewhere '
-        + '(e.g. http://127.0.0.1:8888 for a tunnel). Implies --full. Default: this session\'s own address.',
-    },
-    'cert-dir': {
-      type: 'string',
-      description: 'Repoint the CA-path vars at the dir a guest reads the bundle from. Implies --full. '
-        + 'Default: this session\'s own cert dir.',
-    },
-  },
-  run: (ctx: any) => envAction(ctx),
-});
-
-const statusCommand = define({
-  name: 'status',
-  description: 'Show proxy session status',
-  args: {
-    ...sessionArg,
-    all: {
-      type: 'boolean',
-      description: 'Include ended sessions',
-    },
-    format: {
-      type: 'string',
-      short: 'f',
-      description: 'Output json instead of the table',
-    },
-    watch: {
-      type: 'boolean',
-      description: 'Continuously refresh the status output',
-    },
-    interval: {
-      type: 'string',
-      description: 'Polling interval in milliseconds for `--watch` (default: 1000)',
-    },
-  },
-  run: (ctx: any) => statusAction(ctx),
-});
-
-const auditCommand = define({
-  name: 'audit',
-  description: 'Show a proxy session\'s audit log',
-  args: {
-    ...sessionArg,
-    format: {
-      type: 'string',
-      short: 'f',
-      description: 'Output format: text (default) or json',
-    },
-  },
-  run: (ctx: any) => auditAction(ctx),
-});
-
-const reloadCommand = define({
-  name: 'reload',
-  description: 'Re-resolve the schema and hot-swap a running session\'s policy',
-  args: {
-    ...sessionArg,
-    ...pathArg,
-  },
-  run: (ctx: any) => reloadAction(ctx),
-});
-
-const stopCommand = define({
-  name: 'stop',
-  description: 'Stop one or all proxy sessions',
-  args: {
-    ...sessionArg,
-    all: {
-      type: 'boolean',
-      description: 'Stop all sessions',
-    },
-  },
-  run: (ctx: any) => stopAction(ctx),
-});
-
-const pruneCommand = define({
-  name: 'prune',
-  description: 'Delete ended session records (and their audit logs)',
-  args: {
-    ...sessionArg,
-    yes: {
-      type: 'boolean',
-      short: 'y',
-      description: 'Skip the confirmation prompt',
-    },
-  },
-  run: (ctx: any) => pruneAction(ctx),
-});
-
-const tokenCommand = define({
-  name: 'token',
-  description: 'Print a session\'s data-plane token (for `proxy run --url`)',
-  args: { ...sessionArg },
-  run: (ctx: any) => tokenAction(ctx),
-});
-
-export const commandSpec = define({
-  name: 'proxy',
-  description: 'Manage proxy sessions for placeholder-based agent workflows',
-  subCommands: {
-    run: runCommand,
-    start: startCommand,
-    rules: rulesCommand,
-    env: envCommand,
-    token: tokenCommand,
-    status: statusCommand,
-    audit: auditCommand,
-    reload: reloadCommand,
-    stop: stopCommand,
-    prune: pruneCommand,
-  },
-  examples: `
-Proxy command surface:
-  varlock proxy run -- claude                   # attaches to a running proxy for this dir, else starts one
-  varlock proxy run --session abc12 -- claude   # attach to a specific session (approvals prompt in its terminal)
-  varlock proxy run --new -- claude             # force a fresh, separate proxy
-  varlock proxy run --sandbox -- claude         # run the child in a minimal OS sandbox (macOS)
-  varlock proxy run --sandbox=docker --sandbox-image my-agent -- claude   # run the child in a container
-  varlock proxy start
-  varlock proxy rules                           # summarize the effective @proxy config (no proxy started)
-  varlock proxy env --session abc12             # this session's wiring env (source locally)
-  varlock proxy env --full --proxy-url http://127.0.0.1:8888 --cert-dir /home/user/certs --format json   # full env for a remote sandbox
-  varlock proxy start --expose                  # broker: reachable off-loopback, serving the WS tunnel
-  varlock proxy token                           # read the broker's data-plane token
-  varlock proxy run --url wss://8000-abc.e2b.app -- claude   # guest: run through a remote broker (token via VARLOCK_PROXY_TOKEN)
-  varlock proxy status
-  varlock proxy audit --session abc12
-  varlock proxy reload --session abc12
-  varlock proxy stop --session abc12
-  varlock proxy stop --all
-  varlock proxy prune                           # delete ALL ended session records (+ audit logs)
-  varlock proxy prune --session abc12           # delete one session's record
-  `.trim(),
-});
+export { commandSpec };
 
 // The real verbs are handled by `subCommands`. This parent runs only for a bare
 // `varlock proxy` or an unrecognized verb, so it just points at the surface.

--- a/packages/varlock/src/cli/commands/reveal.command-spec.ts
+++ b/packages/varlock/src/cli/commands/reveal.command-spec.ts
@@ -1,0 +1,37 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'reveal',
+  description: 'Securely view decrypted values of sensitive environment variables',
+  args: {
+    key: {
+      type: 'positional',
+      required: false,
+      description: 'Variable to reveal (omit for an interactive picker)',
+    },
+    copy: {
+      type: 'boolean',
+      description: 'Copy the value to clipboard instead of displaying (auto-clears after 10s)',
+    },
+    path: {
+      type: 'string',
+      short: 'p',
+      multiple: true,
+      description: 'Path to a specific .env file or directory to use as the entry point (can be specified multiple times)',
+    },
+    env: {
+      type: 'string',
+      description: 'Set the environment (e.g., production, development, etc)',
+    },
+  },
+  examples: `
+Securely view the plaintext value of sensitive environment variables.
+Values are shown in an alternate screen buffer so they don't persist in
+terminal scrollback history.
+
+Examples:
+  varlock reveal                  # Interactive picker to select and reveal values
+  varlock reveal MY_SECRET        # Reveal a specific variable
+  varlock reveal MY_SECRET --copy # Copy value to clipboard (auto-clears after 10s)
+`.trim(),
+});

--- a/packages/varlock/src/cli/commands/reveal.command.ts
+++ b/packages/varlock/src/cli/commands/reveal.command.ts
@@ -1,5 +1,4 @@
 import ansis from 'ansis';
-import { define } from 'gunshi';
 import { isCancel } from '@clack/prompts';
 import { gracefulExit } from 'exit-hook';
 
@@ -10,42 +9,9 @@ import { CliExitError } from '../helpers/exit-error';
 import { select } from '../helpers/prompts';
 import { ConfigItem } from '../../env-graph';
 import { redactString } from '../../runtime/lib/redaction';
+import { commandSpec } from './reveal.command-spec';
 
-export const commandSpec = define({
-  name: 'reveal',
-  description: 'Securely view decrypted values of sensitive environment variables',
-  args: {
-    key: {
-      type: 'positional',
-      required: false,
-      description: 'Variable to reveal (omit for an interactive picker)',
-    },
-    copy: {
-      type: 'boolean',
-      description: 'Copy the value to clipboard instead of displaying (auto-clears after 10s)',
-    },
-    path: {
-      type: 'string',
-      short: 'p',
-      multiple: true,
-      description: 'Path to a specific .env file or directory to use as the entry point (can be specified multiple times)',
-    },
-    env: {
-      type: 'string',
-      description: 'Set the environment (e.g., production, development, etc)',
-    },
-  },
-  examples: `
-Securely view the plaintext value of sensitive environment variables.
-Values are shown in an alternate screen buffer so they don't persist in
-terminal scrollback history.
-
-Examples:
-  varlock reveal                  # Interactive picker to select and reveal values
-  varlock reveal MY_SECRET        # Reveal a specific variable
-  varlock reveal MY_SECRET --copy # Copy value to clipboard (auto-clears after 10s)
-`.trim(),
-});
+export { commandSpec };
 
 const CLIPBOARD_CLEAR_DELAY_MS = 10_000;
 

--- a/packages/varlock/src/cli/commands/run.command-spec.ts
+++ b/packages/varlock/src/cli/commands/run.command-spec.ts
@@ -1,0 +1,73 @@
+import { define } from 'gunshi';
+
+import { REDACT_STDOUT_ARG } from '../helpers/redact-stdout-arg';
+
+export const commandSpec = define({
+  name: 'run',
+  description: 'Run a command with your environment variables injected',
+  args: {
+    // watch: {
+    //   type: 'boolean',
+    //   short: 'w',
+    //   description: 'Watch mode',
+    // },
+    ...REDACT_STDOUT_ARG,
+    inject: {
+      type: 'string',
+      short: 'i',
+      description: 'Control what gets injected into the child process env: "all" (default), "vars" (individual vars only, no blob), or "blob" (only __VARLOCK_ENV blob, no individual vars)',
+    },
+    'no-inject-graph': {
+      type: 'boolean',
+      description: 'Deprecated: use --inject vars instead',
+      hidden: true,
+    },
+    'include-internal': {
+      type: 'boolean',
+      description: 'Pass @internal items through to the child process (by default they are stripped, even when set in the ambient env). Use this for a nested `varlock run` whose own resolution needs the internal value (e.g. a secret-zero token).',
+    },
+    filter: {
+      type: 'string',
+      description: 'Filter which items are injected: comma-separated key names/globs (e.g. STRIPE_*), negations (!KEY), decorator selectors (@sensitive, @required), and tag selectors (#tagname, set via @tag(tagname)). Can also be set via the _VARLOCK_FILTER env var (this flag takes precedence)',
+    },
+    path: {
+      type: 'string',
+      short: 'p',
+      multiple: true,
+      description: 'Path to a specific .env file or directory to use as the entry point (can be specified multiple times)',
+    },
+    'clear-cache': {
+      type: 'boolean',
+      description: 'Clear cache and re-resolve all values',
+    },
+    'skip-cache': {
+      type: 'boolean',
+      description: 'Skip cache entirely for this invocation',
+    },
+  },
+  examples: `
+Executes a command in a child process, injecting your resolved and validated environment
+variables from your .env files. Useful when a code-level integration is not possible.
+
+Examples:
+  varlock run -- node app.js                    # Run a Node.js application
+  varlock run -- python script.py               # Run a Python script
+  varlock run -- sh -c 'echo $MY_VAR'           # Use shell expansion for env vars
+  varlock run --inject vars -- sh               # Inject only individual vars, no blob
+  varlock run --inject blob -- node app.js      # Inject only the blob, no individual vars
+  varlock run --path .env.prod -- node app.js   # Use a specific .env file
+  varlock run --path ./config/ -- node app.js   # Use a specific directory
+  varlock run -p ./envs -p ./overrides -- node app.js  # Use multiple directories
+  varlock run --filter="STRIPE_*,!STRIPE_DEBUG_KEY" -- node app.js  # Only inject STRIPE_* keys, excluding one
+
+📍 Important: Use -- to separate varlock options from your command
+
+💡 Tip: For shell expansion of env vars, use: sh -c 'your command here'
+💡 Tip: Output redaction applies automatically when output is piped/redirected (e.g., CI logs);
+   interactive terminals get raw TTY pass-through, so tools like psql and claude just work.
+   Use --no-redact-stdout to disable redaction for piped output, or --redact-stdout to
+   force it (e.g., to override @redactLogs=false).
+💡 Tip: Use --inject vars to prevent __VARLOCK_ENV from being visible in child process env
+💡 Tip: Use --inject blob when your app uses the ENV proxy and doesn't need individual process.env vars
+  `.trim(),
+});

--- a/packages/varlock/src/cli/commands/run.command.ts
+++ b/packages/varlock/src/cli/commands/run.command.ts
@@ -1,5 +1,4 @@
 import { openSync, closeSync } from 'node:fs';
-import { define } from 'gunshi';
 import { gracefulExit } from 'exit-hook';
 
 import { exec } from '../../lib/exec';
@@ -8,7 +7,7 @@ import { loadVarlockEnvGraph } from '../../lib/load-graph';
 import { checkForConfigErrors, checkForNoEnvFiles, checkForSchemaErrors } from '../helpers/error-checks';
 import { getCliItemFilter } from '../helpers/item-filter';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
-import { REDACT_STDOUT_ARG, resolveStdoutRedaction, pipeRedactedStreams } from '../helpers/stdout-redaction';
+import { resolveStdoutRedaction, pipeRedactedStreams } from '../helpers/stdout-redaction';
 import { buildInjectedBlobEnv } from '../helpers/injected-env-blob';
 import { resolveInjectMode } from '../helpers/inject-mode';
 import { CliExitError } from '../helpers/exit-error';
@@ -17,79 +16,12 @@ import { injectedEnvStringForm } from '../../lib/injected-env-provenance';
 import { isEncryptedBlob, encryptEnvBlobSync } from '../../runtime/crypto';
 import { getPreInjectionProcessEnv } from '../../runtime/env';
 import { createDebug } from '../../lib/debug';
+import { commandSpec } from './run.command-spec';
 import type { EnvGraph, SerializedEnvGraph } from '../../env-graph';
 
 const debug = createDebug('varlock:run');
 
-export const commandSpec = define({
-  name: 'run',
-  description: 'Run a command with your environment variables injected',
-  args: {
-    // watch: {
-    //   type: 'boolean',
-    //   short: 'w',
-    //   description: 'Watch mode',
-    // },
-    ...REDACT_STDOUT_ARG,
-    inject: {
-      type: 'string',
-      short: 'i',
-      description: 'Control what gets injected into the child process env: "all" (default), "vars" (individual vars only, no blob), or "blob" (only __VARLOCK_ENV blob, no individual vars)',
-    },
-    'no-inject-graph': {
-      type: 'boolean',
-      description: 'Deprecated: use --inject vars instead',
-      hidden: true,
-    },
-    'include-internal': {
-      type: 'boolean',
-      description: 'Pass @internal items through to the child process (by default they are stripped, even when set in the ambient env). Use this for a nested `varlock run` whose own resolution needs the internal value (e.g. a secret-zero token).',
-    },
-    filter: {
-      type: 'string',
-      description: 'Filter which items are injected: comma-separated key names/globs (e.g. STRIPE_*), negations (!KEY), decorator selectors (@sensitive, @required), and tag selectors (#tagname, set via @tag(tagname)). Can also be set via the _VARLOCK_FILTER env var (this flag takes precedence)',
-    },
-    path: {
-      type: 'string',
-      short: 'p',
-      multiple: true,
-      description: 'Path to a specific .env file or directory to use as the entry point (can be specified multiple times)',
-    },
-    'clear-cache': {
-      type: 'boolean',
-      description: 'Clear cache and re-resolve all values',
-    },
-    'skip-cache': {
-      type: 'boolean',
-      description: 'Skip cache entirely for this invocation',
-    },
-  },
-  examples: `
-Executes a command in a child process, injecting your resolved and validated environment
-variables from your .env files. Useful when a code-level integration is not possible.
-
-Examples:
-  varlock run -- node app.js                    # Run a Node.js application
-  varlock run -- python script.py               # Run a Python script
-  varlock run -- sh -c 'echo $MY_VAR'           # Use shell expansion for env vars
-  varlock run --inject vars -- sh               # Inject only individual vars, no blob
-  varlock run --inject blob -- node app.js      # Inject only the blob, no individual vars
-  varlock run --path .env.prod -- node app.js   # Use a specific .env file
-  varlock run --path ./config/ -- node app.js   # Use a specific directory
-  varlock run -p ./envs -p ./overrides -- node app.js  # Use multiple directories
-  varlock run --filter="STRIPE_*,!STRIPE_DEBUG_KEY" -- node app.js  # Only inject STRIPE_* keys, excluding one
-
-📍 Important: Use -- to separate varlock options from your command
-
-💡 Tip: For shell expansion of env vars, use: sh -c 'your command here'
-💡 Tip: Output redaction applies automatically when output is piped/redirected (e.g., CI logs);
-   interactive terminals get raw TTY pass-through, so tools like psql and claude just work.
-   Use --no-redact-stdout to disable redaction for piped output, or --redact-stdout to
-   force it (e.g., to override @redactLogs=false).
-💡 Tip: Use --inject vars to prevent __VARLOCK_ENV from being visible in child process env
-💡 Tip: Use --inject blob when your app uses the ENV proxy and doesn't need individual process.env vars
-  `.trim(),
-});
+export { commandSpec };
 
 let commandProcess: ReturnType<typeof exec> | undefined;
 let childCommandKilledFromRestart = false;

--- a/packages/varlock/src/cli/commands/scan.command-spec.ts
+++ b/packages/varlock/src/cli/commands/scan.command-spec.ts
@@ -1,0 +1,47 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'scan',
+  description: 'Scan files for sensitive config values that should not be in plaintext',
+  args: {
+    targets: {
+      type: 'positional',
+      required: false,
+      multiple: true,
+      description: 'Files, directories, or globs to scan (defaults to the current directory)',
+    },
+    staged: {
+      type: 'boolean',
+      description: 'Only scan staged git files',
+    },
+    'include-ignored': {
+      type: 'boolean',
+      description: 'Include git-ignored files in the scan',
+    },
+    'install-hook': {
+      type: 'boolean',
+      description: 'Set up varlock scan as a git pre-commit hook',
+    },
+    path: {
+      type: 'string',
+      short: 'p',
+      multiple: true,
+      description: 'Path to a specific .env file (e.g. .env.prod) or directory ending with "/" to use as the schema entry point (can be specified multiple times)',
+    },
+  },
+  examples: `
+Loads your varlock config, resolves all sensitive values, then scans files to
+ensure none of those sensitive values appear in plaintext.
+
+Examples:
+  varlock scan                    # Scan non-git-ignored files in current directory
+  varlock scan --staged           # Only scan staged git files
+  varlock scan --include-ignored  # Scan all files, including git-ignored ones
+  varlock scan --path .env.prod   # Use a specific .env file as the schema entry point
+  varlock scan -p ./envs -p ./overrides  # Use multiple schema entry points
+  varlock scan --install-hook     # Set up as a git pre-commit hook
+  varlock scan ./dist             # Scan a specific directory (e.g. a build output folder)
+  varlock scan ./dist ./public    # Scan multiple directories
+  varlock scan './dist/**/*.js'   # Scan files matching a glob pattern
+  `.trim(),
+});

--- a/packages/varlock/src/cli/commands/scan.command.ts
+++ b/packages/varlock/src/cli/commands/scan.command.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { define } from 'gunshi';
 import ansis from 'ansis';
 import { gracefulExit } from 'exit-hook';
 import _ from '@env-spec/utils/my-dash';
@@ -14,6 +13,7 @@ import { fmt, logLines } from '../helpers/pretty-format';
 import { detectJsPackageManager } from '../helpers/js-package-manager-utils';
 import { isBundledSEA } from '../helpers/install-detection';
 import { loadVarlockEnvGraph } from '../../lib/load-graph';
+import { commandSpec } from './scan.command-spec';
 
 // Directories to always skip when walking the file tree
 const SKIP_DIRS = new Set([
@@ -68,51 +68,7 @@ const BINARY_EXTENSIONS = new Set([
   '.o',
 ]);
 
-export const commandSpec = define({
-  name: 'scan',
-  description: 'Scan files for sensitive config values that should not be in plaintext',
-  args: {
-    targets: {
-      type: 'positional',
-      required: false,
-      multiple: true,
-      description: 'Files, directories, or globs to scan (defaults to the current directory)',
-    },
-    staged: {
-      type: 'boolean',
-      description: 'Only scan staged git files',
-    },
-    'include-ignored': {
-      type: 'boolean',
-      description: 'Include git-ignored files in the scan',
-    },
-    'install-hook': {
-      type: 'boolean',
-      description: 'Set up varlock scan as a git pre-commit hook',
-    },
-    path: {
-      type: 'string',
-      short: 'p',
-      multiple: true,
-      description: 'Path to a specific .env file (e.g. .env.prod) or directory ending with "/" to use as the schema entry point (can be specified multiple times)',
-    },
-  },
-  examples: `
-Loads your varlock config, resolves all sensitive values, then scans files to
-ensure none of those sensitive values appear in plaintext.
-
-Examples:
-  varlock scan                    # Scan non-git-ignored files in current directory
-  varlock scan --staged           # Only scan staged git files
-  varlock scan --include-ignored  # Scan all files, including git-ignored ones
-  varlock scan --path .env.prod   # Use a specific .env file as the schema entry point
-  varlock scan -p ./envs -p ./overrides  # Use multiple schema entry points
-  varlock scan --install-hook     # Set up as a git pre-commit hook
-  varlock scan ./dist             # Scan a specific directory (e.g. a build output folder)
-  varlock scan ./dist ./public    # Scan multiple directories
-  varlock scan './dist/**/*.js'   # Scan files matching a glob pattern
-  `.trim(),
-});
+export { commandSpec };
 
 export interface ScanFinding {
   filePath: string;

--- a/packages/varlock/src/cli/commands/telemetry.command-spec.ts
+++ b/packages/varlock/src/cli/commands/telemetry.command-spec.ts
@@ -1,0 +1,24 @@
+import { define } from 'gunshi';
+
+export const commandSpec = define({
+  name: 'telemetry',
+  description: 'Enable/disable anonymous usage analytics',
+  args: {
+    mode: {
+      type: 'positional',
+      description: '"enable" or "disable"',
+    },
+  },
+  examples: `
+Opts in/out of anonymous usage analytics. This command creates/updates a configuration
+file at $XDG_CONFIG_HOME/varlock/config.json (or ~/.config/varlock/config.json) saving
+your preference.
+
+Examples:
+  varlock telemetry disable    # Opt out of telemetry
+  varlock telemetry enable     # Opt in to telemetry
+
+💡 Tip: You can also temporarily opt out by setting VARLOCK_TELEMETRY_DISABLED=1 or DO_NOT_TRACK=1
+For more information, visit https://varlock.dev/guides/telemetry/
+  `.trim(),
+});

--- a/packages/varlock/src/cli/commands/telemetry.command.ts
+++ b/packages/varlock/src/cli/commands/telemetry.command.ts
@@ -1,36 +1,15 @@
 import { join } from 'node:path';
 import { mkdir, writeFile, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { define } from 'gunshi';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
 import { gracefulExit } from 'exit-hook';
 import { fmt } from '../helpers/pretty-format';
 import { CliExitError } from '../helpers/exit-error';
 import { getUserVarlockDir } from '../../lib/user-config-dir';
+import { commandSpec } from './telemetry.command-spec';
 
 
-export const commandSpec = define({
-  name: 'telemetry',
-  description: 'Enable/disable anonymous usage analytics',
-  args: {
-    mode: {
-      type: 'positional',
-      description: '"enable" or "disable"',
-    },
-  },
-  examples: `
-Opts in/out of anonymous usage analytics. This command creates/updates a configuration
-file at $XDG_CONFIG_HOME/varlock/config.json (or ~/.config/varlock/config.json) saving
-your preference.
-
-Examples:
-  varlock telemetry disable    # Opt out of telemetry
-  varlock telemetry enable     # Opt in to telemetry
-
-💡 Tip: You can also temporarily opt out by setting VARLOCK_TELEMETRY_DISABLED=1 or DO_NOT_TRACK=1
-For more information, visit https://varlock.dev/guides/telemetry/
-  `.trim(),
-});
+export { commandSpec };
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   // TODO: remove this when gunshi supports types/validation for positional args

--- a/packages/varlock/src/cli/commands/typegen.command-spec.ts
+++ b/packages/varlock/src/cli/commands/typegen.command-spec.ts
@@ -1,0 +1,13 @@
+import { define } from 'gunshi';
+
+import { commandSpec as codegenCommandSpec } from './codegen.command-spec';
+
+// Deprecated alias for `varlock codegen` — kept for back-compat. Same behavior, just warns.
+export const commandSpec = define({
+  name: 'typegen',
+  description: '(deprecated) alias for `varlock codegen`',
+  args: codegenCommandSpec.args,
+  examples: 'Deprecated alias for `varlock codegen` — kept for back-compat. Use `varlock codegen` instead.',
+  // hide from `varlock help` — still runnable, but we only advertise `codegen`
+  internal: true,
+});

--- a/packages/varlock/src/cli/commands/typegen.command.ts
+++ b/packages/varlock/src/cli/commands/typegen.command.ts
@@ -1,17 +1,8 @@
-import { define } from 'gunshi';
-
-import { commandSpec as codegenCommandSpec, commandFn as codegenCommandFn } from './codegen.command';
+import { commandFn as codegenCommandFn } from './codegen.command';
 import { type TypedGunshiCommandFn } from '../helpers/gunshi-type-utils';
+import { commandSpec } from './typegen.command-spec';
 
-// Deprecated alias for `varlock codegen` — kept for back-compat. Same behavior, just warns.
-export const commandSpec = define({
-  name: 'typegen',
-  description: '(deprecated) alias for `varlock codegen`',
-  args: codegenCommandSpec.args,
-  examples: 'Deprecated alias for `varlock codegen` — kept for back-compat. Use `varlock codegen` instead.',
-  // hide from `varlock help` — still runnable, but we only advertise `codegen`
-  internal: true,
-});
+export { commandSpec };
 
 export const commandFn: TypedGunshiCommandFn<typeof commandSpec> = async (ctx) => {
   console.warn('[varlock] ⚠️  `varlock typegen` is deprecated — use `varlock codegen` instead.');

--- a/packages/varlock/src/cli/helpers/error-checks.ts
+++ b/packages/varlock/src/cli/helpers/error-checks.ts
@@ -5,6 +5,9 @@ import {
   LoadingError, ParseError, VarlockError,
 } from '../../env-graph/lib/errors';
 import { CliExitError } from './exit-error';
+import { InvalidEnvError } from './invalid-env-error';
+
+export { InvalidEnvError };
 
 function showErrorLocationDetails(err: VarlockError) {
   if (!err.location) return;
@@ -130,14 +133,6 @@ export function showPluginWarnings(envGraph: EnvGraph) {
   }
 }
 
-export class InvalidEnvError extends Error {
-  constructor() {
-    super('Resolved config/env did not pass validation');
-  }
-  getFormattedOutput() {
-    return `\n💥 ${ansis.red(this.message)} 💥\n`;
-  }
-}
 
 export function checkForConfigErrors(envGraph: EnvGraph, opts?: {
   showAll?: boolean;

--- a/packages/varlock/src/cli/helpers/invalid-env-error.ts
+++ b/packages/varlock/src/cli/helpers/invalid-env-error.ts
@@ -1,0 +1,17 @@
+import ansis from 'ansis';
+
+/**
+ * Thrown when resolved config fails validation.
+ *
+ * Kept in its own module (rather than alongside the `checkFor*` helpers in
+ * `error-checks.ts`) so the CLI entry point can catch it without importing
+ * those helpers, which pull in the whole env-graph barrel.
+ */
+export class InvalidEnvError extends Error {
+  constructor() {
+    super('Resolved config/env did not pass validation');
+  }
+  getFormattedOutput() {
+    return `\n💥 ${ansis.red(this.message)} 💥\n`;
+  }
+}

--- a/packages/varlock/src/cli/helpers/redact-stdout-arg.ts
+++ b/packages/varlock/src/cli/helpers/redact-stdout-arg.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared gunshi arg spec for the redaction override, so `varlock run` and
+ * `varlock proxy run` expose an identical flag (including `--no-redact-stdout`,
+ * which only works because of `negatable`).
+ *
+ * Kept in its own module so the command spec files can pull it in without
+ * dragging the redaction implementation (and everything it imports) into the
+ * CLI entry point's static import graph.
+ */
+export const REDACT_STDOUT_ARG = {
+  'redact-stdout': {
+    type: 'boolean',
+    negatable: true,
+    description: 'Override automatic stdout/stderr redaction: --redact-stdout forces redaction of piped/redirected output (e.g., to override @redactLogs=false) and errors if attached to an interactive terminal; --no-redact-stdout disables redaction entirely. Can also be set via the _VARLOCK_REDACT_STDOUT env var (the flag takes precedence)',
+  },
+} as const;

--- a/packages/varlock/src/cli/helpers/stdout-redaction.ts
+++ b/packages/varlock/src/cli/helpers/stdout-redaction.ts
@@ -1,18 +1,7 @@
 import { CliExitError } from './exit-error';
 import { createRedactedStreamWriter } from '../../runtime/lib/redact-stream';
 
-/**
- * Shared gunshi arg spec for the redaction override, so `varlock run` and
- * `varlock proxy run` expose an identical flag (including `--no-redact-stdout`,
- * which only works because of `negatable`).
- */
-export const REDACT_STDOUT_ARG = {
-  'redact-stdout': {
-    type: 'boolean',
-    negatable: true,
-    description: 'Override automatic stdout/stderr redaction: --redact-stdout forces redaction of piped/redirected output (e.g., to override @redactLogs=false) and errors if attached to an interactive terminal; --no-redact-stdout disables redaction entirely. Can also be set via the _VARLOCK_REDACT_STDOUT env var (the flag takes precedence)',
-  },
-} as const;
+export { REDACT_STDOUT_ARG } from './redact-stdout-arg';
 
 /** Parse a tri-state on/off/unset env toggle (e.g. `_VARLOCK_REDACT_STDOUT`). */
 export function parseEnvToggle(value: string | undefined): boolean | undefined {

--- a/packages/varlock/src/lib/formatting.ts
+++ b/packages/varlock/src/lib/formatting.ts
@@ -1,7 +1,7 @@
 import ansis, { type AnsiColors, type AnsiStyles } from 'ansis';
 import _ from '@env-spec/utils/my-dash';
 
-import { ConfigItem, VarlockError } from '../env-graph';
+import type { ConfigItem, VarlockError } from '../env-graph';
 import { redactString } from '../runtime/lib/redaction';
 
 type ColorMod = AnsiStyles | AnsiColors;

--- a/packages/varlock/test/cli-lazy-loading.test.ts
+++ b/packages/varlock/test/cli-lazy-loading.test.ts
@@ -38,29 +38,48 @@ function staticImportsOf(file: string): Array<string> {
   return out;
 }
 
-/** Every chunk reachable from the entry without crossing a dynamic import. */
-function staticClosure(entry: string): Array<string> {
+/**
+ * Every chunk reachable from the entry without crossing a dynamic import.
+ *
+ * A static import target that is not on disk means the build is incomplete or
+ * broken, so it is reported rather than skipped - silently dropping it would
+ * shrink the closure and weaken every assertion made against it.
+ */
+function staticClosure(entry: string): { chunks: Array<string>, missing: Array<string> } {
   const seen = new Set<string>();
+  const missing = new Set<string>();
   const queue = [entry];
   while (queue.length) {
     const f = queue.pop()!;
-    if (seen.has(f) || !existsSync(f)) continue;
+    if (seen.has(f) || missing.has(f)) continue;
+    if (!existsSync(f)) {
+      missing.add(f);
+      continue;
+    }
     seen.add(f);
     queue.push(...staticImportsOf(f));
   }
-  return [...seen];
+  return { chunks: [...seen], missing: [...missing] };
 }
 
 /**
  * Original source files that went into a chunk, via its sourcemap. Release builds
  * null out vendor `sourcesContent` but keep every `sources` path, so this works
  * for dev and release output alike.
+ *
+ * Returns `null` when the chunk ships no sourcemap. That is treated as a failure
+ * rather than "no sources", because the whole check reads the build through its
+ * maps: if sourcemaps were ever turned off, silently mapping every chunk to zero
+ * sources would make the boundary assertions below pass while inspecting nothing.
  */
-function sourcesOf(chunk: string): Array<string> {
+function sourcesOf(chunk: string): Array<string> | null {
   const mapPath = `${chunk}.map`;
-  if (!existsSync(mapPath)) return [];
+  if (!existsSync(mapPath)) return null;
   const map = JSON.parse(readFileSync(mapPath, 'utf8')) as { sources?: Array<string> };
-  return (map.sources ?? []).map((s) => relative(PKG_DIR, resolve(dirname(mapPath), s)));
+  if (!Array.isArray(map.sources)) return null;
+  // An empty `sources` is legitimate for esbuild's generated helper chunk
+  // (__name/__toESM/...), which has no original source and an empty `mappings`.
+  return map.sources.map((s) => relative(PKG_DIR, resolve(dirname(mapPath), s)));
 }
 
 describe('CLI startup bundle boundaries', () => {
@@ -71,8 +90,28 @@ describe('CLI startup bundle boundaries', () => {
     return;
   }
 
-  const closure = staticClosure(ENTRY);
-  const eagerSources = new Set(closure.flatMap(sourcesOf));
+  const { chunks, missing } = staticClosure(ENTRY);
+  const unmapped = chunks.filter((c) => sourcesOf(c) === null).map((c) => relative(PKG_DIR, c)).sort();
+  const eagerSources = new Set(chunks.flatMap((c) => sourcesOf(c) ?? []));
+
+  it('can actually see into the build it is checking', () => {
+    // Fail-closed guard for the checks below, which read the bundle through its
+    // sourcemaps. Without this, dropping `sourcemap` from tsup.config.ts would
+    // turn both boundary assertions into no-ops that still report green.
+    expect(missing.map((f) => relative(PKG_DIR, f)).sort(), [
+      'These chunks are statically imported but missing from dist - the build is',
+      'incomplete. Re-run `bun run build`.',
+    ].join('\n')).toEqual([]);
+
+    expect(unmapped, [
+      'These chunks are reachable from the CLI entry but ship no usable sourcemap,',
+      'so the boundary checks below cannot see what is inside them.',
+      'Keep `sourcemap: true` in tsup.config.ts.',
+    ].join('\n')).toEqual([]);
+
+    // positive control: the entry's own module must be visible through the maps
+    expect(eagerSources.has('src/cli/cli-executable.ts')).toBe(true);
+  });
 
   it('does not eagerly load any command implementation', () => {
     const eagerCommands = [...eagerSources]

--- a/packages/varlock/test/cli-lazy-loading.test.ts
+++ b/packages/varlock/test/cli-lazy-loading.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  dirname, join, resolve, relative,
+} from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_DIR = join(__dirname, '..');
+const ENTRY = join(PKG_DIR, 'dist/cli/cli-executable.js');
+
+/**
+ * The CLI entry must only ever parse command *specs* at startup - every command
+ * implementation stays behind a dynamic import until that command actually runs.
+ *
+ * This is a property of the built bundle, not of the source, which is why it is
+ * checked here rather than by reading `cli-executable.ts`. The bug this guards
+ * against is silent: the entry previously did have `await import(...)` calls for
+ * every command, but because it also statically imported each command module for
+ * its spec, esbuild resolved those dynamic imports to stub chunks that merely
+ * re-exported already-eagerly-loaded code. Every command still worked and every
+ * other test still passed - the CLI just parsed the whole proxy subsystem on
+ * `varlock --version`. A stray `import { x } from './commands/y.command'` in the
+ * entry would reintroduce exactly that, so the assertion has to be made against
+ * the artifact.
+ *
+ * `test:ci` dependsOn `build` in turbo.json, so dist is present and current here.
+ */
+
+/** Static (non-dynamic) relative imports of a built chunk. */
+function staticImportsOf(file: string): Array<string> {
+  const src = readFileSync(file, 'utf8');
+  const out: Array<string> = [];
+  // `import ... from './x.js'` / `export ... from './x.js'` / bare `import './x.js'`.
+  // Dynamic `import('./x.js')` is deliberately excluded - that is the whole point.
+  const re = /(?:^|\n)\s*(?:import|export)(?:\s[^;'"]*?from)?\s*['"](\.[^'"]+)['"]/g;
+  for (const m of src.matchAll(re)) out.push(resolve(dirname(file), m[1]));
+  return out;
+}
+
+/** Every chunk reachable from the entry without crossing a dynamic import. */
+function staticClosure(entry: string): Array<string> {
+  const seen = new Set<string>();
+  const queue = [entry];
+  while (queue.length) {
+    const f = queue.pop()!;
+    if (seen.has(f) || !existsSync(f)) continue;
+    seen.add(f);
+    queue.push(...staticImportsOf(f));
+  }
+  return [...seen];
+}
+
+/**
+ * Original source files that went into a chunk, via its sourcemap. Release builds
+ * null out vendor `sourcesContent` but keep every `sources` path, so this works
+ * for dev and release output alike.
+ */
+function sourcesOf(chunk: string): Array<string> {
+  const mapPath = `${chunk}.map`;
+  if (!existsSync(mapPath)) return [];
+  const map = JSON.parse(readFileSync(mapPath, 'utf8')) as { sources?: Array<string> };
+  return (map.sources ?? []).map((s) => relative(PKG_DIR, resolve(dirname(mapPath), s)));
+}
+
+describe('CLI startup bundle boundaries', () => {
+  if (!existsSync(ENTRY)) {
+    it('requires a build', () => {
+      throw new Error(`${relative(PKG_DIR, ENTRY)} not found - run \`bun run build\` first`);
+    });
+    return;
+  }
+
+  const closure = staticClosure(ENTRY);
+  const eagerSources = new Set(closure.flatMap(sourcesOf));
+
+  it('does not eagerly load any command implementation', () => {
+    const eagerCommands = [...eagerSources]
+      .filter((s) => /^src\/cli\/commands\/.*\.command\.ts$/.test(s))
+      .sort();
+
+    expect(eagerCommands, [
+      'These command implementations are in the CLI entry\'s static import closure,',
+      'so they are parsed on every `varlock` invocation (including `--version`).',
+      'Import the spec from the sibling `*.command-spec.ts` instead, and keep the',
+      'implementation behind the gunshi `lazy()` loader.',
+    ].join('\n')).toEqual([]);
+  });
+
+  it('does not eagerly load the proxy or env-graph engines', () => {
+    // Heavy subsystems only some commands need. They are reached through the
+    // command implementations above, but also via helper modules that used to
+    // pull the env-graph barrel in for a single error class or a type-only
+    // annotation - hence a check that does not depend on the command boundary.
+    const forbidden = [
+      'src/proxy/runtime-proxy.ts',
+      'src/env-graph/lib/env-graph.ts',
+      'src/env-graph/lib/loader.ts',
+      'src/env-graph/lib/config-item.ts',
+    ];
+    const leaked = forbidden.filter((f) => eagerSources.has(f)).sort();
+
+    expect(leaked, [
+      'These modules are parsed on every `varlock` invocation.',
+      'Usually a helper reached from the entry imports the `env-graph` barrel for',
+      'something small - prefer a type-only import, or a deep import of the leaf',
+      'module that actually holds it.',
+    ].join('\n')).toEqual([]);
+  });
+
+  it('keeps every registered command behind a dynamic import', () => {
+    const entrySrc = readFileSync(ENTRY, 'utf8');
+    const dynamic = [...entrySrc.matchAll(/import\(\s*['"]\.[^'"]*?([\w-]+)\.command-[A-Z0-9]+\.js['"]\s*\)/g)]
+      .map((m) => m[1]);
+
+    // every command registered in the entry should have a matching lazy loader
+    const registered = [
+      ...readFileSync(join(PKG_DIR, 'src/cli/cli-executable.ts'), 'utf8')
+        .matchAll(/^subCommands\.set\('([^']+)'/gm),
+    ].map((m) => m[1]);
+
+    expect(registered.length).toBeGreaterThan(15);
+    expect(dynamic.length).toBe(registered.length);
+  });
+});


### PR DESCRIPTION
Two related fixes to what the CLI parses before it can do anything.

## 1. `buildLazyCommand()` provided zero lazy loading

The TODO on it was accurate. `cli-executable.ts` statically imported `{ commandSpec }` from every `*.command.ts`, and because each of those modules held both the spec and the implementation, the static import pulled in the whole module. esbuild then collapsed the `await import('./commands/x.command')` inside `buildLazyCommand` entirely, so no dynamic import survived in the built output at all.

Each command's spec now lives in a sibling `*.command-spec.ts` holding only `name` / `description` / `args` / `examples`, and the entry imports specs only. Commands are registered with gunshi's own `lazy(loader, definition)` instead of the hand-rolled wrapper. Swapping to `lazy()` alone would have changed nothing: the module split is what does the work.

For the three commands with nested subcommands (`proxy`, `cache`, `keychain`), the parent spec embedded the implementations by construction, since each leaf's `run` fn was defined inline. Those spec modules now declare each verb as its own `lazy()` whose loader pulls the run fn out of the implementation module. gunshi reads `subCommands` off the lazy function without invoking the loader, so the tree still resolves for help and completion without loading anything.

Supporting moves:
- `REDACT_STDOUT_ARG` moved to its own leaf module (`helpers/redact-stdout-arg.ts`) so the `run` and `proxy` specs can share the flag without dragging the redaction implementation into the entry. Re-exported from `stdout-redaction.ts`, so nothing else changes.
- Spec files are named `*.command-spec.ts`, not `*.spec.ts`. The latter matches vitest's default test glob and made all 23 of them fail as empty test suites.

## 2. The env-graph barrel was still loaded on every invocation

That left a 559 KB shared chunk (env-graph + the `@env-spec` parser + clack prompts + ansis, merged together) still eagerly loaded. The entry reached the env-graph barrel through three edges:

- `helpers/error-checks.ts` imports `{ EnvGraph, FileBasedDataSource }` from the barrel, but the entry only ever wanted `InvalidEnvError` from that module. Moved that class to its own leaf module and pointed the entry at it. `error-checks.ts` re-exports it, so no other caller changes.
- `lib/formatting.ts` imported `ConfigItem` and `VarlockError` as values, though both are used only as parameter annotations. Making it an `import type` erases the edge at compile time.
- `helpers/telemetry-usage-context.ts` already deep-imports `env-graph/lib/errors`, which is a leaf (its only import is my-dash), so it costs nothing.

Modules statically reachable from the entry: **99 → 45**.

## Numbers

Interleaved A/B against `main`, 40 rounds per command alternating between the two builds back to back so machine drift hits both equally, node 25 on an M2 Max, telemetry disabled. Reporting the minimum, which is the robust statistic for startup timing on a contended machine; the p10 column tracks it closely, which is what makes these trustworthy.

| command | before (min) | after (min) | change | before p10 | after p10 |
|---|---|---|---|---|---|
| `varlock --version` | 145.4 ms | 110.3 ms | **-35.1 ms (-24%)** | 148.3 ms | 114.9 ms |
| `varlock --help` | 177.4 ms | 139.5 ms | **-37.8 ms (-21%)** | 178.1 ms | 142.1 ms |
| `varlock complete bash` | 174.1 ms | 141.6 ms | **-32.5 ms (-19%)** | 176.3 ms | 142.7 ms |
| `varlock load --format json` | 158.1 ms | 158.0 ms | -0.1 ms (0%) | 160.0 ms | 159.4 ms |
| `varlock proxy status` | 211.3 ms | 210.1 ms | -1.2 ms (-1%) | 215.4 ms | 212.1 ms |

`load` and `proxy status` are flat, and that is the expected result: they genuinely need the graph engine and the proxy subsystem, so they still pay for those. The change is that they now pay lazily, and every command that does *not* need them stops paying. Tab completion, which runs on every shell tab-press, is the clearest win.

Static import closure of `dist/cli/cli-executable.js`: **1631 KB / 50 files → 320 KB / 39 files.** Roughly 400 KB of that is the proxy chunk (fix 1) and 559 KB the env-graph/parser/prompts chunk (fix 2).

### On the bundle-size warning

The size bot reports total `dist/` growing 15.4 KB (+0.3%). That is expected and is the trade being made: splitting into more chunks costs a little duplicated module boilerplate on disk. The number that matters for CLI startup is not total bytes shipped but bytes parsed per invocation, and that is the 1631 KB → 320 KB above.

## Verification

- The proxy implementation string `"Proxy items using a generic placeholder"` appears in **no file** in the entry's static closure. 20 dynamic `import('../*.command-*.js')` calls survive in the built entry; previously the dynamic imports resolved to stub modules re-exporting from already-statically-imported chunks, which is why they bought nothing.
- Captured 22 CLI outputs from `main` and from this branch and diffed: top-level `--help`, per-command `--help` for all 8 parents, per-verb `--help` for 6 nested verbs, `--version`, `complete bash`, `complete zsh`, `load --format json`, and three error paths (unknown command, unknown flag, unknown nested verb). **All byte-identical** (the completion scripts embed their own absolute path, normalized before diffing).
- Moving `InvalidEnvError` across a chunk boundary is the risky part of fix 2, since the entry catches it with `instanceof` and this build splits deliberately to avoid duplicate classes. Verified two ways: the class is defined exactly once in the bundle, and a fixture that fails validation prints the formatted `Resolved config/env did not pass validation` message and exits 1 (rather than an unhandled throw) under both `varlock load` and `varlock run`, in the node build and the compiled binary.
- Nested subcommands verified: `proxy status`, `proxy rules`, `keychain list`, `cache status`. Passthrough verified: `varlock run -- sh -c '...'`, and flags after `--` still reach the child.
- Telemetry unchanged. With `DEBUG=varlock:telemetry`, `cli_command_executed` reports `command='proxy status'`, `'cache status'`, `'keychain list'` for nested verbs, `'load'` / `'printenv'` for top-level, `'version'` for `--version`, and no event for `complete`.
- Compiled binary (`bun build --compile`) exercised across every lazy path including all nested verbs and `run` passthrough.
- `vitest --run`: 115 files, 1756 passed, 1 skipped. `tsc --noEmit` clean. `bun run lint` clean.

`InvalidEnvError` is not part of the package's public API, so the published type surface is unchanged.

## 3. A regression guard for the bundle shape

Nothing enforced any of this, and the failure mode is silent. The entry already
*had* `await import()` calls for every command before this PR; they just resolved
to stub chunks re-exporting eagerly-loaded code. Every command worked and every
test passed while `varlock --version` parsed the whole proxy subsystem. A stray
`import { x } from './commands/y.command'` would bring that straight back.

`test/cli-lazy-loading.test.ts` walks the static import closure of the built
`dist/cli/cli-executable.js`, maps each reachable chunk back to its original
modules through the sourcemaps, and asserts:

- no `src/cli/commands/*.command.ts` is eagerly reachable;
- neither the proxy runtime nor the env-graph engine is eagerly reachable (a
  separate check, since those leak in through helper modules too, as fix 2 shows);
- every registered command still has a surviving dynamic import.

Using sourcemap `sources` rather than grepping for marker strings keeps it precise
and lets a failure name the offending module. Release builds null out vendor
`sourcesContent` but keep every `sources` path, so it works against dev and release
output alike; verified against both. `test:ci` dependsOn `build` in `turbo.json`,
so dist is present and current when it runs.

The guard is fail-closed about its own inputs: a reachable chunk with a missing or
malformed sourcemap fails, as does one that is statically imported but absent from
dist, and a positive control asserts the entry's own module is visible through the
maps. Without that, turning sourcemaps off would have made both boundary assertions
pass while inspecting nothing. (An empty `sources` is still accepted for esbuild's
generated helper chunk, which has no original source.)

Confirmed it actually fails on all three regressions it exists to catch:

| regression | result |
|---|---|
| reintroduce `import ... from './commands/proxy.command'` in the entry | 2 tests fail, naming `src/cli/commands/proxy.command.ts` |
| revert the type-only env-graph import in `lib/formatting.ts` | env-graph check fails, naming `config-item.ts` and friends |
| set `sourcemap: false` in `tsup.config.ts` | fails, naming all 39 unmapped chunks (previously would have passed green) |
