### PR TITLE
Add remote HTTP approval provider

### DIFF
--- a/.bumpy/http-approval-provider.md
+++ b/.bumpy/http-approval-provider.md
@@ -1,0 +1,5 @@
+---
+varlock: minor
+---
+
+Proxy: add a fail-closed HTTP approval provider with signed, request-bound decisions and forward pending approval links to remote `proxy run --url` clients over the authenticated tunnel.

--- a/packages/varlock-website/src/content/docs/guides/proxy/running.mdx
+++ b/packages/varlock-website/src/content/docs/guides/proxy/running.mdx
@@ -45,6 +45,58 @@ The workload does not have to be on the same machine. `proxy start --expose` mak
 
 When the guest's only egress is an explicit HTTP proxy (a corporate proxy, or a sandbox gateway like [Docker Sandboxes](/sandboxes/docker-sandboxes/)), `proxy run --url` dials the tunnel through it automatically: it honors `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` and `NO_PROXY` (a loopback or `NO_PROXY`-matched broker still dials direct). Only a plaintext `http://` `CONNECT` proxy is supported (an `https://` proxy, meaning TLS to the proxy itself, and SOCKS are not); a `wss://` broker still works through it, since the tunnel's own TLS runs end to end inside the `CONNECT`. That end-to-end TLS also means a proxy that terminates TLS only ever sees the encrypted tunnel.
 
+### HTTP approvals
+
+Use `--approval-url` on the machine that owns the proxy to replace its terminal prompt with an HTTP approval service:
+
+```bash
+VARLOCK_APPROVAL_TOKEN='broker-to-service-token' \
+VARLOCK_APPROVAL_PUBLIC_KEY='key-id=base64-spki-ed25519-public-key' \
+  varlock proxy start --expose --approval-url https://approvals.example.com/requests
+```
+
+`VARLOCK_APPROVAL_URL` can be used instead of the flag, and `--approval-public-key` can be used instead of `VARLOCK_APPROVAL_PUBLIC_KEY`. These settings belong on the broker, not on `proxy run --url`. `VARLOCK_APPROVAL_TOKEN` is required and must contain at least 32 characters. Varlock removes the approval configuration and `VARLOCK_PROXY_TOKEN` from a proxied child before starting it.
+
+For each request that matches `require-approval`, Varlock sends an `ApprovalRequest` as JSON in a `POST` to the configured URL. It contains the method, verified host, path, placeholder-form body hash, nonce, expiry, rule and names of secrets that would be injected. It never contains secret values. Requests use `Authorization: Bearer <token>`.
+
+The service creates a pending request and returns:
+
+```json
+{
+  "approvalUrl": "https://approvals.example.com/a/opaque-request-link",
+  "statusUrl": "https://approvals.example.com/requests/opaque-id",
+  "pollIntervalMs": 1000
+}
+```
+
+The configured endpoint and returned URLs must use HTTPS; plain HTTP is accepted only on loopback for local development. `statusUrl` must have the same origin as the configured endpoint. Varlock polls it with `GET` until it returns one of these objects:
+
+```json
+{ "status": "pending" }
+{
+  "status": "approved",
+  "nonce": "the-request-nonce",
+  "lifetime": { "kind": "once" },
+  "proof": {
+    "algorithm": "ed25519",
+    "keyId": "approval-key-1",
+    "signature": "base64url-ed25519-signature-without-padding"
+  }
+}
+{ "status": "denied", "reason": "Denied by operator" }
+{ "status": "expired" }
+```
+
+The approval service must authenticate the operator separately; possession of `approvalUrl` must not be sufficient to approve. This makes it safe to display the link beside an untrusted agent. The service signs an approved decision with the Ed25519 private key corresponding to the public key pinned by the broker. The Bearer token authenticates service requests only and is not a decision-signing key. The signed bytes are the UTF-8 encoding of this compact JSON array, in exactly this order:
+
+```json
+["varlock-approval-decision-v1", method, host, path, bodyHash, nonce, expiresAt, ruleIdOrNull, grantKeyOrNull, maxDurationMsOrNull, injectedKeysOrEmptyArray, lifetimeKind, durationMsOrNull]
+```
+
+An approval is accepted only before the request expiry, when the returned nonce matches, and when this proof verifies. The `lifetime.kind` may be `once`, `session`, or `duration`; a duration also includes `durationMs`. The proxy clamps it to the rule's `maxDuration`. Errors, redirects, malformed responses, missing or invalid proofs, mismatched nonces and timeouts deny the request.
+
+The approval URL and request metadata appear in the broker terminal. For a remote `proxy run --url`, the broker also forwards them over an authenticated tunnel event channel, so the same non-authorizing link appears beside the remote agent. Decisions still travel directly between the broker and the approval service; the remote client cannot approve a request through the tunnel.
+
 ## Sessions
 
 Every `varlock proxy` command operates on a **session**: one running proxy with its own short id (printed by `proxy start`, listed by `proxy status`). You target a session in one of two ways:
@@ -160,4 +212,3 @@ varlock proxy run --sandbox -- claude
 ```
 
 Bare `--sandbox` is a built-in macOS jail (loopback-only egress + credential-path and keychain denials). Use `--sandbox=docker` (or `=podman`) for a container whose only egress is the host proxy. Details, flags, and third-party recipes: [Sandboxing](/guides/proxy/sandboxing/).
-

--- a/packages/varlock/src/cli/commands/proxy.command-spec.ts
+++ b/packages/varlock/src/cli/commands/proxy.command-spec.ts
@@ -34,6 +34,20 @@ const allowReloadArg = {
   },
 } as const;
 
+const approvalArgs = {
+  'approval-url': {
+    type: 'string',
+    description: 'Use an HTTP approval service instead of a terminal prompt. The endpoint receives a request-bound '
+      + 'approval request and returns approvalUrl + statusUrl. May also be set with VARLOCK_APPROVAL_URL; set '
+      + 'VARLOCK_APPROVAL_TOKEN (at least 32 characters) for broker authentication.',
+  },
+  'approval-public-key': {
+    type: 'string',
+    description: 'Ed25519 decision-verification key as <key-id>=<base64-SPKI>. May also be set with '
+      + 'VARLOCK_APPROVAL_PUBLIC_KEY. Required with an HTTP approval service.',
+  },
+} as const;
+
 // Fix the proxy's loopback port / CA-cert location so a caller can wire tools to a
 // known endpoint before it boots. Only meaningful when STARTING a proxy (proxy start,
 // or proxy run that isn't attaching), so only those verbs declare them.
@@ -86,6 +100,7 @@ export const runCommandSpec = define({
     ...sessionArg,
     ...pathArg,
     ...allowReloadArg,
+    ...approvalArgs,
     ...bindArgs,
     ...remoteArgs,
     new: {
@@ -128,6 +143,7 @@ export const startCommandSpec = define({
   args: {
     ...pathArg,
     ...allowReloadArg,
+    ...approvalArgs,
     ...bindArgs,
   },
 });

--- a/packages/varlock/src/cli/commands/proxy.command.ts
+++ b/packages/varlock/src/cli/commands/proxy.command.ts
@@ -22,10 +22,17 @@ import {
   type ProxyAuditLog,
 } from '../../proxy/audit';
 import {
+  createApprovalNotificationHub,
   createAutoDenyApprovalProvider,
   createTtyApprovalProvider,
+  type ApprovalPendingNotification,
   type ApprovalProvider,
 } from '../../proxy/approval';
+import {
+  createBearerHttpApprovalAuth,
+  createEd25519DecisionVerifier,
+  createHttpApprovalProvider,
+} from '../../proxy/approval-http';
 import {
   createApprovalGrantStore,
   createGrantingApprovalProvider,
@@ -80,7 +87,11 @@ import { select } from '../helpers/prompts';
 import { wrapCommandWithSandbox } from '../../proxy/sandbox-seatbelt';
 import { runContainerSandbox } from '../../proxy/sandbox-docker';
 import { buildGuestEnvWiring, caDirFromSessionEnv, guestLoopbackWiring } from '../../proxy/guest-wiring';
-import { fetchTunnelBootstrap, startTunnelClientListener } from '../../proxy/tunnel';
+import {
+  fetchTunnelBootstrap,
+  startTunnelClientListener,
+  subscribeTunnelApprovalNotifications,
+} from '../../proxy/tunnel';
 import {
   parseSandboxSpec, isContainerKind, checkSandboxAvailable, type SandboxSpec,
 } from '../../proxy/sandbox';
@@ -428,6 +439,13 @@ function spawnProxiedChild(opts: {
     baseEnv: process.env,
   });
 
+  // Broker control-plane configuration must never enter the proxied child, even
+  // when the broker itself was configured through env vars.
+  delete fullInjectedEnv.VARLOCK_APPROVAL_TOKEN;
+  delete fullInjectedEnv.VARLOCK_APPROVAL_PUBLIC_KEY;
+  delete fullInjectedEnv.VARLOCK_APPROVAL_URL;
+  delete fullInjectedEnv.VARLOCK_PROXY_TOKEN;
+
   // Per-stream TTY auto-detect (interactive terminal -> raw inherit so tools like `claude`
   // work; piped/redirected -> redact). Shared with `varlock run` so they can't diverge.
   const { redactStdout, redactStderr } = resolveStdoutRedaction({
@@ -652,11 +670,87 @@ function formatProxyResponseLog(info: ProxyResponseInfo): string {
   return `${arrow} ${formatProxyTarget(info.method, info.host, info.path)}  ${colorProxyStatus(info.statusCode)}${scrub}${streamed}`;
 }
 
+function formatApprovalNotification(notification: ApprovalPendingNotification): string {
+  const inj = notification.injectedKeys?.length
+    ? ` ${ansis.dim('injecting')} ${ansis.yellow(notification.injectedKeys.join(', '))}`
+    : '';
+  return [
+    '',
+    `🔐 ${ansis.bold('varlock proxy: remote approval required')}`,
+    `   ${formatProxyTarget(notification.method, notification.host, notification.path)}${inj}`,
+    `   ${notification.approvalUrl}`,
+  ].join('\n');
+}
+
+type ApprovalProviderFactory = (
+  onPending: (notification: ApprovalPendingNotification) => void,
+) => ApprovalProvider;
+
+function resolveHttpApprovalUrl(ctx: any): string | undefined {
+  const value = ctx.values['approval-url'] ?? process.env.VARLOCK_APPROVAL_URL;
+  return value ? String(value) : undefined;
+}
+
+function parseApprovalPublicKey(value: string): readonly [string, string] {
+  const separator = value.indexOf('=');
+  const keyId = separator === -1 ? '' : value.slice(0, separator);
+  const encoded = separator === -1 ? '' : value.slice(separator + 1);
+  if (!/^[A-Za-z\d._-]{1,128}$/u.test(keyId) || !encoded) {
+    throw new CliExitError(
+      '`VARLOCK_APPROVAL_PUBLIC_KEY` must use the form `<key-id>=<base64-SPKI>`.',
+      { suggestion: 'Use the key ID configured by the approval service and its Ed25519 public key in SPKI DER form.' },
+    );
+  }
+  return [keyId, encoded];
+}
+
+function createConfiguredApprovalProvider(
+  ctx: any,
+  fallback: () => ApprovalProvider,
+): { factory: ApprovalProviderFactory; isHttp: boolean } {
+  const url = resolveHttpApprovalUrl(ctx);
+  if (!url) return { factory: () => fallback(), isHttp: false };
+  const token = process.env.VARLOCK_APPROVAL_TOKEN;
+  if (!token || token.length < 32) {
+    throw new CliExitError(
+      '`VARLOCK_APPROVAL_TOKEN` must contain at least 32 characters when HTTP approval is enabled.',
+      { suggestion: 'Configure the same random token on the Varlock broker and approval service.' },
+    );
+  }
+  const publicKeyValue = ctx.values['approval-public-key'] ?? process.env.VARLOCK_APPROVAL_PUBLIC_KEY;
+  if (!publicKeyValue) {
+    throw new CliExitError(
+      '`VARLOCK_APPROVAL_PUBLIC_KEY` is required when HTTP approval is enabled.',
+      { suggestion: 'Configure `<key-id>=<base64-SPKI>` using the approval service\'s Ed25519 public key.' },
+    );
+  }
+  const [keyId, encodedPublicKey] = parseApprovalPublicKey(String(publicKeyValue));
+  let decisionVerifier;
+  try {
+    decisionVerifier = createEd25519DecisionVerifier(new Map([[keyId, encodedPublicKey]]));
+  } catch (error) {
+    throw new CliExitError('Could not load `VARLOCK_APPROVAL_PUBLIC_KEY`.', {
+      details: error instanceof Error ? error.message : String(error),
+      suggestion: 'Provide an Ed25519 public key encoded as base64 SPKI DER.',
+    });
+  }
+  const auth = createBearerHttpApprovalAuth(token);
+  return {
+    isHttp: true,
+    factory: (onPending) => createHttpApprovalProvider({
+      url,
+      auth,
+      decisionVerifier,
+      onPending,
+    }),
+  };
+}
+
 async function createRuntimeAndSession(opts: {
   policy: PreparedProxyPolicy;
   entryPaths?: Array<string>;
   command?: Array<string>;
-  approvalProvider: ApprovalProvider;
+  createApprovalProvider: ApprovalProviderFactory;
   /** Persist session/duration approval scopes as standing grants (interactive sessions only). */
   enableApprovalGrants?: boolean;
   /** Mark the session as a hot-reloadable daemon (so `proxy reload` can reload it). */
@@ -693,13 +787,18 @@ async function createRuntimeAndSession(opts: {
   const dataPlaneToken = bindIsLoopback ? undefined : (process.env.VARLOCK_PROXY_TOKEN || randomUUID());
   let lastEndpointAuthWarnAt = 0;
   const statsWriter = createSessionStatsWriter(identity.uuid, EMPTY_PROXY_SESSION_STATS);
+  const approvalNotifications = createApprovalNotificationHub();
+  const baseApprovalProvider = opts.createApprovalProvider((notification) => {
+    emitProxyLog(formatApprovalNotification(notification));
+    approvalNotifications.publish(notification);
+  });
   // When grants are enabled, a session/duration approval is remembered so future
   // matching requests auto-approve without re-prompting (the seam the phone
   // approver reuses). Keyed to this session's uuid; torn down on stop.
   const grantStore = opts.enableApprovalGrants ? createApprovalGrantStore(identity.uuid) : undefined;
   const approvalProvider = grantStore
-    ? createGrantingApprovalProvider({ inner: opts.approvalProvider, store: grantStore })
-    : opts.approvalProvider;
+    ? createGrantingApprovalProvider({ inner: baseApprovalProvider, store: grantStore })
+    : baseApprovalProvider;
   const now = new Date().toISOString();
   // Append-only audit log (Invariant #7): one entry per request decision, no
   // secret values. Persists after the session record is deleted on cleanup.
@@ -721,6 +820,7 @@ async function createRuntimeAndSession(opts: {
     ...(opts.listenHost !== undefined ? { listenHost: opts.listenHost } : {}),
     ...(dataPlaneToken !== undefined ? { dataPlaneToken } : {}),
     approvalProvider,
+    subscribeApprovalNotifications: approvalNotifications.subscribe,
     onActivity: (activity) => {
       statsWriter.onActivity(activity);
       auditLog.record(activity);
@@ -1457,6 +1557,13 @@ export async function runAction(ctx: any) {
       { suggestion: 'Pass `--new` to start a separate proxy, or set them on the `proxy start` daemon you are attaching to.' },
     );
   }
+  if (attachSession && (ctx.values['approval-url'] !== undefined
+    || ctx.values['approval-public-key'] !== undefined)) {
+    throw new CliExitError(
+      '`--approval-url` and `--approval-public-key` only apply to the process that owns the proxy, but this run is attaching to an existing session.',
+      { suggestion: 'Set it on the `proxy start` daemon, or pass `--new` to start a separate proxy.' },
+    );
+  }
 
   let session: ProxySessionRecord;
   let payload: SessionEnvPayload;
@@ -1498,14 +1605,15 @@ export async function runAction(ctx: any) {
       hasTty: isHumanAttended(),
     });
     const allowReload = reloadMode === 'manual';
+    const approval = createConfiguredApprovalProvider(ctx, createAutoDenyApprovalProvider);
     const created = await createRuntimeAndSession({
       policy,
       entryPaths: ctx.values.path,
       command: commandToRunAsArgs,
-      // The child owns this terminal's stdio, so we can't safely prompt here —
-      // require-approval requests fail closed. Use `proxy start` (or attach to one)
-      // for interactive approval.
-      approvalProvider: createAutoDenyApprovalProvider(),
+      // A remote provider does not compete with the child for stdin. Without one,
+      // a self-owned run still fails closed because it cannot use the TTY prompt.
+      createApprovalProvider: approval.factory,
+      enableApprovalGrants: approval.isHttp,
       reloadable: allowReload,
       ...bindOptions,
     });
@@ -1666,17 +1774,17 @@ export async function startAction(ctx: any) {
   });
   const allowReload = reloadMode === 'manual';
   const bindOptions = resolveProxyBindOptions(ctx);
+  const approval = createConfiguredApprovalProvider(
+    ctx,
+    () => guardApprovalPromptForLogging(createTtyApprovalProvider()),
+  );
   const {
     runtime, session, statsWriter, auditLog,
   } = await createRuntimeAndSession({
     policy,
     entryPaths: ctx.values.path,
     ...bindOptions,
-    // The proxy owns this terminal (the agent runs elsewhere and routes through
-    // it), so require-approval requests can prompt here — and session/duration
-    // approvals can be remembered as standing grants. Wrapped so the live request
-    // log defers while the prompt is reading input (shared TTY).
-    approvalProvider: guardApprovalPromptForLogging(createTtyApprovalProvider()),
+    createApprovalProvider: approval.factory,
     enableApprovalGrants: true,
     reloadable: allowReload,
     // The daemon owns this terminal, so tail a live per-request/response log here.
@@ -1900,8 +2008,9 @@ async function runRemoteThroughTunnel(ctx: any, cmd: {
   }
   // Local-proxy flags don't apply when the proxy runs elsewhere.
   if (ctx.values.sandbox !== undefined || ctx.values.port !== undefined || ctx.values['cert-dir'] !== undefined
-    || ctx.values.expose !== undefined || ctx.values['persist-ca']) {
-    throw new CliExitError('`--sandbox`, `--port`, `--cert-dir`, `--persist-ca`, and `--expose` describe a local proxy and cannot be combined with `--url`.');
+    || ctx.values.expose !== undefined || ctx.values['persist-ca'] || ctx.values['approval-url'] !== undefined
+    || ctx.values['approval-public-key'] !== undefined) {
+    throw new CliExitError('`--sandbox`, `--port`, `--cert-dir`, `--persist-ca`, `--expose`, `--approval-url`, and `--approval-public-key` describe a local proxy and cannot be combined with `--url`.');
   }
 
   // 1. Fetch the bootstrap (encoded child-view payload + CA certs) over the WS.
@@ -1923,6 +2032,22 @@ async function runRemoteThroughTunnel(ctx: any, cmd: {
   const listener = await startTunnelClientListener({ url, token });
   const guestProxyUrl = `http://127.0.0.1:${listener.port}`;
 
+  // Keep an authenticated event channel open before starting the child so an
+  // approval URL cannot be missed if its first request is immediate.
+  const approvalEvents = await subscribeTunnelApprovalNotifications({
+    url,
+    token,
+    onNotification: (notification) => console.error(formatApprovalNotification(notification)),
+    onError: (error) => console.error(ansis.yellow(`Approval event channel: ${error.message}`)),
+  }).catch((error) => {
+    listener.close();
+    rmSync(certDir, { recursive: true, force: true });
+    throw new CliExitError('Could not subscribe to broker approval events.', {
+      details: (error as Error).message,
+      suggestion: 'Check that the broker and client run compatible Varlock versions.',
+    });
+  });
+
   // 4. Spawn the command through the same path a local run uses: the wiring is the
   //    loopback proxy + the guest cert dir; redaction seeds from the payload graph.
   const { injectVars, injectBlob } = resolveInjectMode(ctx.values.inject);
@@ -1939,6 +2064,7 @@ async function runRemoteThroughTunnel(ctx: any, cmd: {
   const exitCode = await awaitProxiedChild(commandProcess, {
     commandToRunStr: cmd.commandToRunStr,
     cleanup: async () => {
+      approvalEvents.close();
       try {
         listener.close();
       } catch { /* already closed */ }

--- a/packages/varlock/src/proxy/approval-http.ts
+++ b/packages/varlock/src/proxy/approval-http.ts
@@ -1,0 +1,267 @@
+import { createPublicKey, verify as verifySignature, type KeyObject } from 'node:crypto';
+
+import type {
+  ApprovalDecision,
+  ApprovalLifetime,
+  ApprovalPendingNotification,
+  ApprovalProvider,
+  ApprovalRequest,
+} from './approval';
+
+type CreateApprovalResponse = {
+  approvalUrl?: unknown;
+  statusUrl?: unknown;
+  pollIntervalMs?: unknown;
+};
+
+type ApprovalStatusResponse = {
+  status?: unknown;
+  nonce?: unknown;
+  lifetime?: unknown;
+  reason?: unknown;
+  pollIntervalMs?: unknown;
+  proof?: unknown;
+};
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const MIN_POLL_INTERVAL_MS = 250;
+const MAX_POLL_INTERVAL_MS = 10_000;
+
+export interface HttpApprovalAuth {
+  /** Authentication headers for one service request. Called again while polling so future auth can refresh. */
+  getHeaders(): Promise<Record<string, string>>;
+}
+
+export interface ApprovalDecisionVerifier {
+  verify(input: {
+    proof: unknown;
+    request: ApprovalRequest;
+    lifetime: ApprovalLifetime;
+  }): Promise<boolean>;
+}
+
+export function createBearerHttpApprovalAuth(token: string): HttpApprovalAuth {
+  return {
+    async getHeaders() {
+      return { authorization: `Bearer ${token}` };
+    },
+  };
+}
+
+function deny(req: ApprovalRequest, reason: string): ApprovalDecision {
+  return { approved: false, nonce: req.nonce, reason };
+}
+
+function responseError(response: Response): string {
+  return `approval service returned HTTP ${response.status}`;
+}
+
+async function readObject(response: Response): Promise<Record<string, unknown>> {
+  const body = await response.json();
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw new Error('approval service returned a non-object JSON response');
+  }
+  return body as Record<string, unknown>;
+}
+
+function parseUrl(value: unknown, base: string, field: string): string {
+  if (typeof value !== 'string' || !value) {
+    throw new Error(`approval service response is missing ${field}`);
+  }
+  const parsed = new URL(value, base);
+  const isLoopback = parsed.hostname === 'localhost'
+    || parsed.hostname === '::1'
+    || parsed.hostname === '[::1]'
+    || /^127(?:\.\d{1,3}){3}$/u.test(parsed.hostname);
+  if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isLoopback)) {
+    throw new Error(`approval service returned an insecure ${field}; HTTPS is required outside loopback`);
+  }
+  return parsed.toString();
+}
+
+function parsePollInterval(value: unknown, fallback = DEFAULT_POLL_INTERVAL_MS): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.max(MIN_POLL_INTERVAL_MS, Math.min(MAX_POLL_INTERVAL_MS, Math.round(value)));
+}
+
+function parseLifetime(value: unknown): ApprovalLifetime {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('approval service returned an invalid lifetime');
+  }
+  const lifetime = value as Record<string, unknown>;
+  if (lifetime.kind === 'once' || lifetime.kind === 'session') return { kind: lifetime.kind };
+  if (lifetime.kind === 'duration'
+    && typeof lifetime.durationMs === 'number'
+    && Number.isFinite(lifetime.durationMs)
+    && lifetime.durationMs > 0) {
+    return { kind: 'duration', durationMs: lifetime.durationMs };
+  }
+  throw new Error('approval service returned an invalid lifetime');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+}
+
+async function requestHeaders(auth: HttpApprovalAuth): Promise<Record<string, string>> {
+  return {
+    accept: 'application/json',
+    'content-type': 'application/json',
+    ...(await auth.getHeaders()),
+  };
+}
+
+function approvalDecisionPayload(req: ApprovalRequest, lifetime: ApprovalLifetime): string {
+  return JSON.stringify([
+    'varlock-approval-decision-v1',
+    req.method,
+    req.host,
+    req.path,
+    req.bodyHash,
+    req.nonce,
+    req.expiresAt,
+    req.ruleId ?? null,
+    req.grantKey ?? null,
+    req.maxDurationMs ?? null,
+    req.injectedKeys ?? [],
+    lifetime.kind,
+    lifetime.kind === 'duration' ? lifetime.durationMs : null,
+  ]);
+}
+
+function importEd25519PublicKey(encoded: string): KeyObject {
+  const key = encoded.includes('-----BEGIN PUBLIC KEY-----')
+    ? createPublicKey(encoded)
+    : createPublicKey({ key: Buffer.from(encoded, 'base64'), format: 'der', type: 'spki' });
+  if (key.asymmetricKeyType !== 'ed25519') {
+    throw new Error('approval decision public key must be Ed25519');
+  }
+  return key;
+}
+
+export function createEd25519DecisionVerifier(
+  publicKeys: ReadonlyMap<string, string>,
+): ApprovalDecisionVerifier {
+  const importedKeys = new Map<string, KeyObject>();
+  for (const [keyId, encoded] of publicKeys) {
+    importedKeys.set(keyId, importEd25519PublicKey(encoded));
+  }
+  if (importedKeys.size === 0) throw new Error('at least one approval decision public key is required');
+
+  return {
+    async verify({ proof, request, lifetime }) {
+      if (!proof || typeof proof !== 'object' || Array.isArray(proof)) return false;
+      const candidate = proof as Record<string, unknown>;
+      if (candidate.algorithm !== 'ed25519'
+        || typeof candidate.keyId !== 'string'
+        || typeof candidate.signature !== 'string'
+        || !/^[A-Za-z\d_-]{86}$/u.test(candidate.signature)) return false;
+      const publicKey = importedKeys.get(candidate.keyId);
+      if (!publicKey) return false;
+      try {
+        return verifySignature(
+          null,
+          Buffer.from(approvalDecisionPayload(request, lifetime)),
+          publicKey,
+          Buffer.from(candidate.signature, 'base64url'),
+        );
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+function requestSignal(expiresAt: number): AbortSignal {
+  return AbortSignal.timeout(Math.max(1, expiresAt - Date.now()));
+}
+
+/**
+ * Create an approval provider backed by an HTTP service. The configured endpoint
+ * accepts an ApprovalRequest via POST and returns approvalUrl + statusUrl. Varlock
+ * polls statusUrl until it returns approved, denied, or expired.
+ */
+export function createHttpApprovalProvider(opts: {
+  url: string;
+  auth: HttpApprovalAuth;
+  decisionVerifier: ApprovalDecisionVerifier;
+  onPending?: (notification: ApprovalPendingNotification) => void | Promise<void>;
+}): ApprovalProvider {
+  const createUrl = parseUrl(opts.url, opts.url, 'approval URL');
+
+  return {
+    async requestApproval(req) {
+      try {
+        const createResponse = await fetch(createUrl, {
+          method: 'POST',
+          headers: await requestHeaders(opts.auth),
+          body: JSON.stringify(req),
+          redirect: 'error',
+          signal: requestSignal(req.expiresAt),
+        });
+        if (!createResponse.ok) return deny(req, responseError(createResponse));
+
+        const created = await readObject(createResponse) as CreateApprovalResponse;
+        const approvalUrl = parseUrl(created.approvalUrl, createUrl, 'approvalUrl');
+        const statusUrl = parseUrl(created.statusUrl, createUrl, 'statusUrl');
+        if (new URL(statusUrl).origin !== new URL(createUrl).origin) {
+          return deny(req, 'approval service returned a cross-origin statusUrl');
+        }
+        let pollIntervalMs = parsePollInterval(created.pollIntervalMs);
+
+        await opts.onPending?.({
+          approvalUrl,
+          method: req.method,
+          host: req.host,
+          path: req.path,
+          expiresAt: req.expiresAt,
+          ...(req.ruleId ? { ruleId: req.ruleId } : {}),
+          ...(req.injectedKeys?.length ? { injectedKeys: req.injectedKeys } : {}),
+        });
+
+        while (Date.now() < req.expiresAt) {
+          await sleep(Math.min(pollIntervalMs, Math.max(1, req.expiresAt - Date.now())));
+          if (Date.now() >= req.expiresAt) break;
+
+          const statusResponse = await fetch(statusUrl, {
+            method: 'GET',
+            headers: await requestHeaders(opts.auth),
+            redirect: 'error',
+            signal: requestSignal(req.expiresAt),
+          });
+          if (!statusResponse.ok) return deny(req, responseError(statusResponse));
+
+          const result = await readObject(statusResponse) as ApprovalStatusResponse;
+          pollIntervalMs = parsePollInterval(result.pollIntervalMs, pollIntervalMs);
+          if (result.status === 'pending') continue;
+          if (result.status === 'denied' || result.status === 'expired') {
+            return deny(req, typeof result.reason === 'string' ? result.reason : `approval ${result.status}`);
+          }
+          if (result.status !== 'approved') {
+            return deny(req, 'approval service returned an unknown status');
+          }
+          if (result.nonce !== req.nonce) {
+            return deny(req, 'approval service returned a decision for a different request');
+          }
+          const lifetime = parseLifetime(result.lifetime);
+          if (!await opts.decisionVerifier.verify({ proof: result.proof, request: req, lifetime })) {
+            return deny(req, 'approval service returned an invalid decision proof');
+          }
+          return {
+            approved: true,
+            nonce: req.nonce,
+            lifetime,
+            ...(typeof result.reason === 'string' ? { reason: result.reason } : {}),
+          };
+        }
+        return deny(req, 'approval request expired');
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        return deny(req, `approval service unavailable: ${reason}`);
+      }
+    },
+  };
+}

--- a/packages/varlock/src/proxy/approval.ts
+++ b/packages/varlock/src/proxy/approval.ts
@@ -66,6 +66,37 @@ export interface ApprovalProvider {
   requestApproval(req: ApprovalRequest): Promise<ApprovalDecision>;
 }
 
+/** Metadata shown to the operator while a remote approval is pending. */
+export type ApprovalPendingNotification = {
+  approvalUrl: string;
+  method: string;
+  host: string;
+  path: string;
+  expiresAt: number;
+  ruleId?: string;
+  injectedKeys?: Array<string>;
+};
+
+/** In-process fan-out from an approval provider to local and remote operators. */
+export function createApprovalNotificationHub() {
+  const listeners = new Set<(notification: ApprovalPendingNotification) => void>();
+  return {
+    publish(notification: ApprovalPendingNotification) {
+      for (const listener of listeners) {
+        try {
+          listener(notification);
+        } catch {
+          listeners.delete(listener);
+        }
+      }
+    },
+    subscribe(listener: (notification: ApprovalPendingNotification) => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}
+
 export function hashBody(body: Buffer | string): string {
   return createHash('sha256').update(body).digest('hex');
 }

--- a/packages/varlock/src/proxy/runtime-proxy.ts
+++ b/packages/varlock/src/proxy/runtime-proxy.ts
@@ -13,7 +13,8 @@ import tls from 'node:tls';
 import { URL } from 'node:url';
 
 import {
-  createApprovalRequest, isApprovalValid, type ApprovalProvider,
+  createApprovalRequest, isApprovalValid,
+  type ApprovalPendingNotification, type ApprovalProvider,
 } from './approval';
 import type { ProxyActivity } from './audit';
 import {
@@ -83,6 +84,10 @@ export type StartLocalProxyRuntimeInput = {
    * (deny on timeout/error). Absent ⇒ require-approval requests are denied.
    */
   approvalProvider?: ApprovalProvider;
+  /** Subscribe remote tunnel clients to pending approval notifications. */
+  subscribeApprovalNotifications?: (
+    listener: (notification: ApprovalPendingNotification) => void,
+  ) => () => void;
   /**
    * Enables the `varlock.internal` internal endpoint, which serves the current
    * session-env payload (child-view env + graph; never wire real values) so an
@@ -1124,6 +1129,7 @@ export async function startLocalProxyRuntime({
   onActivity,
   onResponse,
   approvalProvider,
+  subscribeApprovalNotifications,
   internalEndpoint,
   port,
   certDir,
@@ -1710,6 +1716,7 @@ export async function startLocalProxyRuntime({
       token: dataPlaneToken,
       proxyPort: address.port,
       buildBootstrap: buildTunnelBootstrap,
+      ...(subscribeApprovalNotifications ? { subscribeApprovalNotifications } : {}),
       onAuthFailure: () => internalEndpoint?.onAuthFailure?.(),
     })
     : undefined;

--- a/packages/varlock/src/proxy/tunnel.ts
+++ b/packages/varlock/src/proxy/tunnel.ts
@@ -4,6 +4,8 @@ import net from 'node:net';
 import tls from 'node:tls';
 import { createHash, timingSafeEqual, randomBytes } from 'node:crypto';
 
+import type { ApprovalPendingNotification } from './approval';
+
 /**
  * CONNECT-over-WebSocket tunnel for reaching the proxy from a remote sandbox.
  *
@@ -21,6 +23,8 @@ import { createHash, timingSafeEqual, randomBytes } from 'node:crypto';
  *                          byte pipe. On the broker the connection is loopback, so
  *                          it's exempt from the data-plane token check — the WS
  *                          handshake already authenticated it.
+ *  - `{"t":"events"}`    → broker keeps the WS open and forwards pending
+ *                          approval metadata, never secret values.
  *
  * No WebSocket library is shipped, deliberately: bundling CJS `ws` into the ESM
  * npm dist broke Node at import time, and crossws's node adapter refuses to run
@@ -347,10 +351,17 @@ function wrapWsLibSocket(ws: any): TunnelSocketLike {
 function handleTunnelConnection(ws: TunnelSocketLike, opts: {
   proxyPort: number;
   buildBootstrap: () => TunnelBootstrap;
+  subscribeApprovalNotifications?: (
+    listener: (notification: ApprovalPendingNotification) => void,
+  ) => () => void;
 }) {
   let first = true;
   let upstream: net.Socket | undefined;
-  ws.onclose = () => upstream?.destroy();
+  let unsubscribeApprovalNotifications: (() => void) | undefined;
+  ws.onclose = () => {
+    unsubscribeApprovalNotifications?.();
+    upstream?.destroy();
+  };
   ws.onmessage = (data) => {
     if (!first) {
       upstream?.write(data);
@@ -391,6 +402,14 @@ function handleTunnelConnection(ws: TunnelSocketLike, opts: {
       return;
     }
 
+    if (control.t === 'events' && opts.subscribeApprovalNotifications) {
+      unsubscribeApprovalNotifications = opts.subscribeApprovalNotifications((notification) => {
+        ws.sendText(JSON.stringify({ t: 'approval-required', ...notification }));
+      });
+      ws.sendText(JSON.stringify({ t: 'events-ready' }));
+      return;
+    }
+
     ws.close();
   };
 }
@@ -404,6 +423,9 @@ export function attachTunnelServer(httpServer: http.Server, opts: {
   token: string;
   proxyPort: number;
   buildBootstrap: () => TunnelBootstrap;
+  subscribeApprovalNotifications?: (
+    listener: (notification: ApprovalPendingNotification) => void,
+  ) => () => void;
   onAuthFailure?: () => void;
 }): { close: () => void } {
   // Bun path: its node:http drops manual writes on upgrade sockets, so the
@@ -922,6 +944,82 @@ export function fetchTunnelBootstrap(url: string, token: string, timeoutMs = 150
     ws.addEventListener('close', () => {
       clearTimeout(timer);
       reject(new Error('tunnel closed before the bootstrap arrived'));
+    });
+  });
+}
+
+/** Keep a control connection open and surface approval notifications from a remote broker. */
+export function subscribeTunnelApprovalNotifications(opts: {
+  url: string;
+  token: string;
+  onNotification: (notification: ApprovalPendingNotification) => void;
+  onError?: (error: Error) => void;
+}): Promise<{ close: () => void }> {
+  return new Promise((resolve, reject) => {
+    const ws = openTunnelWs(opts.url, opts.token);
+    let ready = false;
+    let closed = false;
+    const timer = setTimeout(() => {
+      reject(new Error('approval event channel timed out'));
+      ws.close();
+    }, 15_000);
+    timer.unref?.();
+
+    ws.addEventListener('open', () => ws.send(JSON.stringify({ t: 'events' })));
+    ws.addEventListener('message', (ev) => {
+      try {
+        const event = JSON.parse(messageToBuffer(ev.data).toString()) as Record<string, unknown>;
+        if (event.t === 'events-ready' && !ready) {
+          ready = true;
+          clearTimeout(timer);
+          resolve({
+            close: () => {
+              closed = true;
+              try {
+                ws.close();
+              } catch { /* already closed */ }
+            },
+          });
+          return;
+        }
+        if (event.t !== 'approval-required'
+          || typeof event.approvalUrl !== 'string'
+          || typeof event.method !== 'string'
+          || typeof event.host !== 'string'
+          || typeof event.path !== 'string'
+          || typeof event.expiresAt !== 'number') return;
+        opts.onNotification({
+          approvalUrl: event.approvalUrl,
+          method: event.method,
+          host: event.host,
+          path: event.path,
+          expiresAt: event.expiresAt,
+          ...(typeof event.ruleId === 'string' ? { ruleId: event.ruleId } : {}),
+          ...(Array.isArray(event.injectedKeys)
+            && event.injectedKeys.every((key) => typeof key === 'string')
+            ? { injectedKeys: event.injectedKeys as Array<string> }
+            : {}),
+        });
+      } catch {
+        // Ignore malformed event messages. They cannot authorize a request.
+      }
+    });
+    ws.addEventListener('error', () => {
+      const error = new Error('approval event channel failed');
+      if (!ready) {
+        clearTimeout(timer);
+        reject(error);
+      } else if (!closed) {
+        opts.onError?.(error);
+      }
+    });
+    ws.addEventListener('close', () => {
+      if (!ready) {
+        clearTimeout(timer);
+        reject(new Error('approval event channel closed before it was ready'));
+      } else if (!closed) {
+        opts.onError?.(new Error('approval event channel closed'));
+      }
     });
   });
 }


### PR DESCRIPTION
Hey together, 
thanks a lot for building Varlock. Makes my life a lot easier when working with secrets and agents. And also thanks a lot @theoephraim for quick reactions (https://github.com/cloudflare/workers-sdk/pull/15256). Hope it gets merged soon. 

But now to the roadblock I hit. Lately I am using remote dev machines, which means my normal secret approval flows with varlock dont work there. So i gave codex some homework to research and it found you guys (of course) already thought about the problem but the final implementation is not done yet.

So I gave it some thought and had codex work on it. Reviewed everything and tested it.

Would love to get your thoughts on it, if this is going in the right direction I am happy to give this some more work as this is currently one of my biggest pains. 

I did not yet add any tests, as I wanted to hear your thoughts. But will happily add some if this is going in the right direction.

Below some thought I wrote together with codex:

----

# Remote HTTP approval provider

Varlock already supports request-bound approvals, lifetimes, and grants. This change makes that approval mechanism usable when the operator is not at the broker terminal.

## What we added to Varlock

- An HTTP implementation of the existing `ApprovalProvider`.
- Broker authentication through a small `HttpApprovalAuth` interface, with Bearer authentication as the initial CLI implementation.
- Signed-decision verification through an `ApprovalDecisionVerifier` interface, with Ed25519 as the initial implementation.
- CLI and environment configuration for the service URL, Bearer token, and pinned public key.
- An `ApprovalPendingNotification` containing the approval URL and safe request metadata.
- An event channel over the existing authenticated tunnel so `proxy run --url` can display that notification remotely.
- Removal of approval-service credentials from the proxied child environment.

The existing terminal provider remains the default.

## HTTP approval flow

When an existing `require-approval` rule matches:

1. Varlock sends the existing request-bound `ApprovalRequest` to the configured service.
2. The service returns an operator-facing `approvalUrl` and broker-facing `statusUrl`.
3. Varlock displays the approval URL locally and forwards it to attached remote clients.
4. The broker polls the status URL.
5. An approval is accepted only if its nonce, expiry, lifetime, and signature are valid.
6. Varlock then applies its existing lifetime clamping and grant behavior.

## Security decisions

The approval URL may be visible to the agent, so possession of it cannot authorize a decision. Operator authentication belongs to the approval service.

The Bearer token and Ed25519 key have separate roles:

- The Bearer token authenticates broker-to-service requests.
- The approval service signs the exact decision with its Ed25519 private key.
- Varlock holds only the public key and verifies the decision locally.

The signature binds the request method, verified host, path, body hash, nonce, expiry, rule, grant scope, secret names, and selected lifetime. A decision therefore cannot be reused for a different request or widened beyond what was approved.

Errors, redirects, malformed responses, invalid proofs, nonce mismatches, and timeouts fail closed. HTTPS is required outside loopback, and the status URL must use the configured service origin.

## Remote notification

The existing tunnel continues carrying proxied traffic. We add a separate authenticated event connection that carries only pending-approval notifications.

The remote client can display the approval link but cannot submit a decision through the tunnel. Decisions still travel directly between the broker and approval service.

## What we reuse unchanged

- The existing `ApprovalRequest` and `ApprovalProvider` model.
- Existing `once`, `session`, and `duration` lifetimes.
- Existing grant keys, duration limits, and grant storage.
- Existing proxy rules and `require-approval` behavior.
- The existing authenticated WebSocket tunnel.

## Reference service

We also built a separate Cloudflare Worker to validate the protocol. It stores pending approvals in Durable Objects, authenticates the operator with WebAuthn, and signs approved decisions with Ed25519. It is one possible implementation of the generic HTTP approval contract.
