### PR TITLE
docs: document OrcaRouter as a named provider in the Crush guide

### DIFF
--- a/packages/varlock-website/src/content/docs/guides/ai-tools/crush.mdx
+++ b/packages/varlock-website/src/content/docs/guides/ai-tools/crush.mdx
@@ -18,6 +18,41 @@ For install, schema setup, and shared patterns, see the [AI Tools overview](/gui
 
 You can also paste a key in the TUI model picker (`ctrl+l`). Prefer env injection so the key is not typed into the UI or stored in project config.
 
+## OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway that exposes many models behind one endpoint, with adaptive routing, automatic failover, zero-markup inference, observability, and guardrails. It works with Crush as a custom `openai-compat` provider, so Crush's model calls can route through OrcaRouter without treating it as an anonymous custom base URL.
+
+Add the provider to `~/.config/crush/crush.json` and reference an env var for the key:
+
+```json title="~/.config/crush/crush.json"
+{
+  "providers": {
+    "orcarouter": {
+      "type": "openai-compat",
+      "base_url": "https://api.orcarouter.ai/v1",
+      "api_key": "$ORCAROUTER_API_KEY",
+      "models": [
+        {
+          "id": "orcarouter/auto",
+          "name": "OrcaRouter Auto"
+        }
+      ]
+    }
+  }
+}
+```
+
+Then declare the key in your schema and run Crush through varlock:
+
+```env-spec
+# @sensitive
+ORCAROUTER_API_KEY=op(op://api-local/orcarouter/api-key)
+```
+
+```bash
+varlock run -- crush
+```
+
 ## In a project
 
 Add to `.env.schema`:


### PR DESCRIPTION
## What

Adds [OrcaRouter](https://www.orcarouter.ai) as a named provider example in the [Crush guide](https://varlock.dev/guides/ai-tools/crush/).

Varlock's AI Tools docs show how to inject provider API keys into terminal coding agents so secrets never sit in a plain text `.env` or shell history. The Crush page already lists `OPENROUTER_API_KEY` and other provider keys, and shows an `OPENROUTER_API_KEY` entry in the `.env.schema` example. This PR adds the same first-class treatment for OrcaRouter: a short section showing the `openai-compat` provider entry in `crush.json` (mirroring how Crush documents custom OpenAI-compatible providers such as DeepSeek), an `ORCAROUTER_API_KEY` entry in the schema, and the `varlock run -- crush` launch command.

## Why

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding it as a named provider in this guide means Crush users on varlock can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint, screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Verification

- `bun run build:libs` passed (27 packages).
- `bun run astro build` for `@varlock/website` passed, 130 pages built, and the generated `/guides/ai-tools/crush/` page contains the new section.
- The OrcaRouter endpoint (`https://api.orcarouter.ai/v1`) returns 200 with a valid OpenAI-compatible response.

I'm an engineer on the OrcaRouter team.
