### PR TITLE
Skip NODE_OPTIONS when spawning the varlock CLI subprocess

### DIFF
--- a/.bumpy/skip-node-options-in-cli-child.md
+++ b/.bumpy/skip-node-options-in-cli-child.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+auto-load and framework integrations no longer pass NODE_OPTIONS to the varlock CLI subprocess, so preloaded modules (e.g. NODE_OPTIONS="-r next-logger") can no longer corrupt its output and crash env loading

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -58,12 +58,15 @@ export function integrationTelemetryEnv(name: string, version: string) {
 
 function mergeExecEnv(
   opts?: ExecSyncVarlockOpts,
-): NodeJS.ProcessEnv | undefined {
+): NodeJS.ProcessEnv {
   const baseEnv = opts?.env ?? process.env;
-  if (!opts?.integrationTelemetry && !opts?.env) return undefined;
 
   const merged = { ...baseEnv } as NodeJS.ProcessEnv;
-  if (opts.integrationTelemetry) {
+  // NODE_OPTIONS is meant for the parent app's node process, not the varlock CLI child.
+  // A preloaded module (e.g. NODE_OPTIONS="-r next-logger") can write to stdout and
+  // corrupt the JSON the CLI emits over stdio, crashing auto-load / integrations.
+  delete merged.NODE_OPTIONS;
+  if (opts?.integrationTelemetry) {
     // __VARLOCK_INTEGRATION is for our internal use only — the integration-provided
     // identity is authoritative and always wins over any inherited/user-set value.
     Object.assign(
@@ -123,7 +126,7 @@ export function execSyncVarlock(
     // which will inject node_modules/.bin into PATH
     try {
       const result = execSync(`varlock ${command}`, {
-        ...(execEnv && { env: execEnv }),
+        env: execEnv,
         ...opts?.cwd && { cwd: opts.cwd },
         stdio: 'pipe',
       });
@@ -157,7 +160,7 @@ export function execSyncVarlock(
         const needsShell = varlockPath.endsWith('.cmd');
         const result = execFileSync(varlockPath, command.split(' '), {
           ...childProcessOpts,
-          ...(execEnv && { env: execEnv }),
+          env: execEnv,
           stdio: 'pipe',
           ...(needsShell && { shell: true }),
         });

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -65,7 +65,10 @@ function mergeExecEnv(
   // NODE_OPTIONS is meant for the parent app's node process, not the varlock CLI child.
   // A preloaded module (e.g. NODE_OPTIONS="-r next-logger") can write to stdout and
   // corrupt the JSON the CLI emits over stdio, crashing auto-load / integrations.
-  delete merged.NODE_OPTIONS;
+  // Windows matches env keys case-insensitively, so casing variants must go too.
+  for (const key of Object.keys(merged)) {
+    if (key.toUpperCase() === 'NODE_OPTIONS') delete merged[key];
+  }
   if (opts?.integrationTelemetry) {
     // __VARLOCK_INTEGRATION is for our internal use only — the integration-provided
     // identity is authoritative and always wins over any inherited/user-set value.

--- a/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
+++ b/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
@@ -47,6 +47,38 @@ describe('execSyncVarlock integration telemetry', () => {
     );
   });
 
+  it('strips NODE_OPTIONS so parent-process preloads cannot corrupt the CLI stdio protocol', () => {
+    process.env.NODE_OPTIONS = '-r some-logger';
+    try {
+      execSyncVarlock('load');
+    } finally {
+      delete process.env.NODE_OPTIONS;
+    }
+
+    expect(execSync).toHaveBeenCalledWith(
+      'varlock load',
+      expect.objectContaining({
+        env: expect.not.objectContaining({ NODE_OPTIONS: expect.anything() }),
+      }),
+    );
+  });
+
+  it('strips NODE_OPTIONS from an explicitly provided env too', () => {
+    execSyncVarlock('load', {
+      env: {
+        ...process.env,
+        NODE_OPTIONS: '-r some-logger',
+      },
+    });
+
+    expect(execSync).toHaveBeenCalledWith(
+      'varlock load',
+      expect.objectContaining({
+        env: expect.not.objectContaining({ NODE_OPTIONS: expect.anything() }),
+      }),
+    );
+  });
+
   it('sets __VARLOCK_INTEGRATION when integrationTelemetry is provided', () => {
     execSyncVarlock('load', {
       integrationTelemetry: {

--- a/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
+++ b/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
@@ -48,11 +48,11 @@ describe('execSyncVarlock integration telemetry', () => {
   });
 
   it('strips NODE_OPTIONS so parent-process preloads cannot corrupt the CLI stdio protocol', () => {
-    process.env.NODE_OPTIONS = '-r some-logger';
+    vi.stubEnv('NODE_OPTIONS', '-r some-logger');
     try {
       execSyncVarlock('load');
     } finally {
-      delete process.env.NODE_OPTIONS;
+      vi.unstubAllEnvs();
     }
 
     expect(execSync).toHaveBeenCalledWith(
@@ -63,20 +63,17 @@ describe('execSyncVarlock integration telemetry', () => {
     );
   });
 
-  it('strips NODE_OPTIONS from an explicitly provided env too', () => {
+  it('strips NODE_OPTIONS from an explicitly provided env too, including casing variants (Windows)', () => {
     execSyncVarlock('load', {
       env: {
         ...process.env,
         NODE_OPTIONS: '-r some-logger',
+        Node_Options: '-r some-logger',
       },
     });
 
-    expect(execSync).toHaveBeenCalledWith(
-      'varlock load',
-      expect.objectContaining({
-        env: expect.not.objectContaining({ NODE_OPTIONS: expect.anything() }),
-      }),
-    );
+    const childEnv = vi.mocked(execSync).mock.calls[0][1]!.env!;
+    expect(Object.keys(childEnv).filter((key) => key.toUpperCase() === 'NODE_OPTIONS')).toEqual([]);
   });
 
   it('sets __VARLOCK_INTEGRATION when integrationTelemetry is provided', () => {


### PR DESCRIPTION
## What

`execSyncVarlock` (used by `varlock/auto-load` and all framework integrations) now strips `NODE_OPTIONS` from the env passed to the spawned varlock CLI.

## Why

Reported by a user: in production they set `NODE_OPTIONS="-r next-logger"` to reformat Next.js logs as JSON. The spawned varlock CLI inherited it, the preloaded logger wrote to stdout, and `JSON.parse` of the CLI's stdio output crashed auto-load.

`NODE_OPTIONS` is meant for the parent app's node process; the CLI subprocess talks over a strict stdio JSON protocol, so any preload/loader flags leaking into it can break loading. Reproduced the crash end-to-end with a preload module and verified the fix resolves it.