### PR TITLE
Fix next.config.ts loading regression (exports is not defined in ES module scope)

### DIFF
--- a/.bumpy/fix-nextjs-config-ts-esm-require.md
+++ b/.bumpy/fix-nextjs-config-ts-esm-require.md
@@ -1,5 +1,6 @@
 ---
 "@varlock/nextjs-integration": patch
+"varlock": minor
 ---
 
-Fix "exports is not defined in ES module scope" when loading next.config.ts. The plugin's CJS build no longer require()s varlock's ESM-only entry points (they are bundled instead), which broke Next's TypeScript config loader.
+Fix "exports is not defined in ES module scope" when using varlockNextConfigPlugin in a next.config.ts file. varlock now ships CJS builds of its runtime entry points (varlock/env, varlock/patch-console, varlock/patch-server-response, varlock/encrypt-env, varlock/exec-sync-varlock) via the `require` condition, so requiring them from CommonJS works through Next's TypeScript config loader and on Node versions without require(esm) support (below 22.12).

--- a/.bumpy/fix-nextjs-config-ts-esm-require.md
+++ b/.bumpy/fix-nextjs-config-ts-esm-require.md
@@ -1,0 +1,5 @@
+---
+"@varlock/nextjs-integration": patch
+---
+
+Fix "exports is not defined in ES module scope" when loading next.config.ts. The plugin's CJS build no longer require()s varlock's ESM-only entry points (they are bundled instead), which broke Next's TypeScript config loader.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,12 @@ This is a monorepo managed with bun workspaces and Turborepo:
 - Use catalog for any potentially common dependencies
 - CI workflows use `bun run` to execute scripts and `bunx` for one-off commands
 
+## Building
+
+- `bun run build` at the repo root builds all packages via Turborepo, in dependency order
+- To build a single package, go through turbo so its workspace deps build first: `bunx turbo run build` from the package directory, or `bunx turbo run build --filter=<pkg>` from the root
+- Do **not** build a package with `bun run --filter <pkg> build`: bun's filter does not build the package's workspace dependencies, and some builds require their dist output to exist (e.g. varlock's d.ts bundling inlines the emitted declarations from `packages/utils`, so it fails if that package was never built)
+
 ## Scripts
 
 - Write any scripts which may end up being saved in **TypeScript** (`.ts`), not JavaScript

--- a/framework-tests/frameworks/nextjs/files/configs/next.config.ts
+++ b/framework-tests/frameworks/nextjs/files/configs/next.config.ts
@@ -1,0 +1,11 @@
+import type { NextConfig } from 'next';
+import { varlockNextConfigPlugin } from '@varlock/nextjs-integration/plugin';
+
+const withVarlock = varlockNextConfigPlugin();
+
+const nextConfig: NextConfig = {
+  productionBrowserSourceMaps: true,
+  typescript: { ignoreBuildErrors: true },
+};
+
+export default withVarlock(nextConfig);

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -104,6 +104,39 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
       });
     });
 
+    // next.config.ts (supported since Next 15) loads through Next's own TS
+    // transpile + require-hook path, which is a different code path than
+    // next.config.mjs. That hook re-transpiles required .mjs files to CJS but
+    // Node still evaluates them as ESM, so the plugin's CJS output must never
+    // require() varlock's ESM-only entry points ("exports is not defined in ES
+    // module scope" regression).
+    nextEnv.describeDevScenario('dev: next.config.ts config loading', {
+      skip: nextVersion < 15,
+      command: `next dev ${getBuildToolFlag(nextVersion, 'turbopack')} --port ${13800 + nextVersion}`,
+      readyPattern: /Ready in|Starting\.\.\./,
+      readyTimeout: 40_000,
+      templateFiles: {
+        'app/page.tsx': 'pages/basic-page.tsx',
+        'next.config.ts': 'configs/next.config.ts',
+      },
+      deleteFiles: ['next.config.mjs'],
+      requests: [
+        {
+          label: 'page load serves env values',
+          path: '/',
+          bodyAssertions: {
+            shouldContain: ['Varlock Framework Test - Next.js', 'env-specific-var--dev'],
+          },
+        },
+      ],
+      outputAssertions: [
+        {
+          description: 'config loads without error',
+          shouldNotContain: ['Failed to load next.config.ts', 'exports is not defined'],
+        },
+      ],
+    });
+
     BUNDLERS.forEach((webpackOrTurbo) => {
       const buildToolFlag = getBuildToolFlag(nextVersion, webpackOrTurbo);
 

--- a/framework-tests/harness/test-fixture.ts
+++ b/framework-tests/harness/test-fixture.ts
@@ -229,7 +229,7 @@ export class FrameworkTestEnv {
    * isolated — e.g. a config override or extra route from one scenario
    * doesn't silently carry over into the next.
    */
-  private applyFiles(scenario: Pick<TestScenario, 'templateFiles' | 'files'>): void {
+  private applyFiles(scenario: Pick<TestScenario, 'templateFiles' | 'files' | 'deleteFiles'>): void {
     for (const dest of this.prevScenarioFiles) {
       const basePath = join(this.filesDir, '_base', dest);
       const destPath = join(this.dir, dest);
@@ -272,6 +272,16 @@ export class FrameworkTestEnv {
           content = `${content}\n${srcRef.append}`;
         }
         writeFileSync(destPath, content);
+      }
+    }
+
+    // Delete skeleton files this scenario doesn't want (e.g. _base/next.config.mjs
+    // when testing next.config.ts, which Next would otherwise ignore). Tracking them
+    // in prevScenarioFiles restores the _base version before the next scenario.
+    if (scenario.deleteFiles) {
+      for (const dest of scenario.deleteFiles) {
+        this.prevScenarioFiles.add(dest);
+        rmSync(join(this.dir, dest), { force: true });
       }
     }
 

--- a/framework-tests/harness/types.ts
+++ b/framework-tests/harness/types.ts
@@ -86,6 +86,8 @@ export interface TestScenario {
   templateFiles?: TemplateFileMap;
   /** Inline files to write (written after templateFiles, can override) */
   files?: Array<ProjectFile>;
+  /** Skeleton files to delete for this scenario (restored from _base before the next one) */
+  deleteFiles?: Array<string>;
   /** Extra env vars for the build command */
   env?: Record<string, string>;
   /** Command to run (auto-prefixed with `{pm} exec`, e.g. 'next build' → 'pnpm exec next build') */
@@ -181,6 +183,8 @@ export interface DevServerScenario {
   templateFiles?: TemplateFileMap;
   /** Inline files to write */
   files?: Array<ProjectFile>;
+  /** Skeleton files to delete for this scenario (restored from _base before the next one) */
+  deleteFiles?: Array<string>;
   /** Extra env vars for the dev server process */
   env?: Record<string, string>;
   /** Command to run (auto-prefixed with `{pm} exec`) */

--- a/packages/integrations/nextjs/src/next-env-compat.ts
+++ b/packages/integrations/nextjs/src/next-env-compat.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import { createHash } from 'crypto';
-import { type SerializedEnvGraph } from 'varlock';
+import type { SerializedEnvGraph } from 'varlock';
 import { initVarlockEnv, resetRedactionMap } from 'varlock/env';
 import { patchGlobalConsole } from 'varlock/patch-console';
 import { execSyncVarlock, VarlockExecError } from 'varlock/exec-sync-varlock';

--- a/packages/integrations/nextjs/src/plugin.ts
+++ b/packages/integrations/nextjs/src/plugin.ts
@@ -10,7 +10,7 @@ import {
 import { patchGlobalConsole } from 'varlock/patch-console';
 import { patchGlobalServerResponse } from 'varlock/patch-server-response';
 
-import { type SerializedEnvGraph } from 'varlock';
+import type { SerializedEnvGraph } from 'varlock';
 import { createWebpackConfigFn } from './webpack-plugin';
 import { injectVarlockInitIntoTurbopackRuntime, isInjectedTurbopackRuntime } from './turbopack-runtime-inject';
 

--- a/packages/integrations/nextjs/src/webpack-plugin.ts
+++ b/packages/integrations/nextjs/src/webpack-plugin.ts
@@ -5,7 +5,7 @@ import {
 } from 'varlock/env';
 import { patchGlobalServerResponse } from 'varlock/patch-server-response';
 
-import { type SerializedEnvGraph } from 'varlock';
+import type { SerializedEnvGraph } from 'varlock';
 import { encryptEnvBlobSync } from 'varlock/encrypt-env';
 import type { NextConfig } from 'next';
 

--- a/packages/integrations/nextjs/tsdown.config.mts
+++ b/packages/integrations/nextjs/tsdown.config.mts
@@ -34,12 +34,19 @@ export default defineConfig([
     define: integrationIdentity,
   },
   // Other entry points only run at build time where varlock is always available.
+  // varlock is still bundled here because varlock's runtime entry points are ESM-only:
+  // a require() of them from this CJS output breaks Node <22.12 (no require(esm)) and
+  // breaks Next's next.config.ts loader, whose require hook re-transpiles required .mjs
+  // files to CJS but Node still evaluates them as ESM ("exports is not defined in ES
+  // module scope").
   {
     entry: [
       'src/plugin.ts',
       'src/loader.ts',
       'src/dynamic-access.ts',
     ],
+
+    noExternal: [/^varlock/],
 
     dts: true,
     sourcemap: true,

--- a/packages/integrations/nextjs/tsdown.config.mts
+++ b/packages/integrations/nextjs/tsdown.config.mts
@@ -34,19 +34,17 @@ export default defineConfig([
     define: integrationIdentity,
   },
   // Other entry points only run at build time where varlock is always available.
-  // varlock is still bundled here because varlock's runtime entry points are ESM-only:
-  // a require() of them from this CJS output breaks Node <22.12 (no require(esm)) and
-  // breaks Next's next.config.ts loader, whose require hook re-transpiles required .mjs
-  // files to CJS but Node still evaluates them as ESM ("exports is not defined in ES
-  // module scope").
+  // These require() varlock's runtime entry points, which is why varlock ships real CJS
+  // builds of them (`require` condition): require() of an .mjs file breaks Node <22.12
+  // (no require(esm)) and breaks Next's next.config.ts loader, whose require hook
+  // re-transpiles required .mjs files to CJS but Node still evaluates them as ESM
+  // ("exports is not defined in ES module scope").
   {
     entry: [
       'src/plugin.ts',
       'src/loader.ts',
       'src/dynamic-access.ts',
     ],
-
-    noExternal: [/^varlock/],
 
     dts: true,
     sourcemap: true,

--- a/packages/varlock/package.json
+++ b/packages/varlock/package.json
@@ -80,8 +80,14 @@
     },
     "./env": {
       "ts-src": "./src/runtime/env.ts",
-      "types": "./dist/runtime/env.d.mts",
-      "import": "./dist/runtime/env.mjs",
+      "import": {
+        "types": "./dist/runtime/env.d.mts",
+        "default": "./dist/runtime/env.mjs"
+      },
+      "require": {
+        "types": "./dist/runtime/env.d.cts",
+        "default": "./dist/runtime/env.cjs"
+      },
       "default": "./dist/runtime/env.mjs"
     },
     "./auto-load": {
@@ -92,8 +98,14 @@
     },
     "./patch-console": {
       "ts-src": "./src/runtime/patch-console.ts",
-      "types": "./dist/runtime/patch-console.d.mts",
-      "import": "./dist/runtime/patch-console.mjs",
+      "import": {
+        "types": "./dist/runtime/patch-console.d.mts",
+        "default": "./dist/runtime/patch-console.mjs"
+      },
+      "require": {
+        "types": "./dist/runtime/patch-console.d.cts",
+        "default": "./dist/runtime/patch-console.cjs"
+      },
       "default": "./dist/runtime/patch-console.mjs"
     },
     "./patch-response": {
@@ -104,8 +116,14 @@
     },
     "./patch-server-response": {
       "ts-src": "./src/runtime/patch-server-response.ts",
-      "types": "./dist/runtime/patch-server-response.d.mts",
-      "import": "./dist/runtime/patch-server-response.mjs",
+      "import": {
+        "types": "./dist/runtime/patch-server-response.d.mts",
+        "default": "./dist/runtime/patch-server-response.mjs"
+      },
+      "require": {
+        "types": "./dist/runtime/patch-server-response.d.cts",
+        "default": "./dist/runtime/patch-server-response.cjs"
+      },
       "default": "./dist/runtime/patch-server-response.mjs"
     },
     "./init-server": {
@@ -122,14 +140,26 @@
     },
     "./encrypt-env": {
       "ts-src": "./src/runtime/crypto.ts",
-      "types": "./dist/runtime/crypto.d.mts",
-      "import": "./dist/runtime/crypto.mjs",
+      "import": {
+        "types": "./dist/runtime/crypto.d.mts",
+        "default": "./dist/runtime/crypto.mjs"
+      },
+      "require": {
+        "types": "./dist/runtime/crypto.d.cts",
+        "default": "./dist/runtime/crypto.cjs"
+      },
       "default": "./dist/runtime/crypto.mjs"
     },
     "./exec-sync-varlock": {
       "ts-src": "./src/lib/exec-sync-varlock.ts",
-      "types": "./dist/lib/exec-sync-varlock.d.mts",
-      "import": "./dist/lib/exec-sync-varlock.mjs",
+      "import": {
+        "types": "./dist/lib/exec-sync-varlock.d.mts",
+        "default": "./dist/lib/exec-sync-varlock.mjs"
+      },
+      "require": {
+        "types": "./dist/lib/exec-sync-varlock.d.cts",
+        "default": "./dist/lib/exec-sync-varlock.cjs"
+      },
       "default": "./dist/lib/exec-sync-varlock.mjs"
     },
     "./config": {

--- a/packages/varlock/tsdown.config.ts
+++ b/packages/varlock/tsdown.config.ts
@@ -53,8 +53,10 @@ export default defineConfig([
     publint: true, // validate the published package shape
     attw: {
       level: 'error',
-      // varlock is esm-only: the node10 algorithm and `require()` from a cjs consumer
-      // are both out of scope (engines.node is >=22.3, and require(esm) covers the rest)
+      // varlock is esm-first: the node10 algorithm and `require()` of the esm-only
+      // entrypoints are out of scope (engines.node is >=22.3, and require(esm) covers
+      // the rest). The runtime entrypoints additionally ship real CJS builds (see the
+      // cjs config below) for consumers that must require() them.
       profile: 'esm-only',
       // internal test harness, deliberately only reachable via the `ts-src` condition
       excludeEntrypoints: ['./test-helpers'],
@@ -95,6 +97,39 @@ export default defineConfig([
     onSuccess: process.env.BUILD_TYPE === 'release'
       ? 'bun run scripts/strip-vendor-sourcemap-content.ts'
       : undefined,
+  },
+  // CJS builds of the runtime entry points that integrations require() from CJS output
+  // (nextjs plugin, expo metro/babel). require(esm) is flagged on Node 22.0-22.11, and
+  // Next's next.config.ts require hook cannot load .mjs files at all (it re-transpiles
+  // them to CJS but Node still evaluates .mjs as ESM). These modules already coordinate
+  // state across multiple instances via globalThis, so a CJS copy alongside the ESM one
+  // is safe. Exposed via the `require` condition in package.json exports.
+  {
+    entry: [
+      'src/runtime/env.ts',
+      'src/runtime/patch-server-response.ts',
+      'src/runtime/patch-console.ts',
+      'src/runtime/crypto.ts',
+      'src/lib/exec-sync-varlock.ts',
+    ],
+
+    noExternal: ['@env-spec/utils'],
+
+    dts: true,
+    sourcemap: true,
+    treeshake: true,
+
+    clean: false, // main build already cleaned
+    outDir: 'dist',
+
+    format: ['cjs'],
+    platform: 'node',
+    target: 'node22',
+
+    define: {
+      __VARLOCK_SEA_BUILD__: 'false',
+      __VARLOCK_BUILD_TYPE__: JSON.stringify(process.env.BUILD_TYPE || 'dev'),
+    },
   },
   initBundle('init-server'),
   initBundle('init-edge'),


### PR DESCRIPTION
Fixes a regression from the tsdown migration (#1021): using `varlockNextConfigPlugin` in a `next.config.ts` file fails with

```
Failed to load next.config.ts
ReferenceError: exports is not defined in ES module scope
```

## Root cause

Next's `next.config.ts` loader transpiles the config and everything it requires through a `require.extensions` hook that converts ESM to CJS via SWC, then calls `mod._compile`. For `.mjs` files, Node's `Module._compile` routes to `loadESMFromCJS`, so the SWC-produced CJS code gets evaluated as ESM and the injected `exports` references blow up.

Pre-tsdown this never triggered because varlock's dist was extensionless `.js`. Post-tsdown, `plugin.cjs` does `require('varlock/env')` etc., and those entry points became ESM-only `.mjs` files. The trigger is varlock 1.17.1, independent of the integration version (verified all 4 published combos). The same requires also break outright on Node 22.0-22.11, where `require(esm)` is behind a flag. `createRequire` in the user's config does not work around it: the extension hooks are process-global.

## Fix

- varlock now ships real CJS builds of its runtime entry points (`env`, `patch-console`, `patch-server-response`, `encrypt-env`, `exec-sync-varlock`), exposed via the `require` condition. Requiring them from CJS stays CJS end to end, which is safe through Next's hook and on Node without `require(esm)`. This also covers the expo integration's CJS outputs, which had the same latent exposure. Multiple instances coexisting with the ESM builds is already handled: env and redaction state live on `globalThis` by design, and the patches guard via markers on the patched globals.
- The nextjs plugin keeps requiring the installed varlock (no bundling), so its runtime glue can never version-skew against the CLI. `next-env-compat` stays bundled (required for Vercel serverless tracing, #584) but only carries runtime glue; env loading always execs the installed CLI.
- Convert `import { type SerializedEnvGraph } from 'varlock'` to `import type`. The old form left a side-effect `require("varlock")` in the output that pulled the entire varlock index at runtime, and was inlining ~475KB of never-executed loader machinery into `next-env-compat.cjs` (516KB -> 41KB).

## Tests

New framework-test dev scenario loads the app through a real `next.config.ts` (runs on Next 15, 16, and canary), with new `deleteFiles` harness support to drop the skeleton `next.config.mjs` that would otherwise shadow it. Verified the scenario fails against the pre-fix build and passes with the fix. Full Next 16 suite (both bundlers), expo suite, and varlock unit tests all pass.

Also documents in AGENTS.md that single-package builds must go through turbo (`bunx turbo run build` from the package dir), since `bun run --filter <pkg> build` skips workspace dependency builds. That gap is what led the automated review to a false build-failure finding.