### PR TITLE
test(nuxt): cover config-time env freshness across dev restarts

### DIFF
--- a/framework-tests/frameworks/nuxt/files/configs/nuxt.config.config-time-env.ts
+++ b/framework-tests/frameworks/nuxt/files/configs/nuxt.config.config-time-env.ts
@@ -1,0 +1,21 @@
+// Config-time env access via varlock/auto-load, mapped into settings nuxt only
+// reads while evaluating the config. `app.head.title` lands in the served HTML
+// and `runtimeConfig.public` in the runtime config, so both are observable from
+// a request - which is what makes dev-restart freshness testable.
+import 'varlock/auto-load';
+import { ENV } from 'varlock/env';
+
+export default defineNuxtConfig({
+  modules: ['@varlock/nuxt-integration'],
+  compatibilityDate: '2025-01-01',
+  app: {
+    head: {
+      title: ENV.PUBLIC_VAR,
+    },
+  },
+  runtimeConfig: {
+    public: {
+      varlockConfigProbe: ENV.PUBLIC_VAR,
+    },
+  },
+});

--- a/framework-tests/frameworks/nuxt/nuxt-shared.ts
+++ b/framework-tests/frameworks/nuxt/nuxt-shared.ts
@@ -15,6 +15,8 @@ Two things make Nuxt different from a plain vite app, and both are covered here:
    routes are never in vite's module graph at all. The module registers the
    same init as a nitro plugin; the server-route and leak scenarios cover it.
 */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import {
   describe, beforeAll, afterAll,
 } from 'vitest';
@@ -27,6 +29,11 @@ export function defineNuxtTests(nuxtVersion: number, testDir: string, opts: { po
   // Nuxt 4's default layout nests the app under `app/`; Nuxt 3's srcDir is the
   // project root itself
   const appEntryPath = nuxtVersion >= 4 ? 'app/app.vue' : 'app.vue';
+  // the dev-restart scenario edits one value in the fixture schema mid-session;
+  // derived from the fixture rather than inlined so the two can't drift apart
+  const baseSchema = readFileSync(path.join(testDir, 'files/schemas/.env.schema'), 'utf8');
+  const editedSchema = baseSchema.replace('PUBLIC_VAR=public-var-value', 'PUBLIC_VAR=restarted-var-value');
+  if (editedSchema === baseSchema) throw new Error('nuxt fixture schema no longer contains PUBLIC_VAR=public-var-value');
 
   describe(`Nuxt v${nuxtVersion}`, () => {
     const env = new FrameworkTestEnv({
@@ -135,18 +142,8 @@ export function defineNuxtTests(nuxtVersion: number, testDir: string, opts: { po
       ],
     });
 
-    // TODO: `nuxt dev` produces no output at all when spawned by this harness
-    // (detached + shell), so the ready pattern never matches - the process stays
-    // alive but silent for the full timeout. The same spawn (same command, cwd,
-    // env, pnpm version, `--no-fork`, stdin from /dev/null) streams output
-    // normally outside vitest, so this is harness plumbing rather than an
-    // integration bug: dev mode has been verified by hand to serve `ENV` in both
-    // pages and server routes, redact secrets from logs, and block leaked values
-    // in responses. The build and production-server scenarios below cover the
-    // same code paths through the nitro plugin.
     const devPort = port();
     env.describeDevScenario('dev: ENV available in pages and server routes', {
-      skip: true,
       command: `nuxt dev --no-fork --port ${devPort} < /dev/null`,
       readyPattern: new RegExp(`localhost:${devPort}`),
       readyTimeout: 120_000,
@@ -159,7 +156,9 @@ export function defineNuxtTests(nuxtVersion: number, testDir: string, opts: { po
         {
           path: '/api/env',
           bodyAssertions: {
-            shouldContain: ['"PUBLIC_VAR":"public-var-value"', '"HAS_SECRET":"yes"'],
+            // nitro pretty-prints JSON responses in dev, so the key/value pairs
+            // carry a space that the production-server scenarios don't have
+            shouldContain: ['"PUBLIC_VAR": "public-var-value"', '"HAS_SECRET": "yes"'],
             shouldNotContain: ['super-secret-value'],
           },
         },
@@ -177,6 +176,66 @@ export function defineNuxtTests(nuxtVersion: number, testDir: string, opts: { po
           description: 'secret is redacted from server logs',
           shouldContain: ['secret-log-test:'],
           shouldNotContain: ['super-secret-value'],
+        },
+      ],
+    });
+
+    // An env file edit restarts the dev server in-process: the nuxt CLI closes
+    // the old instance and re-evaluates nuxt.config in the SAME process. The
+    // config's `import 'varlock/auto-load'` is already in the module cache and
+    // does not re-execute, so without the module re-resolving env on the way
+    // into a restart, every config-time `ENV` read would replay the values from
+    // first boot - runtime values (server routes, pages) would update while
+    // `app.head.title` and `runtimeConfig` stayed pinned to the old ones until a
+    // manual restart.
+    const restartPort = port();
+    env.describeDevScenario('dev: config-time env is refreshed on restart', {
+      command: `nuxt dev --no-fork --port ${restartPort} < /dev/null`,
+      // nuxt logs the `Local:` banner only on first boot; the nitro build line
+      // is re-logged on every restart and comes after both vite builds
+      readyPattern: /Nuxt Nitro server built/,
+      readyTimeout: 120_000,
+      timeout: 300_000,
+      templateFiles: {
+        'nuxt.config.ts': 'configs/nuxt.config.config-time-env.ts',
+        'server/api/env.get.ts': 'routes/env-endpoint.ts',
+        'server/api/runtime-config.get.ts': 'routes/runtime-config-endpoint.ts',
+      },
+      requests: [
+        {
+          label: 'config-time title before the edit',
+          path: '/',
+          bodyAssertions: { shouldContain: ['<title>public-var-value</title>'] },
+        },
+        {
+          // rewrite the schema with a new PUBLIC_VAR - the module watches every
+          // varlock-loaded env file, so this triggers the restart
+          label: 'config-time title after the auto-restart',
+          path: '/',
+          fileEdits: { '.env.schema': editedSchema },
+          bodyAssertions: {
+            shouldContain: ['<title>restarted-var-value</title>'],
+            shouldNotContain: ['public-var-value'],
+          },
+        },
+        {
+          // the same value read at config time, via runtimeConfig
+          label: 'runtimeConfig captured at config time is fresh',
+          path: '/api/runtime-config',
+          bodyAssertions: {
+            shouldContain: ['"varlockConfigProbe": "restarted-var-value"'],
+            shouldNotContain: ['public-var-value'],
+          },
+        },
+        {
+          // runtime reads reach ENV through the nitro init plugin rather than
+          // config evaluation - asserting both pins down which half went stale
+          label: 'runtime env is fresh too',
+          path: '/api/env',
+          bodyAssertions: {
+            shouldContain: ['"PUBLIC_VAR": "restarted-var-value"'],
+            shouldNotContain: ['public-var-value'],
+          },
         },
       ],
     });

--- a/framework-tests/harness/dev-server.ts
+++ b/framework-tests/harness/dev-server.ts
@@ -45,32 +45,59 @@ function killProcess(child: ChildProcess): Promise<void> {
   });
 }
 
+const sleep = (ms: number) => new Promise<void>((r) => {
+  setTimeout(r, ms);
+});
+
 /**
  * Fetch a URL with retries (server may report ready before accepting connections).
+ *
+ * A 503 is also retried, since dev servers serve one while (re)building rather than
+ * holding the connection - Nuxt's restart, for example, logs its build steps before
+ * the app is renderable again, so a request fired on that banner lands on the
+ * "loading" response. Callers that actually expect a 503 opt out.
  */
 async function fetchWithRetry(
   url: string,
-  retries = 3,
-  delayMs = 500,
-  timeoutMs = 15_000,
+  opts: {
+    retries?: number,
+    delayMs?: number,
+    timeoutMs?: number,
+    /** retry while the server answers 503 (default true) */
+    retryWhileUnavailable?: boolean,
+    /** how long to keep retrying a 503 before returning it */
+    unavailableTimeoutMs?: number,
+  } = {},
 ): Promise<DevServerRequestResult> {
+  const {
+    retries = 3, delayMs = 500, timeoutMs = 15_000,
+    retryWhileUnavailable = true, unavailableTimeoutMs = 30_000,
+  } = opts;
+
+  const attempt = async () => {
+    const resp = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    const body = await resp.text();
+    return { status: resp.status, body, headers: Object.fromEntries(resp.headers.entries()) };
+  };
+
+  const unavailableDeadline = Date.now() + unavailableTimeoutMs;
   for (let i = 0; i < retries; i++) {
     try {
-      const resp = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
-      const body = await resp.text();
-      return { status: resp.status, body, headers: Object.fromEntries(resp.headers.entries()) };
-    } catch {
-      if (i < retries - 1) {
-        await new Promise<void>((r) => {
-          setTimeout(r, delayMs);
-        });
+      const result = await attempt();
+      if (result.status !== 503 || !retryWhileUnavailable) return result;
+      // still building, keep polling (this does not consume a connection retry)
+      while (Date.now() < unavailableDeadline) {
+        await sleep(delayMs);
+        const retried = await attempt();
+        if (retried.status !== 503) return retried;
       }
+      return result;
+    } catch {
+      if (i < retries - 1) await sleep(delayMs);
     }
   }
   // final attempt — let it throw
-  const resp = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
-  const body = await resp.text();
-  return { status: resp.status, body, headers: Object.fromEntries(resp.headers.entries()) };
+  return attempt();
 }
 
 /**
@@ -122,6 +149,11 @@ function waitForReady(
 /**
  * Wait for the ready pattern to appear in NEW output (after a given chunk offset).
  * Used after file edits to detect that the dev server has restarted.
+ *
+ * `matched` is reported separately from `url` because a restart banner does not
+ * always repeat the server URL - Nuxt, for example, prints the `Local:` line only
+ * on first boot and just re-logs its build steps on restart. Callers keep the URL
+ * they already have when a match carries none.
  */
 function waitForNewReady(
   child: ChildProcess,
@@ -131,18 +163,18 @@ function waitForNewReady(
   stderrOffset: number,
   pattern: string | RegExp,
   timeout: number,
-): Promise<string | undefined> {
+): Promise<{ matched: boolean, url?: string }> {
   return new Promise((resolve) => {
     const regex = typeof pattern === 'string' ? new RegExp(pattern) : pattern;
     let resolved = false;
-    function done(url: string | undefined) {
+    function done(matched: boolean, url?: string) {
       if (resolved) return;
       resolved = true;
       clearTimeout(timer); // eslint-disable-line no-use-before-define
       child.stdout?.removeListener('data', onData); // eslint-disable-line no-use-before-define
       child.stderr?.removeListener('data', onData); // eslint-disable-line no-use-before-define
       child.removeListener('close', onClose); // eslint-disable-line no-use-before-define
-      resolve(url);
+      resolve({ matched, url });
     }
 
     function checkNewOutput() {
@@ -151,18 +183,18 @@ function waitForNewReady(
         + stderrChunks.slice(stderrOffset).join('')).replace(ANSI_PATTERN, '');
       if (regex.test(newOut)) {
         const urlMatch = newOut.match(URL_PATTERN);
-        done(urlMatch ? urlMatch[0] : undefined);
+        done(true, urlMatch ? urlMatch[0] : undefined);
       }
     }
 
     const onData = () => checkNewOutput();
-    const onClose = () => done(undefined);
+    const onClose = () => done(false);
 
     child.stdout?.on('data', onData);
     child.stderr?.on('data', onData);
     child.on('close', onClose);
 
-    const timer = setTimeout(() => done(undefined), timeout);
+    const timer = setTimeout(() => done(false), timeout);
   });
 }
 
@@ -202,13 +234,18 @@ export async function runDevServer(
     ...scenario.env,
   };
 
-  // The harness runs under vitest, so process.env carries VITEST / VITEST_* vars.
-  // Astro v7's dev server plugin (vite-plugin-astro-server) bails out of mounting
-  // its SSR request handler when it sees process.env.VITEST — an escape hatch for
-  // Astro's own vitest suite — which makes every SSR route 404 ("Cannot GET").
+  // The harness runs under vitest, so process.env carries VITEST / VITEST_* vars
+  // plus a generic TEST=true. Both make dev servers behave differently:
+  //  - Astro v7's dev server plugin (vite-plugin-astro-server) bails out of mounting
+  //    its SSR request handler when it sees process.env.VITEST — an escape hatch for
+  //    Astro's own vitest suite — which makes every SSR route 404 ("Cannot GET").
+  //  - `TEST` is what std-env's `isTest` reads, and consola drops its log level to
+  //    `warn` when that is set. Nuxt's CLI logs everything through consola at info
+  //    level, so the server starts and serves requests but emits no output at all:
+  //    the ready pattern never matches and the scenario times out silently.
   // Strip these so the spawned dev server doesn't think it's running under vitest.
   for (const key of Object.keys(spawnEnv)) {
-    if (key === 'VITEST' || key.startsWith('VITEST_')) {
+    if (key === 'VITEST' || key.startsWith('VITEST_') || key === 'TEST') {
       delete (spawnEnv as Record<string, string | undefined>)[key];
     }
   }
@@ -297,7 +334,7 @@ export async function runDevServer(
           });
         } else {
           log('File edits applied, waiting for server restart...');
-          const newUrl = await waitForNewReady(
+          const restarted = await waitForNewReady(
             child,
             stdoutChunks,
             stderrChunks,
@@ -306,7 +343,7 @@ export async function runDevServer(
             scenario.readyPattern,
             readyTimeout,
           );
-          if (!newUrl) {
+          if (!restarted.matched) {
             logError('Server did not restart after file edit');
             dumpOutput();
             return {
@@ -317,8 +354,9 @@ export async function runDevServer(
               error: 'Server did not become ready again after file edit',
             };
           }
-          // Update URL in case the port changed (e.g. when using --port 0)
-          currentUrl = newUrl;
+          // Update URL in case the port changed (e.g. when using --port 0). A
+          // restart banner that doesn't repeat the URL keeps the existing one.
+          if (restarted.url) currentUrl = restarted.url;
           log(`Server restarted at ${currentUrl}`);
         }
       }
@@ -326,7 +364,7 @@ export async function runDevServer(
       const url = `${currentUrl}${req.path}`;
       log(`Request ${i + 1}/${scenario.requests.length}: GET ${url}`);
       try {
-        const result = await fetchWithRetry(url);
+        const result = await fetchWithRetry(url, { retryWhileUnavailable: req.expectedStatus !== 503 });
         log(`Response: status=${result.status}, body=${result.body.length} bytes`);
         responses.push(result);
       } catch (err) {

--- a/framework-tests/harness/repack.ts
+++ b/framework-tests/harness/repack.ts
@@ -11,6 +11,7 @@ const PACKAGE_NAMES = [
   '@varlock/vite-integration',
   '@varlock/cloudflare-integration',
   '@varlock/expo-integration',
+  '@varlock/nuxt-integration',
 ];
 
 // REPACK is set by the npm script, but ensure it's set if run directly


### PR DESCRIPTION
Adds the missing regression guard for config-time `ENV` across module-triggered dev restarts, and fixes the harness issues that made a `nuxt dev` test impossible to write.

## Which behavior changed

**No behavior change, and no docs correction.** The reported staleness (config-time `ENV` going stale across auto-restarts while runtime values update) is real, but it was already fixed in #985 by the `restart`/`close` hooks that call `refreshVarlockEnv()` before the CLI re-evaluates the config. Reports against it came from preview build `1f1cc6c`, which predates that fix landing in the same PR.

Verified by building current `main` into a copy of the Nuxt example:

| | title (config-time) | greeting (runtime) |
|---|---|---|
| current `main` | updates | updates |
| `refreshVarlockEnv` hooks patched out | **stale** | updates |

The second row reproduces the original report exactly, which also confirms the fix is load-bearing.

Both sentences in the docs are accurate as written, including the `nuxt.config.ts`-only reload path (the `close` hook), checked by putting a value in an unwatched `.env.local` and touching the config.

## The test

`nuxt dev` restarts in-process: the CLI closes the old instance and re-evaluates `nuxt.config` in the same process. The config's `import 'varlock/auto-load'` is already in the module cache and never re-executes, so config-time reads only stay fresh because the module refreshes the shared `ENV` store on the way into a restart. Nothing covered that.

The new scenario maps a schema value into both `app.head.title` and `runtimeConfig`, edits `.env.schema` mid-session, and asserts the served values update after the auto-restart. It also asserts a runtime value so a failure localizes to the config-time path.

Negative control: with the hooks removed, the two config-time assertions fail and the runtime one passes.

## Harness fixes

The `nuxt dev` scenario was `skip: true` with a TODO saying the server produced no output under vitest. Three things were in the way:

- **`TEST` was silencing Nuxt.** Vitest sets `TEST=true`, std-env's `isTest` reads it, and consola drops its log level to `warn`. The server started and served requests while emitting nothing, so the ready pattern never matched. Now stripped alongside `VITEST*`. That scenario is un-skipped and passing on both majors.
- **`waitForNewReady` required the restart banner to repeat the server URL.** Nuxt prints `Local:` only on first boot, so a real restart was reported as "did not restart". `matched` is now tracked separately from `url`.
- **Dev servers answer 503 while rebuilding.** The post-restart request landed on Nuxt's loading page; 503 is now retried unless a scenario expects it.

Also registers `@varlock/nuxt-integration` in `repack.ts`, which was missing, so `bun run repack` was leaving the nuxt integration stale.

## Testing

- Nuxt v3 + v4: 60/60 pass.
- Astro, Next.js, vite, sveltekit: pass, unchanged from baseline.
- 24 tanstack-start and 6 cloudflare failures reproduce identically on a clean tree locally, so they are pre-existing and unrelated. Worth a separate look if CI is green on them.