### PR TITLE
Stop deleting runtime env vars when booting from a build-baked snapshot

### DIFF
--- a/.bumpy/fix-baked-env-delete-runtime-vars.md
+++ b/.bumpy/fix-baked-env-delete-runtime-vars.md
@@ -1,0 +1,7 @@
+---
+varlock: patch
+"@varlock/nextjs-integration": patch
+"@varlock/vite-integration": patch
+---
+
+Fixes runtime-provided env vars being deleted from `process.env` when a server boots from the env snapshot baked into the build output (e.g. a Next.js standalone container where the varlock CLI is unavailable). Introduced in 1.17.1, this could take down a service that passes config at boot with `docker run -e ...`.

--- a/framework-tests/frameworks/nextjs/files/pages/runtime-boot-page.tsx
+++ b/framework-tests/frameworks/nextjs/files/pages/runtime-boot-page.tsx
@@ -1,0 +1,14 @@
+import { ENV } from 'varlock/env';
+
+// force runtime rendering so the page reflects boot-time env values
+export const dynamic = 'force-dynamic';
+
+export default function RuntimeBootPage() {
+  return (
+    <main>
+      <h1>Varlock Framework Test - runtime boot</h1>
+      <p>{`runtime var via ENV: ${ENV.RUNTIME_BOOT_VAR}`}</p>
+      <p>{`runtime var via process.env: ${process.env.RUNTIME_BOOT_VAR}`}</p>
+    </main>
+  );
+}

--- a/framework-tests/frameworks/nextjs/nextjs-shared.ts
+++ b/framework-tests/frameworks/nextjs/nextjs-shared.ts
@@ -605,6 +605,71 @@ export function defineNextjsTests(versionOrCanary: number | 'canary', testDir: s
             ],
           });
         });
+
+        describe.skipIf(!runBuildScenarios)('output=standalone', () => {
+          // Regression test for the reported incident: a standalone server booted in a
+          // container with no reachable varlock CLI falls back to the env blob baked into
+          // the bundled runtime at build time. Items that resolved to undefined at build
+          // used to have their runtime-provided values DELETED from process.env, taking
+          // the service down (`docker run -e REDIS_URL=...`).
+          //
+          // The standalone output is copied outside the project tree (so varlock cannot be
+          // found by walking up to the fixture node_modules) and booted with a stripped
+          // environment, mimicking a real container image.
+          const standalonePort = 15000 + (nextVersion * 10) + (webpackOrTurbo === 'turbopack' ? 5 : 0);
+          const standaloneCopyDir = `/tmp/varlock-next-standalone-${label}-${webpackOrTurbo}`;
+          const standaloneBootCommand = [
+            `next build ${buildToolFlag}`.replace(/\s+/g, ' ').trim(),
+            `rm -rf ${standaloneCopyDir}`,
+            `cp -R .next/standalone ${standaloneCopyDir}`,
+            // remove all package-manager bin dirs so the varlock CLI is unreachable
+            `find ${standaloneCopyDir} -type d -name .bin -prune -exec rm -rf {} +`,
+            // server.js is nested at the traced workspace root, which varies by next
+            // version (it walks up to whatever lockfiles it finds above the project)
+            `cd "$(dirname "$(find ${standaloneCopyDir} -name server.js -not -path "*/node_modules/*" | head -1)")"`,
+            'NODE_BIN="$(command -v node)"',
+            [
+              'env -i PATH=/usr/bin:/bin NODE_ENV=production',
+              `HOSTNAME=127.0.0.1 PORT=${standalonePort}`,
+              'RUNTIME_BOOT_VAR=runtime-boot-value',
+              '"$NODE_BIN" server.js',
+            ].join(' '),
+          ].join(' && ');
+
+          nextEnv.describeDevScenario('standalone boot does not delete runtime-provided env vars', {
+            command: `sh -c '${standaloneBootCommand}'`,
+            env: { NODE_ENV: 'production' },
+            readyPattern: /Ready in|Starting\.\.\./,
+            readyTimeout: 240_000,
+            timeout: 300_000,
+            templateFiles: {
+              '.env.schema': {
+                path: 'schemas/.env.schema',
+                append: '\n# provided at boot time only (e.g. `docker run -e ...`)\nRUNTIME_BOOT_VAR= # @dynamic\n',
+              },
+              'next.config.mjs': {
+                path: '_base/next.config.mjs',
+                replacements: { '// OUTPUT-MODE': "output: 'standalone'," },
+              },
+              'app/page.tsx': 'pages/runtime-boot-page.tsx',
+            },
+            requests: [
+              {
+                label: 'boot-provided value survives in process.env',
+                path: '/',
+                bodyAssertions: {
+                  shouldContain: [
+                    'Varlock Framework Test - runtime boot',
+                    'runtime var via process.env: runtime-boot-value',
+                    // the baked snapshot stays authoritative for ENV: it resolved this
+                    // item to undefined at build time and cannot validate a runtime value
+                    'runtime var via ENV: undefined',
+                  ],
+                },
+              },
+            ],
+          });
+        });
       });
     });
   });

--- a/packages/integrations/nextjs/src/turbopack-runtime-inject.ts
+++ b/packages/integrations/nextjs/src/turbopack-runtime-inject.ts
@@ -39,9 +39,19 @@ export function injectVarlockInitIntoTurbopackRuntime(nextDirPath: string) {
       + 'See https://varlock.dev/guides/encrypted-deployments/ for details.',
     );
   }
+  // The baked env is a build-time fallback. Flag the payload as build-resolved so
+  // `initVarlockEnv` skips its stale-echo cleanup and never deletes runtime-provided
+  // vars. The flag lives INSIDE the payload so it travels with the blob (child
+  // processes, encryption round-trips) and can never outlive it.
   let envPayload = rawEnv;
+  try {
+    envPayload = JSON.stringify({ ...JSON.parse(envPayload), injectedAtBuild: true });
+  } catch {
+    // not plaintext JSON (e.g. an already-encrypted ambient blob) - bake as-is,
+    // without provenance, so the boot behaves like a plain injected blob
+  }
   if (encryptionKey) {
-    envPayload = encryptEnvBlobSync(rawEnv, encryptionKey);
+    envPayload = encryptEnvBlobSync(envPayload, encryptionKey);
   }
 
   // Find turbopack runtime files ([turbopack]_runtime.js) and edge-wrapper files.

--- a/packages/integrations/nextjs/src/webpack-plugin.ts
+++ b/packages/integrations/nextjs/src/webpack-plugin.ts
@@ -205,9 +205,21 @@ export function createWebpackConfigFn(
             + 'Consider enabling `@encryptInjectedEnv` — see https://varlock.dev/guides/encrypted-deployments/',
           );
         }
+        // The baked env is a build-time fallback: a blob already present in the actual
+        // runtime env (a fresh boot-time resolution, e.g. `varlock run`) always wins.
+        // Flag the payload as build-resolved so `initVarlockEnv` skips its stale-echo
+        // cleanup and never deletes runtime-provided vars. The flag lives INSIDE the
+        // payload so it travels with the blob (child processes, encryption round-trips)
+        // and can never outlive it.
         let envPayload = rawEnv;
-        if (rawEnv && encryptionKey) {
-          envPayload = encryptEnvBlobSync(rawEnv, encryptionKey);
+        if (envPayload) {
+          try {
+            envPayload = JSON.stringify({ ...JSON.parse(envPayload), injectedAtBuild: true });
+          } catch {
+            // not plaintext JSON (e.g. an already-encrypted ambient blob) - bake as-is,
+            // without provenance, so the boot behaves like a plain injected blob
+          }
+          if (encryptionKey) envPayload = encryptEnvBlobSync(envPayload, encryptionKey);
         }
         const envInline = envPayload
           ? `process.env.__VARLOCK_ENV = process.env.__VARLOCK_ENV || ${JSON.stringify(envPayload)};`

--- a/packages/integrations/vite/src/index.ts
+++ b/packages/integrations/vite/src/index.ts
@@ -409,12 +409,16 @@ export function buildVarlockSsrInitCode(opts: VarlockSsrInitCodeOptions = {}): s
           );
         }
       }
-      const serialized = JSON.stringify(varlockLoadedEnv);
+      // `injectedAtBuild` marks the payload as resolved at BUILD time, so `initVarlockEnv`
+      // skips its stale-echo cleanup (no resolution happened in the booted process) and
+      // never deletes runtime-provided vars. Living inside the payload, the provenance
+      // survives encryption and never outlives the payload it describes.
+      const serialized = JSON.stringify({ ...varlockLoadedEnv, injectedAtBuild: true });
       if (encryptionKey) {
         const encrypted = encryptEnvBlobSync(serialized, encryptionKey);
         lines.push(`globalThis.__varlockEncryptedEnv = ${JSON.stringify(encrypted)};`);
       } else {
-        lines.push(`globalThis.__varlockLoadedEnv = ${JSON.stringify(varlockLoadedEnv)};`);
+        lines.push(`globalThis.__varlockLoadedEnv = ${serialized};`);
       }
     }
 

--- a/packages/varlock/src/env-graph/lib/env-graph.ts
+++ b/packages/varlock/src/env-graph/lib/env-graph.ts
@@ -111,6 +111,15 @@ export type SerializedEnvGraph = {
   }>;
   /** Keys that were genuine process.env overrides at this invocation, so nested varlock invocations re-apply exactly those (and nothing else) as overrides. */
   overrideKeys?: Array<string>;
+  /**
+   * true = this payload was resolved at BUILD time and baked into build output. Set only
+   * by the integration injection preludes, never by the graph serializer. It lives INSIDE
+   * the payload so the provenance travels with the blob (child processes, encryption
+   * round-trips) and can never outlive it: a fresh resolution always produces an unflagged
+   * blob, so nothing ever needs to clear it. `initVarlockEnv` uses it to skip the
+   * stale-echo cleanup of ambient values, since no resolution happened in this process.
+   */
+  injectedAtBuild?: boolean;
   /** Present only when config has errors — consumers can check `if (data.errors)` */
   errors?: SerializedEnvGraphErrors;
 };

--- a/packages/varlock/src/runtime/env.ts
+++ b/packages/varlock/src/runtime/env.ts
@@ -594,7 +594,11 @@ export function initVarlockEnv(opts?: {
         // echo (a genuine ambient value would have acted as an override and resolved to it),
         // so clear it rather than leave it shadowing the fresh resolution.
         // `@injectUndefinedAsEmpty` opts back into dotenv-style empty-string injection.
-        delete process.env[itemKey];
+        // EXCEPT when the blob was baked into the build output (`injectedAtBuild`): no
+        // resolution happened in this process, so the echo reasoning cannot hold and a
+        // present value is genuine runtime env (e.g. `docker run -e REDIS_URL=...` against
+        // a Next.js standalone image). Deleting it destroys runtime-provided config.
+        if (!serializedEnvData.injectedAtBuild) delete process.env[itemKey];
       } else {
         envState.injectedProcessEnvKeys?.push(itemKey);
         process.env[itemKey] = envStrValue ?? '';

--- a/packages/varlock/src/runtime/test/build-injected-env.test.ts
+++ b/packages/varlock/src/runtime/test/build-injected-env.test.ts
@@ -1,0 +1,118 @@
+/*
+  Tests for initVarlockEnv behavior when the env blob was baked into the build output,
+  identified by the `injectedAtBuild: true` flag the injection preludes (webpack/turbopack
+  runtime preludes, vite `resolved-env` SSR entry) bake INSIDE the payload. Because the
+  flag lives inside the blob, provenance travels with it to child processes and through
+  encryption, and can never outlive the payload: a fresh resolution always produces an
+  unflagged blob.
+
+  A build-baked blob was resolved at BUILD time, so the stale-echo cleanup (which assumes
+  a resolution happened in this process) must not run against it. Baked values stay
+  authoritative for ENV, but runtime-provided values are never deleted from process.env.
+*/
+import {
+  describe, it, expect, beforeEach, afterEach, vi,
+} from 'vitest';
+
+const ENV_STATE_KEY = '__varlockEnvState';
+const REDACTION_STATE_KEY = '__varlockRedactionState';
+
+const TEST_KEYS = ['BIE_UNSET', 'BIE_SET', 'BIE_BLOB_ONLY'];
+
+type BlobItem = { value?: any, envStr?: string, isSensitive?: boolean };
+function makeEnvBlob(
+  config: Record<string, BlobItem>,
+  opts: { settings?: Record<string, any>, injectedAtBuild?: boolean } = {},
+) {
+  return JSON.stringify({
+    sources: [],
+    settings: opts.settings || {},
+    ...(opts.injectedAtBuild ? { injectedAtBuild: opts.injectedAtBuild } : {}),
+    config: Object.fromEntries(
+      Object.entries(config).map(([key, item]) => [key, { isSensitive: false, ...item }]),
+    ),
+  });
+}
+
+async function importFreshEnvModuleCopy() {
+  vi.resetModules();
+  return import('../env');
+}
+
+function cleanup() {
+  delete (globalThis as any)[ENV_STATE_KEY];
+  delete (globalThis as any)[REDACTION_STATE_KEY];
+  delete (globalThis as any).__varlockLoadedEnv;
+  delete process.env.__VARLOCK_ENV;
+  for (const key of TEST_KEYS) delete process.env[key];
+}
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+describe('build-injected env blob (injectedAtBuild payload flag)', () => {
+  it('keeps a runtime value for an item that resolved to undefined at build time', async () => {
+    // the reported regression: this value used to be DELETED from process.env, taking
+    // down a standalone container booted with `docker run -e REDIS_URL=...`
+    process.env.BIE_UNSET = 'redis://redis:6379';
+    process.env.__VARLOCK_ENV = makeEnvBlob({ BIE_UNSET: { value: undefined } }, { injectedAtBuild: true });
+    const envModule = await importFreshEnvModuleCopy();
+    envModule.initVarlockEnv();
+
+    expect(process.env.BIE_UNSET).toBe('redis://redis:6379');
+  });
+
+  it('baked values stay authoritative for defined items', async () => {
+    process.env.BIE_SET = 'runtime-value';
+    process.env.BIE_UNSET = 'another-runtime-value';
+    process.env.__VARLOCK_ENV = makeEnvBlob({
+      BIE_SET: { value: 'build-value' },
+      BIE_UNSET: { value: undefined },
+      BIE_BLOB_ONLY: { value: 'blob-only-value' },
+    }, { injectedAtBuild: true });
+    const envModule = await importFreshEnvModuleCopy();
+    envModule.initVarlockEnv();
+
+    expect((envModule.ENV as any).BIE_SET).toBe('build-value');
+    expect(process.env.BIE_SET).toBe('build-value');
+    expect(process.env.BIE_BLOB_ONLY).toBe('blob-only-value');
+    // but a runtime value for an item that resolved to undefined is left alone
+    expect(process.env.BIE_UNSET).toBe('another-runtime-value');
+  });
+
+  it('blob-only boot (no runtime values present) uses baked values', async () => {
+    process.env.__VARLOCK_ENV = makeEnvBlob({
+      BIE_SET: { value: 'build-value' },
+      BIE_UNSET: { value: undefined },
+    }, { injectedAtBuild: true });
+    const envModule = await importFreshEnvModuleCopy();
+    envModule.initVarlockEnv();
+
+    expect(process.env.BIE_SET).toBe('build-value');
+    expect((envModule.ENV as any).BIE_SET).toBe('build-value');
+    expect(process.env.BIE_UNSET).toBeUndefined();
+  });
+
+  it('applies when the blob comes via globalThis.__varlockLoadedEnv (vite resolved-env)', async () => {
+    process.env.BIE_UNSET = 'redis://redis:6379';
+    (globalThis as any).__varlockLoadedEnv = JSON.parse(
+      makeEnvBlob({ BIE_UNSET: { value: undefined } }, { injectedAtBuild: true }),
+    );
+    const envModule = await importFreshEnvModuleCopy();
+    envModule.initVarlockEnv();
+
+    expect(process.env.BIE_UNSET).toBe('redis://redis:6379');
+  });
+
+  it('an unflagged blob is a fresh resolution: stale-echo cleanup still applies', async () => {
+    // provenance lives inside the payload, so replacing a baked blob with a freshly
+    // resolved one (auto-load, next compat, vite reload) inherently clears it - a fresh
+    // blob must keep existing semantics no matter what booted earlier
+    process.env.BIE_UNSET = 'stale-parent-value';
+    process.env.__VARLOCK_ENV = makeEnvBlob({ BIE_UNSET: { value: undefined } });
+    const envModule = await importFreshEnvModuleCopy();
+    envModule.initVarlockEnv();
+
+    expect(process.env.BIE_UNSET).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes a destructive silent failure reported from production: a Next.js standalone container passing env vars at boot (`docker run -e REDIS_URL=...`) had those vars **deleted from `process.env`** by varlock at startup, taking the service down.

Replaces #1053, which grew a warning path, a next-env-compat change, and an unrelated vite decrypt fix on top of the actual regression fix. This is the regression fix alone.

## Root cause

In a container where the varlock CLI is unreachable, the standalone server falls back to the env blob baked into the bundled runtime at build time. `initVarlockEnv` treated that blob like a fresh resolution, so items that resolved to undefined at build time (`REDIS_URL=` in the schema, no value in the build env) triggered the stale-echo cleanup from #1038, deleting the runtime-provided value. That cleanup assumes a resolution happened in this process (a genuine ambient value would have acted as an override and resolved to it), which is false for a blob resolved on a build machine.

The deletion shipped only in `varlock@1.17.1`; 1.17.0 and earlier are unaffected.

## The fix

The injection preludes (nextjs webpack + turbopack, vite `resolved-env` SSR entry) bake an `injectedAtBuild: true` flag INSIDE the serialized payload, before encryption where applicable. `initVarlockEnv` skips the stale-echo cleanup for a flagged blob.

Provenance lives in the payload rather than beside it, so it travels with the blob to child/worker processes and through encryption round-trips, and can never outlive it: any fresh resolution produces an unflagged blob, so no marker clearing is needed anywhere.

## What is deliberately unchanged

Baked values stay authoritative for `ENV`, and a runtime value is still not applied to a baked snapshot (it cannot be validated or coerced against one, since the blob carries no schema info). That silent-ignore predates this bug and exists in every released version. Surfacing or enforcing it is a product change, not a patch fixing a destructive regression, and it belongs with `varlock freeze` (#1049) where baking becomes explicit and the contract can be enforced honestly.

Consequence worth naming: after this fix a runtime-provided `REDIS_URL` stays in `process.env` but `ENV.REDIS_URL` is still `undefined`. That split is exactly the 1.17.0 behavior, and restoring it is the point.

## Testing

- Unit coverage for the no-delete fix, blob-only boots, the `globalThis` (vite) blob path, and unflagged blobs keeping existing fresh-resolution semantics.
- One framework-test scenario per bundler booting a real standalone build copied outside the project tree with a stripped environment (mimicking a container image), asserting the boot-provided value survives in `process.env`.

## Follow-ups

Land `varlock freeze` (#1049) as the single explicit pinning mechanism, then rework the integrations so baking is explicit or platform-automatic, and enforce the frozen contract there. `injectedAtBuild` is a bridge and should collapse into the seal at that point.