### PR TITLE
Bump smoke-tests to vitest 4 to drop the worker rpc timeout flake

### DIFF
--- a/smoke-tests/package.json
+++ b/smoke-tests/package.json
@@ -12,7 +12,7 @@
     "@types/node": "^22.0.0",
     "typescript": "^5.9.3",
     "varlock": "link:../packages/varlock",
-    "vitest": "^3.2.4"
+    "vitest": "^4.0.18"
   },
   "pnpm": {
     "overrides": {

--- a/smoke-tests/tsconfig.json
+++ b/smoke-tests/tsconfig.json
@@ -10,5 +10,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["tests/**/*.ts"]
+  "include": ["tests/**/*.ts", "helpers/**/*.ts", "vitest.config.ts"]
 }

--- a/smoke-tests/vitest.config.ts
+++ b/smoke-tests/vitest.config.ts
@@ -1,11 +1,6 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  esbuild: {
-    // Prevent vite:esbuild from walking up to the root tsconfig.json
-    // which extends @varlock/tsconfig (unavailable in smoke-test pnpm environment)
-    tsconfigRaw: '{}',
-  },
   test: {
     testTimeout: 60000, // Some tests involve building frameworks
     hookTimeout: 60000, // Framework builds use 120s per-test overrides


### PR DESCRIPTION
## What

- `smoke-tests`: vitest `^3.2.4` -> `^4.0.18` (matches the root catalog)
- Drop the `esbuild.tsconfigRaw` block from `smoke-tests/vitest.config.ts`
- Add `helpers/**/*.ts` and `vitest.config.ts` to the `smoke-tests/tsconfig.json` include set

## Why

The ubuntu smoke job on the release PR failed with an unhandled `[vitest-worker]: Timeout calling "onTaskUpdate"` error even though all 168 tests passed (https://github.com/dmno-dev/varlock/actions/runs/33596804177/job/100142117083).

vitest 3 gives the worker-to-main rpc a 60s timeout. The smoke suite blocks its worker with long `spawnSync` calls (Rust/C#/Java builds in `lang-modules.test.ts`) while the main thread is busy with other files, so the reply can arrive after the deadline. vitest 4 sets that rpc timeout to `-1`, which removes this flake class.

vite 8 (pulled in by vitest 4) transforms with oxc, so the old `esbuild.tsconfigRaw` workaround was ignored and only produced a "both esbuild and oxc options were set" warning. Oxc discovers the tsconfig per file and honours `include`, so sources not covered by `tests/**` (the `helpers/` modules) walked up to the root tsconfig, whose `extends` target is not installed in the isolated smoke-test pnpm environment. Widening the smoke-tests tsconfig include keeps every transformed source on the self-contained config. Verified locally by pointing the root `extends` at a nonexistent package and running the full suite.

Full smoke suite passes locally under vitest 4 (17 files, 166 passed, 3 skipped for missing toolchains).