### PR TITLE
Fix CLI discovery in Bun-compiled workspace apps

### DIFF
--- a/.bumpy/bun-compiled-cli-resolution.md
+++ b/.bumpy/bun-compiled-cli-resolution.md
@@ -1,0 +1,5 @@
+---
+varlock: patch
+---
+
+Find the Varlock CLI next to Bun-compiled workspace executables.

--- a/packages/varlock-website/src/content/docs/integrations/bun.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/bun.mdx
@@ -20,6 +20,18 @@ You may also use the `--no-env-file` CLI flag when invoking scripts with `bun`/`
 
 Note that if you are building a standalone executable using `bun build`, you can use the `--no-compile-autoload-dotenv` flag to disable this behavior in the final executable.
 
+### Compiled executables
+
+`bun build --compile` bundles the `varlock/auto-load` runtime code into your executable, but it does not bundle the separate Varlock CLI that resolves your config. If the executable resolves config when it starts, keep the `varlock` package and its `node_modules/.bin/varlock` entry in the runtime image. In a monorepo, keep the package-level `node_modules` directory next to the compiled application output.
+
+You can also launch the executable through the CLI. This resolves the config before the application starts, so the bundled `varlock/auto-load` code reuses the injected environment instead of looking for the CLI again:
+
+```sh
+varlock run -- ./dist/server
+```
+
+If your deployment otherwise contains only the compiled executable, install the [standalone Varlock binary](/getting-started/installation/#as-a-standalone-binary) in the runtime image and launch the application through `varlock run`.
+
 
 ### Using a preload script (optional)
 One option we have with bun is to use a [preload script](https://bun.com/docs/runtime/bunfig#preload), configured in `bunfig.toml`. If you do this, you will no longer have to use `bun run varlock run -- yourscript` or use `import 'varlock/auto-load'` in your code!

--- a/packages/varlock-website/src/content/docs/integrations/bun.mdx
+++ b/packages/varlock-website/src/content/docs/integrations/bun.mdx
@@ -22,7 +22,16 @@ Note that if you are building a standalone executable using `bun build`, you can
 
 ### Compiled executables
 
-`bun build --compile` bundles the `varlock/auto-load` runtime code into your executable, but it does not bundle the separate Varlock CLI that resolves your config. If the executable resolves config when it starts, keep the `varlock` package and its `node_modules/.bin/varlock` entry in the runtime image. In a monorepo, keep the package-level `node_modules` directory next to the compiled application output.
+`bun build --compile` bundles the `varlock/auto-load` runtime code into your executable, but it does not bundle the separate Varlock CLI that resolves your config. If the executable resolves config when it starts, your deployment must also include the installed `varlock` package and its dependencies. The executable looks for `node_modules/.bin/varlock` in its directory and each parent directory.
+
+For example, this monorepo layout keeps the CLI available to the compiled server:
+
+```text
+apps/server/dist/server
+apps/server/node_modules/.bin/varlock
+```
+
+If your deployment platform installs or prunes dependencies, declare `varlock` as a production dependency in a package whose `node_modules` directory is deployed with the executable.
 
 You can also launch the executable through the CLI. This resolves the config before the application starts, so the bundled `varlock/auto-load` code reuses the injected environment instead of looking for the CLI again:
 
@@ -30,7 +39,7 @@ You can also launch the executable through the CLI. This resolves the config bef
 varlock run -- ./dist/server
 ```
 
-If your deployment otherwise contains only the compiled executable, install the [standalone Varlock binary](/getting-started/installation/#as-a-standalone-binary) in the runtime image and launch the application through `varlock run`.
+If your deployment otherwise contains only the compiled executable, install the [standalone Varlock binary](/getting-started/installation/#as-a-standalone-binary) in the deployment environment and launch the application through `varlock run`.
 
 
 ### Using a preload script (optional)

--- a/packages/varlock/src/lib/detect-runtime.ts
+++ b/packages/varlock/src/lib/detect-runtime.ts
@@ -30,6 +30,14 @@ export const isDeno: boolean = typeof Deno !== 'undefined'
 /** @see {@link https://bun.sh/guides/util/detect-bun} */
 export const isBun = processVersions && processVersions.bun != null;
 
+/** @see {@link https://bun.com/docs/bundler/executables#detecting-standalone-mode} */
+export function isBunStandaloneExecutable(): boolean {
+  const bunGlobal = (globalThis as typeof globalThis & {
+    Bun?: { isStandaloneExecutable?: boolean },
+  }).Bun;
+  return Boolean(bunGlobal?.isStandaloneExecutable);
+}
+
 
 
 export const isBrowser = typeof window !== 'undefined'

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -145,8 +145,7 @@ export function execSyncVarlock(
 
     // if varlock was not found, it either means it is not installed
     // or we must find the path to node_modules/.bin ourselves.
-    // Search from cwd (if provided), callerDir, the running executable, then
-    // process.cwd().
+    // Search from cwd (if provided), callerDir, then process.cwd().
     // This handles monorepo setups where cwd may be an unrelated workspace
     // root while varlock is only installed in a sub-package - the callerDir
     // supplied by auto-load.ts points inside that sub-package's node_modules.
@@ -154,10 +153,14 @@ export function execSyncVarlock(
     // virtual /$bunfs filesystem, while process.execPath points at the real
     // executable inside the workspace.
     const cwdStr = opts?.cwd ? String(opts.cwd) : undefined;
+    const bunGlobal = (globalThis as typeof globalThis & {
+      Bun?: { isStandaloneExecutable?: boolean },
+    }).Bun;
+    const isBunStandaloneExecutable = Boolean(bunGlobal?.isStandaloneExecutable);
     const searchDirs = [
       ...(cwdStr ? [cwdStr] : []),
       ...(opts?.callerDir ? [opts.callerDir] : []),
-      path.dirname(process.execPath),
+      ...(isBunStandaloneExecutable ? [path.dirname(process.execPath)] : []),
       process.cwd(),
     ];
 

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -145,14 +145,19 @@ export function execSyncVarlock(
 
     // if varlock was not found, it either means it is not installed
     // or we must find the path to node_modules/.bin ourselves.
-    // Search from cwd (if provided), callerDir, then process.cwd().
+    // Search from cwd (if provided), callerDir, the running executable, then
+    // process.cwd().
     // This handles monorepo setups where cwd may be an unrelated workspace
     // root while varlock is only installed in a sub-package - the callerDir
     // supplied by auto-load.ts points inside that sub-package's node_modules.
+    // Bun-compiled executables are the exception: callerDir points into Bun's
+    // virtual /$bunfs filesystem, while process.execPath points at the real
+    // executable inside the workspace.
     const cwdStr = opts?.cwd ? String(opts.cwd) : undefined;
     const searchDirs = [
       ...(cwdStr ? [cwdStr] : []),
       ...(opts?.callerDir ? [opts.callerDir] : []),
+      path.dirname(process.execPath),
       process.cwd(),
     ];
 

--- a/packages/varlock/src/lib/exec-sync-varlock.ts
+++ b/packages/varlock/src/lib/exec-sync-varlock.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
 import { execFileSync, execSync } from 'node:child_process';
+import { isBunStandaloneExecutable } from './detect-runtime';
 
 const platform = os.platform();
 const isWindows = platform.match(/^win/i);
@@ -153,14 +154,10 @@ export function execSyncVarlock(
     // virtual /$bunfs filesystem, while process.execPath points at the real
     // executable inside the workspace.
     const cwdStr = opts?.cwd ? String(opts.cwd) : undefined;
-    const bunGlobal = (globalThis as typeof globalThis & {
-      Bun?: { isStandaloneExecutable?: boolean },
-    }).Bun;
-    const isBunStandaloneExecutable = Boolean(bunGlobal?.isStandaloneExecutable);
     const searchDirs = [
       ...(cwdStr ? [cwdStr] : []),
       ...(opts?.callerDir ? [opts.callerDir] : []),
-      ...(isBunStandaloneExecutable ? [path.dirname(process.execPath)] : []),
+      ...(isBunStandaloneExecutable() ? [path.dirname(process.execPath)] : []),
       process.cwd(),
     ];
 

--- a/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
+++ b/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
@@ -18,6 +18,7 @@ describe('execSyncVarlock integration telemetry', () => {
 
   afterEach(() => {
     delete process.env.__VARLOCK_INTEGRATION;
+    vi.unstubAllGlobals();
   });
 
   it('integrationTelemetryEnv formats __VARLOCK_INTEGRATION', () => {
@@ -98,6 +99,7 @@ describe('execSyncVarlock integration telemetry', () => {
   it('finds a workspace CLI relative to a Bun-compiled executable', () => {
     const originalExecPath = process.execPath;
     process.execPath = '/app/apps/server/dist/server';
+    vi.stubGlobal('Bun', { isStandaloneExecutable: true });
     vi.mocked(execSync).mockImplementationOnce(() => {
       throw Object.assign(new Error('varlock: not found'), { status: 127 });
     });
@@ -115,6 +117,36 @@ describe('execSyncVarlock integration telemetry', () => {
 
     expect(execFileSync).toHaveBeenCalledWith(
       '/app/apps/server/node_modules/.bin/varlock',
+      ['load'],
+      expect.objectContaining({ stdio: 'pipe' }),
+    );
+  });
+
+  it('does not search relative to the runtime executable outside a Bun-compiled executable', () => {
+    const originalExecPath = process.execPath;
+    process.execPath = '/runtime/bin/bun';
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/project');
+    vi.stubGlobal('Bun', { isStandaloneExecutable: false });
+    vi.mocked(execSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error('varlock: not found'), { status: 127 });
+    });
+    const existsSyncSpy = vi.spyOn(fs, 'existsSync').mockImplementation((filePath) => {
+      return filePath === '/runtime/bin/node_modules/.bin'
+        || filePath === '/runtime/bin/node_modules/.bin/varlock'
+        || filePath === '/project/node_modules/.bin'
+        || filePath === '/project/node_modules/.bin/varlock';
+    });
+
+    try {
+      execSyncVarlock('load');
+    } finally {
+      process.execPath = originalExecPath;
+      cwdSpy.mockRestore();
+      existsSyncSpy.mockRestore();
+    }
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      '/project/node_modules/.bin/varlock',
       ['load'],
       expect.objectContaining({ stdio: 'pipe' }),
     );

--- a/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
+++ b/packages/varlock/src/lib/test/exec-sync-varlock.test.ts
@@ -2,6 +2,7 @@ import {
   describe, it, expect, vi, beforeEach, afterEach,
 } from 'vitest';
 import { execSync, execFileSync } from 'node:child_process';
+import fs from 'node:fs';
 import { integrationTelemetryEnv, execSyncVarlock } from '../exec-sync-varlock';
 
 vi.mock('node:child_process', () => ({
@@ -91,6 +92,31 @@ describe('execSyncVarlock integration telemetry', () => {
           __VARLOCK_INTEGRATION: '@varlock/nextjs-integration@1.1.3',
         }),
       }),
+    );
+  });
+
+  it('finds a workspace CLI relative to a Bun-compiled executable', () => {
+    const originalExecPath = process.execPath;
+    process.execPath = '/app/apps/server/dist/server';
+    vi.mocked(execSync).mockImplementationOnce(() => {
+      throw Object.assign(new Error('varlock: not found'), { status: 127 });
+    });
+    const existsSyncSpy = vi.spyOn(fs, 'existsSync').mockImplementation((filePath) => {
+      return filePath === '/app/apps/server/node_modules/.bin'
+        || filePath === '/app/apps/server/node_modules/.bin/varlock';
+    });
+
+    try {
+      execSyncVarlock('load', { callerDir: '/$bunfs/root' });
+    } finally {
+      process.execPath = originalExecPath;
+      existsSyncSpy.mockRestore();
+    }
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      '/app/apps/server/node_modules/.bin/varlock',
+      ['load'],
+      expect.objectContaining({ stdio: 'pipe' }),
     );
   });
 });


### PR DESCRIPTION
## Summary

- search for the project Varlock CLI relative to the running executable
- cover Bun compiled executables whose module paths use the virtual `/$bunfs` filesystem
- document runtime CLI requirements for compiled Bun applications

## Why

A compiled Bun application can run from a package such as `/app/apps/server/dist/server` while `import.meta.dirname` points into `/$bunfs` and the process working directory is `/app`. In an isolated workspace install, the CLI remains at `/app/apps/server/node_modules/.bin/varlock`, so the existing search paths miss it.