### PR TITLE
Add domain data type for bare domain names

### DIFF
--- a/.bumpy/domain-data-type-vscode.md
+++ b/.bumpy/domain-data-type-vscode.md
@@ -1,0 +1,5 @@
+---
+env-spec-language: minor
+---
+
+Add completions and diagnostics for the new `domain` data type

--- a/.bumpy/domain-data-type.md
+++ b/.bumpy/domain-data-type.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+New `domain` data type for validating bare domain names (hostnames), with options for wildcards, single-label hostnames, lowercasing, and regex matching

--- a/.bumpy/domain-data-type.md
+++ b/.bumpy/domain-data-type.md
@@ -2,4 +2,4 @@
 varlock: minor
 ---
 
-New `domain` data type for validating bare domain names (hostnames), with options for wildcards, single-label hostnames, lowercasing, and regex matching
+New `domain` data type for validating bare domain names (hostnames), with options for wildcards, single-label hostnames, IPv4 values (for HOST-style vars), lowercasing, and regex matching

--- a/packages/varlock-website/src/content/docs/reference/data-types.mdx
+++ b/packages/varlock-website/src/content/docs/reference/data-types.mdx
@@ -179,6 +179,25 @@ API_URL=https://api.example.com/v1
 </div>
 
 <div>
+### `domain`
+Checks for a bare domain name (hostname) like `example.com`, with no protocol, port, or path. Useful for cookie domains, CORS config, or building URLs from parts.
+
+**Options:**
+- `allowWildcard` (boolean): Allow a leading wildcard label like `*.example.com`
+- `allowSingleLabel` (boolean): Allow single-label hostnames like `localhost` or internal service names
+- `normalize` (boolean): Convert to lowercase
+- `matches` (string|RegExp): Regular expression pattern the domain must match
+
+```env-spec
+# @type=domain
+COOKIE_DOMAIN=app.example.com
+
+# @type=domain(allowWildcard=true)
+CORS_DOMAIN=*.example.com
+```
+</div>
+
+<div>
 ### `enum`
 Checks a value is contained in a list of possible values - it must match one exactly. Members can also be sourced from other items (see [Dynamic type options](#dynamic-type-options)).
 

--- a/packages/varlock-website/src/content/docs/reference/data-types.mdx
+++ b/packages/varlock-website/src/content/docs/reference/data-types.mdx
@@ -185,6 +185,7 @@ Checks for a bare domain name (hostname) like `example.com`, with no protocol, p
 **Options:**
 - `allowWildcard` (boolean): Allow a leading wildcard label like `*.example.com`
 - `allowSingleLabel` (boolean): Allow single-label hostnames like `localhost` or internal service names
+- `allowIp` (boolean): Also accept an IPv4 address, useful for HOST-style vars that hold a hostname in one environment and an IP in another
 - `normalize` (boolean): Convert to lowercase
 - `matches` (string|RegExp): Regular expression pattern the domain must match
 
@@ -194,6 +195,9 @@ COOKIE_DOMAIN=app.example.com
 
 # @type=domain(allowWildcard=true)
 CORS_DOMAIN=*.example.com
+
+# @type=domain(allowIp=true)
+DB_HOST=10.0.3.12
 ```
 </div>
 

--- a/packages/varlock/src/env-graph/lib/data-types.ts
+++ b/packages/varlock/src/env-graph/lib/data-types.ts
@@ -487,7 +487,8 @@ const DomainDataType = createEnvGraphDataType(
           domain = domain.slice(2);
         }
 
-        if (domain.length === 0 || domain.length > 253) {
+        // the 253-char total limit (RFC 1035) counts the wildcard label too, so check `val`
+        if (domain.length === 0 || val.length > 253) {
           throw new ValidationError('Value must be a valid domain name');
         }
 

--- a/packages/varlock/src/env-graph/lib/data-types.ts
+++ b/packages/varlock/src/env-graph/lib/data-types.ts
@@ -429,6 +429,8 @@ const UrlDataType = createEnvGraphDataType(
 );
 
 
+const IP_V4_ADDRESS_REGEX = /^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}$/;
+
 // hostname label per RFC 1123 - alphanumeric + hyphens, no leading/trailing hyphen, max 63 chars
 const DOMAIN_LABEL_REGEX = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i;
 
@@ -443,6 +445,8 @@ const DomainDataType = createEnvGraphDataType(
     allowWildcard?: boolean;
     /** allow single-label hostnames like `localhost` or internal service names (default false) */
     allowSingleLabel?: boolean;
+    /** also accept an IPv4 address - useful for HOST-style vars like DB_HOST (default false) */
+    allowIp?: boolean;
     /** convert to lowercase */
     normalize?: boolean;
     /** A regular expression or string pattern that the domain must match. */
@@ -473,31 +477,37 @@ const DomainDataType = createEnvGraphDataType(
         throw new ValidationError('Domain must not include credentials or an @ sign');
       }
 
-      let domain = val;
-      if (domain.startsWith('*.')) {
-        if (!settings?.allowWildcard) {
-          throw new ValidationError('Wildcard domains are not allowed', { tip: 'set allowWildcard=true to allow them' });
+      // a valid IPv4 address skips the domain structure checks (matches still applies below)
+      if (!(settings?.allowIp && IP_V4_ADDRESS_REGEX.test(val))) {
+        let domain = val;
+        if (domain.startsWith('*.')) {
+          if (!settings?.allowWildcard) {
+            throw new ValidationError('Wildcard domains are not allowed', { tip: 'set allowWildcard=true to allow them' });
+          }
+          domain = domain.slice(2);
         }
-        domain = domain.slice(2);
-      }
 
-      if (domain.length === 0 || domain.length > 253) {
-        throw new ValidationError('Value must be a valid domain name');
-      }
+        if (domain.length === 0 || domain.length > 253) {
+          throw new ValidationError('Value must be a valid domain name');
+        }
 
-      const labels = domain.split('.');
-      if (labels.some((label) => !DOMAIN_LABEL_REGEX.test(label))) {
-        throw new ValidationError('Value must be a valid domain name');
-      }
-      // an all-numeric final label means this is really an IP address, not a domain
-      if (/^\d+$/.test(labels[labels.length - 1])) {
-        throw new ValidationError('Value must be a domain name, not an IP address', { tip: 'use @type=ip for IP addresses' });
-      }
-      if (labels.length < 2 && !settings?.allowSingleLabel) {
-        throw new ValidationError(
-          'Domain must include at least two labels (e.g. "example.com")',
-          { tip: 'set allowSingleLabel=true to allow hostnames like "localhost"' },
-        );
+        const labels = domain.split('.');
+        if (labels.some((label) => !DOMAIN_LABEL_REGEX.test(label))) {
+          throw new ValidationError('Value must be a valid domain name');
+        }
+        // an all-numeric final label means this is really an IP address (or a malformed one)
+        if (/^\d+$/.test(labels[labels.length - 1])) {
+          if (settings?.allowIp) {
+            throw new ValidationError('Value must be a valid domain name or IPv4 address');
+          }
+          throw new ValidationError('Value must be a domain name, not an IP address', { tip: 'use @type=ip for IP addresses, or set allowIp=true to allow both' });
+        }
+        if (labels.length < 2 && !settings?.allowSingleLabel) {
+          throw new ValidationError(
+            'Domain must include at least two labels (e.g. "example.com")',
+            { tip: 'set allowSingleLabel=true to allow hostnames like "localhost"' },
+          );
+        }
       }
 
       if (settings?.matches) {
@@ -594,7 +604,6 @@ const EmailDataType = createEnvGraphDataType(
   }),
 );
 
-const IP_V4_ADDRESS_REGEX = /^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}$/;
 const IP_V6_ADDRESS_REGEX = /^(?:(?:[a-fA-F\d]{1,4}:){7}(?:[a-fA-F\d]{1,4}|:)|(?:[a-fA-F\d]{1,4}:){6}(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|:[a-fA-F\d]{1,4}|:)|(?:[a-fA-F\d]{1,4}:){5}(?::(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,2}|:)|(?:[a-fA-F\d]{1,4}:){4}(?:(?::[a-fA-F\d]{1,4}){0,1}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,3}|:)|(?:[a-fA-F\d]{1,4}:){3}(?:(?::[a-fA-F\d]{1,4}){0,2}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,4}|:)|(?:[a-fA-F\d]{1,4}:){2}(?:(?::[a-fA-F\d]{1,4}){0,3}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,5}|:)|(?:[a-fA-F\d]{1,4}:){1}(?:(?::[a-fA-F\d]{1,4}){0,4}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,6}|:)|(?::(?:(?::[a-fA-F\d]{1,4}){0,5}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-fA-F\d]{1,4}){1,7}|:)))(?:%[0-9a-zA-Z]{1,})?$/;
 const IpAddressDataType = createEnvGraphDataType(
   (settings?: {

--- a/packages/varlock/src/env-graph/lib/data-types.ts
+++ b/packages/varlock/src/env-graph/lib/data-types.ts
@@ -429,6 +429,94 @@ const UrlDataType = createEnvGraphDataType(
 );
 
 
+// hostname label per RFC 1123 - alphanumeric + hyphens, no leading/trailing hyphen, max 63 chars
+const DOMAIN_LABEL_REGEX = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i;
+
+/**
+ * Bare domain name (hostname) - e.g. `example.com`, `api.internal.example.com`.
+ * No protocol, path, port, or query string. Useful for things like cookie domains,
+ * CORS config, or building URLs from parts.
+ */
+const DomainDataType = createEnvGraphDataType(
+  (settings?: {
+    /** allow a leading wildcard label, e.g. `*.example.com` (default false) */
+    allowWildcard?: boolean;
+    /** allow single-label hostnames like `localhost` or internal service names (default false) */
+    allowSingleLabel?: boolean;
+    /** convert to lowercase */
+    normalize?: boolean;
+    /** A regular expression or string pattern that the domain must match. */
+    matches?: RegExp | string;
+  }) => ({
+    name: 'domain',
+    icon: 'mdi:web',
+    typeDescription: 'bare domain name (hostname) with no protocol, port, or path',
+    // A valid, unique domain at the reserved `.invalid` TLD (RFC 2606).
+    generatePlaceholder: (seed) => `${seed}.invalid`,
+    coerce(rawVal) {
+      let val = coerceToString(rawVal).trim();
+      if (settings?.normalize) val = val.toLowerCase();
+      return val;
+    },
+    validate(val) {
+      // friendlier errors for the most likely mistakes (pasting a full URL)
+      if (val.includes('://')) {
+        throw new ValidationError('Domain must not include a protocol', { tip: 'use @type=url for full URLs' });
+      }
+      if (val.includes('/')) {
+        throw new ValidationError('Domain must not include a path', { tip: 'use @type=url for full URLs' });
+      }
+      if (val.includes(':')) {
+        throw new ValidationError('Domain must not include a port');
+      }
+      if (val.includes('@')) {
+        throw new ValidationError('Domain must not include credentials or an @ sign');
+      }
+
+      let domain = val;
+      if (domain.startsWith('*.')) {
+        if (!settings?.allowWildcard) {
+          throw new ValidationError('Wildcard domains are not allowed', { tip: 'set allowWildcard=true to allow them' });
+        }
+        domain = domain.slice(2);
+      }
+
+      if (domain.length === 0 || domain.length > 253) {
+        throw new ValidationError('Value must be a valid domain name');
+      }
+
+      const labels = domain.split('.');
+      if (labels.some((label) => !DOMAIN_LABEL_REGEX.test(label))) {
+        throw new ValidationError('Value must be a valid domain name');
+      }
+      // an all-numeric final label means this is really an IP address, not a domain
+      if (/^\d+$/.test(labels[labels.length - 1])) {
+        throw new ValidationError('Value must be a domain name, not an IP address', { tip: 'use @type=ip for IP addresses' });
+      }
+      if (labels.length < 2 && !settings?.allowSingleLabel) {
+        throw new ValidationError(
+          'Domain must include at least two labels (e.g. "example.com")',
+          { tip: 'set allowSingleLabel=true to allow hostnames like "localhost"' },
+        );
+      }
+
+      if (settings?.matches) {
+        let regex: RegExp;
+        if (_.isString(settings.matches)) {
+          regex = parseRegexLikeString(settings.matches) ?? new RegExp(settings.matches);
+        } else {
+          regex = settings.matches;
+        }
+        if (!regex.test(val)) {
+          throw new ValidationError(`Domain must match regex "${settings.matches}"`);
+        }
+      }
+      return true;
+    },
+  }),
+);
+
+
 const SimpleObjectDataType = createEnvGraphDataType({
   name: 'simple-object',
   icon: 'tabler:code-dots', // curly brackets with nothing inside
@@ -984,6 +1072,7 @@ export const BaseDataTypes: Array<EnvGraphDataTypeFactory> = [
   EnumDataType,
   EmailDataType,
   UrlDataType,
+  DomainDataType,
   IpAddressDataType,
   PortDataType,
   SemverDataType,

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -270,6 +270,49 @@ describe('domain data type', () => {
     });
   });
 
+  describe('allowIp', () => {
+    it('accepts an IPv4 address when enabled', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain(allowIp=true)
+        MY_HOST=192.168.1.1
+      `);
+      expect(g.configSchema.MY_HOST.isValid).toBe(true);
+      expect(g.configSchema.MY_HOST.resolvedValue).toBe('192.168.1.1');
+    });
+
+    it('still accepts domains when enabled', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain(allowIp=true)
+        MY_HOST=db.internal.example.com
+      `);
+      expect(g.configSchema.MY_HOST.isValid).toBe(true);
+    });
+
+    it('rejects a malformed IPv4 address', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain(allowIp=true)
+        MY_HOST=192.168.1.999
+      `);
+      expect(g.configSchema.MY_HOST.isValid).toBe(false);
+    });
+
+    it('rejects an IPv6 address', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain(allowIp=true)
+        MY_HOST=::1
+      `);
+      expect(g.configSchema.MY_HOST.isValid).toBe(false);
+    });
+
+    it('rejects an IP with a port', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain(allowIp=true)
+        MY_HOST=192.168.1.1:5432
+      `);
+      expect(g.configSchema.MY_HOST.isValid).toBe(false);
+    });
+  });
+
   describe('normalize', () => {
     it('lowercases the value when enabled', async () => {
       const g = await loadAndResolve(outdent`

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -189,6 +189,126 @@ describe('url data type - path values', () => {
   });
 });
 
+describe('domain data type', () => {
+  it('accepts a basic domain', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=domain
+      MY_DOMAIN=example.com
+    `);
+    expect(g.configSchema.MY_DOMAIN.isValid).toBe(true);
+    expect(g.configSchema.MY_DOMAIN.resolvedValue).toBe('example.com');
+  });
+
+  it('accepts nested subdomains', async () => {
+    const g = await loadAndResolve(outdent`
+      # @type=domain
+      MY_DOMAIN=api.internal.example.co.uk
+    `);
+    expect(g.configSchema.MY_DOMAIN.isValid).toBe(true);
+  });
+
+  it.each([
+    ['protocol', 'https://example.com'],
+    ['path', 'example.com/foo'],
+    ['port', 'example.com:8080'],
+    ['credentials', 'user@example.com'],
+    ['spaces', '"exam ple.com"'],
+    ['empty label', 'example..com'],
+    ['leading dot', '.example.com'],
+    ['trailing dot', 'example.com.'],
+    ['leading hyphen in label', '-foo.example.com'],
+    ['ip address', '192.168.1.1'],
+  ])('rejects a value with %s', async (_desc, value) => {
+    const g = await loadAndResolve(outdent`
+      # @type=domain
+      MY_DOMAIN=${value}
+    `);
+    expect(g.configSchema.MY_DOMAIN.isValid).toBe(false);
+  });
+
+  describe('allowWildcard', () => {
+    it('rejects wildcard domains by default', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain
+        MY_DOMAIN=*.example.com
+      `);
+      expect(g.configSchema.MY_DOMAIN.isValid).toBe(false);
+    });
+
+    it('accepts wildcard domains when enabled', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain(allowWildcard=true)
+        MY_DOMAIN=*.example.com
+      `);
+      expect(g.configSchema.MY_DOMAIN.isValid).toBe(true);
+    });
+
+    it('rejects a bare wildcard even when enabled', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain(allowWildcard=true)
+        MY_DOMAIN=*.
+      `);
+      expect(g.configSchema.MY_DOMAIN.isValid).toBe(false);
+    });
+  });
+
+  describe('allowSingleLabel', () => {
+    it('rejects single-label hostnames by default', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain
+        MY_DOMAIN=localhost
+      `);
+      expect(g.configSchema.MY_DOMAIN.isValid).toBe(false);
+    });
+
+    it('accepts single-label hostnames when enabled', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain(allowSingleLabel=true)
+        MY_DOMAIN=localhost
+      `);
+      expect(g.configSchema.MY_DOMAIN.isValid).toBe(true);
+    });
+  });
+
+  describe('normalize', () => {
+    it('lowercases the value when enabled', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain(normalize=true)
+        MY_DOMAIN=App.Example.COM
+      `);
+      expect(g.configSchema.MY_DOMAIN.isValid).toBe(true);
+      expect(g.configSchema.MY_DOMAIN.resolvedValue).toBe('app.example.com');
+    });
+
+    it('accepts mixed case without normalize (domains are case-insensitive)', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain
+        MY_DOMAIN=App.Example.COM
+      `);
+      expect(g.configSchema.MY_DOMAIN.isValid).toBe(true);
+      expect(g.configSchema.MY_DOMAIN.resolvedValue).toBe('App.Example.COM');
+    });
+  });
+
+  describe('matches', () => {
+    it('accepts a domain matching the pattern', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain(matches=/\\.example\\.com$/)
+        MY_DOMAIN=api.example.com
+      `);
+      expect(g.configSchema.MY_DOMAIN.isValid).toBe(true);
+    });
+
+    it('rejects a domain not matching the pattern', async () => {
+      const g = await loadAndResolve(outdent`
+        # @type=domain(matches=/\\.example\\.com$/)
+        MY_DOMAIN=api.other.com
+      `);
+      expect(g.configSchema.MY_DOMAIN.isValid).toBe(false);
+    });
+  });
+});
+
 describe('string data type - matches option', () => {
   it('accepts string matching regex literal', async () => {
     const g = await loadAndResolve(outdent`

--- a/packages/varlock/src/env-graph/test/data-types.test.ts
+++ b/packages/varlock/src/env-graph/test/data-types.test.ts
@@ -243,6 +243,20 @@ describe('domain data type', () => {
       expect(g.configSchema.MY_DOMAIN.isValid).toBe(true);
     });
 
+    it('counts the wildcard label toward the 253-char total length limit', async () => {
+      // suffix is exactly 253 chars (valid alone), so the wildcard form is 255 and must fail
+      const suffix = ['a'.repeat(63), 'b'.repeat(63), 'c'.repeat(63), 'd'.repeat(61)].join('.');
+      expect(suffix.length).toBe(253);
+      const g = await loadAndResolve(outdent`
+        # @type=domain(allowWildcard=true)
+        OK_DOMAIN=${suffix}
+        # @type=domain(allowWildcard=true)
+        TOO_LONG_DOMAIN=*.${suffix}
+      `);
+      expect(g.configSchema.OK_DOMAIN.isValid).toBe(true);
+      expect(g.configSchema.TOO_LONG_DOMAIN.isValid).toBe(false);
+    });
+
     it('rejects a bare wildcard even when enabled', async () => {
       const g = await loadAndResolve(outdent`
         # @type=domain(allowWildcard=true)

--- a/packages/vscode-plugin/src/diagnostics-core.ts
+++ b/packages/vscode-plugin/src/diagnostics-core.ts
@@ -386,6 +386,49 @@ function validateUrlValue(value: string, options: TypeInfo['options']) {
   return undefined;
 }
 
+const DOMAIN_LABEL_REGEX = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i;
+
+function validateDomainValue(value: string, options: TypeInfo['options']) {
+  if (value.includes('://') || value.includes('/')) {
+    return 'Domain must not include a protocol or path (use @type=url for full URLs).';
+  }
+  if (value.includes(':')) return 'Domain must not include a port.';
+  if (value.includes('@')) return 'Domain must not include an @ sign.';
+
+  let domain = value;
+  if (domain.startsWith('*.')) {
+    if (!parseBooleanOption(options.allowWildcard)) {
+      return 'Wildcard domains are not allowed unless allowWildcard=true.';
+    }
+    domain = domain.slice(2);
+  }
+
+  if (domain.length === 0 || domain.length > 253) return 'Value must be a valid domain name.';
+  const labels = domain.split('.');
+  if (labels.some((label) => !DOMAIN_LABEL_REGEX.test(label))) {
+    return 'Value must be a valid domain name.';
+  }
+  if (/^\d+$/.test(labels[labels.length - 1])) {
+    return 'Value must be a domain name, not an IP address.';
+  }
+  if (labels.length < 2 && !parseBooleanOption(options.allowSingleLabel)) {
+    return 'Domain must include at least two labels unless allowSingleLabel=true.';
+  }
+
+  if (typeof options.matches === 'string' && options.matches.length > 0) {
+    const pattern = extractRegexPattern(options.matches);
+    if (!pattern || pattern.length > MAX_MATCHES_PATTERN_LENGTH) return undefined;
+    try {
+      const regex = new RegExp(pattern);
+      if (!regex.test(value)) return `Domain must match \`${options.matches}\`.`;
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}
+
 export function validateStaticValue(typeInfo: TypeInfo, value: string) {
   switch (typeInfo.name) {
     case 'string':
@@ -402,6 +445,8 @@ export function validateStaticValue(typeInfo: TypeInfo, value: string) {
         : 'Value must be a valid email address.';
     case 'url':
       return validateUrlValue(value, typeInfo.options);
+    case 'domain':
+      return validateDomainValue(value, typeInfo.options);
     case 'ip': {
       const version = Number(typeInfo.options.version);
       const detectedVersion = isIP(value);

--- a/packages/vscode-plugin/src/diagnostics-core.ts
+++ b/packages/vscode-plugin/src/diagnostics-core.ts
@@ -11,15 +11,15 @@ const INCOMPATIBLE_DECORATOR_PAIRS = [
 ] as const;
 
 /** Extract a regex pattern string from a plain pattern, `regex("pattern")` wrapper, or `/pattern/flags` literal. */
-function extractRegexPattern(value: unknown): string | undefined {
+function extractRegexPattern(value: unknown): { pattern: string, flags: string } | undefined {
   if (typeof value !== 'string') return undefined;
   // regex literal syntax: /pattern/flags
   const regexLiteral = value.match(/^\/(.*)\/([gimsuy]*)$/s);
-  if (regexLiteral) return regexLiteral[1].replaceAll('\\/', '/');
+  if (regexLiteral) return { pattern: regexLiteral[1].replaceAll('\\/', '/'), flags: regexLiteral[2] };
   // legacy regex() wrapper: regex("pattern")
   const wrapped = value.match(/^regex\("(.*)"\)$/s);
-  if (wrapped) return wrapped[1];
-  return value;
+  if (wrapped) return { pattern: wrapped[1], flags: '' };
+  return { pattern: value, flags: '' };
 }
 
 export type TypeInfo = {
@@ -299,11 +299,11 @@ function validateStringValue(value: string, options: TypeInfo['options']) {
   }
 
   if (typeof options.matches === 'string') {
-    const pattern = extractRegexPattern(options.matches);
-    if (!pattern || pattern.length > MAX_MATCHES_PATTERN_LENGTH) return undefined;
+    const extracted = extractRegexPattern(options.matches);
+    if (!extracted?.pattern || extracted.pattern.length > MAX_MATCHES_PATTERN_LENGTH) return undefined;
 
     try {
-      const regex = new RegExp(pattern);
+      const regex = new RegExp(extracted.pattern, extracted.flags);
       if (!regex.test(value)) return `Value must match \`${options.matches}\`.`;
     } catch {
       return undefined;
@@ -373,10 +373,10 @@ function validateUrlValue(value: string, options: TypeInfo['options']) {
   }
 
   if (typeof options.matches === 'string' && options.matches.length > 0) {
-    const pattern = extractRegexPattern(options.matches);
-    if (!pattern || pattern.length > MAX_MATCHES_PATTERN_LENGTH) return undefined;
+    const extracted = extractRegexPattern(options.matches);
+    if (!extracted?.pattern || extracted.pattern.length > MAX_MATCHES_PATTERN_LENGTH) return undefined;
     try {
-      const regex = new RegExp(pattern);
+      const regex = new RegExp(extracted.pattern, extracted.flags);
       if (!regex.test(value)) return `URL must match \`${options.matches}\`.`;
     } catch {
       return undefined;
@@ -388,7 +388,9 @@ function validateUrlValue(value: string, options: TypeInfo['options']) {
 
 const DOMAIN_LABEL_REGEX = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i;
 
-function validateDomainValue(value: string, options: TypeInfo['options']) {
+function validateDomainValue(rawValue: string, options: TypeInfo['options']) {
+  // mirror runtime coercion, which lowercases before validation when normalize=true
+  const value = parseBooleanOption(options.normalize) ? rawValue.toLowerCase() : rawValue;
   if (value.includes('://') || value.includes('/')) {
     return 'Domain must not include a protocol or path (use @type=url for full URLs).';
   }
@@ -405,7 +407,8 @@ function validateDomainValue(value: string, options: TypeInfo['options']) {
       domain = domain.slice(2);
     }
 
-    if (domain.length === 0 || domain.length > 253) return 'Value must be a valid domain name.';
+    // the 253-char total limit (RFC 1035) counts the wildcard label too, so check `value`
+    if (domain.length === 0 || value.length > 253) return 'Value must be a valid domain name.';
     const labels = domain.split('.');
     if (labels.some((label) => !DOMAIN_LABEL_REGEX.test(label))) {
       return 'Value must be a valid domain name.';
@@ -421,10 +424,10 @@ function validateDomainValue(value: string, options: TypeInfo['options']) {
   }
 
   if (typeof options.matches === 'string' && options.matches.length > 0) {
-    const pattern = extractRegexPattern(options.matches);
-    if (!pattern || pattern.length > MAX_MATCHES_PATTERN_LENGTH) return undefined;
+    const extracted = extractRegexPattern(options.matches);
+    if (!extracted?.pattern || extracted.pattern.length > MAX_MATCHES_PATTERN_LENGTH) return undefined;
     try {
-      const regex = new RegExp(pattern);
+      const regex = new RegExp(extracted.pattern, extracted.flags);
       if (!regex.test(value)) return `Domain must match \`${options.matches}\`.`;
     } catch {
       return undefined;

--- a/packages/vscode-plugin/src/diagnostics-core.ts
+++ b/packages/vscode-plugin/src/diagnostics-core.ts
@@ -395,24 +395,29 @@ function validateDomainValue(value: string, options: TypeInfo['options']) {
   if (value.includes(':')) return 'Domain must not include a port.';
   if (value.includes('@')) return 'Domain must not include an @ sign.';
 
-  let domain = value;
-  if (domain.startsWith('*.')) {
-    if (!parseBooleanOption(options.allowWildcard)) {
-      return 'Wildcard domains are not allowed unless allowWildcard=true.';
+  // a valid IPv4 address skips the domain structure checks (matches still applies below)
+  if (!(parseBooleanOption(options.allowIp) && isIP(value) === 4)) {
+    let domain = value;
+    if (domain.startsWith('*.')) {
+      if (!parseBooleanOption(options.allowWildcard)) {
+        return 'Wildcard domains are not allowed unless allowWildcard=true.';
+      }
+      domain = domain.slice(2);
     }
-    domain = domain.slice(2);
-  }
 
-  if (domain.length === 0 || domain.length > 253) return 'Value must be a valid domain name.';
-  const labels = domain.split('.');
-  if (labels.some((label) => !DOMAIN_LABEL_REGEX.test(label))) {
-    return 'Value must be a valid domain name.';
-  }
-  if (/^\d+$/.test(labels[labels.length - 1])) {
-    return 'Value must be a domain name, not an IP address.';
-  }
-  if (labels.length < 2 && !parseBooleanOption(options.allowSingleLabel)) {
-    return 'Domain must include at least two labels unless allowSingleLabel=true.';
+    if (domain.length === 0 || domain.length > 253) return 'Value must be a valid domain name.';
+    const labels = domain.split('.');
+    if (labels.some((label) => !DOMAIN_LABEL_REGEX.test(label))) {
+      return 'Value must be a valid domain name.';
+    }
+    if (/^\d+$/.test(labels[labels.length - 1])) {
+      return parseBooleanOption(options.allowIp)
+        ? 'Value must be a valid domain name or IPv4 address.'
+        : 'Value must be a domain name, not an IP address.';
+    }
+    if (labels.length < 2 && !parseBooleanOption(options.allowSingleLabel)) {
+      return 'Domain must include at least two labels unless allowSingleLabel=true.';
+    }
   }
 
   if (typeof options.matches === 'string' && options.matches.length > 0) {

--- a/packages/vscode-plugin/src/intellisense-catalog.ts
+++ b/packages/vscode-plugin/src/intellisense-catalog.ts
@@ -337,6 +337,7 @@ export const DATA_TYPES: Array<DataTypeInfo> = [
     optionSnippets: [
       { name: 'allowWildcard', insertText: `allowWildcard=${booleanChoiceSnippet()}`, documentation: 'Allow a leading wildcard label, e.g. `*.example.com`.' },
       { name: 'allowSingleLabel', insertText: `allowSingleLabel=${booleanChoiceSnippet()}`, documentation: 'Allow single-label hostnames like `localhost`.' },
+      { name: 'allowIp', insertText: `allowIp=${booleanChoiceSnippet()}`, documentation: 'Also accept an IPv4 address (useful for HOST-style vars like `DB_HOST`).' },
       { name: 'normalize', insertText: `normalize=${booleanChoiceSnippet()}`, documentation: 'Lowercase the domain before validation.' },
       { name: 'matches', insertText: 'matches=${1:"pattern"}', documentation: 'A regular expression that the domain must match.' },
     ],

--- a/packages/vscode-plugin/src/intellisense-catalog.ts
+++ b/packages/vscode-plugin/src/intellisense-catalog.ts
@@ -330,6 +330,18 @@ export const DATA_TYPES: Array<DataTypeInfo> = [
     ],
   },
   {
+    name: 'domain',
+    summary: 'Bare domain name (hostname) with no protocol, port, or path.',
+    documentation: 'Example: `@type=domain` or `@type=domain(allowWildcard=true)`.',
+    insertText: 'domain',
+    optionSnippets: [
+      { name: 'allowWildcard', insertText: `allowWildcard=${booleanChoiceSnippet()}`, documentation: 'Allow a leading wildcard label, e.g. `*.example.com`.' },
+      { name: 'allowSingleLabel', insertText: `allowSingleLabel=${booleanChoiceSnippet()}`, documentation: 'Allow single-label hostnames like `localhost`.' },
+      { name: 'normalize', insertText: `normalize=${booleanChoiceSnippet()}`, documentation: 'Lowercase the domain before validation.' },
+      { name: 'matches', insertText: 'matches=${1:"pattern"}', documentation: 'A regular expression that the domain must match.' },
+    ],
+  },
+  {
     name: 'simple-object',
     summary: 'JSON-like object value.',
     documentation: 'Coerces plain objects or JSON strings into objects.',

--- a/packages/vscode-plugin/test/diagnostics-core.test.ts
+++ b/packages/vscode-plugin/test/diagnostics-core.test.ts
@@ -230,6 +230,18 @@ describe('diagnostics-core', () => {
 
     expect(validateStaticValue(domainType({ matches: '\\.example\\.com$' }), 'api.example.com')).toBeUndefined();
     expect(validateStaticValue(domainType({ matches: '\\.example\\.com$' }), 'api.other.com')).toContain('must match');
+
+    // parity with runtime: matches applies to the normalized value, and regex flags are honored
+    expect(validateStaticValue(
+      domainType({ normalize: 'true', matches: '/^api\\.example\\.com$/' }),
+      'API.EXAMPLE.COM',
+    )).toBeUndefined();
+    expect(validateStaticValue(domainType({ matches: '/^api\\./i' }), 'API.example.com')).toBeUndefined();
+
+    // the wildcard label counts toward the 253-char total length limit
+    const suffix253 = ['a'.repeat(63), 'b'.repeat(63), 'c'.repeat(63), 'd'.repeat(61)].join('.');
+    expect(validateStaticValue(domainType({ allowWildcard: 'true' }), suffix253)).toBeUndefined();
+    expect(validateStaticValue(domainType({ allowWildcard: 'true' }), `*.${suffix253}`)).toContain('valid domain');
   });
 
   it('validates matches (regex) url option', () => {

--- a/packages/vscode-plugin/test/diagnostics-core.test.ts
+++ b/packages/vscode-plugin/test/diagnostics-core.test.ts
@@ -203,6 +203,30 @@ describe('diagnostics-core', () => {
     ).toBeUndefined();
   });
 
+  it('validates domain values and options', () => {
+    const domainType = (options: Record<string, string> = {}) => (
+      { name: 'domain', args: [], options } as const
+    );
+
+    expect(validateStaticValue(domainType(), 'example.com')).toBeUndefined();
+    expect(validateStaticValue(domainType(), 'api.internal.example.co.uk')).toBeUndefined();
+
+    expect(validateStaticValue(domainType(), 'https://example.com')).toContain('protocol or path');
+    expect(validateStaticValue(domainType(), 'example.com/foo')).toContain('protocol or path');
+    expect(validateStaticValue(domainType(), 'example.com:8080')).toContain('port');
+    expect(validateStaticValue(domainType(), 'example..com')).toContain('valid domain');
+    expect(validateStaticValue(domainType(), '192.168.1.1')).toContain('IP address');
+
+    expect(validateStaticValue(domainType(), '*.example.com')).toContain('allowWildcard');
+    expect(validateStaticValue(domainType({ allowWildcard: 'true' }), '*.example.com')).toBeUndefined();
+
+    expect(validateStaticValue(domainType(), 'localhost')).toContain('allowSingleLabel');
+    expect(validateStaticValue(domainType({ allowSingleLabel: 'true' }), 'localhost')).toBeUndefined();
+
+    expect(validateStaticValue(domainType({ matches: '\\.example\\.com$' }), 'api.example.com')).toBeUndefined();
+    expect(validateStaticValue(domainType({ matches: '\\.example\\.com$' }), 'api.other.com')).toContain('must match');
+  });
+
   it('validates matches (regex) url option', () => {
     expect(
       validateStaticValue(

--- a/packages/vscode-plugin/test/diagnostics-core.test.ts
+++ b/packages/vscode-plugin/test/diagnostics-core.test.ts
@@ -205,7 +205,7 @@ describe('diagnostics-core', () => {
 
   it('validates domain values and options', () => {
     const domainType = (options: Record<string, string> = {}) => (
-      { name: 'domain', args: [], options } as const
+      { name: 'domain', args: [], options }
     );
 
     expect(validateStaticValue(domainType(), 'example.com')).toBeUndefined();
@@ -222,6 +222,11 @@ describe('diagnostics-core', () => {
 
     expect(validateStaticValue(domainType(), 'localhost')).toContain('allowSingleLabel');
     expect(validateStaticValue(domainType({ allowSingleLabel: 'true' }), 'localhost')).toBeUndefined();
+
+    expect(validateStaticValue(domainType({ allowIp: 'true' }), '192.168.1.1')).toBeUndefined();
+    expect(validateStaticValue(domainType({ allowIp: 'true' }), 'db.example.com')).toBeUndefined();
+    expect(validateStaticValue(domainType({ allowIp: 'true' }), '192.168.1.999')).toContain('IPv4');
+    expect(validateStaticValue(domainType({ allowIp: 'true' }), '192.168.1.1:5432')).toContain('port');
 
     expect(validateStaticValue(domainType({ matches: '\\.example\\.com$' }), 'api.example.com')).toBeUndefined();
     expect(validateStaticValue(domainType({ matches: '\\.example\\.com$' }), 'api.other.com')).toContain('must match');


### PR DESCRIPTION
Adds a new `domain` data type for bare domain names (hostnames) like `example.com`, since this is a common config shape currently only coverable with `url` or `string`.

Validates RFC 1123 hostname structure (label charset/length, 253-char total), and rejects values with a protocol, path, port, or credentials with errors pointing at `@type=url` / `@type=ip` where appropriate. Requires at least two labels by default.

Options:
- `allowWildcard`: permit a leading `*.` label (certs, CORS)
- `allowSingleLabel`: permit `localhost` / internal service names
- `allowIp`: also accept an IPv4 address, for HOST-style vars (`DB_HOST`) that hold a hostname in one env and an IP in another
- `normalize`: lowercase before validation
- `matches`: regex constraint, same syntax as `string`/`url`

Also generates proxy placeholders as `<seed>.invalid` (reserved TLD), and includes VSCode extension support (completions + static value diagnostics), docs, and tests.

Deliberately rejected for now: trailing-dot FQDNs, leading-dot cookie-domain form, IPv6 (incl. bracketed literals), and `host:port` values.