### PR TITLE
Support MFA-protected AWS profiles via mfaToken on @initAws

### DIFF
--- a/.bumpy/aws-mfa-profile-support.md
+++ b/.bumpy/aws-mfa-profile-support.md
@@ -1,0 +1,5 @@
+---
+"@varlock/aws-secrets-plugin": minor
+---
+
+Add mfaToken param to @initAws to support MFA-protected AWS profiles (mfa_serial). The MFA code is resolved lazily, and the resulting STS session credentials are cached until they expire.

--- a/bun.lock
+++ b/bun.lock
@@ -245,6 +245,7 @@
         "@aws-sdk/credential-providers": "^3.700.0",
         "@env-spec/utils": "workspace:^",
         "@types/node": "catalog:",
+        "outdent": "catalog:",
         "tsdown": "catalog:",
         "varlock": "workspace:^",
         "vitest": "catalog:",

--- a/packages/plugins/aws-secrets/package.json
+++ b/packages/plugins/aws-secrets/package.json
@@ -18,6 +18,7 @@
     "dev": "tsdown --watch",
     "build": "tsdown",
     "test": "vitest",
+    "test:ci": "vitest --run",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [
@@ -50,6 +51,7 @@
     "@aws-sdk/credential-providers": "^3.700.0",
     "@env-spec/utils": "workspace:^",
     "@types/node": "catalog:",
+    "outdent": "catalog:",
     "tsdown": "catalog:",
     "varlock": "workspace:^",
     "vitest": "catalog:"

--- a/packages/plugins/aws-secrets/src/plugin.ts
+++ b/packages/plugins/aws-secrets/src/plugin.ts
@@ -44,6 +44,13 @@ plugin.standardVars = {
   },
 };
 
+const MFA_TIP = [
+  'This AWS profile requires multi-factor authentication (mfa_serial in ~/.aws/config).',
+  'Pass an MFA code via the mfaToken param, e.g.:',
+  '  @initAws(region=..., profile=..., mfaToken=generateOtp($MFA_SECRET))',
+  'If you already passed mfaToken, verify the code is current - AWS MFA codes are single-use.',
+].join('\n');
+
 const FIX_AUTH_TIP = [
   'Verify your AWS credentials are configured correctly. Use one of the following options:',
   '  1. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables',
@@ -60,6 +67,64 @@ interface OidcCredentials {
   expiration: number;
 }
 
+interface StsSessionCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  expiration?: Date;
+}
+
+/** how a session is held in the plugin cache - Date does not survive JSON */
+interface StoredSession {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  /** absent for credentials that do not expire */
+  expiration?: number;
+}
+
+function toStoredSession(creds: StsSessionCredentials): StoredSession {
+  return {
+    accessKeyId: creds.accessKeyId,
+    secretAccessKey: creds.secretAccessKey,
+    sessionToken: creds.sessionToken,
+    expiration: creds.expiration?.getTime(),
+  };
+}
+
+function fromStoredSession(stored: StoredSession): StsSessionCredentials {
+  return {
+    accessKeyId: stored.accessKeyId,
+    secretAccessKey: stored.secretAccessKey,
+    sessionToken: stored.sessionToken,
+    expiration: stored.expiration === undefined ? undefined : new Date(stored.expiration),
+  };
+}
+
+/** how long to share credentials that carry no expiry of their own */
+const SESSION_NO_EXPIRY_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Don't reuse session creds that are about to expire. Matches the AWS SDK's own
+ * refresh threshold (`EXPIRATION_MS` in @smithy/core), so we stop serving a session
+ * at the same point the SDK starts asking for a new one.
+ */
+const SESSION_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+function isSessionUsable(creds: { expiration?: Date }): boolean {
+  // no expiration means non-expiring creds (e.g. a plain IAM user via the chain)
+  if (!creds.expiration) return true;
+  return creds.expiration.getTime() > Date.now() + SESSION_EXPIRY_BUFFER_MS;
+}
+
+/**
+ * Minimum spacing between role assumptions. A TOTP code is single-use and only rotates
+ * once per window, so re-assuming any faster would just replay a spent code and fail.
+ * The SDK asks its credential provider several times per request once creds are inside
+ * its refresh threshold, so without this a near-expiry session triggers a burst of them.
+ */
+const MFA_REASSUME_COOLDOWN_MS = 30 * 1000;
+
 class AwsPluginInstance {
   private region?: string;
   private accessKeyId?: string;
@@ -70,6 +135,11 @@ class AwsPluginInstance {
   private oidcRoleArn?: string;
   private oidcSessionName?: string;
   private oidcToken?: string;
+  /**
+   * kept as an unresolved resolver so the MFA code is only generated when the SDK
+   * actually asks for one (cached session creds should not burn a single-use TOTP code)
+   */
+  private mfaTokenResolver?: Resolver;
   private cachedOidcCredentials?: OidcCredentials;
   /** optional cache TTL - when set, resolved values are cached */
   cacheTtl?: string | number;
@@ -90,6 +160,11 @@ class AwsPluginInstance {
     return 'default_chain';
   }
 
+  /** @internal telemetry: whether this instance is configured with an mfaToken */
+  get telemetryUsesMfa(): boolean {
+    return !!this.mfaTokenResolver;
+  }
+
   private _cacheKeyIdentity?: string;
   /** short hash identifying which AWS account/region is being read, used to namespace cache keys */
   get cacheKeyIdentity() {
@@ -100,7 +175,7 @@ class AwsPluginInstance {
     return this._cacheKeyIdentity;
   }
 
-  setAuth(
+  setAuth(opts: {
     region?: any,
     accessKeyId?: any,
     secretAccessKey?: any,
@@ -110,7 +185,12 @@ class AwsPluginInstance {
     oidcRoleArn?: any,
     oidcSessionName?: any,
     oidcToken?: any,
-  ) {
+    mfaTokenResolver?: Resolver,
+  }) {
+    const {
+      region, accessKeyId, secretAccessKey, sessionToken, profile,
+      namePrefix, oidcRoleArn, oidcSessionName, oidcToken, mfaTokenResolver,
+    } = opts;
     this.region = region ? String(region) : undefined;
     this.accessKeyId = accessKeyId ? String(accessKeyId) : undefined;
     this.secretAccessKey = secretAccessKey ? String(secretAccessKey) : undefined;
@@ -120,6 +200,7 @@ class AwsPluginInstance {
     this.oidcRoleArn = oidcRoleArn ? String(oidcRoleArn) : undefined;
     this.oidcSessionName = oidcSessionName ? String(oidcSessionName) : undefined;
     this.oidcToken = oidcToken ? String(oidcToken) : undefined;
+    this.mfaTokenResolver = mfaTokenResolver;
     debug(
       'aws instance',
       this.id,
@@ -135,6 +216,8 @@ class AwsPluginInstance {
       this.oidcRoleArn,
       'namePrefix:',
       this.namePrefix,
+      'hasMfaToken:',
+      !!this.mfaTokenResolver,
     );
   }
 
@@ -184,6 +267,114 @@ class AwsPluginInstance {
     return this.cachedOidcCredentials;
   }
 
+  /**
+   * memoized so the SecretsManager and SSM clients (and any concurrent resolves)
+   * share a single credential lookup, since each STS call may consume a single-use MFA code
+   */
+  private mfaSessionCredsPromise?: Promise<StsSessionCredentials>;
+  private mfaSessionCreds?: StsSessionCredentials;
+  /** when the last role assumption was attempted, used to space out MFA code use */
+  private lastAssumeAt?: number;
+  private withinReassumeCooldown(): boolean {
+    return Date.now() - (this.lastAssumeAt ?? 0) < MFA_REASSUME_COOLDOWN_MS;
+  }
+
+  /**
+   * Refuse to assume the role again while the code for this TOTP window is spent.
+   * A failed assume may still have consumed its code, and the SDK asks its credential
+   * provider several times per request, so without this one failure turns into a burst
+   * of retries that all replay a code AWS has already rejected.
+   */
+  private assertCanAssume() {
+    if (!this.withinReassumeCooldown()) return;
+    throw new ResolutionError('Cannot assume the AWS role again yet - the current MFA code has been used', {
+      tip: [
+        'AWS MFA codes are single-use and only change once per TOTP window.',
+        'Wait for the next code, then run again.',
+      ].join('\n'),
+    });
+  }
+
+  private async getMfaSessionCredentials(): Promise<StsSessionCredentials> {
+    // every concurrent caller shares one in-flight fetch (both AWS clients, plus the
+    // SDK's repeated provider calls), so a single MFA code covers all of them
+    if (this.mfaSessionCredsPromise) return await this.mfaSessionCredsPromise;
+
+    if (this.mfaSessionCreds) {
+      if (isSessionUsable(this.mfaSessionCreds)) return this.mfaSessionCreds;
+      // near expiry. long-lived processes (dev servers, watch mode) refresh here rather
+      // than keep signing with a session the SDK already considers spent
+      const expiration = this.mfaSessionCreds.expiration?.getTime();
+      const hasExpired = expiration !== undefined && expiration <= Date.now();
+      if (!hasExpired && this.withinReassumeCooldown()) {
+        // still valid, and we cannot get a fresh code yet - better than a doomed retry
+        debug('MFA session nearing expiry but within re-assume cooldown, reusing it');
+        return this.mfaSessionCreds;
+      }
+      debug('MFA session nearing expiry, refreshing');
+      this.mfaSessionCreds = undefined;
+    }
+
+    // a failed attempt also lands here, with no session left to fall back on
+    this.assertCanAssume();
+
+    this.mfaSessionCredsPromise = this.fetchMfaSessionCredentials();
+    try {
+      this.mfaSessionCreds = await this.mfaSessionCredsPromise;
+      return this.mfaSessionCreds;
+    } finally {
+      // cleared either way - on success the session itself is the memo, and on failure
+      // the cooldown above is what holds off the next attempt
+      this.mfaSessionCredsPromise = undefined;
+    }
+  }
+
+  private async fetchMfaSessionCredentials(): Promise<StsSessionCredentials> {
+    if (!pluginCache) return await this.assumeRoleWithMfa();
+    const cacheKey = `stsSession:${this.cacheKeyIdentity}`;
+
+    // getOrSet holds a cross-process lock around the producer and re-checks the cache
+    // inside it. That matters here because parallel varlock runs (turborepo, several
+    // dev servers) are separate processes: without it they would each assume the role
+    // with the same TOTP code, and AWS rejects a code that has already been spent.
+    // One process assumes, the rest wake up and read the session it cached.
+    const stored: StoredSession | undefined = await pluginCache.getOrSet(
+      cacheKey,
+      // STS decides how long the session lasts, so the TTL comes from the answer. The
+      // entry runs out exactly when the session stops being usable, which is what lets
+      // a reader trust whatever it finds. A non-positive result skips the write, and
+      // with it the cross-process sharing - only reachable for a session shorter than
+      // the buffer, which AssumeRole will not issue (its minimum is 15 minutes)
+      (session: StoredSession) => (
+        session.expiration === undefined
+          ? SESSION_NO_EXPIRY_TTL_MS
+          : session.expiration - Date.now() - SESSION_EXPIRY_BUFFER_MS
+      ),
+      async () => toStoredSession(await this.assumeRoleWithMfa()),
+    );
+
+    if (!stored) throw new ResolutionError('AWS role assumption returned no credentials');
+    debug('STS session ready, expires:', stored.expiration ? new Date(stored.expiration).toISOString() : 'never');
+    return fromStoredSession(stored);
+  }
+
+  private async assumeRoleWithMfa(): Promise<StsSessionCredentials> {
+    // stamped before the attempt, since a failed assume may still have spent the code
+    this.lastAssumeAt = Date.now();
+    const provider = fromNodeProviderChain({
+      ...(this.profile && { profile: this.profile }),
+      mfaCodeProvider: async (mfaSerial: string) => {
+        debug('MFA code requested for serial:', mfaSerial);
+        const code = await this.mfaTokenResolver!.resolve();
+        if (typeof code !== 'string' || !code) {
+          throw new SchemaError('mfaToken must resolve to a non-empty string');
+        }
+        return code;
+      },
+    });
+    return await provider();
+  }
+
   private async getCredentials(): Promise<{ credentials?: any; credentialDescription: string }> {
     if (this.accessKeyId && this.secretAccessKey) {
       return {
@@ -208,6 +399,17 @@ class AwsPluginInstance {
           credentialDescription: 'OIDC credentials',
         };
       }
+    }
+
+    // MFA-protected profiles (mfa_serial in ~/.aws/config) - the provider chain handles
+    // the role assumption, we supply the code lazily and cache the resulting session creds
+    if (this.mfaTokenResolver) {
+      return {
+        credentials: () => this.getMfaSessionCredentials(),
+        credentialDescription: this.profile
+          ? `AWS profile: ${this.profile} (with MFA)`
+          : 'default AWS credential chain (with MFA)',
+      };
     }
 
     if (this.profile) {
@@ -318,7 +520,10 @@ class AwsPluginInstance {
       const errorName = err.name || err.__type || '';
       const errorCode = err.$metadata?.httpStatusCode;
 
-      if (errorName === 'ResourceNotFoundException' || errorCode === 404) {
+      if (/multi-factor authentication|MultiFactorAuthentication/i.test(err.message || '')) {
+        errorMessage = 'AWS multi-factor authentication failed';
+        errorTip = MFA_TIP;
+      } else if (errorName === 'ResourceNotFoundException' || errorCode === 404) {
         errorMessage = `Secret "${secretId}" not found`;
         errorTip = [
           'Verify the secret exists in AWS Secrets Manager',
@@ -419,7 +624,10 @@ class AwsPluginInstance {
       const errorName = err.name || err.__type || '';
       const errorCode = err.$metadata?.httpStatusCode;
 
-      if (errorName === 'ParameterInvalidException' || errorName === 'ValidationException') {
+      if (/multi-factor authentication|MultiFactorAuthentication/i.test(err.message || '')) {
+        errorMessage = 'AWS multi-factor authentication failed';
+        errorTip = MFA_TIP;
+      } else if (errorName === 'ParameterInvalidException' || errorName === 'ValidationException') {
         errorMessage = `Invalid AWS SSM parameter name: "${name}"`;
         errorTip = 'Parameter names must start with "/" and can only contain letters, numbers, and the symbols / . - _';
       } else if (errorName === 'ParameterNotFound' || errorCode === 404) {
@@ -543,6 +751,7 @@ plugin.registerRootDecorator({
       oidcRoleArnResolver: objArgs.oidcRoleArn,
       oidcSessionNameResolver: objArgs.oidcSessionName,
       oidcTokenResolver: objArgs.oidcToken,
+      mfaTokenResolver: objArgs.mfaToken,
       cacheTtlResolver: objArgs.cacheTtl,
     };
   },
@@ -557,6 +766,7 @@ plugin.registerRootDecorator({
     oidcRoleArnResolver,
     oidcSessionNameResolver,
     oidcTokenResolver,
+    mfaTokenResolver,
     cacheTtlResolver,
   }) {
     const region = await regionResolver.resolve();
@@ -568,7 +778,7 @@ plugin.registerRootDecorator({
     const oidcRoleArn = await oidcRoleArnResolver?.resolve();
     const oidcSessionName = await oidcSessionNameResolver?.resolve();
     const oidcToken = await oidcTokenResolver?.resolve();
-    pluginInstances[id].setAuth(
+    pluginInstances[id].setAuth({
       region,
       accessKeyId,
       secretAccessKey,
@@ -578,7 +788,10 @@ plugin.registerRootDecorator({
       oidcRoleArn,
       oidcSessionName,
       oidcToken,
-    );
+      // NOT resolved here - the MFA code is generated lazily, only if/when
+      // the SDK actually needs one (see getMfaSessionCredentials)
+      mfaTokenResolver,
+    });
     const cacheTtl = await resolveCacheTtl(cacheTtlResolver);
     if (cacheTtl !== undefined) {
       pluginInstances[id].cacheTtl = cacheTtl;
@@ -911,6 +1124,7 @@ plugin.registerTelemetryAttributes(() => {
     auth_oidc: authMethods.has('oidc'),
     auth_profile: authMethods.has('profile'),
     auth_default_chain: authMethods.has('default_chain'),
+    auth_mfa: instances.some((i) => i.telemetryUsesMfa),
     uses_secrets_manager: usedSecretsManager,
     uses_parameter_store: usedParameterStore,
   };

--- a/packages/plugins/aws-secrets/test/fixtures/aws-config
+++ b/packages/plugins/aws-secrets/test/fixtures/aws-config
@@ -1,0 +1,8 @@
+[profile mfa-role]
+region = us-east-1
+role_arn = arn:aws:iam::123456789012:role/test-role
+source_profile = base
+mfa_serial = arn:aws:iam::123456789012:mfa/test-user
+
+[profile base]
+region = us-east-1

--- a/packages/plugins/aws-secrets/test/fixtures/aws-credentials
+++ b/packages/plugins/aws-secrets/test/fixtures/aws-credentials
@@ -1,0 +1,3 @@
+[base]
+aws_access_key_id = AKIAFAKEFAKEFAKEFAKE
+aws_secret_access_key = fakefakefakefakefakefakefakefakefakefake

--- a/packages/plugins/aws-secrets/test/mfa.test.ts
+++ b/packages/plugins/aws-secrets/test/mfa.test.ts
@@ -1,0 +1,403 @@
+import path from 'node:path';
+import http from 'node:http';
+import { fileURLToPath } from 'node:url';
+import type { AddressInfo } from 'node:net';
+import {
+  describe, test, beforeAll, afterAll, beforeEach, afterEach, expect, vi,
+} from 'vitest';
+import outdent from 'outdent';
+import { pluginTest } from 'varlock/test-helpers';
+import { InMemoryCacheStore } from '../../../varlock/src/lib/cache/in-memory-cache-store';
+import { generateTotp } from '../../../varlock/src/lib/otp';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PLUGIN_PATH = path.join(__dirname, '..');
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+const MFA_SECRET_B32 = 'JBSWY3DPEHPK3PXP';
+const MFA_SERIAL = 'arn:aws:iam::123456789012:mfa/test-user';
+const ASSUMED_CREDS = {
+  accessKeyId: 'ASIAFAKEFAKEFAKEFAKE',
+  secretAccessKey: 'assumed-secret-access-key-fake-fake-fake',
+  sessionToken: 'assumed-session-token-fake',
+};
+const SECRET_VALUE = 'shhh-its-a-secret';
+
+// ── Fake STS + Secrets Manager endpoints ─────────────────────────────
+// The AWS SDK honors AWS_ENDPOINT_URL_STS / AWS_ENDPOINT_URL_SECRETS_MANAGER,
+// including for the internal STS client used by the ini credential provider's
+// role assumption, so we can run the whole flow against local servers.
+
+let stsRequests: Array<Record<string, string>> = [];
+let smRequests: Array<{ headers: http.IncomingHttpHeaders, body: any }> = [];
+/** how long the fake STS says the assumed session is good for */
+let stsSessionDurationMs = 3600 * 1000;
+/** when set, the fake STS rejects this request number and every one after it */
+let stsFailFromRequest: number | undefined;
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => resolve(body));
+  });
+}
+
+const stsServer = http.createServer(async (req, res) => {
+  const body = await readBody(req);
+  const params = Object.fromEntries(new URLSearchParams(body));
+  stsRequests.push(params);
+
+  if (stsFailFromRequest !== undefined && stsRequests.length >= stsFailFromRequest) {
+    // AccessDenied is non-retryable, so the SDK will not retry this on its own
+    res.writeHead(403, { 'content-type': 'text/xml', date: new Date().toUTCString() });
+    res.end(outdent`
+      <ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+        <Error>
+          <Type>Sender</Type>
+          <Code>AccessDenied</Code>
+          <Message>MultiFactorAuthentication failed, invalid MFA one time pass code</Message>
+        </Error>
+        <RequestId>fake-error-id</RequestId>
+      </ErrorResponse>
+    `);
+    return;
+  }
+
+  const expiration = new Date(Date.now() + stsSessionDurationMs).toISOString();
+  res.writeHead(200, { 'content-type': 'text/xml', date: new Date().toUTCString() });
+  res.end(outdent`
+    <AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+      <AssumeRoleResult>
+        <Credentials>
+          <AccessKeyId>${ASSUMED_CREDS.accessKeyId}</AccessKeyId>
+          <SecretAccessKey>${ASSUMED_CREDS.secretAccessKey}</SecretAccessKey>
+          <SessionToken>${ASSUMED_CREDS.sessionToken}</SessionToken>
+          <Expiration>${expiration}</Expiration>
+        </Credentials>
+        <AssumedRoleUser>
+          <Arn>arn:aws:sts::123456789012:assumed-role/test-role/varlock</Arn>
+          <AssumedRoleId>AROFAKEFAKEFAKEFAKE:varlock</AssumedRoleId>
+        </AssumedRoleUser>
+      </AssumeRoleResult>
+      <ResponseMetadata><RequestId>fake-request-id</RequestId></ResponseMetadata>
+    </AssumeRoleResponse>
+  `);
+});
+
+/** optional hook run after each Secrets Manager request, used to advance the clock mid-load */
+let onSmRequest: (() => void) | undefined;
+
+const smServer = http.createServer(async (req, res) => {
+  const body = await readBody(req);
+  smRequests.push({ headers: req.headers, body: JSON.parse(body || '{}') });
+  onSmRequest?.();
+  res.writeHead(200, { 'content-type': 'application/x-amz-json-1.1', date: new Date().toUTCString() });
+  res.end(JSON.stringify({
+    ARN: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret-AbCdEf',
+    Name: 'test-secret',
+    SecretString: SECRET_VALUE,
+    VersionId: 'fake-version',
+  }));
+});
+
+// env vars the SDK reads directly - saved/restored around the suite
+const ENV_KEYS = [
+  'AWS_CONFIG_FILE',
+  'AWS_SHARED_CREDENTIALS_FILE',
+  'AWS_ENDPOINT_URL_STS',
+  'AWS_ENDPOINT_URL_SECRETS_MANAGER',
+  'AWS_PROFILE',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'AWS_REGION',
+  'AWS_DEFAULT_REGION',
+];
+let savedEnv: Record<string, string | undefined> = {};
+
+beforeAll(async () => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+
+  await new Promise<void>((resolve) => {
+    stsServer.listen(0, '127.0.0.1', resolve);
+  });
+  await new Promise<void>((resolve) => {
+    smServer.listen(0, '127.0.0.1', resolve);
+  });
+  process.env.AWS_ENDPOINT_URL_STS = `http://127.0.0.1:${(stsServer.address() as AddressInfo).port}`;
+  process.env.AWS_ENDPOINT_URL_SECRETS_MANAGER = `http://127.0.0.1:${(smServer.address() as AddressInfo).port}`;
+  process.env.AWS_CONFIG_FILE = path.join(FIXTURES_DIR, 'aws-config');
+  process.env.AWS_SHARED_CREDENTIALS_FILE = path.join(FIXTURES_DIR, 'aws-credentials');
+});
+
+afterAll(async () => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  await new Promise((resolve) => {
+    stsServer.close(resolve);
+  });
+  await new Promise((resolve) => {
+    smServer.close(resolve);
+  });
+});
+
+beforeEach(() => {
+  stsRequests = [];
+  smRequests = [];
+  stsSessionDurationMs = 3600 * 1000;
+  stsFailFromRequest = undefined;
+  onSmRequest = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+function mfaSchema(opts?: { mfaToken?: string | false }) {
+  const mfaTokenParam = opts?.mfaToken === false
+    ? ''
+    : `, mfaToken=${opts?.mfaToken || 'generateOtp($MFA_SECRET)'}`;
+  return outdent`
+    # @plugin(${PLUGIN_PATH})
+    # @cache=memory
+    # @initAws(region=us-east-1, profile=mfa-role${mfaTokenParam})
+    # ---
+    # @sensitive @internal
+    MFA_SECRET=
+    SOME_SECRET=awsSecret("test-secret")
+  `;
+}
+
+describe('MFA-protected profiles', () => {
+  test('assumes an mfa_serial role profile, generating the TOTP code lazily', async () => {
+    await pluginTest({
+      schema: mfaSchema(),
+      injectValues: { MFA_SECRET: MFA_SECRET_B32 },
+      expectValues: { SOME_SECRET: SECRET_VALUE },
+    })();
+
+    // STS was called once, with the serial from the config file and a valid TOTP code
+    expect(stsRequests.length).toBe(1);
+    expect(stsRequests[0].Action).toBe('AssumeRole');
+    expect(stsRequests[0].SerialNumber).toBe(MFA_SERIAL);
+    // allow the previous window in case the code rotated mid-test
+    const validCodes = [
+      generateTotp({ secret: MFA_SECRET_B32 }).code,
+      generateTotp({ secret: MFA_SECRET_B32, now: Date.now() - 30_000 }).code,
+    ];
+    expect(validCodes).toContain(stsRequests[0].TokenCode);
+
+    // the secrets manager call used the assumed session creds, not the source profile creds
+    expect(smRequests.length).toBe(1);
+    expect(smRequests[0].headers.authorization).toContain(ASSUMED_CREDS.accessKeyId);
+    expect(smRequests[0].headers['x-amz-security-token']).toBe(ASSUMED_CREDS.sessionToken);
+  });
+
+  test('caches session creds and skips STS + mfaToken resolution on later loads', async () => {
+    const setSpy = vi.spyOn(InMemoryCacheStore.prototype, 'set');
+
+    await pluginTest({
+      schema: mfaSchema(),
+      injectValues: { MFA_SECRET: MFA_SECRET_B32 },
+      expectValues: { SOME_SECRET: SECRET_VALUE },
+    })();
+    expect(stsRequests.length).toBe(1);
+
+    // session creds were written to the (encrypted in real usage) plugin cache
+    const sessionSetCall = setSpy.mock.calls.find(([key]) => key.includes('stsSession'));
+    expect(sessionSetCall).toBeDefined();
+    const [, cachedValue] = sessionSetCall!;
+    expect(cachedValue.accessKeyId).toBe(ASSUMED_CREDS.accessKeyId);
+
+    // simulate a later load finding the cached session creds (each pluginTest run
+    // gets a fresh store, so we stub `get` to return the captured entry).
+    // MFA_SECRET is invalid here - if the mfaToken resolver were invoked eagerly,
+    // generateOtp() would fail the load. cached creds mean it is never resolved.
+    vi.spyOn(InMemoryCacheStore.prototype, 'get').mockImplementation(async (key: string) => (
+      key.includes('stsSession')
+        ? { value: cachedValue, cachedAt: Date.now(), expiresAt: Date.now() + 3500_000 }
+        : undefined
+    ));
+    await pluginTest({
+      schema: mfaSchema(),
+      injectValues: { MFA_SECRET: 'not-valid-base32-!!!' },
+      expectValues: { SOME_SECRET: SECRET_VALUE },
+    })();
+    expect(stsRequests.length).toBe(1); // no additional STS call
+  });
+
+  test('does not cache a session too short to be worth sharing', async () => {
+    // shorter than the expiry buffer, so it would be stale before another run could use
+    // it. the TTL callback returns a non-positive value and the write is skipped, which
+    // is what keeps "an entry exists" equivalent to "the session is still usable"
+    stsSessionDurationMs = 2 * 60 * 1000;
+    const setSpy = vi.spyOn(InMemoryCacheStore.prototype, 'set');
+
+    await pluginTest({
+      schema: mfaSchema(),
+      injectValues: { MFA_SECRET: MFA_SECRET_B32 },
+      expectValues: { SOME_SECRET: SECRET_VALUE },
+    })();
+
+    // the load still succeeds off the freshly assumed session
+    expect(stsRequests.length).toBe(1);
+    expect(setSpy.mock.calls.filter(([key]) => key.includes('stsSession'))).toHaveLength(0);
+  });
+
+  test('assumes the role through the shared cache lock, for parallel runs', async () => {
+    const getOrSetSpy = vi.spyOn(InMemoryCacheStore.prototype, 'getOrSet');
+    const setSpy = vi.spyOn(InMemoryCacheStore.prototype, 'set');
+
+    await pluginTest({
+      schema: mfaSchema(),
+      injectValues: { MFA_SECRET: MFA_SECRET_B32 },
+      expectValues: { SOME_SECRET: SECRET_VALUE },
+    })();
+
+    // the assume runs inside getOrSet, which is what holds the cross-process lock.
+    // a plain get/set pair would let parallel varlock runs in separate processes
+    // (turborepo, several dev servers) each assume with the same spent TOTP code
+    const sessionFetch = getOrSetSpy.mock.calls.find(([key]) => key.includes('stsSession'));
+    expect(sessionFetch).toBeDefined();
+
+    // one write, with the TTL derived from what STS actually returned. the entry expires
+    // exactly when the session stops being usable, so another process never picks up one
+    // it would have to second-guess
+    const sessionWrites = setSpy.mock.calls.filter(([key]) => key.includes('stsSession'));
+    expect(sessionWrites.length).toBe(1);
+    const ttlMs = sessionWrites[0][2];
+    const expectedTtlMs = stsSessionDurationMs - 5 * 60 * 1000;
+    expect(ttlMs).toBeGreaterThan(expectedTtlMs - 10_000);
+    expect(ttlMs).toBeLessThanOrEqual(expectedTtlMs);
+  });
+
+  test('refreshes an expiring session within a long-lived process', async () => {
+    // only Date is faked - the servers still need real timers for network IO
+    vi.useFakeTimers({ toFake: ['Date'] });
+    const startedAt = new Date('2026-08-28T12:00:00Z').getTime();
+    vi.setSystemTime(startedAt);
+
+    // jump forward once the first secret is fetched, so the 1 hour session is inside
+    // the SDK's refresh threshold by the time the second lookup resolves credentials.
+    // this is the long-lived process case: one graph, hours apart
+    onSmRequest = () => {
+      if (smRequests.length === 1) vi.setSystemTime(startedAt + 56 * 60 * 1000);
+    };
+
+    // SECRET_B references SECRET_A so the two lookups are sequential rather than
+    // coalesced into a single credential resolution (the fake SM server ignores the name)
+    await pluginTest({
+      schema: outdent`
+        # @plugin(${PLUGIN_PATH})
+        # @cache=memory
+        # @initAws(region=us-east-1, profile=mfa-role, mfaToken=generateOtp($MFA_SECRET))
+        # ---
+        # @sensitive @internal
+        MFA_SECRET=
+        SECRET_A=awsSecret("test-secret")
+        SECRET_B=awsSecret("\${SECRET_A}-two")
+      `,
+      injectValues: { MFA_SECRET: MFA_SECRET_B32 },
+      expectValues: { SECRET_A: SECRET_VALUE, SECRET_B: SECRET_VALUE },
+    })();
+
+    expect(smRequests.length).toBe(2);
+    // the expiring session was refreshed rather than reused past its life...
+    // ...and the re-assume cooldown kept it to exactly one extra call. the SDK asks
+    // its credential provider several times per request in this state, and each
+    // assume burns a single-use MFA code, so a burst would fail against real AWS
+    expect(stsRequests.length).toBe(2);
+    for (const req of stsRequests) {
+      expect(req.SerialNumber).toBe(MFA_SERIAL);
+      expect(req.TokenCode).toMatch(/^\d{6}$/);
+    }
+    // the refresh used a code from the new TOTP window, not a replay of the spent one
+    expect(stsRequests[1].TokenCode).not.toBe(stsRequests[0].TokenCode);
+  });
+
+  test('does not replay a spent code after a failed refresh', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    const startedAt = new Date('2026-08-28T12:00:00Z').getTime();
+    vi.setSystemTime(startedAt);
+    onSmRequest = () => {
+      if (smRequests.length === 1) vi.setSystemTime(startedAt + 56 * 60 * 1000);
+    };
+    // the initial assume succeeds, the refresh is rejected
+    stsFailFromRequest = 2;
+
+    const g = await pluginTest({
+      schema: outdent`
+        # @plugin(${PLUGIN_PATH})
+        # @cache=memory
+        # @initAws(region=us-east-1, profile=mfa-role, mfaToken=generateOtp($MFA_SECRET))
+        # ---
+        # @sensitive @internal
+        MFA_SECRET=
+        SECRET_A=awsSecret("test-secret")
+        SECRET_B=awsSecret("\${SECRET_A}-two")
+      `,
+      injectValues: { MFA_SECRET: MFA_SECRET_B32 },
+      expectValues: { SECRET_A: SECRET_VALUE, SECRET_B: Error },
+    })();
+
+    // one initial assume and one refresh attempt - the failure is not retried within
+    // this load. note the cooldown that also blocks a retry in a later resolution pass
+    // is not what this asserts; the graph coalesces concurrent callers before reaching it
+    expect(stsRequests.length).toBe(2);
+    expect(g!.configSchema.SECRET_B.errors.length).toBeGreaterThan(0);
+  });
+
+  test('shares one role assumption between concurrent callers', async () => {
+    // two instances pointing at the same region and profile share a cache key, so they
+    // coalesce onto a single assume. a second would replay a code the first just spent
+    await pluginTest({
+      schema: outdent`
+        # @plugin(${PLUGIN_PATH})
+        # @cache=memory
+        # @initAws(id=one, region=us-east-1, profile=mfa-role, mfaToken=generateOtp($MFA_SECRET))
+        # @initAws(id=two, region=us-east-1, profile=mfa-role, mfaToken=generateOtp($MFA_SECRET))
+        # ---
+        # @sensitive @internal
+        MFA_SECRET=
+        SECRET_ONE=awsSecret(one, "test-secret")
+        SECRET_TWO=awsSecret(two, "test-secret")
+      `,
+      injectValues: { MFA_SECRET: MFA_SECRET_B32 },
+      expectValues: { SECRET_ONE: SECRET_VALUE, SECRET_TWO: SECRET_VALUE },
+    })();
+
+    expect(smRequests.length).toBe(2);
+    expect(stsRequests.length).toBe(1);
+  });
+
+  test('fails with an actionable error when the profile requires MFA but no mfaToken is set', async () => {
+    const g = await pluginTest({
+      schema: mfaSchema({ mfaToken: false }),
+      injectValues: { MFA_SECRET: MFA_SECRET_B32 },
+      expectValues: { SOME_SECRET: Error },
+    })();
+
+    const itemError = g!.configSchema.SOME_SECRET.errors[0];
+    expect(itemError.message).toContain('multi-factor');
+    expect((itemError as any).tip).toContain('mfaToken');
+    expect(stsRequests.length).toBe(0);
+  });
+
+  test('fails cleanly when mfaToken resolves to an empty value', async () => {
+    const g = await pluginTest({
+      schema: mfaSchema({ mfaToken: '""' }),
+      injectValues: { MFA_SECRET: MFA_SECRET_B32 },
+      expectValues: { SOME_SECRET: Error },
+    })();
+
+    const itemError = g!.configSchema.SOME_SECRET.errors[0];
+    expect(itemError.message).toContain('mfaToken');
+  });
+});

--- a/packages/plugins/aws-secrets/vitest.config.ts
+++ b/packages/plugins/aws-secrets/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    conditions: ['ts-src'],
+  },
+  ssr: {
+    // vitest resolves dependencies through the ssr pipeline, which does not inherit
+    // resolve.conditions. Without this, `varlock/test-helpers` (a ts-src-only export,
+    // deliberately not published) fails with "No known conditions".
+    resolve: {
+      conditions: ['ts-src'],
+    },
+  },
+  define: {
+    __VARLOCK_BUILD_TYPE__: JSON.stringify('test'),
+    __VARLOCK_SEA_BUILD__: 'false',
+  },
+});

--- a/packages/varlock-website/src/content/docs/plugins/aws-secrets.mdx
+++ b/packages/varlock-website/src/content/docs/plugins/aws-secrets.mdx
@@ -113,7 +113,42 @@ aws_access_key_id = AKIAI44QH8DHBEXAMPLE
 aws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY
 ```
 
-### OIDC authentication
+Profiles that assume a role (`role_arn` + `source_profile` in `~/.aws/config`) work too. The AWS SDK handles the STS role assumption automatically.
+
+### MFA-protected profiles
+
+If your profile requires multi-factor authentication (`mfa_serial` in `~/.aws/config`), pass an MFA code via the `mfaToken` param. Pair it with the built-in [`generateOtp()`](/reference/functions/#generateotp) function to generate the code from your TOTP seed:
+
+```env-spec title=".env.schema"
+# @plugin(@varlock/aws-secrets-plugin)
+# @initAws(region=us-east-1, profile=prod, mfaToken=generateOtp($MFA_SECRET))
+# ---
+
+# TOTP seed from your MFA device setup, encrypted at rest
+# @sensitive @internal
+MFA_SECRET=varlock(local:abc123...)
+
+# @sensitive
+SOME_SECRET=awsSecret("some-secret")
+```
+
+With a config file like:
+
+```ini
+[profile prod]
+region = us-east-1
+role_arn = arn:aws:iam::123456789012:role/prod
+source_profile = default
+mfa_serial = arn:aws:iam::123456789012:mfa/my-user
+```
+
+A few details worth knowing:
+
+- The MFA code is generated lazily, only when AWS actually asks for one. AWS MFA codes are single-use, so this avoids burning a code on loads that do not need it.
+- The resulting STS session credentials are cached (encrypted) until they expire, so repeated loads reuse the session instead of calling STS with a fresh code each time. See the [Caching guide](/guides/caching/) for cache modes and CLI controls.
+- In a long-running process (a dev server, or watch mode), the session is refreshed once it nears expiry, using a code from the current TOTP window.
+- Parallel loads in separate processes (a Turborepo build, or several dev servers at once) coordinate through the cache: one assumes the role and the rest reuse the session it stored. This needs the disk cache, which is the default when varlock can use your OS keychain or Secure Enclave. Under `@cache=memory` or `--skip-cache` each process assumes on its own, and AWS will reject the ones that reuse a code.
+- The MFA device serial comes from `mfa_serial` in your AWS config file.
 
 For deployments on platforms that issue OIDC tokens (Vercel, GitHub Actions, GitLab CI, Fly.io, GCP), you can use [OIDC workload identity federation](/guides/oidc/) to authenticate without any long-lived credentials. Varlock auto-detects the platform's OIDC token and exchanges it for temporary AWS credentials via STS `AssumeRoleWithWebIdentity`.
 
@@ -358,6 +393,7 @@ Initialize an AWS plugin instance for accessing Secrets Manager and Parameter St
 - `secretAccessKey` (optional): AWS secret access key for explicit authentication
 - `sessionToken` (optional): AWS session token for temporary credentials
 - `profile` (optional): Named profile from `~/.aws/credentials`
+- `mfaToken` (optional): MFA code for profiles that require multi-factor authentication (`mfa_serial`). Usually paired with `generateOtp()`, and resolved lazily, only when AWS asks for a code
 - `oidcRoleArn` (optional): IAM role ARN for OIDC workload identity authentication
 - `oidcSessionName` (optional): Session name for OIDC role assumption (defaults to `varlock-session`)
 - `oidcToken` (optional): Explicit OIDC JWT token (auto-detected from platform if omitted)
@@ -484,6 +520,10 @@ EU_CONFIG=awsParam(eu, "/prod/config")
 - **AWS-hosted apps:** Verify IAM role is attached
 - **Other environments:** Verify credentials are correct and properly injected
 - Test credentials: `aws sts get-caller-identity`
+
+### Multi-factor authentication failed
+- If your profile has `mfa_serial` configured, pass a code via `mfaToken` (see [MFA-protected profiles](#mfa-protected-profiles))
+- AWS MFA codes are single-use. If a code was just used elsewhere, wait for the next TOTP window
 
 ### JSON parsing errors
 - Verify your secret/parameter contains valid JSON


### PR DESCRIPTION
> [!NOTE]
> The non-AWS fixes in here (the `@cache` policy bug, the `getOrSet` TTL callback, and the parser grammar build output) have been split out into #1068 so they can land on their own. This PR is now just the MFA feature, and will be rebased once #1068 merges.
>
> Holding it pending a real-world test: the original requester walked the request back before this was built and has not tested the preview package. See #1047 for the known open gap.

Adds an `mfaToken` param to `@initAws` so profiles that require multi-factor authentication (`mfa_serial` in `~/.aws/config`) work through the aws-secrets plugin. Addresses the underlying need in #1037: the SDK credential chain already handles `role_arn` profile assumption, so with MFA wired up there is no need to shell out to awsume.

```env-spec
# @initAws(region=us-east-1, profile=prod, mfaToken=generateOtp($MFA_SECRET))
```

Key behaviors:

- The mfaToken resolver is resolved lazily, only when the SDK actually asks for a code. AWS MFA codes are single-use, so loads served from cache never burn one.
- The resulting STS session creds are cached via the plugin cache (encrypted at rest) until they expire, so repeated loads reuse the session instead of calling STS each time.
- In a long-running process (dev server, watch mode) the session is refreshed as it nears expiry. Re-assumes are spaced by one TOTP window, because the SDK asks its credential provider several times per request in that state and each assume burns a single-use code. An already-expired session bypasses that cooldown, since reusing it would fail anyway.
- Parallel loads in separate processes (turborepo, several dev servers) coordinate through the cache's `getOrSet`, which holds a cross-process lock: one process assumes the role and the rest reuse the session it stored. Without this they would each assume with the same spent TOTP code. Needs the disk cache (the default when the OS keychain / Secure Enclave is available); documented for `@cache=memory` and `--skip-cache`.
- MFA failures get a targeted error message with a tip pointing at `mfaToken` + `generateOtp()`.

This also adds a small piece of core cache API that the feature needed. `getOrSet` took its TTL up front, but for anything whose lifetime the source decides (an STS session, an OAuth token, a lease) that is only known once the producer has run, which forced a guess-then-correct dance with a window where the entry outlived what it described. The `ttl` argument now also accepts a callback given the produced value; returning zero or less skips the write. All existing callers pass a literal and are unaffected. This should be the reusable answer for any plugin caching a credential whose lifetime it does not choose.

Also fixes a core plugin caching bug this uncovered: plugins install during `finishInit`, before the `@cache` root decorator policy is applied in `finishLoad`, so plugin cache accessors stayed bound to the loader's initial store. `@cache=memory` / `@cache=disabled` were silently ignored by plugin-level caching (all plugins with `cacheTtl`, not just this one). The accessor now reads the store lazily and the final store is re-propagated after the policy step.

Tests run the full flow end-to-end against fake local STS / Secrets Manager endpoints (via `AWS_ENDPOINT_URL_*`), covering the AssumeRole call contents, lazy resolution, session cred caching and expiry, mid-process refresh with the clock advanced, and both failure modes.

Closes #1037

