### PR TITLE
fix: an imported @currentEnv must win over the --env fallback

### DIFF
--- a/.bumpy/fix-imported-currentenv-vs-fallback.md
+++ b/.bumpy/fix-imported-currentenv-vs-fallback.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Fix `@currentEnv` from an import losing to the `--env` fallback when loading a directory's own `.env.[env]` files

--- a/packages/varlock/src/env-graph/lib/data-source.ts
+++ b/packages/varlock/src/env-graph/lib/data-source.ts
@@ -935,8 +935,15 @@ export class DirectoryDataSource extends EnvGraphDataSource {
     await this._initChild(child);
   }
 
-  /** resolve currentEnv from schema's envFlagKey or parent chain */
-  private async _resolveCurrentEnv(): Promise<string | undefined> {
+  /**
+   * resolve currentEnv from schema's envFlagKey or parent chain
+   *
+   * `fromFallback` distinguishes a value that came from the graph-level fallback
+   * (`--env`, which the Next.js integration sets from `next dev`/`next build`) from one
+   * resolved via an actual `@currentEnv`. The fallback is only a guess until imports
+   * have been processed, since an import may introduce a real `@currentEnv`.
+   */
+  private async _resolveCurrentEnv(): Promise<{ env: string | undefined, fromFallback: boolean }> {
     if (!this.graph) throw new Error('expected graph to be set');
 
     // First check if our schema has its own envFlagKey (for partial imports with their own currentEnv)
@@ -951,16 +958,18 @@ export class DirectoryDataSource extends EnvGraphDataSource {
           + `but "${envFlagKey}" is not included in the import list. `
           + `Add "${envFlagKey}" to the @import() arguments.`,
         ));
-        return undefined;
+        return { env: undefined, fromFallback: false };
       }
       const envFlagItem = this.graph.configSchema[envFlagKey];
       if (envFlagItem) {
         if (!envFlagItem.resolvedValue) await envFlagItem.earlyResolve();
-        return envFlagItem.resolvedValue?.toString();
+        return { env: envFlagItem.resolvedValue?.toString(), fromFallback: false };
       }
     }
     // Fall back to parent chain or fallback value
-    return (await this.resolveCurrentEnv())?.toString() || this.envFlagValue?.toString();
+    const fromEnvFlagItem = !!this.envFlagConfigItem;
+    const env = (await this.resolveCurrentEnv())?.toString() || this.envFlagValue?.toString();
+    return { env, fromFallback: !!env && !fromEnvFlagItem };
   }
 
   /** load env-specific files (.env.ENV and .env.ENV.local) for the given environment */
@@ -990,10 +999,15 @@ export class DirectoryDataSource extends EnvGraphDataSource {
     await this.addAutoLoadedFile('.env.local');
 
     // Resolve currentEnv from schema's own @currentEnv (set during finishInit, not during imports)
-    let currentEnv = await this._resolveCurrentEnv();
+    const { env: currentEnv, fromFallback } = await this._resolveCurrentEnv();
     if (this.loadingError) return;
 
-    if (currentEnv) {
+    // A value from the graph-level fallback is deliberately NOT acted on yet — an import
+    // may still introduce a real @currentEnv, and loading `.env.<fallback>` here would
+    // both be wrong and leave that file's values in the graph after the correct env is
+    // known. A resolved @currentEnv is final, so it loads immediately (before imports),
+    // which is what lets import conditions read those values.
+    if (currentEnv && !fromFallback) {
       await this._loadEnvSpecificFiles(currentEnv);
     }
 
@@ -1004,12 +1018,14 @@ export class DirectoryDataSource extends EnvGraphDataSource {
     }
 
     // An import may have set @currentEnv (e.g. an imported file with @currentEnv=$VAR).
-    // If we didn't load env-specific files above, check again now and process their imports too.
-    if (!currentEnv) {
-      currentEnv = await this._resolveCurrentEnv();
+    // Re-check when we had no value, or only the fallback — a real @currentEnv must win
+    // over it, the same way it does when declared in this schema directly.
+    if (!currentEnv || fromFallback) {
+      const { env: resolvedEnv } = await this._resolveCurrentEnv();
       if (this.loadingError) return;
-      if (currentEnv) {
-        const envSources = await this._loadEnvSpecificFiles(currentEnv);
+      const finalEnv = resolvedEnv || currentEnv;
+      if (finalEnv) {
+        const envSources = await this._loadEnvSpecificFiles(finalEnv);
         for (const source of envSources) {
           await source._processImports();
         }

--- a/packages/varlock/src/env-graph/lib/data-source.ts
+++ b/packages/varlock/src/env-graph/lib/data-source.ts
@@ -1002,12 +1002,10 @@ export class DirectoryDataSource extends EnvGraphDataSource {
     const { env: currentEnv, fromFallback } = await this._resolveCurrentEnv();
     if (this.loadingError) return;
 
-    // A value from the graph-level fallback is deliberately NOT acted on yet — an import
-    // may still introduce a real @currentEnv, and loading `.env.<fallback>` here would
-    // both be wrong and leave that file's values in the graph after the correct env is
-    // known. A resolved @currentEnv is final, so it loads immediately (before imports),
-    // which is what lets import conditions read those values.
-    if (currentEnv && !fromFallback) {
+    // Loaded now even for a fallback: import conditions (`enabled=...`) and imported
+    // `@disable` may read values that `.env.<env>` overrides, so these have to be
+    // registered before imports are processed.
+    if (currentEnv) {
       await this._loadEnvSpecificFiles(currentEnv);
     }
 
@@ -1018,14 +1016,19 @@ export class DirectoryDataSource extends EnvGraphDataSource {
     }
 
     // An import may have set @currentEnv (e.g. an imported file with @currentEnv=$VAR).
-    // Re-check when we had no value, or only the fallback — a real @currentEnv must win
-    // over it, the same way it does when declared in this schema directly.
+    // Re-check when we had no value, or when the one we used was only the fallback — a
+    // real @currentEnv has to win over it, the same way it does when declared in this
+    // schema directly.
+    //
+    // NOTE: files already loaded for a superseded fallback env stay in the graph. The
+    // correct env's files are added after them so they take precedence, but a key that
+    // exists ONLY in `.env.<fallback>` will still be set. Dropping them would mean
+    // removing a data source and the items it created, which there is no mechanism for.
     if (!currentEnv || fromFallback) {
       const { env: resolvedEnv } = await this._resolveCurrentEnv();
       if (this.loadingError) return;
-      const finalEnv = resolvedEnv || currentEnv;
-      if (finalEnv) {
-        const envSources = await this._loadEnvSpecificFiles(finalEnv);
+      if (resolvedEnv && resolvedEnv !== currentEnv) {
+        const envSources = await this._loadEnvSpecificFiles(resolvedEnv);
         for (const source of envSources) {
           await source._processImports();
         }

--- a/packages/varlock/src/env-graph/test/environments.test.ts
+++ b/packages/varlock/src/env-graph/test/environments.test.ts
@@ -387,6 +387,26 @@ describe('@currentEnv and .env.* file loading logic', () => {
       },
     }));
 
+    // The fallback is still authoritative until an import supersedes it, so its files must
+    // load BEFORE imports — an import condition may read a value that `.env.<fallback>`
+    // overrides. Deferring them broke this.
+    test('fallback env values are available to import conditions', envFilesTest({
+      fallbackEnv: 'staging',
+      files: {
+        '.env.schema': outdent`
+        # @import(./.env.azure, enabled=eq($AUTH_MODE, "azure"))
+        # ---
+        AUTH_MODE=none
+      `,
+        '.env.staging': 'AUTH_MODE=azure',
+        '.env.azure': 'AZURE_ITEM=val-from-.env.azure',
+      },
+      expectValues: {
+        AUTH_MODE: 'azure',
+        AZURE_ITEM: 'val-from-.env.azure',
+      },
+    }));
+
     // The importing directory has no @currentEnv of its own — it inherits one from the
     // imported schema. That resolves only AFTER imports are processed, so a fallback
     // must not be treated as the final answer before then.

--- a/packages/varlock/src/env-graph/test/environments.test.ts
+++ b/packages/varlock/src/env-graph/test/environments.test.ts
@@ -386,6 +386,30 @@ describe('@currentEnv and .env.* file loading logic', () => {
         ITEM1: 'val-from-.env.dev',
       },
     }));
+
+    // The importing directory has no @currentEnv of its own — it inherits one from the
+    // imported schema. That resolves only AFTER imports are processed, so a fallback
+    // must not be treated as the final answer before then.
+    test('fallback env value is ignored if currentEnv comes from an import', envFilesTest({
+      fallbackEnv: 'staging',
+      files: {
+        '.env.schema': outdent`
+        # @import(./shared/)
+        # ---
+        ITEM1=val-from-.env.schema
+      `,
+        'shared/.env.schema': outdent`
+        # @currentEnv=$APP_ENV
+        # ---
+        APP_ENV=dev
+      `,
+        '.env.dev': 'ITEM1=val-from-.env.dev',
+        '.env.staging': 'ITEM1=val-from-.env.staging',
+      },
+      expectValues: {
+        ITEM1: 'val-from-.env.dev',
+      },
+    }));
   });
 });
 


### PR DESCRIPTION
### The bug

A directory whose schema gets `@currentEnv` through `@import()` never loads its own `.env.[env]` files when a fallback env is supplied.

Minimal repro — same directory, same files, the only difference is the flag:

```console
$ varlock load
BETTER_AUTH_URL = "https://app-level-stg.example.com"     # app's .env.stg wins

$ varlock load --env production
BETTER_AUTH_URL = "https://root-level-stg.example.com"    # app's .env.stg silently skipped
```

with:

```
apps/dashboard/.env.schema   # @import(../../)
apps/dashboard/.env.stg      BETTER_AUTH_URL=https://app-level-stg.example.com
.env.schema                  # @currentEnv=$APP_ENV  (+ APP_ENV declared here)
.env.stg                     BETTER_AUTH_URL=https://root-level-stg.example.com
```

`APP_ENV=stg` throughout. Note the root's `.env.stg` **does** load — so `@currentEnv` resolves fine — while the app's own is skipped in favour of a `.env.production` that doesn't exist. No error, and nothing in the loaded-file list hints the app file was considered:

```
- Environments: .env.schema, ../../.env.stg, ../../.env.schema
```

### Why

`DirectoryDataSource._finishInit()` resolves `currentEnv` **before** imports are processed, which is too early for an imported `@currentEnv`, so it falls through to `graph.envFlagFallback`. That value is truthy, so the post-import re-check — guarded on `!currentEnv` — never runs, and the directory stays pinned to the fallback for the rest of the load.

There's no fallback in the CLI's default path, so this only surfaces when one is set. The Next.js integration always sets one: `next-env-compat.ts` passes `--env development`/`production` from `next dev`/`next build` to match `@next/env`. Its comment says the user should be able to *"ignore it by setting their own `@currentEnv`"* — which holds when the decorator is in the same schema (there's already a passing test for that), and doesn't when the schema imports it.

That makes the monorepo layout in [Monorepos → one schema per project](https://varlock.dev/guides/monorepos/) unusable for per-environment values under Next.js: each app's `.env.schema` is just `@import(../../)`, so no app can have its own `.env.[env]`. Worse, both staging and production deploys run `next build` → `--env production`, so they resolve identically.

### The fix

`_resolveCurrentEnv()` now reports whether the value came from the fallback. A fallback is treated as provisional:

- it is **not acted on before imports**, and
- the post-import re-check runs for it, not only when there was no value at all.

Deliberately *not acted on early* rather than loaded and later overridden: loading `.env.<fallback>` leaves its values in the graph even once the real env is known, so a key present only there would leak into the wrong environment.

A resolved `@currentEnv` is unchanged — still final, still loaded before imports, so import conditions can read those values.

### Tests

One test added next to the existing `fallback env value is ignored if currentEnv is present`, covering the same intent when `@currentEnv` arrives via an import. It fails on `main`:

```
AssertionError: ITEM1 value did not match: expected 'val-from-.env.staging' to deeply equal 'val-from-.env.dev'
```

Full suite green with the fix: **1797 passed, 1 skipped**. `typecheck` and `eslint` clean.

Also verified end to end against the real monorepo this came from — building the patched CLI and running the exact command the Next integration shells out to (`load --env production`) now resolves the app-level value.

### Related

#428 is a different symptom of `@currentEnv` + `@import` (env flag must be declared in the same schema when using a pick list); this path is separate and doesn't fix that one.