### PR TITLE
fix: don't treat cosmetic env file edits as env changes

### DIFF
--- a/.bumpy/nextjs-reload-changed-log.md
+++ b/.bumpy/nextjs-reload-changed-log.md
@@ -1,0 +1,5 @@
+---
+"@varlock/nextjs-integration": patch
+---
+
+The env reload log now reports "no changes found" correctly. It previously always said "changes found", because the comparison also picked up formatting and internal bookkeeping that shift on every reload

--- a/.bumpy/wrangler-cosmetic-edit-restart.md
+++ b/.bumpy/wrangler-cosmetic-edit-restart.md
@@ -1,0 +1,5 @@
+---
+"@varlock/cloudflare-integration": patch
+---
+
+`varlock-wrangler dev` no longer restarts wrangler when an env file is saved with only cosmetic changes (whitespace, comments) that leave every resolved value the same

--- a/framework-tests/frameworks/cloudflare/wrangler.test.ts
+++ b/framework-tests/frameworks/cloudflare/wrangler.test.ts
@@ -217,7 +217,9 @@ describe('Cloudflare Workers varlock-wrangler only', () => {
           shouldContain: ['public_var::public-test-value'],
         },
       },
-      // second request — write the same .env.schema content (simulates macOS spurious watch events)
+      // second request — rewrite .env.schema with content that resolves to the same env
+      // (simulates macOS spurious watch events, and cosmetic saves like a changed
+      // trailing newline, which move the source content fingerprint but nothing else)
       // use fileEditDelay so we wait without expecting a restart
       {
         path: '/',

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -193,6 +193,19 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
               },
             },
             {
+              // Byte-level change that resolves to the same env: the reload runs, but
+              // must report "no changes found" and keep serving the same value.
+              label: 'cosmetic content change: reloads but reports no env changes',
+              path: '/',
+              fileEdits: {
+                '.env.dev': '# a comment that changes the file bytes\nENV_SPECIFIC_VAR=env-specific-var--dev',
+              },
+              fileEditDelay: 2500,
+              bodyAssertions: {
+                shouldContain: ['Varlock Framework Test - Next.js', 'env-specific-var--dev'],
+              },
+            },
+            {
               label: 'change to content: env is reloaded, updated value served',
               path: '/',
               fileEdits: {
@@ -236,6 +249,10 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
             },
           ],
           outputAssertions: [
+            {
+              description: 'cosmetic env file edit reloads but reports no changes',
+              shouldContain: ['reloaded env, no changes found'],
+            },
             {
               description: 'runtime secret logs are redacted, leak detection fires, no raw secret in dev logs',
               shouldContain: ['runtime-secret-log-test:', 'DETECTED LEAKED SENSITIVE CONFIG'],

--- a/packages/integrations/cloudflare/src/varlock-wrangler.ts
+++ b/packages/integrations/cloudflare/src/varlock-wrangler.ts
@@ -61,11 +61,32 @@ function loadSerializedGraph() {
     json: stdout,
     graph: JSON.parse(stdout) as {
       basePath?: string,
-      sources: Array<{ label: string, enabled: boolean, path?: string }>,
+      sources: Array<{ label: string, enabled: boolean, path?: string, contentHash?: string }>,
       settings?: { encryptInjectedEnv?: boolean },
       config: Record<string, { value: unknown, isSensitive: boolean, isDynamic?: boolean }>,
     },
   };
+}
+
+type SerializedGraph = ReturnType<typeof loadSerializedGraph>['graph'];
+
+/**
+ * Comparison key used to decide whether a reload actually changed the env.
+ *
+ * `sources[].contentHash` fingerprints the raw bytes of each env file so injected-env
+ * reuse can spot edits. It also moves on cosmetic saves (a reordered comment, a trailing
+ * newline) that leave every resolved value identical, so it must not count as a change
+ * here, or every save would restart wrangler.
+ */
+function envComparisonKey(graph: SerializedGraph): string {
+  return JSON.stringify({
+    ...graph,
+    sources: (graph.sources ?? []).map((source) => {
+      const withoutHash: Partial<typeof source> = { ...source };
+      delete withoutHash.contentHash;
+      return withoutHash;
+    }),
+  });
 }
 
 function tmpPath(prefix: string) {
@@ -568,7 +589,7 @@ async function handleDev(args: Array<string>) {
   // watch env source files for changes and restart wrangler with fresh data
   const DEBOUNCE_MS = 300;
   let restartTimeout: ReturnType<typeof setTimeout> | undefined;
-  let cachedGraphJson = loaded.json;
+  let cachedEnvKey = envComparisonKey(loaded.graph);
   const changedFiles = new Set<string>();
   function scheduleRestart(changedFilePath?: string) {
     if (changedFilePath) changedFiles.add(changedFilePath);
@@ -580,7 +601,8 @@ async function handleDev(args: Array<string>) {
       changedFiles.clear();
       try {
         const freshLoaded = loadSerializedGraph();
-        if (freshLoaded.json === cachedGraphJson) {
+        const freshEnvKey = envComparisonKey(freshLoaded.graph);
+        if (freshEnvKey === cachedEnvKey) {
           const changedMsg = changedFileList.length
             ? `change detected in ${changedFileList.length} env source file${changedFileList.length === 1 ? '' : 's'}`
             : 'change detected in env source files';
@@ -588,7 +610,7 @@ async function handleDev(args: Array<string>) {
           restartTimeout = undefined;
           return;
         }
-        cachedGraphJson = freshLoaded.json;
+        cachedEnvKey = freshEnvKey;
         loaded = freshLoaded;
         configIsValid = true;
         cachedContent = formatEnvFileContent(freshLoaded);
@@ -610,7 +632,7 @@ async function handleDev(args: Array<string>) {
             try {
               const parsed = JSON.parse(err.stdout);
               loaded = { json: err.stdout, graph: parsed };
-              cachedGraphJson = err.stdout;
+              cachedEnvKey = envComparisonKey(parsed);
               cachedContent = `${formatEnvLine('__VARLOCK_ENV', err.stdout)}\n`;
               await handle.update(cachedContent);
               console.error('\n[varlock-wrangler] \u26a0\ufe0f config is invalid \u2014 fix the error(s) above and save to reload\n');

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -160,6 +160,31 @@ function computeSourceStateHash(sources: SerializedEnvGraph['sources'], basePath
 }
 
 
+/**
+ * Comparison key for "did this reload actually change the env".
+ *
+ * Only the resolved items and settings count. The rest of the serialized graph moves
+ * without the env changing: `sources[].contentHash` fingerprints raw file bytes, and the
+ * source list itself churns in dev because `enableExtraFileWatchers` creates and deletes a
+ * Next-watched `.env` file to trigger reloads, so a load can catch it mid-flight.
+ *
+ * This also normalizes formatting, since the CLI pretty-prints `json-full` unless
+ * `--compact` is passed while the copy in `process.env.__VARLOCK_ENV` is a compact
+ * re-stringify.
+ *
+ * Returns undefined when there is nothing parseable to compare.
+ */
+export function envComparisonKey(serializedEnv: string | undefined): string | undefined {
+  if (!serializedEnv) return undefined;
+  try {
+    const graph = JSON.parse(serializedEnv);
+    return JSON.stringify({ config: graph?.config ?? {}, settings: graph?.settings ?? {} });
+  } catch {
+    return undefined;
+  }
+}
+
+
 // Next.js only watches a fixed set of .env files for changes. Varlock may load
 // additional files (e.g. .env.schema, .env.staging, custom sources). We watch
 // those extra files and trigger a reload by touching one of Next's watched files.
@@ -594,7 +619,7 @@ export function loadEnvConfig(
   }
 
   lastReloadAt = new Date();
-  const previousSerializedEnv = process.env.__VARLOCK_ENV;
+  const previousEnvKey = envComparisonKey(process.env.__VARLOCK_ENV);
 
   debug('>> RELOADING ENV');
   replaceProcessEnv(initialEnv);
@@ -624,7 +649,9 @@ export function loadEnvConfig(
     // follow-up events would produce.
     suppressSkipLogUntil = Date.now() + 1200;
     if (loadCount >= 2 && forceReload) {
-      const envChanged = stdout !== previousSerializedEnv;
+      const freshEnvKey = envComparisonKey(stdout);
+      // an unparseable key on either side means we can't tell, so report a change
+      const envChanged = !freshEnvKey || !previousEnvKey || freshEnvKey !== previousEnvKey;
       if (effectiveReloadSummary) {
         if (envChanged) {
           logUserInfo(`✅ [varlock] change detected in ${effectiveReloadSummary}; reloaded env, changes found.`);

--- a/packages/integrations/nextjs/test/env-comparison-key.test.ts
+++ b/packages/integrations/nextjs/test/env-comparison-key.test.ts
@@ -1,0 +1,82 @@
+import {
+  describe, it, expect, vi,
+} from 'vitest';
+
+vi.mock('varlock/exec-sync-varlock', () => ({
+  execSyncVarlock: vi.fn(),
+  VarlockExecError: class VarlockExecError extends Error {},
+}));
+vi.mock('varlock/env', () => ({
+  initVarlockEnv: vi.fn(),
+  resetRedactionMap: vi.fn(),
+}));
+vi.mock('varlock/patch-console', () => ({
+  patchGlobalConsole: vi.fn(),
+}));
+
+const { envComparisonKey } = await import('../src/next-env-compat');
+
+const GRAPH = {
+  basePath: '/proj',
+  sources: [
+    {
+      type: 'schema', label: '.env.schema', enabled: true, path: '.env.schema', contentHash: 'aaaaaaaaaaaaaaaa',
+    },
+  ],
+  settings: { redactLogs: true },
+  config: { PUBLIC_VAR: { value: 'hello', isSensitive: false } },
+};
+
+describe('envComparisonKey', () => {
+  it('ignores formatting differences', () => {
+    // the CLI pretty-prints `json-full` unless --compact is passed, while the copy kept
+    // in process.env.__VARLOCK_ENV is a compact re-stringify
+    expect(envComparisonKey(JSON.stringify(GRAPH, null, 2)))
+      .toBe(envComparisonKey(JSON.stringify(GRAPH)));
+  });
+
+  it('ignores source content fingerprints', () => {
+    const edited = {
+      ...GRAPH,
+      sources: [{ ...GRAPH.sources[0], contentHash: 'bbbbbbbbbbbbbbbb' }],
+    };
+    expect(envComparisonKey(JSON.stringify(edited))).toBe(envComparisonKey(JSON.stringify(GRAPH)));
+  });
+
+  it('ignores source list churn from the reload trigger file', () => {
+    // enableExtraFileWatchers creates and deletes a Next-watched .env to trigger reloads,
+    // so a load can catch it mid-flight and report a source that resolves nothing
+    const withTriggerFile = {
+      ...GRAPH,
+      sources: [
+        ...GRAPH.sources, {
+          type: 'values', label: '.env', enabled: false, path: '.env',
+        },
+      ],
+    };
+    expect(envComparisonKey(JSON.stringify(withTriggerFile))).toBe(envComparisonKey(JSON.stringify(GRAPH)));
+  });
+
+  it('detects a changed resolved value', () => {
+    const changed = { ...GRAPH, config: { PUBLIC_VAR: { value: 'goodbye', isSensitive: false } } };
+    expect(envComparisonKey(JSON.stringify(changed))).not.toBe(envComparisonKey(JSON.stringify(GRAPH)));
+  });
+
+  it('detects an added or removed item', () => {
+    const added = {
+      ...GRAPH,
+      config: { ...GRAPH.config, OTHER_VAR: { value: 'x', isSensitive: false } },
+    };
+    expect(envComparisonKey(JSON.stringify(added))).not.toBe(envComparisonKey(JSON.stringify(GRAPH)));
+  });
+
+  it('detects a changed setting', () => {
+    const changed = { ...GRAPH, settings: { redactLogs: false } };
+    expect(envComparisonKey(JSON.stringify(changed))).not.toBe(envComparisonKey(JSON.stringify(GRAPH)));
+  });
+
+  it('returns undefined for missing or unparseable input', () => {
+    expect(envComparisonKey(undefined)).toBeUndefined();
+    expect(envComparisonKey('not json')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes the `Framework Tests (cloudflare)` failure on main (`wrangler.test.ts > no restart on unchanged env content`), plus a related bug the investigation turned up in the Next.js integration.

## cloudflare: don't restart wrangler on cosmetic env file edits

#1029 added `sources[].contentHash` (a hash of each env file's raw bytes) to the serialized graph so injected-env blob reuse can detect edits. `varlock-wrangler dev` decides whether to restart by comparing the whole serialized graph, so it started treating any byte-level edit as an env change, including whitespace-only saves that leave every resolved value identical.

That is what broke the test: it rewrites `.env.schema` with the same content minus a trailing newline, so the restart moved wrangler to a new random port (`--port 0`) and the harness's next request hit the dead port. The three other failures in that job were the cascade.

The restart comparison now excludes `contentHash`. Everything else in the graph still counts, since the worker receives the whole blob.

## nextjs: report env reload changes accurately

The reload log compared a pretty-printed `load --format json-full` against the compact re-stringify kept in `__VARLOCK_ENV`, so it always reported "changes found". This predates #1029.

Normalizing the formatting was not enough. `enableExtraFileWatchers` triggers a reload by creating and deleting a Next-watched `.env` file, and the reload it triggers can observe that file, so the fresh graph carries a phantom disabled `.env` source the previous one didn't. The comparison now uses resolved items and settings only, which is what the log actually claims changed.

## Tests

- `no restart on unchanged env content` keeps writing content that is not byte-identical, so it now guards the regression; comment updated to say so.
- New request + output assertion in the shared Next.js dev scenario: a cosmetic `.env.dev` edit reloads but must log "no changes found". Verified it fails without the fix, on v14/v15/v16 across webpack and turbopack.
- Unit tests for `envComparisonKey` covering each ignored-vs-detected case.
